### PR TITLE
fix: enforce runtime permission checks on missing endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1037,14 +1037,28 @@ async def platform_chat_send(request: PlatformChatRequest):
 
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
-async def platform_chat_session_get(session_id: str):
+async def platform_chat_session_get(
+    session_id: str,
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
-async def platform_chat_session_reset(session_id: str):
+async def platform_chat_session_reset(
+    session_id: str,
+    workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
+):
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 
@@ -1633,6 +1647,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1645,6 +1663,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1660,6 +1682,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
Severity: Medium
Vulnerability: Missing authorization checks on several sensitive API endpoints (`list_databases`, `list_graphs`, `list_agents`, and chat session handlers).
Impact: Without these checks, an attacker could potentially enumerate databases, graphs, and agents or access platform chat sessions regardless of their role.
Fix: Added `require_runtime_permission` to these endpoints in `runtime/agent_server.py`.
Validation: Checked with `bash scripts/ci/run_basic_ci.sh` and the core `seocho/tests/` suite. Manual inspection of `git diff` confirms parameters are structurally correct.
Risks: Minimal. The `workspace_id` parameters fallback to `default="default"`, retaining backward compatibility. The changes purely add a fast app-level check.

---
*PR created automatically by Jules for task [15406166987979389588](https://jules.google.com/task/15406166987979389588) started by @tteon*