### PR TITLE
ci: skip site deploy until Pages is enabled

### DIFF
--- a/.github/workflows/docs-site-deploy.yml
+++ b/.github/workflows/docs-site-deploy.yml
@@ -16,7 +16,46 @@ permissions:
   id-token: write
 
 jobs:
+  pages-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      pages_enabled: ${{ steps.check.outputs.enabled }}
+
+    steps:
+      - name: Check GitHub Pages availability
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          status=$(curl -sS -o /tmp/pages.json -w "%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pages")
+
+          if [ "${status}" = "200" ]; then
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ "${status}" = "404" ]; then
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "### GitHub Pages not enabled"
+              echo ""
+              echo "Skipped deployment because \`${GITHUB_REPOSITORY}\` does not have GitHub Pages enabled yet."
+              echo "Enable \`Settings > Pages > Build and deployment > Source: GitHub Actions\` and rerun this workflow to publish \`seocho.blog\`."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          echo "Unexpected GitHub Pages API status: ${status}" >&2
+          cat /tmp/pages.json >&2
+          exit 1
+
   build:
+    needs: pages-preflight
+    if: needs.pages-preflight.outputs.pages_enabled == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -48,6 +87,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
+    if: needs.build.result == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- add a GitHub Pages preflight to `docs-site-deploy`
- skip build/deploy with a workflow summary when Pages is not enabled for `tteon/seocho`
- keep the workflow green until the one-time repository Pages setting is turned on

## Why
The site migration landed cleanly, but the first post-merge deploy failed with `Error: Failed to create deployment ... Ensure GitHub Pages has been enabled`.

## Validation
- `bash scripts/ci/check-doc-contracts.sh`
- `git diff --check`

## Follow-up
After enabling `Settings > Pages > Build and deployment > Source: GitHub Actions`, rerun `Deploy seocho.blog` from Actions or trigger the workflow manually.
