### PR TITLE
feat(ui): improve keyboard accessibility with clear focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+- Interactive UI elements must maintain explicit keyboard accessibility patterns, such as using `button:focus-visible` with outlines and `box-shadow` on `:focus` for inputs.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -574,3 +574,15 @@ body {
     stroke-dashoffset: -16;
   }
 }
+
+/* Accessibility Focus States */
+button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  box-shadow: 0 0 0 2px rgba(47, 129, 247, 0.4);
+}


### PR DESCRIPTION
**What**
Implemented explicit keyboard focus states for interactive UI elements in `evaluation/static/styles.css`. Buttons now use `:focus-visible` with an outline, while text inputs and selects use `:focus` with a box shadow.
Also created the required `.jules/palette.md` journal file.

**Why**
The previous styling omitted clear indicators for keyboard users tab-navigating the interface. Adding focus states is a critical and foundational accessibility requirement.

**Accessibility / UX Impact**
High positive impact for keyboard accessibility users. Mouse users are largely unaffected since `button` uses `:focus-visible` (which typically triggers only on keyboard interaction) rather than a raw `:focus`.

**Validation**
- `bash scripts/ci/run_basic_ci.sh` passed successfully.
- Ran a local Playwright script simulating Tab keypresses against the dev server (`evaluation.server:app` on port 8501) and visually verified the application of the newly added styles.

**Risks**
Very low. Changes are purely visual CSS additions and confined strictly to the `evaluation/static/styles.css` presentation layer. Does not alter backend behavior, trace schemas, or routing logic.

---
*PR created automatically by Jules for task [1285313972596164711](https://jules.google.com/task/1285313972596164711) started by @tteon*