### PR TITLE
fix(security): add missing authz checks to platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,35 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    history_rows = platform_session_store.get(session_id)
+    if history_rows:
+        workspace_id = "default"
+        for row in history_rows:
+            if "metadata" in row and "workspace_id" in row["metadata"]:
+                workspace_id = row["metadata"]["workspace_id"]
+                break
+        try:
+            require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+        except PermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in history_rows]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history_rows = platform_session_store.get(session_id)
+    if history_rows:
+        workspace_id = "default"
+        for row in history_rows:
+            if "metadata" in row and "workspace_id" in row["metadata"]:
+                workspace_id = row["metadata"]["workspace_id"]
+                break
+        try:
+            require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+        except PermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
Severity: High
Vulnerability: Insecure Direct Object Reference (IDOR) / Missing Authorization
Impact: Any user with knowledge of a `session_id` could read the chat history or delete the chat session of any other user across workspaces.
Fix: Added `require_runtime_permission` checks to both `platform_chat_session_get` and `platform_chat_session_reset`. The fix retrieves the session first, securely extracts the `workspace_id` from the session metadata, and validates it against the policy engine, raising a 403 Forbidden on failure. Empty sessions safely bypass the check as they leak no data and have no owner.
Validation: Verified that `bash scripts/ci/run_basic_ci.sh` passes completely, ensuring no regressions in the runtime API contracts. 
Risks: Minimal. The endpoints now enforce existing runtime policy identical to other platform endpoints. Users with malformed or missing session metadata might fall back to the "default" workspace, which is standard behavior for the local single-tenant MVP.

---
*PR created automatically by Jules for task [8682817810481775447](https://jules.google.com/task/8682817810481775447) started by @tteon*