### PR TITLE
fix: enforce authz on exposed endpoints and allow DELETE method in CORS

### DIFF
--- a/extraction/agent_server.py
+++ b/extraction/agent_server.py
@@ -792,28 +792,14 @@ async def platform_chat_send(request: PlatformChatRequest):
 
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
-async def platform_chat_session_get(
-    session_id: str,
-    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
-):
-    try:
-        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+async def platform_chat_session_get(session_id: str):
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
-async def platform_chat_session_reset(
-    session_id: str,
-    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
-):
-    try:
-        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+async def platform_chat_session_reset(session_id: str):
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 
@@ -1257,38 +1243,20 @@ async def batch_health():
 
 
 @app.get(RuntimePath.DATABASES)
-async def list_databases(
-    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
-):
+async def list_databases():
     """List all registered databases."""
-    try:
-        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
     return {"databases": db_registry.list_databases()}
 
 
 @app.get(RuntimePath.GRAPHS)
-async def list_graphs(
-    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
-):
+async def list_graphs():
     """List registered graph targets."""
-    try:
-        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
     return {"graphs": [target.to_public_dict() for target in graph_registry.list_graphs()]}
 
 
 @app.get(RuntimePath.AGENTS)
-async def list_agents(
-    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
-):
+async def list_agents():
     """List all active DB-bound agents."""
-    try:
-        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
     return {"agents": agent_factory.list_agents()}
 
 

--- a/extraction/agent_server.py
+++ b/extraction/agent_server.py
@@ -101,7 +101,7 @@ _cors_origins = [
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
-    allow_methods=["POST", "GET"],
+    allow_methods=["POST", "GET", "DELETE"],
     allow_headers=["*"],
 )
 
@@ -792,14 +792,28 @@ async def platform_chat_send(request: PlatformChatRequest):
 
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
-async def platform_chat_session_get(session_id: str):
+async def platform_chat_session_get(
+    session_id: str,
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
+):
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
-async def platform_chat_session_reset(session_id: str):
+async def platform_chat_session_reset(
+    session_id: str,
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
+):
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 
@@ -1243,20 +1257,38 @@ async def batch_health():
 
 
 @app.get(RuntimePath.DATABASES)
-async def list_databases():
+async def list_databases(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
+):
     """List all registered databases."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"databases": db_registry.list_databases()}
 
 
 @app.get(RuntimePath.GRAPHS)
-async def list_graphs():
+async def list_graphs(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
+):
     """List registered graph targets."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"graphs": [target.to_public_dict() for target in graph_registry.list_graphs()]}
 
 
 @app.get(RuntimePath.AGENTS)
-async def list_agents():
+async def list_agents(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)
+):
     """List all active DB-bound agents."""
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
## Feature
This PR adds missing authorization checks to multiple sensitive endpoints and fixes a CORS misconfiguration.

## Why
These endpoints were previously accessible without enforcing runtime policies. Specifically:
- `list_databases`, `list_graphs`, `list_agents` exposed global registry information.
- `platform_chat_session_get` and `platform_chat_session_reset` lacked policy checks entirely, presenting a risk to privacy and application integrity.
Additionally, the `platform_chat_session_reset` endpoint relies on the HTTP `DELETE` method which was not permitted by the `CORSMiddleware`, causing browser requests to fail.

## Design
- `workspace_id: str = Query(default="default", ...)` was added to the signature of these unprotected endpoints to preserve backward compatibility (similar to other endpoints).
- `require_runtime_permission()` calls were added to validate `"read_databases"`, `"read_agents"`, and `"run_platform"` actions.
- `"DELETE"` was added to the `allow_methods` list in `CORSMiddleware`.

## Expected Effect
Unauthorized or cross-workspace access to database registries, agents, and platform sessions will return a `403 Forbidden` response. Frontend web applications will successfully complete `DELETE` requests.

## Validation
- Ran `pytest extraction/tests/test_api_endpoints.py`
- Ran `bash scripts/ci/run_basic_ci.sh`
All tests complete successfully, indicating no regressions.

## Risks
Endpoints now enforce workspace isolation and policy checks, which may surface permission errors if downstream clients rely on the previously unprotected behavior without valid credentials or authorization setup. However, the default workspace behavior mitigates backward compatibility risk for internal SDK flows.

---
*PR created automatically by Jules for task [18308365976890591370](https://jules.google.com/task/18308365976890591370) started by @tteon*