### PR TITLE
Refactor Reset Trace button inline styles to CSS class

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,18 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
What: Refactored the `Reset Trace` button in the evaluation UI (`evaluation/static/index.html`) by moving inline styles and inline JavaScript event handlers (`onmouseover`, `onmouseout`) into a dedicated CSS class (`.reset-session-btn`) in `evaluation/static/styles.css`.
Why: Removing inline styles and JS event handlers improves maintainability, prepares for CSP (Content Security Policy) compliance, and adheres to UX best practices for separating logic and presentation.
Accessibility / UX Impact: Replaces an abrupt color snap with a smooth color transition (`transition: color 0.2s;`) on hover, providing better visual feedback without altering the DOM structure or breaking focus states.
Validation: Verified locally using a Playwright script to capture a screenshot of the button's hover state, confirming no visual regressions. Standard CI (`bash scripts/ci/run_basic_ci.sh`) also passed.
Risks: Minimal to none. The `id` attribute (`resetSessionBtn`) remains unchanged, ensuring no impact on existing click event listeners in the application logic.

---
*PR created automatically by Jules for task [11875897710446121442](https://jules.google.com/task/11875897710446121442) started by @tteon*