### PR TITLE
fix: secure platform chat session endpoints against IDOR

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1039,12 +1039,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    if history:
+        workspace_id = next((turn.metadata.get("workspace_id") for turn in history if "workspace_id" in turn.metadata), "default")
+        try:
+            require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+        except PermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e))
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    if history:
+        workspace_id = next((turn.metadata.get("workspace_id") for turn in history if "workspace_id" in turn.metadata), "default")
+        try:
+            require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+        except PermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** Insecure Direct Object Reference (IDOR) on session read/delete endpoints.
**Impact:** An attacker could potentially retrieve or clear the full platform chat history of another user's active session just by knowing or guessing the `session_id`.
**Fix:** Added `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` checks to `platform_chat_session_get` and `platform_chat_session_reset`. The workspace ID is safely extracted from the existing session turn metadata.
**Validation:** Validated via `bash scripts/ci/run_basic_ci.sh`. The CI shell contract, module ownership contract, and fast pytests pass successfully.
**Risks:** If session metadata is entirely absent or structurally malformed due to an older version format without a `workspace_id` in its history, it falls back to the `"default"` workspace, which matches the existing default fallback behavior for platform chat creation.

---
*PR created automatically by Jules for task [18143336392785314103](https://jules.google.com/task/18143336392785314103) started by @tteon*