### PR TITLE
fix: restore agent fallback CI and normalize example links

### DIFF
--- a/docs/AGENT_DESIGN_SPECS.md
+++ b/docs/AGENT_DESIGN_SPECS.md
@@ -95,6 +95,6 @@ You can still override it per call by passing an explicit `reasoning_cycle=...`.
 
 ## Included Examples
 
-- [planning_multi_agent_finance.yaml](/tmp/seocho-land-finder-e2e/examples/agent_designs/planning_multi_agent_finance.yaml)
-- [reflection_chain_finance.yaml](/tmp/seocho-land-finder-e2e/examples/agent_designs/reflection_chain_finance.yaml)
-- [memory_tool_use_finance.yaml](/tmp/seocho-land-finder-e2e/examples/agent_designs/memory_tool_use_finance.yaml)
+- [planning_multi_agent_finance.yaml](../examples/agent_designs/planning_multi_agent_finance.yaml)
+- [reflection_chain_finance.yaml](../examples/agent_designs/reflection_chain_finance.yaml)
+- [memory_tool_use_finance.yaml](../examples/agent_designs/memory_tool_use_finance.yaml)

--- a/docs/INDEXING_DESIGN_SPECS.md
+++ b/docs/INDEXING_DESIGN_SPECS.md
@@ -161,6 +161,6 @@ debate = client.debate(
 
 ## Included Examples
 
-- [lpg_finance_provenance.yaml](/tmp/seocho-land-finder-e2e/examples/indexing_designs/lpg_finance_provenance.yaml)
-- [rdf_deductive_finance.yaml](/tmp/seocho-land-finder-e2e/examples/indexing_designs/rdf_deductive_finance.yaml)
-- [hybrid_inquiry_finance.yaml](/tmp/seocho-land-finder-e2e/examples/indexing_designs/hybrid_inquiry_finance.yaml)
+- [lpg_finance_provenance.yaml](../examples/indexing_designs/lpg_finance_provenance.yaml)
+- [rdf_deductive_finance.yaml](../examples/indexing_designs/rdf_deductive_finance.yaml)
+- [hybrid_inquiry_finance.yaml](../examples/indexing_designs/hybrid_inquiry_finance.yaml)

--- a/docs/PYTHON_INTERFACE_QUICKSTART.md
+++ b/docs/PYTHON_INTERFACE_QUICKSTART.md
@@ -689,7 +689,7 @@ does not declare a binding like `profile`, `ontology_id`, `package_id`, or
 `path`, SEOCHO raises a `ValueError`.
 
 See [AGENT_DESIGN_SPECS.md](AGENT_DESIGN_SPECS.md) and the
-[`examples/agent_designs/`](/tmp/seocho-land-finder-e2e/examples/agent_designs)
+[`examples/agent_designs/`](../examples/agent_designs/)
 directory for three starter patterns:
 
 - planning + multi-agent collaboration
@@ -723,7 +723,7 @@ prompt by default so the model can preserve source-grounded scalar properties
 without collapsing period-specific metrics.
 
 See [INDEXING_DESIGN_SPECS.md](INDEXING_DESIGN_SPECS.md) and the
-[`examples/indexing_designs/`](/tmp/seocho-land-finder-e2e/examples/indexing_designs)
+[`examples/indexing_designs/`](../examples/indexing_designs/)
 directory for starter designs covering:
 
 - LPG + provenance-first indexing

--- a/seocho/tests/test_session_agent.py
+++ b/seocho/tests/test_session_agent.py
@@ -292,7 +292,7 @@ class TestSession:
             async def run(self, **_kwargs):
                 raise RuntimeError("agent backend unavailable")
 
-        import extraction.agents_runtime as _agents_runtime
+        import seocho.agents_runtime as _agents_runtime
         monkeypatch.setattr(_agents_runtime, "get_agents_runtime", lambda: _FailingAdapter())
         monkeypatch.setattr(Session, "_get_indexing_agent", lambda self: object())
         monkeypatch.setattr(Session, "_get_pipeline_engine", lambda self: FakePipelineEngine())

--- a/seocho/tests/test_user_facing_edge_cases.py
+++ b/seocho/tests/test_user_facing_edge_cases.py
@@ -152,7 +152,7 @@ class TestSilentAgentModeFallback:
             def run_streamed(self, **_: Any) -> Any:
                 raise RuntimeError("boom: streaming backend offline")
 
-        import extraction.agents_runtime as ar  # type: ignore
+        import seocho.agents_runtime as ar  # type: ignore
 
         monkeypatch.setattr(ar, "get_agents_runtime", lambda: _BoomRuntime())
 


### PR DESCRIPTION
What:
- replace the remaining `/tmp/seocho-land-finder-e2e/...` example links in canonical docs with repo-relative `../examples/...` links
- restore the agent fallback regression tests so they monkeypatch `seocho.agents_runtime`, which is the canonical runtime shim that `Session` actually uses

Why:
The source docs were still advertising broken local-filesystem paths, and the repo's `Basic CI` was already red on the known agent fallback regression because those tests were monkeypatching the legacy compatibility shim instead of the canonical runtime adapter.

Validation:
- `rg -n "/tmp/seocho-land-finder-e2e/examples/" docs README.md examples`
- `git diff --check`
- `bash scripts/ci/check-doc-contracts.sh`
- `uv run pytest seocho/tests/test_session_agent.py seocho/tests/test_user_facing_edge_cases.py -q`
- `bash scripts/ci/run_basic_ci.sh`

Risks:
- Docs change is link-target normalization only.
- Test change is limited to the monkeypatch target used by the existing regression harness; no product behavior is modified.