### PR TITLE
UX/A11y: Refactor Reset Trace button inline styles to CSS class

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,3 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+Moved inline styles to class for UI reset trace button to improve maintainability and avoid inline Javascript.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,19 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Reset Session Button */
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
## What
Replaced inline styling and `onmouseover`/`onmouseout` handlers on the "Reset Trace" button in `evaluation/static/index.html` with a `.reset-session-btn` CSS class defined in `evaluation/static/styles.css`.

## Why
Using inline JavaScript and styles violates separation of concerns, degrades maintainability, and is poor practice for Content Security Policy (CSP).

## Accessibility / UX Impact
Added a `transition: color 0.2s` for a smoother hover interaction state, slightly improving the visual experience for end users.

## Validation
- Verified with a Playwright script taking a screenshot locally and confirming there are no inline styles for the button (`style_attr is None or "background" not in style_attr`).
- Ran `bash scripts/ci/run_basic_ci.sh`, all tests passed.

## Risks
None. This is a very targeted CSS refactor confined to a single button in the evaluation UI.

---
*PR created automatically by Jules for task [12558391395290767876](https://jules.google.com/task/12558391395290767876) started by @tteon*