### PR TITLE
fix(a11y): enhance keyboard focus visibility in UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,2 @@
+# UX and Accessibility Learnings
+- 2025-04-14: Added global `button:focus-visible` styling (`outline: 2px solid var(--accent-blue); outline-offset: 2px;`) and ensured all `.control` inputs and textareas have a consistent `box-shadow` on `:focus` to match `.composer textarea`. Keep this pattern consistent for any new interactive elements added to `evaluation/static/styles.css`.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -212,6 +212,7 @@ body {
 .control select:focus,
 .control input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 .ingest-controls {
@@ -245,6 +246,7 @@ body {
 
 .ingest-grow textarea:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 #ingestBtn {
@@ -383,6 +385,11 @@ body {
 
 .composer button:hover:not(:disabled) {
   opacity: 0.9;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }
 
 /* Right Pane: AIP Workflow Canvas */


### PR DESCRIPTION
- **What**: Added clear keyboard focus outlines to UI inputs and buttons in `evaluation/static/styles.css`. Logged the change to `.jules/palette.md`.
- **Why**: Keyboard navigation was visually ambiguous due to missing focus states. Many inputs lacked sufficient visual indicators, and buttons had none at all.
- **Accessibility / UX Impact**: Enables confident keyboard-only operation by providing distinct blue focus rings (`box-shadow` for inputs, `outline` for buttons) for all interactive elements without causing layout shifts.
- **Validation**: Local CSS applied successfully, visually confirmed via Playwright screenshots, and `bash scripts/ci/run_basic_ci.sh` passed.
- **Risks**: Low. Isolated CSS change; no runtime, backend, or multi-agent behavior changes.

---
*PR created automatically by Jules for task [7960316388540764789](https://jules.google.com/task/7960316388540764789) started by @tteon*