### PR TITLE
perf: Precompile regex constants in semantic_agents.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+For performance optimization, regex patterns used for tokenization and normalization must be pre-compiled as module-level constants (prefixed with `_RE_`) to prevent recompilation in hot paths and loops.

--- a/seocho/query/semantic_agents.py
+++ b/seocho/query/semantic_agents.py
@@ -112,12 +112,26 @@ DEFAULT_SEMANTIC_ARTIFACT_DIR = "outputs/semantic_artifacts"
 QUERY_CONTRACT_FAILURE_CODE = "query_execution_failed_or_contract_error"
 
 
+
+_RE_NON_ALPHANUM = re.compile(r"[^a-z0-9]+")
+_RE_QUOTED = re.compile(r'"([^"]+)"')
+_RE_SINGLE_QUOTED = re.compile(r"'([^']+)'")
+_RE_CAPS = re.compile(r"\b(?:[A-Z][a-zA-Z0-9&.-]{1,}|[A-Z]{2,})(?:\s+[A-Z][a-zA-Z0-9&.-]{1,})*\b")
+_RE_TOKENS = re.compile(r"[A-Za-z0-9][A-Za-z0-9&._-]{2,}")
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_POSSESSIVE = re.compile(r"'s\b", flags=re.IGNORECASE)
+_RE_COMPANY_SUFFIX = re.compile(r"\b(corporation|corp|company|co|incorporated)\b\.?", flags=re.IGNORECASE)
+_RE_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_RE_ALPHANUM_TOKENS = re.compile(r"[a-z0-9]+")
+_RE_NUMERIC = re.compile(r"\d+(?:\.\d+)?")
+
 def _normalize(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+    return _RE_NON_ALPHANUM.sub(" ", value.lower()).strip()
 
 
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALPHANUM.sub("", str(value).lower())
 
 
 def _query_rows(
@@ -618,14 +632,11 @@ class SemanticEntityResolver:
         self._query_diagnostics: List[Dict[str, Any]] = []
 
     def extract_question_entities(self, question: str) -> List[str]:
-        quoted = [m.group(1).strip() for m in re.finditer(r'"([^"]+)"', question)]
-        single_quoted = [m.group(1).strip() for m in re.finditer(r"'([^']+)'", question)]
+        quoted = [m.group(1).strip() for m in _RE_QUOTED.finditer(question)]
+        single_quoted = [m.group(1).strip() for m in _RE_SINGLE_QUOTED.finditer(question)]
         caps = [
             m.group(0).strip()
-            for m in re.finditer(
-                r"\b(?:[A-Z][a-zA-Z0-9&.-]{1,}|[A-Z]{2,})(?:\s+[A-Z][a-zA-Z0-9&.-]{1,})*\b",
-                question,
-            )
+            for m in _RE_CAPS.finditer(question)
         ]
 
         entities: List[str] = []
@@ -641,7 +652,7 @@ class SemanticEntityResolver:
             entities.append(cleaned)
 
         if not entities:
-            for token in re.findall(r"[A-Za-z0-9][A-Za-z0-9&._-]{2,}", question):
+            for token in _RE_TOKENS.findall(question):
                 key = token.lower()
                 if key in STOPWORDS or key.isdigit():
                     continue
@@ -943,9 +954,9 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _clean_span(value: str) -> str:
-        cleaned = re.sub(r"\s+", " ", value.strip())
+        cleaned = _RE_WHITESPACE.sub(" ", value.strip())
         cleaned = cleaned.strip(".,:;!?()[]{}")
-        cleaned = re.sub(r"'s\b", "", cleaned, flags=re.IGNORECASE)
+        cleaned = _RE_POSSESSIVE.sub("", cleaned)
         tokens = cleaned.split()
         while len(tokens) > 1 and tokens[0].lower() in LEADING_ENTITY_WRAPPER_TOKENS:
             tokens = tokens[1:]
@@ -967,7 +978,7 @@ class SemanticEntityResolver:
             terms.append(cleaned)
 
         for raw in (resolved_text, entity_text):
-            compact = re.sub(r"\b(corporation|corp|company|co|incorporated)\b\.?", "", raw, flags=re.IGNORECASE)
+            compact = _RE_COMPANY_SUFFIX.sub("", raw)
             compact = cls._clean_span(compact)
             if not compact:
                 continue
@@ -980,7 +991,7 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _normalize(value: str) -> str:
-        return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+        return _RE_NON_ALPHANUM.sub(" ", value.lower()).strip()
 
     @staticmethod
     def _lexical_similarity(a: str, b: str) -> float:
@@ -1001,8 +1012,8 @@ class SemanticEntityResolver:
     def _label_boost(labels: Sequence[str], label_hints: Set[str]) -> float:
         if not labels or not label_hints:
             return 0.0
-        normalized_labels = {re.sub(r"[^a-z0-9]+", "", str(label).lower()) for label in labels}
-        normalized_hints = {re.sub(r"[^a-z0-9]+", "", hint.lower()) for hint in label_hints}
+        normalized_labels = {_RE_NON_ALPHANUM.sub("", str(label).lower()) for label in labels}
+        normalized_hints = {_RE_NON_ALPHANUM.sub("", hint.lower()) for hint in label_hints}
         if normalized_labels & normalized_hints:
             return 0.15
         return 0.0
@@ -2004,7 +2015,7 @@ class AnswerGenerationAgent:
             return ""
         sentences = [
             sentence.strip()
-            for sentence in re.split(r"(?<=[.!?])\s+", supporting_fact)
+            for sentence in _RE_SENTENCE_SPLIT.split(supporting_fact)
             if sentence.strip()
         ]
         if not sentences:
@@ -2012,7 +2023,7 @@ class AnswerGenerationAgent:
 
         question_terms = {
             token
-            for token in re.findall(r"[a-z0-9]+", question.lower())
+            for token in _RE_ALPHANUM_TOKENS.findall(question.lower())
             if token not in STOPWORDS and len(token) > 1
         }
         if not question_terms:
@@ -2022,8 +2033,8 @@ class AnswerGenerationAgent:
             question_terms.update({"ceo", "cfo", "chairman", "board", "director", "officer"})
 
         def score(sentence: str) -> tuple[int, int, int]:
-            terms = set(re.findall(r"[a-z0-9]+", sentence.lower()))
-            numeric_hits = len(set(re.findall(r"\d+(?:\.\d+)?", sentence.lower())) & question_terms)
+            terms = set(_RE_ALPHANUM_TOKENS.findall(sentence.lower()))
+            numeric_hits = len(set(_RE_NUMERIC.findall(sentence.lower())) & question_terms)
             return (len(terms & question_terms), numeric_hits, len(sentence))
 
         best_sentence = max(sentences, key=score)


### PR DESCRIPTION
### What
Extracted all inline `re.sub`, `re.findall`, `re.finditer`, and `re.split` string literals into module-level compiled constants (`_RE_*`) in `seocho/query/semantic_agents.py`.

### Why
To address repeated validation and loop work bottlenecks as defined in the priority areas. Inline regex recompilation adds unnecessary overhead, especially in loops traversing sentences or extracting tokens (like the direct answer scoring loop).

### Expected Impact
Qualitative impact: Reduced CPU overhead during query routing and answer synthesis, particularly on large token streams or when iterating over long supporting facts.

### Validation
Ran `bash scripts/ci/run_basic_ci.sh`, specifically checking syntax, docs linting, and all Python unit tests related to query answering. They all pass seamlessly.

### Risks
Extremely low risk. The actual pattern logic, strings, and regex flags remain identical; only the instantiation structure changed.

---
*PR created automatically by Jules for task [1471884483943052664](https://jules.google.com/task/1471884483943052664) started by @tteon*