### PR TITLE
Sec: Add missing workspace authorization checks to list endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1529,20 +1529,38 @@ async def batch_health():
 
 
 @app.get(RuntimePath.DATABASES)
-async def list_databases():
+async def list_databases(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List all registered databases."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"databases": db_registry.list_databases()}
 
 
 @app.get(RuntimePath.GRAPHS)
-async def list_graphs():
+async def list_graphs(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List registered graph targets."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"graphs": [target.to_public_dict() for target in graph_registry.list_graphs()]}
 
 
 @app.get(RuntimePath.AGENTS)
-async def list_agents():
+async def list_agents(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List all active DB-bound agents."""
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
## Severity
Medium

## Vulnerability
The `DATABASES`, `GRAPHS`, and `AGENTS` list endpoints in the runtime agent server (`runtime/agent_server.py`) lacked the standard `require_runtime_permission` checks that enforce workspace isolation and RBAC.

## Impact
A malicious or unauthorized user could potentially query these endpoints without a valid `workspace_id` or proper permissions, allowing them to enumerate active databases, graph targets, and agent profiles, which is a potential information leak and a violation of the multi-tenant isolation policy.

## Fix
Added `workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)` to `list_databases`, `list_graphs`, and `list_agents` endpoints. Included `require_runtime_permission` checks for `read_databases` and `read_agents` actions, mapping to a 403 `HTTPException` if unauthorized.

## Validation
- `uv run pytest tests/` passed (9/9).
- `bash scripts/ci/run_basic_ci.sh` passed.
- Verified manual changes and verified that missing permission checks were correctly caught.

## Risks
The fallback to `"default"` `workspace_id` ensures backward compatibility for callers not explicitly supplying it, so the risk of breakage is low. However, clients using strict non-default workspaces that were previously bypassing checks will now be correctly blocked if unauthorized.

---
*PR created automatically by Jules for task [6530456439120947242](https://jules.google.com/task/6530456439120947242) started by @tteon*