### PR TITLE
fix: Add missing authorization checks on runtime endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1633,7 +1633,13 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
+
+
 
 
 @app.get(RuntimePath.GRAPHS)
@@ -1645,10 +1651,16 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
     }
+
+
 
 
 @app.get(RuntimePath.AGENTS)
@@ -1660,7 +1672,13 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
+
+
 
 
 @app.post("/rules/infer", response_model=RuleInferResponse)


### PR DESCRIPTION
### Severity
Medium

### Vulnerability
Missing authorization checks on the `list_databases`, `list_graphs`, and `list_agents` API endpoints. 

### Impact
Unauthenticated users with access to the API could potentially query these endpoints to enumerate sensitive information such as the existing databases, graphs targets, and active DB-bound agents without proper authorization checks.

### Fix
Added `require_runtime_permission` checks within a `try/except PermissionError` block to properly raise `HTTPException(status_code=403)` when the authorization fails for these endpoints. The correct action types were used: `read_databases` for databases/graphs and `read_agents` for agents.

### Validation
Ran `bash scripts/ci/run_basic_ci.sh` which executes canonical runtime shell contract checks, basic CI coverage, and agent docs linting. All checks passed successfully.

### Risks
The risk is low as this strictly enforces the existing intended authorization behavior outlined in the `AGENTS.md` and `runtime/policy.py` contracts.


---
*PR created automatically by Jules for task [7035320276095120863](https://jules.google.com/task/7035320276095120863) started by @tteon*