### PR TITLE
Refactor Reset Trace button styling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,3 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+- In the evaluation UI, avoid using inline styles and inline JavaScript event handlers (e.g., `onmouseover`, `onmouseout`). Use standard CSS rules and pseudo-classes (`:hover`, `:focus-visible`) in `evaluation/static/styles.css` for better maintainability and keyboard accessibility.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -160,6 +160,21 @@ body {
   color: var(--text-muted);
 }
 
+#resetSessionBtn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+#resetSessionBtn:hover {
+  color: #fff;
+}
+
 .status-wrap {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**What**
Refactored the `#resetSessionBtn` in the evaluation UI. Removed inline CSS and `onmouseover`/`onmouseout` event handlers from `evaluation/static/index.html` and migrated the styling and hover effects to `evaluation/static/styles.css`. Also added a 0.2s color transition on hover.

**Why**
Inline styles and JS event handlers for basic visual behavior hurt maintainability and go against standard UI development practices. Moving them to a stylesheet ensures better separation of concerns and easier global styling adjustments.

**Accessibility / UX Impact**
The button behavior remains the same for users, but it now has a slightly smoother visual transition when hovered. This makes the UI feel slightly more polished, and the code is now more maintainable.

**Validation**
- `bash scripts/ci/run_basic_ci.sh` passed.
- Frontend verification via Playwright screenshot confirmed the button is visible and styles are correctly applied.
- Reviewed changes locally to `index.html` and `styles.css`.

**Risks**
None. This is an entirely cosmetic, CSS-only refactor for a single button.

---
*PR created automatically by Jules for task [11027871090659327174](https://jules.google.com/task/11027871090659327174) started by @tteon*