### PR TITLE
chore: improve accessibility of reset trace button

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -38,8 +38,7 @@
         </div>
         <div class="status-wrap">
           <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+            class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,24 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Top Bar Controls */
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+}
+
+.reset-session-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
### What
Migrated inline styles and javascript hover states for the "Reset Trace" button in `evaluation/static/index.html` to a dedicated CSS class (`.reset-session-btn`) in `evaluation/static/styles.css`. Also added a `:focus-visible` state.

### Why
To improve code maintainability by separating content from presentation, and to satisfy Content Security Policies (CSP) which discourage inline Javascript event handlers (`onmouseover`/`onmouseout`).

### Accessibility / UX Impact
The button now has a visible focus outline when navigated via keyboard (`:focus-visible`), drastically improving accessibility for keyboard users, which was previously missing. 

### Validation
Verified the new styles and hover/focus states dynamically using a Playwright script. General test suite (`bash scripts/ci/run_basic_ci.sh`) also passed with no regressions. 

### Risks
Extremely low. Changes are purely cosmetic and limited to the presentation logic of a single UI button.

---
*PR created automatically by Jules for task [753217001886133722](https://jules.google.com/task/753217001886133722) started by @tteon*