### PR TITLE
Fix Cypher injection vulnerability in dynamic query construction

### DIFF
--- a/seocho/query/cypher_builder.py
+++ b/seocho/query/cypher_builder.py
@@ -246,7 +246,7 @@ class CypherBuilder:
         )
 
     def _entity_lookup(self, entity: str, label: str, workspace_id: str, limit: int) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":{label}" if label else ""
+        label_clause = f":`{label.replace('`', '')}`" if label else ""
         normalized = normalize_entity(entity)
         return (
             f"MATCH (n{label_clause})\n"
@@ -273,9 +273,9 @@ class CypherBuilder:
         workspace_id: str,
         limit: int,
     ) -> Tuple[str, Dict[str, Any]]:
-        a_label = f":{anchor_label}" if anchor_label else ""
-        t_label = f":{target_label}" if target_label else ""
-        rel_clause = f":{self._rel_name(rel_type)}" if rel_type else ""
+        a_label = f":`{anchor_label.replace('`', '')}`" if anchor_label else ""
+        t_label = f":`{target_label.replace('`', '')}`" if target_label else ""
+        rel_clause = f":`{self._rel_name(rel_type).replace('`', '')}`" if rel_type else ""
 
         anchor_norm = normalize_entity(anchor)
         where_parts = [
@@ -314,7 +314,7 @@ class CypherBuilder:
         )
 
     def _neighbors(self, entity: str, label: str, workspace_id: str, limit: int) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":{label}" if label else ""
+        label_clause = f":`{label.replace('`', '')}`" if label else ""
         normalized = normalize_entity(entity)
         return (
             f"MATCH (n{label_clause})\n"
@@ -358,7 +358,7 @@ class CypherBuilder:
         )
 
     def _count(self, label: str, workspace_id: str) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":{label}" if label else ""
+        label_clause = f":`{label.replace('`', '')}`" if label else ""
         return (
             f"MATCH (n{label_clause})\n"
             "WHERE $workspace_id = '' OR coalesce(n._workspace_id, '') = $workspace_id\n"
@@ -367,7 +367,7 @@ class CypherBuilder:
         )
 
     def _list_all(self, label: str, workspace_id: str, limit: int) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":{label}" if label else ""
+        label_clause = f":`{label.replace('`', '')}`" if label else ""
         return (
             f"MATCH (n{label_clause})\n"
             "WHERE $workspace_id = '' OR coalesce(n._workspace_id, '') = $workspace_id\n"


### PR DESCRIPTION
### Severity
High.

### Vulnerability
In `seocho/query/cypher_builder.py`, dynamic Neo4j Cypher queries were constructed by unsafely interpolating string values for node labels and relationship types (e.g. `label_clause = f":{label}" if label else ""`). In Cypher, structural elements like labels cannot be parameterized normally, but leaving them unescaped allows an attacker providing malicious label or relationship inputs to break out of the label/relationship declaration and inject arbitrary Cypher clauses.

### Impact
An attacker capable of controlling or influencing the `label` or `rel_type` values could execute arbitrary Cypher queries against the backend graph database. This could lead to data exfiltration, unauthorized modification, or denial of service by exhausting database resources.

### Fix
Structural elements inside Cypher queries are now safely escaped by removing any existing backticks from the user input and explicitly wrapping the strings in backticks (e.g., ``label_clause = f":`{label.replace('`', '')}`" if label else ""``). This confines the input to be strictly interpreted as a literal label or relationship type, preventing injection.

### Validation
- Ran `uv run pytest seocho/tests/test_cypher_builder.py` locally and verified all 15 tests passed.
- Executed `bash scripts/ci/run_basic_ci.sh`, and all 237 tests and contract checks completed successfully.

### Risks
Very low. Standard Neo4j labels and relationship types do not naturally contain backticks, so stripping them will not cause data lookup regressions. The fix does not affect semantic retrieval policies or multi-agent behavior.

---
*PR created automatically by Jules for task [13184219512239450800](https://jules.google.com/task/13184219512239450800) started by @tteon*