### PR TITLE
perf: optimize prompt history file I/O to JSONL append

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.

--- a/extraction/prompt_manager.py
+++ b/extraction/prompt_manager.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class PromptManager:
     def __init__(self, cfg: Any):
         self.cfg = cfg
-        default_history = Path(__file__).resolve().parent / "prompt_history.json"
+        default_history = Path(__file__).resolve().parent / "prompt_history.jsonl"
         self.history_file = Path(os.getenv("PROMPT_HISTORY_FILE", str(default_history)))
         self.user_prompts = self._load_user_prompts()
 
@@ -40,28 +40,11 @@ class PromptManager:
             "latency": latency,
         }
 
-        history = []
-        if self.history_file.exists():
-            try:
-                history = json.loads(self.history_file.read_text(encoding="utf-8"))
-                if not isinstance(history, list):
-                    history = []
-            except json.JSONDecodeError:
-                logger.warning("Prompt history file contained invalid JSON: %s", self.history_file)
-                history = []
-            except OSError as exc:
-                logger.warning("Failed to read prompt history file %s: %s", self.history_file, exc)
-                history = []
-
-        history.append(entry)
-
         try:
-            self.history_file.write_text(
-                json.dumps(history, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
+            with open(self.history_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         except OSError as exc:
-            logger.warning("Failed to write prompt history file %s: %s", self.history_file, exc)
+            logger.warning("Failed to write to prompt history file %s: %s", self.history_file, exc)
 
     def _load_user_prompts(self) -> Dict[str, str]:
         user_prompts_path = Path(__file__).resolve().parent / "user_prompts.yaml"


### PR DESCRIPTION
### What
Updated `extraction/prompt_manager.py` to use a `.jsonl` file extension for `default_history` and rewrote the `log_result` method to append lines in O(1) time rather than reading and fully rewriting the file in O(N²) time. Also recorded this learning in `.jules/bolt.md`.

### Why
The previous implementation loaded the entire JSON array, appended an item, and rewrote the entire file on every prompt logging event. As the history file grew, this bounded I/O bottleneck caused increasing latency that impacted downstream tasks. Changing to append-only JSONL format directly addresses the "avoidable file I/O or JSONL overhead" priority area.

### Expected Impact
*   Qualitative: Significantly reduced, constant-time file I/O overhead during agent runtimes that log extensive prompt history.
*   The `PROMPT_HISTORY_FILE` defaults to a `.jsonl` extension instead of `.json`.

### Validation
*   Ran `uv pip install -e .[ci] && bash scripts/ci/run_basic_ci.sh` – 237/237 tests passed successfully.
*   Verified the codebase specific learnings in `.jules/bolt.md` via `cat`.

### Risks
*   Tools previously expecting a strict monolithic JSON array in `prompt_history.json` might fail if they aren't configured to read `prompt_history.jsonl` line-by-line. Given that Opik is preferred for team observability and JSONL is designated as the canonical trace format, this is a planned transition.

---
*PR created automatically by Jules for task [7958268506613002144](https://jules.google.com/task/7958268506613002144) started by @tteon*