### PR TITLE
UX: Add keyboard focus states to reset button and navigation rail

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -114,6 +114,11 @@ body {
   border-left: 2px solid transparent;
 }
 
+.rail-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
+}
+
 .rail-btn:hover {
   color: var(--text-main);
 }
@@ -580,4 +585,26 @@ button:focus-visible {
   to {
     stroke-dashoffset: -16;
   }
+}
+
+
+/* #resetSessionBtn Styles */
+#resetSessionBtn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+#resetSessionBtn:hover {
+  color: #fff;
+}
+
+#resetSessionBtn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
### What
Moved inline styling and javascript hover events from `#resetSessionBtn` to `evaluation/static/styles.css` and added missing `:focus-visible` states to both `#resetSessionBtn` and `.rail-btn`.

### Why
To improve code maintainability and properly support keyboard navigation accessibility as mandated by the UX maintenance playbook (`.jules/palette.md`).

### Accessibility / UX Impact
Keyboard users navigating via Tab will now see clear, distinct visual feedback (a 2px solid blue outline) when focusing on the main reset button and the sidebar navigation items, which were previously indistinguishable from their unfocused state.

### Validation
Ran a Playwright verification script locally to assert that `.rail-btn.active` and `#resetSessionBtn` correctly computed the `rgb(47, 129, 247) solid 2px` outline on focus. Ran standard CI suite to ensure no broader application side-effects.

### Risks
No significant risks. Changes are limited purely to presentation-layer HTML and CSS.

---
*PR created automatically by Jules for task [1104807301070010810](https://jules.google.com/task/1104807301070010810) started by @tteon*