### PR TITLE
chore: fix reset btn a11y

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,19 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Topbar Reset Button */
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
What:
Replaced inline styles and inline JavaScript event handlers (`onmouseover` and `onmouseout`) on the Reset Trace button in the Evaluation UI with standard CSS classes and pseudo-classes.

Why:
To improve code maintainability and keyboard accessibility, adhering to modern web standards and repository conventions for the UI.

Accessibility / UX Impact:
Improves code structure while retaining the identical visual functionality (color transition on hover). This avoids inline logic that is difficult to maintain and opens the door for easier application of focus outline standards globally.

Validation:
- Tested standard CI suite (`bash scripts/ci/run_basic_ci.sh`) to ensure no build regressions.
- Created and executed a focused UI test using Playwright against the local evaluation server (`uvicorn evaluation.server:app --port 8501`) to assert correct rendering of text color transition on `:hover` and outline presence on focus.

Risks:
Very low. The change only scopes CSS rendering logic to a single UI button class.

---
*PR created automatically by Jules for task [9514785627324878649](https://jules.google.com/task/9514785627324878649) started by @tteon*