### PR TITLE
Add missing authz/policy checks to metadata endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional, Literal
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException, Request, Depends, Query
+
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -1454,21 +1455,48 @@ async def batch_health():
 
 
 @app.get(RuntimePath.DATABASES)
-async def list_databases():
+async def list_databases(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List all registered databases."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    # Databases themselves are global in MVP, but filtering could be added here if database registry tracked workspace_scope.
     return {"databases": db_registry.list_databases()}
 
 
+
+
+
 @app.get(RuntimePath.GRAPHS)
-async def list_graphs():
+async def list_graphs(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List registered graph targets."""
-    return {"graphs": [target.to_public_dict() for target in graph_registry.list_graphs()]}
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    graphs = [target.to_public_dict() for target in graph_registry.list_graphs()]
+    return {"graphs": graphs}
+
+
 
 
 @app.get(RuntimePath.AGENTS)
-async def list_agents():
-    """List all active DB-bound agents."""
+async def list_agents(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    # Agents are bound to graph targets. If graph targets become workspace-scoped, this could filter agent keys by graph workspace_scope.
     return {"agents": agent_factory.list_agents()}
+
+
 
 
 @app.post("/rules/infer", response_model=RuleInferResponse)


### PR DESCRIPTION
Added missing authorization/policy checks to the `/databases`, `/graphs`, and `/agents` endpoints in `runtime/agent_server.py`.

### Severity
High (Information Disclosure)

### Vulnerability
The endpoints `/databases`, `/graphs`, and `/agents` in `runtime/agent_server.py` lacked authorization checks (`require_runtime_permission`). This allowed any user, regardless of their role or workspace scope, to view all registered databases, graph targets, and active agents in the system.

### Impact
An unauthorized user could enumerate all database and agent resources available on the backend server, bypassing intended workspace isolation and role-based access control.

### Fix
Added `workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)` to the signature of each of the three endpoints.
Added a try-except block to each endpoint to enforce the appropriate runtime permission (`read_databases` or `read_agents`) using `require_runtime_permission`, returning a 403 HTTP response if the policy denies access.

### Validation
- Ran `bash scripts/ci/run_basic_ci.sh` which executed all 127 tests successfully.
- Code review was approved.

### Risks
- The fix preserves backwards compatibility by defaulting `workspace_id` to `"default"` if not provided, reducing the risk of breaking existing API clients.
- Currently, the returned metadata lists (e.g., all databases) are global in the MVP implementation and not additionally filtered by `workspace_id` after the permission check. This is consistent with the MVP design but should be revisited when full multi-tenancy is implemented.

---
*PR created automatically by Jules for task [17094142876846882260](https://jules.google.com/task/17094142876846882260) started by @tteon*