### PR TITLE
UI: Fix Reset Trace button accessibility focus state and inline styles

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,23 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-btn:hover {
+  color: #fff;
+}
+
+.reset-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
### What
Extracted hardcoded inline styles and JavaScript hover handlers from the "Reset Trace" button (`#resetSessionBtn`) in `evaluation/static/index.html` into a new `.reset-btn` class in `evaluation/static/styles.css`.

### Why
To remove technical debt (inline styles/JS) and resolve a keyboard navigation accessibility issue where the button lacked a focus indicator.

### Accessibility / UX Impact
- **Fixes:** The button now explicitly shows a standard blue outline (`:focus-visible`) when focused via keyboard navigation, complying with the repository's `.jules/palette.md` strict accessibility constraints.
- **Improves:** Hover behavior is now handled cleanly via standard CSS (`:hover`) rather than legacy inline JS `onmouseover` event listeners.

### Validation
- Validated UI rendering visually via Playwright screenshot assertions, confirming the `:focus-visible` standard outline and `:hover` states function correctly.
- Ran `bash scripts/ci/run_basic_ci.sh`, and confirmed changes did not regress any existing backend/shell contracts or docs.

### Risks
- Low risk: The change is isolated solely to the presentation layer of a single button within the development/evaluation UI console. No business logic, endpoints, or DOM structures were modified.

---
*PR created automatically by Jules for task [1374674623004078664](https://jules.google.com/task/1374674623004078664) started by @tteon*