### PR TITLE
perf: Pre-compile regular expressions in semantic_query_flow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+For performance optimization, regex patterns used for tokenization and normalization must be pre-compiled as module-level constants (prefixed with `_RE_`) to prevent recompilation in hot paths and loops.

--- a/extraction/semantic_query_flow.py
+++ b/extraction/semantic_query_flow.py
@@ -235,6 +235,9 @@ def build_evidence_bundle(
     )
 
 
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_SPACES = re.compile(r"\s+")
+
 def _entity_name(payload: Dict[str, Any]) -> str:
     return str(payload.get("name") or payload.get("display_name") or "").strip()
 
@@ -245,10 +248,10 @@ def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_tar
         if not isinstance(labels, list):
             continue
         normalized_labels = {
-            re.sub(r"[^a-z0-9]+", "", str(label).lower())
+            _RE_NON_ALNUM.sub("", str(label).lower())
             for label in labels
         }
-        if normalized_labels & {re.sub(r"[^a-z0-9]+", "", item.lower()) for item in normalized_targets}:
+        if normalized_labels & {_RE_NON_ALNUM.sub("", item.lower()) for item in normalized_targets}:
             entity_name = _entity_name(entity)
             if entity_name:
                 return entity_name
@@ -256,11 +259,11 @@ def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_tar
 
 
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM.sub("", str(value).lower())
 
 
 def _slugify_symbol(value: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+    slug = _RE_NON_ALNUM.sub("-", str(value).lower()).strip("-")
     return slug or "term"
 
 
@@ -589,7 +592,7 @@ class CypherQueryValidator:
     """Validate constrained Cypher plans before execution."""
 
     def validate(self, plan: CypherPlan, constraint_slice: Dict[str, Any]) -> Dict[str, Any]:
-        normalized_query = " " + re.sub(r"\s+", " ", plan.query.upper()) + " "
+        normalized_query = " " + _RE_SPACES.sub(" ", plan.query.upper()) + " "
         violations: List[str] = []
         if "$node_id" not in plan.query:
             violations.append("missing_node_binding")
@@ -1447,13 +1450,13 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _clean_span(value: str) -> str:
-        cleaned = re.sub(r"\s+", " ", value.strip())
+        cleaned = _RE_SPACES.sub(" ", value.strip())
         cleaned = cleaned.strip(".,:;!?()[]{}")
         return cleaned
 
     @staticmethod
     def _normalize(value: str) -> str:
-        return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+        return _RE_NON_ALNUM.sub(" ", value.lower()).strip()
 
     @staticmethod
     def _lexical_similarity(a: str, b: str) -> float:
@@ -1474,8 +1477,8 @@ class SemanticEntityResolver:
     def _label_boost(labels: Sequence[str], label_hints: Set[str]) -> float:
         if not labels or not label_hints:
             return 0.0
-        normalized_labels = {re.sub(r"[^a-z0-9]+", "", str(label).lower()) for label in labels}
-        normalized_hints = {re.sub(r"[^a-z0-9]+", "", hint.lower()) for hint in label_hints}
+        normalized_labels = {_RE_NON_ALNUM.sub("", str(label).lower()) for label in labels}
+        normalized_hints = {_RE_NON_ALNUM.sub("", hint.lower()) for hint in label_hints}
         if normalized_labels & normalized_hints:
             return 0.15
         return 0.0


### PR DESCRIPTION
## What
Refactored inline regular expressions (such as `re.sub(r"[^a-z0-9]+", ...)`) in `extraction/semantic_query_flow.py` to use pre-compiled module-level constants (`_RE_NON_ALNUM` and `_RE_SPACES`).

## Why
Functions like `_first_entity_with_labels`, `_normalize_symbol`, and `_label_boost` execute in tight loops over entities and labels. Repeatedly passing string patterns to `re.sub` inline incurs cache lookup overhead for the Python regular expression engine. Using explicit `re.compile` at the module level is a classic, maintainable Python optimization that shaves off overhead in these hot paths.

## Expected Impact
Small, steady reduction in CPU overhead during semantic query intent routing and entity matching. The impact is qualitative but structurally sound for loops involving large label sets or many candidates.

## Validation
* Code inspection confirms identical text transformation logic.
* Relevant focused test `uv run pytest extraction/tests/test_semantic_query_flow.py` passed successfully.
* `bash scripts/ci/run_basic_ci.sh` passed successfully.

## Risks
Very low. The regex patterns (`[^a-z0-9]+` and `\s+`) and their replacement behaviors are strictly identical. Dependency behavior is unchanged.

---
*PR created automatically by Jules for task [17376353186902741050](https://jules.google.com/task/17376353186902741050) started by @tteon*