### PR TITLE
Improve UX keyboard focus accessibility in evaluation UI (Draft)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+- Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -212,6 +212,7 @@ body {
 .control select:focus,
 .control input:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 .ingest-controls {
@@ -245,6 +246,7 @@ body {
 
 .ingest-grow textarea:focus {
   border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 #ingestBtn {
@@ -526,6 +528,11 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #484f58;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }
 
 /* Animations */


### PR DESCRIPTION
What: Added `focus-visible` states for buttons and missing `box-shadow` on focus for inputs, selects, and textareas in `evaluation/static/styles.css`.
Why: Improve keyboard navigation accessibility by providing a clear visual indicator for keyboard users.
Accessibility / UX Impact: Keyboard users can now clearly see the active element they are focused on when tabbing through the UI.
Validation: Tested locally via an automated Playwright Python script validating CSS `outline` and `box-shadow` properties, and verified basic CI pipeline passes.
Risks: Low risk CSS-only change.

---
*PR created automatically by Jules for task [9904572380526098875](https://jules.google.com/task/9904572380526098875) started by @tteon*