### PR TITLE
[DRAFT] fix: add aria-label attributes to evaluation ui form controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,1 +1,2 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
+- Form controls (`<input>`, `<select>`, `<textarea>`) in the evaluation UI should use explicit `aria-label` attributes to satisfy strict accessibility requirements, even if they are implicitly wrapped within a `<label>` element.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -48,7 +48,7 @@
       <section class="controls">
         <label class="control">
           <span>Mode</span>
-          <select id="modeSelect">
+          <select id="modeSelect" aria-label="Mode">
             <option value="semantic">Semantic (DAG)</option>
             <option value="debate">Debate (Parallel)</option>
             <option value="router">Router (Sequential)</option>
@@ -56,22 +56,22 @@
         </label>
         <label class="control">
           <span>Workspace</span>
-          <input id="workspaceInput" value="default" />
+          <input id="workspaceInput" value="default" aria-label="Workspace" />
         </label>
         <label class="control">
           <span>Databases</span>
-          <input id="databasesInput" value="kgnormal,kgfibo" />
+          <input id="databasesInput" value="kgnormal,kgfibo" aria-label="Databases" />
         </label>
       </section>
 
       <section class="ingest-controls">
         <label class="control">
           <span>Ingest DB</span>
-          <input id="ingestDbInput" value="kgnormal" />
+          <input id="ingestDbInput" value="kgnormal" aria-label="Ingest DB" />
         </label>
         <label class="control ingest-grow">
           <span>Raw Records (one line per record)</span>
-          <textarea id="ingestInput" rows="2"
+          <textarea id="ingestInput" rows="2" aria-label="Raw Records"
             placeholder="Example: ACME acquired Beta in 2024.&#10;Example: Beta provides risk analytics to ACME."></textarea>
         </label>
         <button id="ingestBtn" type="button">Ingest Raw</button>


### PR DESCRIPTION
### What
Added explicit `aria-label` attributes to the mode selector, workspace input, databases input, ingest DB input, and raw records textarea in `evaluation/static/index.html`.

### Why
To improve accessibility for screen readers. Some strict accessibility linters flag implicit labeling (wrapping form controls within `<label>` tags alongside text) as insufficient and require explicit accessible names via `aria-label` or `for`/`id` linking. Adding `aria-label` satisfies this requirement cleanly without structural DOM changes.

### Accessibility / UX Impact
- **Impact:** Screen reader users will now hear a precise, explicit label when navigating these form controls, removing ambiguity.
- **Visuals:** Zero visual impact.

### Validation
- Executed `scripts/ci/run_basic_ci.sh` which passed.
- Executed `scripts/pm/lint-agent-docs.sh` which passed.
- Wrote and ran a Playwright script checking for `input:not([aria-label])`, `select:not([aria-label])`, and `textarea:not([aria-label])`. Verified count is 0.

### Risks
- Adding `aria-label` overrides implicit labels, but the supplied names mirror the adjacent visible text, so there is negligible risk of context loss.

---
*PR created automatically by Jules for task [5931592572458696562](https://jules.google.com/task/5931592572458696562) started by @tteon*