### PR TITLE
fix: add missing authz checks to agent_server listing endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1529,21 +1529,40 @@ async def batch_health():
 
 
 @app.get(RuntimePath.DATABASES)
-async def list_databases():
+async def list_databases(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List all registered databases."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"databases": db_registry.list_databases()}
 
 
 @app.get(RuntimePath.GRAPHS)
-async def list_graphs():
+async def list_graphs(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List registered graph targets."""
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"graphs": [target.to_public_dict() for target in graph_registry.list_graphs()]}
 
 
 @app.get(RuntimePath.AGENTS)
-async def list_agents():
+async def list_agents(
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
     """List all active DB-bound agents."""
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"agents": agent_factory.list_agents()}
+
 
 
 @app.post("/rules/infer", response_model=RuleInferResponse)


### PR DESCRIPTION
Severity: Low to Medium
Vulnerability: The `/databases`, `/graphs`, and `/agents` API endpoints were completely unauthenticated. They exposed potentially sensitive internal infrastructure metadata to anyone able to access the API.
Impact: An attacker could map out the databases, graph targets, and active DB-bound agents configured on the server, potentially gaining intelligence useful for further attacks.
Fix: Added the `workspace_id` query parameter (defaulting to "default" for backward compatibility) and added `require_runtime_permission` checks to all three endpoints, ensuring the requester has the appropriate `read_databases` or `read_agents` permission within that workspace. Unhandled `PermissionError`s are converted into 403 `HTTPException`s.
Validation: Ran basic CI suite (`bash scripts/ci/run_basic_ci.sh`) and explicitly verified that the `test_server_runtime.py` and other test files pass with 100% success rate without breaking any functionality.
Risks: Minimal. Since `workspace_id` defaults to `"default"`, backwards compatibility with existing clients that don't send the `workspace_id` query parameter should be preserved assuming they have permissions in the "default" workspace.

---
*PR created automatically by Jules for task [17433885270209654016](https://jules.google.com/task/17433885270209654016) started by @tteon*