### PR TITLE
Refactor #resetSessionBtn inline styles to CSS

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,18 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+#resetSessionBtn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+#resetSessionBtn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
### What
Removed inline `style`, `onmouseover`, and `onmouseout` attributes from the `#resetSessionBtn` button in `evaluation/static/index.html`. Added corresponding rules with a smooth color transition to `evaluation/static/styles.css`.

### Why
Inline styles and event handlers are harder to maintain, violate strict CSPs, and duplicate logic that belongs in CSS. This refactor cleanly moves presentation logic back to the stylesheet.

### Accessibility / UX Impact
The visual functionality remains identical, but the addition of `transition: color 0.2s;` in the CSS makes the hover interaction slightly smoother, improving the perceived quality of the UI.

### Validation
* Verified the file contents changed as expected.
* Ran a Playwright UI test that successfully asserted the hover color change from muted text to white `#fff`.
* Successfully ran the `scripts/ci/run_basic_ci.sh` suite with zero new failures.

### Risks
Extremely low. This is a targeted UI presentation refactor on a single, isolated button element using standard CSS rules.

---
*PR created automatically by Jules for task [14440364962767785637](https://jules.google.com/task/14440364962767785637) started by @tteon*