### PR TITLE
Refactor reset trace button to remove inline styles and scripts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,4 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+
+- In the evaluation UI, avoid using inline styles and inline JavaScript event handlers (e.g., `onmouseover`, `onmouseout`). Use standard CSS rules and pseudo-classes (`:hover`, `:focus-visible`) in `evaluation/static/styles.css` for better maintainability and keyboard accessibility.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,19 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Reset Trace Button */
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.reset-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
### What
Refactored the `#resetSessionBtn` in `evaluation/static/index.html` to remove inline CSS styles and inline JavaScript event handlers (`onmouseover` / `onmouseout`). Replaced them with a `.reset-btn` CSS class definition in `evaluation/static/styles.css` that leverages the `:hover` pseudo-class and a CSS transition for a smoother effect.

### Why
Using inline JavaScript for hover effects and inline styles reduces maintainability, makes it harder to enforce Content Security Policies (CSPs), and goes against web development best practices. Moving styles to a stylesheet creates a cleaner separation of concerns.

### Accessibility / UX Impact
The visual appearance and behavior of the button remain identical. However, the hover state now transitions more smoothly due to the addition of `transition: color 0.2s, border-color 0.2s;`, providing a slightly improved micro-interaction. It also ensures the global `:focus-visible` outline styles apply correctly without competing with inline definitions.

### Validation
1. Visually verified the change by writing and executing a Playwright script that rendered the UI, hovered the button, and captured a screenshot and video of the hover state.
2. The UI correctly renders the hover styles defined in the CSS class without the need for JavaScript handlers.
3. Ran `scripts/ci/run_basic_ci.sh` which passed.
4. Ran `scripts/pm/lint-agent-docs.sh` which passed.

### Risks
Minimal to none. This is a small, bounded CSS and HTML refactoring of a single button with no change to its core functionality or layout constraints.

---
*PR created automatically by Jules for task [6363157155400898415](https://jules.google.com/task/6363157155400898415) started by @tteon*