### PR TITLE
feat: add finance-compliance usecase example and USECASES entry point

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,9 @@ extraction/                 ← HTTP transport layer (server-only)
 | Extend ontology features | `seocho/ontology.py` |
 | Fix a bug in the HTTP client | `seocho/client.py` |
 
+Looking for a concrete place to contribute? Pick a usecase and add a starter
+ontology or sample docs alongside it: [`docs/USECASES.md`](docs/USECASES.md).
+
 ## Running Tests
 
 ```bash

--- a/docs/USECASES.md
+++ b/docs/USECASES.md
@@ -1,0 +1,53 @@
+# SEOCHO Usecases
+
+SEOCHO is middleware for teams that want ontology-governed knowledge graphs
+built from their own documents. The usecases below are the ones we maintain
+working end-to-end demos for. Each links to a runnable example in the
+repository plus a longer narrative walk-through (the blog post).
+
+We deliberately keep this list short. A usecase only appears here when there
+is actual code behind it that a reader can run in under five minutes.
+
+## 1. Finance Compliance
+
+**What**: Turn a folder of filings, inquiries, incidents, and policy docs
+into an auditable compliance knowledge graph. Ask questions that cross
+regulator / regulation / incident / control / policy boundaries.
+
+**Who benefits**: Compliance teams, internal audit, second-line risk
+functions — anyone who re-reads the same filings to reconcile "which rule,
+which incident, which control."
+
+**Try it**: [`examples/finance-compliance/`](../examples/finance-compliance/)
+— 6 mock documents, 6 entity types, runs in under a minute on
+`pip install "seocho[local]"`.
+
+**What you will see**: The ontology declares the entities and relationships
+you already think in (`Company → SUBJECT_TO → Regulation → ENFORCED_BY →
+Regulator`, etc.). Ingestion populates the graph from plain text. Questions
+like "which control evidence mitigates incident I-2026-007" return an
+answer grounded in typed paths, not a free-text paragraph.
+
+**Blog walk-through**: *(coming soon — drafted in `tteon.github.io`)*
+
+## Contributing a new usecase
+
+A new usecase entry lands here only when the accompanying repo example
+actually runs. The order of work is:
+
+1. Open a draft PR that adds `examples/<your-usecase>/` with at minimum a
+   starter ontology, 5–10 sample docs, and a `quickstart.py` that runs
+   end-to-end on `pip install "seocho[local]"`.
+2. Have one other contributor run the quickstart against a fresh clone.
+3. Add the usecase section to this file.
+4. (Optional but encouraged) Drop a narrative walk-through into the blog.
+
+Usecases we would welcome contributions for:
+
+- **Healthcare consent tracking** — patients, consents, studies, revocations.
+- **Supplier risk** — suppliers, contracts, incidents, alternates.
+- **Engineering team memory** — services, incidents, runbooks, owners.
+- **Legal contract obligations** — parties, obligations, deadlines, breaches.
+
+None of these exist as working demos yet. The finance compliance example is
+the pattern to copy.

--- a/examples/finance-compliance/README.md
+++ b/examples/finance-compliance/README.md
@@ -1,0 +1,74 @@
+# Finance Compliance Usecase
+
+A complete, runnable example showing how a regulated finance team can turn a
+folder of filings, inquiries, incidents, and policy documents into an
+ontology-governed knowledge graph — and ask questions that cross entity
+boundaries.
+
+This is intentionally small (6 mock documents, 6 entity types) so you can read
+it end-to-end in a few minutes, then swap in your own ontology and docs.
+
+## What you get
+
+- `ontology.py` — the starter finance-compliance ontology
+  (`Company`, `Regulator`, `Regulation`, `ComplianceIncident`,
+  `ControlEvidence`, `Policy`) with six relationships.
+- `sample_docs/` — six short mock filings covering a quarterly disclosure,
+  a regulator inquiry, an incident, control attestation, board minutes,
+  and a policy update.
+- `quickstart.py` — ingests the docs into an embedded local graph and asks
+  four cross-entity questions.
+
+## Run it
+
+```bash
+pip install "seocho[local]"
+export OPENAI_API_KEY=...
+python examples/finance-compliance/quickstart.py
+```
+
+Swap to another provider:
+
+```bash
+python examples/finance-compliance/quickstart.py --llm deepseek/deepseek-chat
+```
+
+Only ingest (skip Q&A, useful for inspecting the resulting graph):
+
+```bash
+python examples/finance-compliance/quickstart.py --skip-query
+```
+
+The graph is written to `.seocho/local.lbug` (embedded LadybugDB) by default.
+
+## Example questions the graph answers
+
+- Which regulations is Acme Financial Services subject to, and who enforces
+  them?
+- What incidents have been reported, and which regulations do they relate to?
+- Which control evidence mitigates incident I-2026-007?
+- Which policies govern trade surveillance at Acme Financial Services?
+
+The ontology forces the answer into a shape you can audit — each answer
+traces back to a typed path in the graph, not a free-text summary.
+
+## Why finance compliance
+
+Compliance teams already think in terms of "which regulation, which control,
+which incident, which policy." Those nouns are the ontology. Once they're
+declared, every new filing either fits the schema (and enriches the graph)
+or fails loudly enough to be fixed. That is the self-benefit: analysts stop
+re-reading the same filings and instead query a structured history.
+
+## Contributing
+
+Open a PR that adds:
+
+- A starter ontology for a new domain (e.g. `healthcare-consent`,
+  `logistics-supplier-risk`) following the same pattern.
+- Additional mock docs for this usecase — we specifically want adversarial
+  examples (conflicting incident severities, regulator name aliases,
+  overlapping policy versions).
+- Real Q&A evaluations against a labeled answer set.
+
+See `docs/USECASES.md` for the broader usecase plan.

--- a/examples/finance-compliance/ontology.py
+++ b/examples/finance-compliance/ontology.py
@@ -1,0 +1,75 @@
+"""Starter ontology for the finance-compliance usecase.
+
+Small enough to read in one sitting (6 entities, 6 relationships) and shaped
+around what a regulated-finance team actually tracks: which regulations the
+company is subject to, who enforces them, what went wrong (incidents), what
+is being done about it (controls), and what policies govern behavior.
+
+Swap in domain names that match your environment — the shape is the point.
+"""
+
+from seocho import NodeDef, Ontology, P, RelDef
+
+
+def build_ontology() -> Ontology:
+    return Ontology(
+        name="finance_compliance",
+        description="Starter ontology for finance compliance knowledge graphs.",
+        nodes={
+            "Company": NodeDef(
+                description="A regulated financial entity.",
+                properties={
+                    "name": P(str, unique=True),
+                    "ticker": P(str),
+                    "jurisdiction": P(str),
+                },
+            ),
+            "Regulator": NodeDef(
+                description="A government or industry body that enforces regulations.",
+                properties={
+                    "name": P(str, unique=True),
+                    "jurisdiction": P(str),
+                },
+            ),
+            "Regulation": NodeDef(
+                description="A specific rule or statute that governs company behavior.",
+                properties={
+                    "name": P(str, unique=True),
+                    "code": P(str),
+                    "jurisdiction": P(str),
+                },
+            ),
+            "ComplianceIncident": NodeDef(
+                description="A reported breach, near-miss, or anomaly.",
+                properties={
+                    "summary": P(str, unique=True),
+                    "date": P(str),
+                    "severity": P(str),
+                },
+            ),
+            "ControlEvidence": NodeDef(
+                description="Evidence that a control is operating (attestation, test, log).",
+                properties={
+                    "summary": P(str, unique=True),
+                    "date": P(str),
+                    "status": P(str),
+                },
+            ),
+            "Policy": NodeDef(
+                description="An internal policy that governs company behavior.",
+                properties={
+                    "name": P(str, unique=True),
+                    "version": P(str),
+                    "effective_date": P(str),
+                },
+            ),
+        },
+        relationships={
+            "SUBJECT_TO": RelDef(source="Company", target="Regulation"),
+            "ENFORCED_BY": RelDef(source="Regulation", target="Regulator"),
+            "REPORTED": RelDef(source="Company", target="ComplianceIncident"),
+            "RELATES_TO": RelDef(source="ComplianceIncident", target="Regulation"),
+            "MITIGATED_BY": RelDef(source="ComplianceIncident", target="ControlEvidence"),
+            "GOVERNED_BY": RelDef(source="Company", target="Policy"),
+        },
+    )

--- a/examples/finance-compliance/quickstart.py
+++ b/examples/finance-compliance/quickstart.py
@@ -1,0 +1,79 @@
+"""End-to-end finance-compliance usecase: load ontology, ingest mock filings,
+ask questions that cross entity boundaries.
+
+Run from the repository root:
+
+    OPENAI_API_KEY=... python examples/finance-compliance/quickstart.py
+
+Swap to another provider with --llm (e.g. deepseek/deepseek-chat).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Make `ontology.py` importable when running this file from any cwd.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from ontology import build_ontology  # noqa: E402
+
+from seocho import Seocho  # noqa: E402
+
+
+QUESTIONS = [
+    "Which regulations is Acme Financial Services subject to, and who enforces them?",
+    "What incidents have been reported, and which regulations do they relate to?",
+    "Which control evidence mitigates incident I-2026-007?",
+    "Which policies govern trade surveillance at Acme Financial Services?",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--llm", default="openai/gpt-4o", help="Provider/model string.")
+    parser.add_argument(
+        "--skip-query",
+        action="store_true",
+        help="Only ingest; skip the natural-language Q&A pass.",
+    )
+    args = parser.parse_args()
+
+    if args.llm.startswith("openai/") and not os.getenv("OPENAI_API_KEY"):
+        print(
+            "OPENAI_API_KEY not set. Export the key or pass "
+            "--llm deepseek/deepseek-chat (requires DEEPSEEK_API_KEY) etc.",
+            file=sys.stderr,
+        )
+        return 2
+
+    docs_dir = Path(__file__).parent / "sample_docs"
+    doc_paths = sorted(docs_dir.glob("*.txt"))
+    if not doc_paths:
+        print(f"No sample docs found under {docs_dir}", file=sys.stderr)
+        return 2
+
+    onto = build_ontology()
+    s = Seocho.local(onto, llm=args.llm)
+
+    for path in doc_paths:
+        print(f"ingesting {path.name}")
+        s.add(path.read_text())
+
+    if args.skip_query:
+        print("\ningest complete (--skip-query set)")
+        return 0
+
+    print()
+    for question in QUESTIONS:
+        print(f"Q: {question}")
+        answer = s.ask(question)
+        print(f"A: {answer}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/finance-compliance/sample_docs/01_quarterly_filing.txt
+++ b/examples/finance-compliance/sample_docs/01_quarterly_filing.txt
@@ -1,0 +1,6 @@
+Acme Financial Services Inc. (ACME, US jurisdiction) filed its Q1 2026
+quarterly disclosure. The company is subject to the Market Conduct Rule
+(MCR-401), enforced by the Financial Markets Supervisory Authority (FMSA,
+United States). No material incidents occurred this quarter. Internal
+Policy "Client Onboarding v3.2" remained in effect throughout the period,
+effective since 2025-11-01.

--- a/examples/finance-compliance/sample_docs/02_regulator_inquiry.txt
+++ b/examples/finance-compliance/sample_docs/02_regulator_inquiry.txt
@@ -1,0 +1,5 @@
+On 2026-02-14 the Financial Markets Supervisory Authority (FMSA) opened
+an informational inquiry into Acme Financial Services Inc.'s trade
+surveillance program. The inquiry references Market Conduct Rule MCR-401
+and specifically its sub-provision on post-trade review timing. Acme has
+30 days to respond. No enforcement action has been filed.

--- a/examples/finance-compliance/sample_docs/03_incident_report.txt
+++ b/examples/finance-compliance/sample_docs/03_incident_report.txt
@@ -1,0 +1,6 @@
+Incident I-2026-007: On 2026-02-03, Acme Financial Services Inc. reported
+a client-data-access misconfiguration that exposed 42 client records to
+internal staff without a business-need justification. Severity: medium.
+The incident relates to the Client Privacy Regulation (CPR-210, US), which
+is enforced by the Financial Markets Supervisory Authority. No external
+exposure occurred. Remediation described in attestation A-2026-014.

--- a/examples/finance-compliance/sample_docs/04_control_attestation.txt
+++ b/examples/finance-compliance/sample_docs/04_control_attestation.txt
@@ -1,0 +1,5 @@
+Attestation A-2026-014 (dated 2026-02-20): The Acme Financial Services
+Access Review Control has been re-tested. Status: passing. The control
+review mitigates incident I-2026-007 by enforcing business-need checks on
+all privileged internal access. Control owner: Head of Information
+Security. Next re-test scheduled 2026-05-20.

--- a/examples/finance-compliance/sample_docs/05_board_minutes.txt
+++ b/examples/finance-compliance/sample_docs/05_board_minutes.txt
@@ -1,0 +1,6 @@
+Acme Financial Services Inc. board meeting minutes, 2026-03-05. The board
+discussed the FMSA informational inquiry referencing MCR-401 and the
+recent incident I-2026-007. The board approved Policy "Trade Surveillance
+v2.0" (effective 2026-04-01) to replace the prior v1.8. Audit committee
+confirmed that attestation A-2026-014 adequately covers the access-review
+remediation path.

--- a/examples/finance-compliance/sample_docs/06_policy_update.txt
+++ b/examples/finance-compliance/sample_docs/06_policy_update.txt
@@ -1,0 +1,5 @@
+Policy Document: Trade Surveillance v2.0 (version 2.0, effective
+2026-04-01). Governs all post-trade review workflows at Acme Financial
+Services Inc. Updated to tighten review timing required under Market
+Conduct Rule MCR-401. Replaces Trade Surveillance v1.8 (effective since
+2024-07-01). Owners: Head of Compliance, Head of Trading Operations.


### PR DESCRIPTION
First working usecase slice: a runnable finance-compliance example with a 6-entity starter ontology, 6 mock compliance filings, and a quickstart script that runs end-to-end on Seocho.local (embedded LadybugDB). Adds docs/USECASES.md as the landing page that enumerates maintained demos and points contributors at concrete starting shapes, and a single-line CONTRIBUTING pointer so newcomers land on a usecase instead of searching.

Scope intentionally tight — only usecase #1 is listed. Future usecases (healthcare consent, supplier risk, etc.) are named as contribution slots rather than pre-advertised.

Bead: seocho-lwj