### PR TITLE
Refactor `#resetSessionBtn` inline styles to external CSS

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -160,6 +160,21 @@ body {
   color: var(--text-muted);
 }
 
+#resetSessionBtn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+#resetSessionBtn:hover {
+  color: #fff;
+}
+
 .status-wrap {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**What**
Refactored the `#resetSessionBtn` in the evaluation UI to remove inline styles and inline JavaScript event handlers (`onmouseover` and `onmouseout`), moving them to standard CSS rules.

**Why**
Using inline JavaScript for styling (like `onmouseover`) and inline CSS violates strict Content Security Policy (CSP) best practices and makes the code harder to maintain. Moving the styles to `styles.css` using standard `:hover` pseudo-classes is a cleaner, more standardized approach.

**Accessibility / UX Impact**
This is primarily a maintainability and minor UX improvement. The button now uses a standard CSS transition (`transition: color 0.2s`) on hover, providing a slightly smoother visual interaction without altering the core design or layout. It also reduces DOM clutter.

**Validation**
- Verified the UI visually using a Playwright script that launched the evaluation server, navigated to the page, triggered the hover state, and captured a screenshot.
- Verified that all CI tests pass (`bash scripts/ci/run_basic_ci.sh`), ensuring no regressions were introduced.

**Risks**
Minimal risk. This is an isolated styling refactor on a single button.

---
*PR created automatically by Jules for task [15698777275233023058](https://jules.google.com/task/15698777275233023058) started by @tteon*