### PR TITLE
perf(tracing): optimize export_traces_csv to stream jsonl to csv

### DIFF
--- a/seocho/tracing.py
+++ b/seocho/tracing.py
@@ -744,41 +744,41 @@ def export_traces_csv(
             "elapsed_seconds",
         ]
 
-    records = []
-    with open(jsonl_path, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                raw = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            out = raw.get("output", {})
-            meta = raw.get("metadata", {})
-            usage = meta.get("usage", {})
-
-            record = {
-                "timestamp": raw.get("timestamp", ""),
-                "name": raw.get("name", ""),
-                "model": meta.get("model", raw.get("input", {}).get("model", "")),
-                "input_tokens": usage.get("prompt_tokens", ""),
-                "output_tokens": usage.get("completion_tokens", ""),
-                "total_tokens": usage.get("total_tokens", ""),
-                "nodes": out.get("nodes", ""),
-                "relationships": out.get("relationships", ""),
-                "score": out.get("score", ""),
-                "validation_errors": out.get("validation_errors", ""),
-                "result_count": out.get("result_count", ""),
-                "reasoning_attempts": out.get("reasoning_attempts", ""),
-                "elapsed_seconds": meta.get("elapsed_seconds", ""),
-            }
-            records.append(record)
-
-    with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv_mod.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+    count = 0
+    with open(csv_path, "w", newline="", encoding="utf-8") as out_f:
+        writer = csv_mod.DictWriter(out_f, fieldnames=fields, extrasaction="ignore")
         writer.writeheader()
-        writer.writerows(records)
 
-    return len(records)
+        with open(jsonl_path, "r") as in_f:
+            for line in in_f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                out = raw.get("output", {})
+                meta = raw.get("metadata", {})
+                usage = meta.get("usage", {})
+
+                record = {
+                    "timestamp": raw.get("timestamp", ""),
+                    "name": raw.get("name", ""),
+                    "model": meta.get("model", raw.get("input", {}).get("model", "")),
+                    "input_tokens": usage.get("prompt_tokens", ""),
+                    "output_tokens": usage.get("completion_tokens", ""),
+                    "total_tokens": usage.get("total_tokens", ""),
+                    "nodes": out.get("nodes", ""),
+                    "relationships": out.get("relationships", ""),
+                    "score": out.get("score", ""),
+                    "validation_errors": out.get("validation_errors", ""),
+                    "result_count": out.get("result_count", ""),
+                    "reasoning_attempts": out.get("reasoning_attempts", ""),
+                    "elapsed_seconds": meta.get("elapsed_seconds", ""),
+                }
+                writer.writerow(record)
+                count += 1
+
+    return count


### PR DESCRIPTION
**What**
Refactored `export_traces_csv` in `seocho/tracing.py` to stream JSONL lines directly to the output CSV file instead of first appending all lines to a Python list in memory.

**Why**
The previous implementation used `records.append(record)` to build a full list of all parsed JSON trace lines before writing anything to the CSV. For large trace files (which are common in evaluation pipelines), this caused an O(N) memory scaling bottleneck, unnecessarily inflating the local worker footprint and risking Out-Of-Memory (OOM) errors during trace exports. This change adheres to the instruction: "When exporting or processing large `.jsonl` files (e.g., in tracing or logging), stream the data iteratively line-by-line rather than loading the entire file into memory".

**Expected Impact**
- O(1) memory complexity during trace export, drastically reducing the peak memory footprint.
- Minor speedup due to avoiding large list allocations and subsequent garbage collection.

**Validation**
- Validated via a standalone python script that created a dummy jsonl, successfully ran the export function, and verified the output CSV contents line-by-line.
- Ran `bash scripts/ci/run_basic_ci.sh` which executed all relevant tests and module checks to ensure zero breakage or regressions.
- Ran `uv run pytest seocho/tests/test_tracing.py` which cleanly passed.

**Risks**
- Extremely low risk. The returned count value and the exact schema written to the CSV is fully preserved. Behavior differs only slightly if the target jsonl is missing, in which case it will now write an empty CSV with just headers instead of halting prior to file creation, which is arguably safer and more deterministic for downstream pipeline tasks.

---
*PR created automatically by Jules for task [9392109144850698316](https://jules.google.com/task/9392109144850698316) started by @tteon*