### PR TITLE
Fix O(N) memory bottleneck in CSV trace export

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,3 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+
+When processing JSONL trace exports in `seocho/tracing.py`, always stream rows directly from the file to `csv.DictWriter.writerow` instead of accumulating a full list of dicts in memory (e.g., via `records.append(record)`), as trace files can grow arbitrarily large resulting in O(N) memory exhaustion.

--- a/seocho/tracing.py
+++ b/seocho/tracing.py
@@ -744,41 +744,41 @@ def export_traces_csv(
             "elapsed_seconds",
         ]
 
-    records = []
-    with open(jsonl_path, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                raw = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            out = raw.get("output", {})
-            meta = raw.get("metadata", {})
-            usage = meta.get("usage", {})
-
-            record = {
-                "timestamp": raw.get("timestamp", ""),
-                "name": raw.get("name", ""),
-                "model": meta.get("model", raw.get("input", {}).get("model", "")),
-                "input_tokens": usage.get("prompt_tokens", ""),
-                "output_tokens": usage.get("completion_tokens", ""),
-                "total_tokens": usage.get("total_tokens", ""),
-                "nodes": out.get("nodes", ""),
-                "relationships": out.get("relationships", ""),
-                "score": out.get("score", ""),
-                "validation_errors": out.get("validation_errors", ""),
-                "result_count": out.get("result_count", ""),
-                "reasoning_attempts": out.get("reasoning_attempts", ""),
-                "elapsed_seconds": meta.get("elapsed_seconds", ""),
-            }
-            records.append(record)
-
-    with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv_mod.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+    count = 0
+    with open(csv_path, "w", newline="", encoding="utf-8") as out_f:
+        writer = csv_mod.DictWriter(out_f, fieldnames=fields, extrasaction="ignore")
         writer.writeheader()
-        writer.writerows(records)
 
-    return len(records)
+        with open(jsonl_path, "r") as in_f:
+            for line in in_f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                out = raw.get("output", {})
+                meta = raw.get("metadata", {})
+                usage = meta.get("usage", {})
+
+                record = {
+                    "timestamp": raw.get("timestamp", ""),
+                    "name": raw.get("name", ""),
+                    "model": meta.get("model", raw.get("input", {}).get("model", "")),
+                    "input_tokens": usage.get("prompt_tokens", ""),
+                    "output_tokens": usage.get("completion_tokens", ""),
+                    "total_tokens": usage.get("total_tokens", ""),
+                    "nodes": out.get("nodes", ""),
+                    "relationships": out.get("relationships", ""),
+                    "score": out.get("score", ""),
+                    "validation_errors": out.get("validation_errors", ""),
+                    "result_count": out.get("result_count", ""),
+                    "reasoning_attempts": out.get("reasoning_attempts", ""),
+                    "elapsed_seconds": meta.get("elapsed_seconds", ""),
+                }
+                writer.writerow(record)
+                count += 1
+
+    return count


### PR DESCRIPTION
What:
Changed `export_traces_to_csv` in `seocho/tracing.py` to write each trace record to the output CSV file directly as it is parsed from the JSONL file.

Why:
The previous implementation accumulated all trace records into an in-memory `records` list before writing them out with `writer.writerows(records)`. Because JSONL trace files can grow arbitrarily large during prolonged sessions, this caused an avoidable O(N) memory scaling bottleneck.

Expected Impact:
Memory usage during trace CSV export will remain O(1) regardless of the trace file size. This prevents out-of-memory crashes or unnecessary memory pressure on the local machine or server during debugging and trace collection.

Validation:
- Read the modified file to verify the logic was rewritten cleanly.
- `uv run pytest seocho/tests/test_tracing.py` passes successfully, validating that the mapping and formatting behavior remains identical.
- `bash scripts/ci/run_basic_ci.sh` passes successfully for shell contracts and module ownership.

Risks:
- Negligible risk. If the JSONL path is missing, the CSV file is now touched/created immediately before throwing the exception, which is a very minor behavioral difference but generally immaterial for local script workflows. Behavior of the CSV output fields remains perfectly intact.

---
*PR created automatically by Jules for task [4687150844814411366](https://jules.google.com/task/4687150844814411366) started by @tteon*