### PR TITLE
perf: stream JSONL to CSV iteratively during export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+When converting or exporting JSONL files to CSV format, prefer iterative streaming by reading row-by-row with `for line in f:` rather than eagerly reading the entire file into memory as a list using `readlines()` or `.append()`. This eliminates O(N) memory scaling bottlenecks and handles extremely large trace artifacts natively.

--- a/seocho/tracing.py
+++ b/seocho/tracing.py
@@ -744,9 +744,11 @@ def export_traces_csv(
             "elapsed_seconds",
         ]
 
-    records = []
-    with open(jsonl_path, "r") as f:
-        for line in f:
+    count = 0
+    with open(jsonl_path, "r", encoding="utf-8") as f_in, open(csv_path, "w", newline="", encoding="utf-8") as f_out:
+        writer = csv_mod.DictWriter(f_out, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        for line in f_in:
             line = line.strip()
             if not line:
                 continue
@@ -774,11 +776,7 @@ def export_traces_csv(
                 "reasoning_attempts": out.get("reasoning_attempts", ""),
                 "elapsed_seconds": meta.get("elapsed_seconds", ""),
             }
-            records.append(record)
+            writer.writerow(record)
+            count += 1
 
-    with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv_mod.DictWriter(f, fieldnames=fields, extrasaction="ignore")
-        writer.writeheader()
-        writer.writerows(records)
-
-    return len(records)
+    return count


### PR DESCRIPTION
**What**
Refactored the `export_traces_csv` function in `seocho/tracing.py` to stream JSON lines directly to the CSV file line-by-line rather than fully materializing the JSON structures into an intermediary list.

**Why**
The previous implementation eagerly loaded all parsed JSON representations into memory via `.append()`. For extremely large trace artifacts or long-running index batch operations, this posed an O(N) memory scaling bottleneck and unnecessarily prolonged garbage collection overhead. Iterative streaming addresses this memory pressure effectively.

**Expected Impact**
A drastic reduction in peak memory consumption while processing and converting traces into CSV formats. Execution speed may also improve slightly via reduced GC cycles due to smaller allocation sizes.

**Validation**
Ran `pytest seocho/tests/test_tracing.py`, which passed. Also ran `bash scripts/ci/run_basic_ci.sh`, confirming no behavior changes or CI regressions.

**Risks**
If the CSV writing crashes midway, a partial artifact will be left behind on disk, compared to the previously atomical behavior. This is acceptable since large file chunk processing naturally relies on resuming or retrying logic from a fresh file anyways.

---
*PR created automatically by Jules for task [1080357761932583573](https://jules.google.com/task/1080357761932583573) started by @tteon*