### PR TITLE
[DRAFT] UI: Add explicit focus and focus-visible outlines for keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+# UX and Accessibility Maintenance Logs
+
+## Key Learnings & Decisions
+- Interactive UI elements must maintain explicit keyboard accessibility patterns.
+- Specifically, `button:focus-visible` must use an explicit `outline` rather than relying solely on background changes.
+- Inputs (`input`, `select`, `textarea`) must use `box-shadow` to enhance visual contrast on `:focus`.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -49,6 +49,11 @@ body {
   display: flex;
 }
 
+button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
 /* App Layout - Dual Pane */
 .app-shell {
   display: flex;
@@ -212,6 +217,7 @@ body {
 .control select:focus,
 .control input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 .ingest-controls {
@@ -245,6 +251,7 @@ body {
 
 .ingest-grow textarea:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 #ingestBtn {

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,18 @@
+## What
+Added explicit `button:focus-visible` rules with a `var(--accent-blue)` outline to `evaluation/static/styles.css`.
+Added `box-shadow` to `.control select:focus`, `.control input:focus`, and `.ingest-grow textarea:focus`.
+Added `.jules/palette.md` to log codebase-specific accessibility rules for interactive elements.
+
+## Why
+Currently, UI interactive elements primarily rely on border color changes on focus, which might be too subtle for keyboard users or those with visual impairments. Explicit outlines and stronger visual indicators are necessary for good keyboard accessibility.
+
+## Accessibility / UX Impact
+Improves keyboard navigation. Users navigating the application via keyboard will now see a clear, distinct outline around buttons and inputs, confirming where the current focus lies.
+
+## Validation
+- Checked that CI tests (`bash scripts/ci/run_basic_ci.sh`) pass.
+- Linted agent docs (`bash scripts/pm/lint-agent-docs.sh`) pass.
+- Verified visual changes using Playwright scripts against the local frontend evaluation server to confirm expected focus states on both a `button` and `textarea`.
+
+## Risks
+Negligible. This is a CSS-only visual update restricted to `:focus` and `:focus-visible` pseudoclasses. It does not alter DOM structure or application logic.


### PR DESCRIPTION
## What
Added explicit `button:focus-visible` rules with a `var(--accent-blue)` outline to `evaluation/static/styles.css`.
Added `box-shadow` to `.control select:focus`, `.control input:focus`, and `.ingest-grow textarea:focus`.
Added `.jules/palette.md` to log codebase-specific accessibility rules for interactive elements.

## Why
Currently, UI interactive elements primarily rely on border color changes on focus, which might be too subtle for keyboard users or those with visual impairments. Explicit outlines and stronger visual indicators are necessary for good keyboard accessibility.

## Accessibility / UX Impact
Improves keyboard navigation. Users navigating the application via keyboard will now see a clear, distinct outline around buttons and inputs, confirming where the current focus lies.

## Validation
- Checked that CI tests (`bash scripts/ci/run_basic_ci.sh`) pass.
- Linted agent docs (`bash scripts/pm/lint-agent-docs.sh`) pass.
- Verified visual changes using Playwright scripts against the local frontend evaluation server to confirm expected focus states on both a `button` and `textarea`.

## Risks
Negligible. This is a CSS-only visual update restricted to `:focus` and `:focus-visible` pseudoclasses. It does not alter DOM structure or application logic.

---
*PR created automatically by Jules for task [5448913502084989020](https://jules.google.com/task/5448913502084989020) started by @tteon*