### PR TITLE
perf: Optimize PromptManager log_result to use append-only JSONL format

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+When logging history, traces, or metadata (such as prompt history), prefer append-only .jsonl format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks. Noticed in extraction/prompt_manager.py log_result.

--- a/extraction/prompt_manager.py
+++ b/extraction/prompt_manager.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class PromptManager:
     def __init__(self, cfg: Any):
         self.cfg = cfg
-        default_history = Path(__file__).resolve().parent / "prompt_history.json"
+        default_history = Path(__file__).resolve().parent / "prompt_history.jsonl"
         self.history_file = Path(os.getenv("PROMPT_HISTORY_FILE", str(default_history)))
         self.user_prompts = self._load_user_prompts()
 
@@ -40,26 +40,9 @@ class PromptManager:
             "latency": latency,
         }
 
-        history = []
-        if self.history_file.exists():
-            try:
-                history = json.loads(self.history_file.read_text(encoding="utf-8"))
-                if not isinstance(history, list):
-                    history = []
-            except json.JSONDecodeError:
-                logger.warning("Prompt history file contained invalid JSON: %s", self.history_file)
-                history = []
-            except OSError as exc:
-                logger.warning("Failed to read prompt history file %s: %s", self.history_file, exc)
-                history = []
-
-        history.append(entry)
-
         try:
-            self.history_file.write_text(
-                json.dumps(history, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
+            with open(self.history_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         except OSError as exc:
             logger.warning("Failed to write prompt history file %s: %s", self.history_file, exc)
 


### PR DESCRIPTION
What:
Changed `extraction/prompt_manager.py`'s `log_result` method to append new entries directly to a JSON Lines (`.jsonl`) file rather than reading the entire history array, appending in-memory, and rewriting the entire file.

Why:
The previous approach scaled O(N²) in terms of file I/O and JSON parsing overhead relative to the number of logs. When the prompt history grows large, every single logged execution causes significant file system activity and processing delay. Concurrent logging would also likely result in data corruption.

Expected Impact:
Drastically reduced overhead (O(1) instead of O(N)) when logging prompts, improving throughput. Safe concurrent file append capabilities relative to the read-parse-rewrite process.

Validation:
Validated by running the CI validation suite (`bash scripts/ci/run_basic_ci.sh`) and specific tests in `extraction/tests/test_api_endpoints.py` and `extraction/tests/test_context_event_scripts.py` passing perfectly.

Risks:
Consumers explicitly relying on the history file being a pure JSON array (rather than a `.jsonl` lines file) would need to adapt to iterating over lines instead of `json.loads`ing the entire file. The standard default has been shifted to `.jsonl`.

---
*PR created automatically by Jules for task [2172902524976638489](https://jules.google.com/task/2172902524976638489) started by @tteon*