### PR TITLE
Fix missing authz/policy checks on API endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1037,14 +1037,28 @@ async def platform_chat_send(request: PlatformChatRequest):
 
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
-async def platform_chat_session_get(session_id: str):
+async def platform_chat_session_get(
+    session_id: str,
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
-async def platform_chat_session_reset(session_id: str):
+async def platform_chat_session_reset(
+    session_id: str,
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 
@@ -1633,6 +1647,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1645,6 +1663,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1660,6 +1682,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
### Severity
Medium.

### Vulnerability
Missing authorization (IDOR / Broken Access Control) on several sensitive data enumeration and platform session endpoints. Specifically:
- `/databases`
- `/graphs`
- `/agents`
- `/platform/chat/session` (GET and DELETE)

### Impact
Any user could list active agents, databases, graph targets, and arbitrarily read or clear platform chat sessions of other tenants/users, bypassing expected application-level isolation and authorization checks.

### Fix
Added the `require_runtime_permission` decorator logic to these endpoints. For endpoints that lacked a `workspace_id` parameter (like the platform chat session routes), the standard query parameter `workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN)` was safely added to the endpoint signature. The explicit `role="user"` default for single-tenant MVP was maintained.

### Validation
Ran the local CI test suite `bash scripts/ci/run_basic_ci.sh` which passed.
Ran specific endpoint and policy unit tests `uv run pytest extraction/tests/test_api_endpoints.py` and `uv run pytest extraction/tests/test_policy.py`, confirming the routes correctly enforce the permission error without breaking compatibility.

### Risks
Minimal. Existing clients that hit `/platform/chat/session` without providing a `workspace_id` will fall back to `"default"`, preventing 422 Unprocessable Entity errors, while still enforcing the app-level RBAC check.

---
*PR created automatically by Jules for task [6108755446634693410](https://jules.google.com/task/6108755446634693410) started by @tteon*