### PR TITLE
refactor(ui): extract inline styles and JS from Reset Trace button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,4 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+
+- In the evaluation UI, avoid using inline styles and inline JavaScript event handlers (e.g., `onmouseover`, `onmouseout`). Use standard CSS rules and pseudo-classes (`:hover`, `:focus-visible`) in `evaluation/static/styles.css` for better maintainability and keyboard accessibility.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,18 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
## What
Refactored the `#resetSessionBtn` in the evaluation UI to remove hardcoded inline styles and inline JavaScript event handlers (`onmouseover` / `onmouseout`). The styling and hover logic are now managed by a new `.reset-btn` class in `evaluation/static/styles.css`.

## Why
Inline styles and JavaScript handlers are poor practice for maintainability and violate strict Content Security Policy (CSP) guidelines. Moving these to standard CSS improves the codebase's health and consistency.

## Accessibility / UX Impact
- **Maintainability:** Styles are now centralized in the CSS file.
- **UX:** Added `transition: color 0.2s;` to the new class to provide a smoother, more polished visual transition when the user hovers over the button.
- **Accessibility:** Behavior remains intact, but semantic separation of concerns (HTML vs CSS) is improved.

## Validation
- Explicitly verified the modified HTML and CSS files.
- Visually verified the frontend changes using a Playwright script to capture screenshots and videos of the button's hover and focus states.
- Ran the local CI script (`bash scripts/ci/run_basic_ci.sh`) and confirmed all 259 tests and module contracts passed successfully.

## Risks
- Very low risk. The change is isolated to a single button in the evaluation UI and does not affect runtime orchestration, semantic retrieval, or existing backend functionality.

---
*PR created automatically by Jules for task [13351105361556383321](https://jules.google.com/task/13351105361556383321) started by @tteon*