### PR TITLE
fix: Accessibility and hover UX for trace reset button in evaluation UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,3 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+- Avoid inline events (`onmouseover`, `onmouseout`) for hover states on interactive UI elements as they bypass keyboard accessibility. Use CSS classes with `:hover` and `:focus-visible` pseudo-classes to ensure consistent rendering across pointer and keyboard interactions.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,24 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Reset Session Button Styles */
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-btn:hover {
+  color: #fff;
+}
+
+.reset-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
### What
Replaced inline styling and Javascript `onmouseover`/`onmouseout` event handlers on the "Reset Trace" button in `evaluation/static/index.html` with a proper CSS class (`.reset-btn`) defined in `evaluation/static/styles.css`.

### Why
Inline mouse event handlers only trigger on pointer interaction, making the UI feel inconsistent and inaccessible to keyboard users navigating via Tab. CSS state pseudo-classes like `:hover` and `:focus-visible` ensure that styling is handled responsively and robustly for all interaction mediums.

### Accessibility / UX Impact
- Keyboard users now see a clear `outline: 2px solid var(--accent-blue)` when focusing the button, matching the design system standard for buttons in the application.
- Standardized styling logic using CSS classes rather than mixed-concern inline styles.

### Validation
1. Added CSS `.reset-btn`, `.reset-btn:hover`, and `.reset-btn:focus-visible`.
2. Verified DOM modification correctly sets the `class="reset-btn"` attribute.
3. Wrote and ran a Playwright automated script asserting that focusing the element returns the `rgb(47, 129, 247)` solid outline, and hovering returns the `rgb(255, 255, 255)` text color.
4. Clean CI execution with `bash scripts/ci/run_basic_ci.sh`.

### Risks
Low risk. This is an additive styling enhancement strictly confined to a single button inside the `evaluation/static/` frontend view. It does not mutate DOM node identity (id remains `resetSessionBtn`) or JavaScript logic.

---
*PR created automatically by Jules for task [9760421428383665036](https://jules.google.com/task/9760421428383665036) started by @tteon*