### PR TITLE
Refactor "Reset Trace" button for improved keyboard accessibility

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button class="reset-btn" id="resetSessionBtn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -166,6 +166,22 @@ body {
   gap: 1rem;
 }
 
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-btn:hover,
+.reset-btn:focus-visible {
+  color: #fff;
+}
+
 .status {
   padding: 0.25rem 0.75rem;
   font-size: 0.75rem;


### PR DESCRIPTION
### What
Refactored the "Reset Trace" button (`#resetSessionBtn`) in the evaluation UI by removing inline styles and inline JavaScript event handlers, migrating them to a reusable CSS class (`.reset-btn`).

### Why
The button previously relied on inline styles and `onmouseover`/`onmouseout` handlers for hover effects, which bypassed standard focus states and violated accessibility guidelines. Moving styles to CSS allows the use of pseudo-classes like `:hover` and `:focus-visible`, and eliminates potential CSP issues related to inline scripts.

### Accessibility / UX Impact
- **Impact:** High improvement for keyboard navigation. Keyboard users can now clearly see when the "Reset Trace" button is focused, as it properly triggers a visual change (white text color) consistent with the hover state.

### Validation
- **Unit Tests:** Ran `bash scripts/ci/run_basic_ci.sh` to ensure no runtime contracts or core components were broken. (All relevant UI and CI checks passed).
- **Visual/Frontend Verification:** Used a local Playwright script (`verify_ui.py`) to launch the `evaluation.server`, navigate to `http://localhost:8501`, and programmatically hover over the button. The resulting screenshot and video confirmed the button maintained its original visual appearance and correctly applied the hover style via the new CSS class.

### Risks
- **Very Low:** The change is highly localized to a single button and its corresponding CSS file within the evaluation app. It does not introduce new dependencies or affect backend runtime logic.

---
*PR created automatically by Jules for task [10193349120540483625](https://jules.google.com/task/10193349120540483625) started by @tteon*