### PR TITLE
feat: add a11y focus states to ui controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+# Palette UX and Accessibility Journal
+
+- Interactive UI elements in `evaluation/static/styles.css` must maintain explicit keyboard accessibility patterns, such as using `button:focus-visible` with outlines and `box-shadow` on `:focus` for inputs, to ensure usability via keyboard navigation.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -212,6 +212,7 @@ body {
 .control select:focus,
 .control input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 .ingest-controls {
@@ -245,6 +246,7 @@ body {
 
 .ingest-grow textarea:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 #ingestBtn {
@@ -383,6 +385,11 @@ body {
 
 .composer button:hover:not(:disabled) {
   opacity: 0.9;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }
 
 /* Right Pane: AIP Workflow Canvas */


### PR DESCRIPTION
What
Added explicit `:focus` and `:focus-visible` styles with outlines and box-shadows to `select`, `input`, `textarea`, and `button` elements in `evaluation/static/styles.css`. Also created the `.jules/palette.md` journal to document this rule.

Why
These focus states ensure that keyboard navigation provides clear visual feedback to users, making the application more accessible. The `.jules/palette.md` journal logs this requirement for future reference.

Accessibility / UX Impact
Improves keyboard navigation accessibility. Form controls and buttons now clearly indicate when they have focus.

Validation
Ran the CI test suite via `bash scripts/ci/run_basic_ci.sh`. Visual validation was done using a local Playwright script to verify focus states for elements.

Risks
Low risk; these are purely CSS changes scoped to focus states for interactive elements.

---
*PR created automatically by Jules for task [15770831987521591017](https://jules.google.com/task/15770831987521591017) started by @tteon*