### PR TITLE
Fix Cypher injection vulnerability in schema manager

### DIFF
--- a/extraction/schema_manager.py
+++ b/extraction/schema_manager.py
@@ -45,31 +45,35 @@ class SchemaManager:
                     for prop_name, config in props.items():
                         # 1. Unique Constraints
                         if config.get('constraint') == 'UNIQUE':
-                            constraint_name = f"constraint_{label}_{prop_name}_unique"
-                            query = f"CREATE CONSTRAINT {constraint_name} IF NOT EXISTS FOR (n:{label}) REQUIRE n.{prop_name} IS UNIQUE"
+                            safe_label = label.replace('`', '')
+                            safe_prop = prop_name.replace('`', '')
+                            constraint_name = f"constraint_{safe_label}_{safe_prop}_unique"
+                            query = f"CREATE CONSTRAINT `{constraint_name}` IF NOT EXISTS FOR (n:`{safe_label}`) REQUIRE n.`{safe_prop}` IS UNIQUE"
                             try:
                                 session.run(query)
-                                logger.info("Applied UNIQUE constraint on :%s(%s)", label, prop_name)
+                                logger.info("Applied UNIQUE constraint on :%s(%s)", safe_label, safe_prop)
                             except (ServiceUnavailable, SessionExpired) as e:
                                 raise Neo4jConnectionError(
-                                    f"Neo4j connection failed applying constraint on :{label}({prop_name}): {e}"
+                                    f"Neo4j connection failed applying constraint on :{safe_label}({safe_prop}): {e}"
                                 ) from e
                             except Exception as e:
-                                logger.error("Failed to apply constraint on :%s(%s): %s", label, prop_name, e)
+                                logger.error("Failed to apply constraint on :%s(%s): %s", safe_label, safe_prop, e)
 
                         # 2. Indexes
                         if config.get('index') is True:
-                            index_name = f"index_{label}_{prop_name}"
-                            query = f"CREATE INDEX {index_name} IF NOT EXISTS FOR (n:{label}) ON (n.{prop_name})"
+                            safe_label = label.replace('`', '')
+                            safe_prop = prop_name.replace('`', '')
+                            index_name = f"index_{safe_label}_{safe_prop}"
+                            query = f"CREATE INDEX `{index_name}` IF NOT EXISTS FOR (n:`{safe_label}`) ON (n.`{safe_prop}`)"
                             try:
                                 session.run(query)
-                                logger.info("Applied INDEX on :%s(%s)", label, prop_name)
+                                logger.info("Applied INDEX on :%s(%s)", safe_label, safe_prop)
                             except (ServiceUnavailable, SessionExpired) as e:
                                 raise Neo4jConnectionError(
-                                    f"Neo4j connection failed applying index on :{label}({prop_name}): {e}"
+                                    f"Neo4j connection failed applying index on :{safe_label}({safe_prop}): {e}"
                                 ) from e
                             except Exception as e:
-                                logger.error("Failed to apply index on :%s(%s): %s", label, prop_name, e)
+                                logger.error("Failed to apply index on :%s(%s): %s", safe_label, safe_prop, e)
         except (ServiceUnavailable, SessionExpired) as e:
             raise Neo4jConnectionError(
                 f"Neo4j connection failed during schema application for '{database}': {e}"

--- a/extraction/tests/test_schema_manager_injection.py
+++ b/extraction/tests/test_schema_manager_injection.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import yaml
+import tempfile
+import os
+
+from schema_manager import SchemaManager
+
+def test_schema_manager_escapes_backticks_and_cypher_injection():
+    yaml_content = """
+nodes:
+  "Malicious`Label) DETACH DELETE n //":
+    properties:
+      "malicious`prop) DELETE n //":
+        constraint: UNIQUE
+        index: true
+    """
+
+    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as f:
+        f.write(yaml_content)
+        temp_path = f.name
+
+    try:
+        manager = SchemaManager(uri="bolt://localhost:7687", user="test", password="test")
+        manager.driver = MagicMock()
+        mock_session = MagicMock()
+        manager.driver.session.return_value.__enter__.return_value = mock_session
+
+        manager.apply_schema(database="test_db", yaml_path=temp_path)
+
+        # Verify the calls sent to session.run
+        calls = mock_session.run.call_args_list
+        assert len(calls) == 2 # One constraint, one index
+
+        constraint_query = calls[0][0][0]
+        index_query = calls[1][0][0]
+
+        # Original label and prop had backticks, they should be stripped
+        # Malicious`Label) DETACH DELETE n // -> MaliciousLabel) DETACH DELETE n //
+        # malicious`prop) DELETE n // -> maliciousprop) DELETE n //
+
+        expected_label = "MaliciousLabel) DETACH DELETE n //"
+        expected_prop = "maliciousprop) DELETE n //"
+        expected_constraint_name = f"constraint_{expected_label}_{expected_prop}_unique"
+        expected_index_name = f"index_{expected_label}_{expected_prop}"
+
+        expected_constraint_query = f"CREATE CONSTRAINT `{expected_constraint_name}` IF NOT EXISTS FOR (n:`{expected_label}`) REQUIRE n.`{expected_prop}` IS UNIQUE"
+        expected_index_query = f"CREATE INDEX `{expected_index_name}` IF NOT EXISTS FOR (n:`{expected_label}`) ON (n.`{expected_prop}`)"
+
+        assert constraint_query == expected_constraint_query
+        assert index_query == expected_index_query
+
+    finally:
+        os.unlink(temp_path)


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** Unsafe dynamic Cypher/query construction leading to injection.
**Impact:** A malicious payload extracted from documentation (via LLM `records`) could insert arbitrary Cypher queries into `extraction/schema_manager.py` when it attempts to `session.run` queries for constraints and indexes.
**Fix:** Modified `apply_schema` to remove existing backticks from dynamically constructed schema identifiers (`label` and `prop_name`), and then explicitly wrap the values in backticks.
**Validation:** Verified the fix passes all unit tests and integration pipelines by executing `bash scripts/ci/run_basic_ci.sh` along with explicit linting of agent docs.
**Risks:** Low. Only impacts schema application which is now fully escaped.

---
*PR created automatically by Jules for task [6200813466811123728](https://jules.google.com/task/6200813466811123728) started by @tteon*