### PR TITLE
UX: Refactor inline styles and event handlers to external CSS in console UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,3 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+- Extracted inline CSS styles and JS `onmouseover`/`onmouseout` handlers in `evaluation/static/index.html` to CSS classes (`.reset-session-btn`, `.chat-system-msg`, etc) in `evaluation/static/styles.css` to improve maintainability and CSP compliance.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>
@@ -83,7 +81,7 @@
         <!-- Left: Chat & Reasoning Pane -->
         <div class="chat-pane">
           <div class="chat-log" id="chatLog" aria-live="polite">
-            <div style="font-family:var(--font-mono); font-size:0.7rem; color:var(--text-muted); text-align:center;">//
+            <div class="chat-system-msg">//
               System Authenticated. Trace visualization ready.</div>
           </div>
 
@@ -100,9 +98,8 @@
             [ NO ACTIVE RUN ]<br /><br />
             Awaiting payload to render DAG Trace...
           </div>
-          <div id="dagScrollLayer" style="position:relative; width:100%; min-height:100%;">
-            <svg id="dagEdges"
-              style="position: absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; z-index:0;"></svg>
+          <div id="dagScrollLayer" class="dag-scroll-layer">
+            <svg id="dagEdges" class="dag-edges-svg"></svg>
             <div id="dagContainer" class="dag-container"></div>
           </div>
         </div>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,42 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Additional refactored styles from index.html inline attributes */
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+}
+
+.chat-system-msg {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.dag-scroll-layer {
+  position: relative;
+  width: 100%;
+  min-height: 100%;
+}
+
+.dag-edges-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}


### PR DESCRIPTION
## What
Extracted inline CSS and inline JavaScript event handlers (`onmouseover` / `onmouseout`) from `evaluation/static/index.html` into corresponding CSS classes in `evaluation/static/styles.css`.

## Why
Inline styles and event handlers decrease maintainability and violate best practices for separation of concerns and Content Security Policy (CSP) compliance. Moving them to the CSS file ensures cleaner markup and allows leveraging pseudo-classes like `:hover`.

## Accessibility / UX Impact
- The hover transition on the `Reset Trace` button is now handled by a smoother CSS `transition: color 0.2s`, slightly improving the visual experience.
- Moving away from inline JS reduces the risk of blocking interaction due to strict CSPs in some environments.

## Validation
- Ran the local evaluation server (`uvicorn evaluation.server:app --port 8501`).
- Used Playwright (`verify_hover.py`) to verify the hover transition correctly turns the text color to `#fff`.
- Took visual verification screenshots of the new button state.
- Ran `bash scripts/ci/run_basic_ci.sh` to ensure no backend regressions.

## Risks
The change is purely cosmetic and structural for the frontend CSS. It is low-risk. No backend or multi-agent runtime configurations were modified.

---
*PR created automatically by Jules for task [11753572943601808513](https://jules.google.com/task/11753572943601808513) started by @tteon*