### PR TITLE
chore: Pre-compile regex constants for string normalization in semantic layers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+Regex patterns used for text normalization and tokenization in hot paths (like iterating over rows, facts, labels, or relationships during semantic resolution or Cypher construction) should be pre-compiled as module-level constants to avoid recompilation overhead inside loops.

--- a/extraction/ontology_hints.py
+++ b/extraction/ontology_hints.py
@@ -13,11 +13,13 @@ import os
 import re
 from typing import Dict, List, Set
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+
 logger = logging.getLogger(__name__)
 
 
 def _normalize(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return _RE_NON_ALNUM_TO_SPACE.sub(" ", value.lower()).strip()
 
 
 class OntologyHintStore:

--- a/extraction/ontology_hints_builder.py
+++ b/extraction/ontology_hints_builder.py
@@ -10,8 +10,10 @@ import re
 from typing import Dict, Iterable, List, Sequence, Set
 
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+
 def normalize_text(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return _RE_NON_ALNUM_TO_SPACE.sub(" ", value.lower()).strip()
 
 
 def keyword_tokens(value: str) -> Set[str]:

--- a/extraction/semantic_query_flow.py
+++ b/extraction/semantic_query_flow.py
@@ -72,6 +72,10 @@ from seocho.query.strategy_chooser import (
     IntentSupportValidator as CanonicalIntentSupportValidator,
 )
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+_RE_NON_ALNUM_TO_EMPTY = re.compile(r"[^a-z0-9]+")
+_RE_WHITESPACE = re.compile(r"\s+")
+
 logger = logging.getLogger(__name__)
 
 
@@ -245,10 +249,10 @@ def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_tar
         if not isinstance(labels, list):
             continue
         normalized_labels = {
-            re.sub(r"[^a-z0-9]+", "", str(label).lower())
+            _RE_NON_ALNUM_TO_EMPTY.sub("", str(label).lower())
             for label in labels
         }
-        if normalized_labels & {re.sub(r"[^a-z0-9]+", "", item.lower()) for item in normalized_targets}:
+        if normalized_labels & {_RE_NON_ALNUM_TO_EMPTY.sub("", item.lower()) for item in normalized_targets}:
             entity_name = _entity_name(entity)
             if entity_name:
                 return entity_name
@@ -256,11 +260,11 @@ def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_tar
 
 
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM_TO_EMPTY.sub("", str(value).lower())
 
 
 def _slugify_symbol(value: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+    slug = _RE_NON_ALNUM_TO_EMPTY.sub("-", str(value).lower()).strip("-")
     return slug or "term"
 
 
@@ -589,7 +593,7 @@ class CypherQueryValidator:
     """Validate constrained Cypher plans before execution."""
 
     def validate(self, plan: CypherPlan, constraint_slice: Dict[str, Any]) -> Dict[str, Any]:
-        normalized_query = " " + re.sub(r"\s+", " ", plan.query.upper()) + " "
+        normalized_query = " " + _RE_WHITESPACE.sub(" ", plan.query.upper()) + " "
         violations: List[str] = []
         if "$node_id" not in plan.query:
             violations.append("missing_node_binding")
@@ -1447,13 +1451,13 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _clean_span(value: str) -> str:
-        cleaned = re.sub(r"\s+", " ", value.strip())
+        cleaned = _RE_WHITESPACE.sub(" ", value.strip())
         cleaned = cleaned.strip(".,:;!?()[]{}")
         return cleaned
 
     @staticmethod
     def _normalize(value: str) -> str:
-        return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+        return _RE_NON_ALNUM_TO_SPACE.sub(" ", value.lower()).strip()
 
     @staticmethod
     def _lexical_similarity(a: str, b: str) -> float:
@@ -1474,8 +1478,8 @@ class SemanticEntityResolver:
     def _label_boost(labels: Sequence[str], label_hints: Set[str]) -> float:
         if not labels or not label_hints:
             return 0.0
-        normalized_labels = {re.sub(r"[^a-z0-9]+", "", str(label).lower()) for label in labels}
-        normalized_hints = {re.sub(r"[^a-z0-9]+", "", hint.lower()) for hint in label_hints}
+        normalized_labels = {_RE_NON_ALNUM_TO_EMPTY.sub("", str(label).lower()) for label in labels}
+        normalized_hints = {_RE_NON_ALNUM_TO_EMPTY.sub("", hint.lower()) for hint in label_hints}
         if normalized_labels & normalized_hints:
             return 0.15
         return 0.0

--- a/extraction/semantic_vocabulary.py
+++ b/extraction/semantic_vocabulary.py
@@ -21,11 +21,13 @@ from semantic_artifact_store import (
     list_semantic_artifacts,
 )
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+
 logger = logging.getLogger(__name__)
 
 
 def _normalize(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return _RE_NON_ALNUM_TO_SPACE.sub(" ", value.lower()).strip()
 
 
 class ManagedVocabularyResolver:

--- a/runtime/memory_service.py
+++ b/runtime/memory_service.py
@@ -20,6 +20,8 @@ from seocho.query.answering import build_evidence_bundle
 from seocho.query.query_proxy import QueryProxy, QueryRequest as GraphQueryRequest
 
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+
 class GraphMemoryService:
     """Memory-first facade over runtime ingest and semantic graph search."""
 
@@ -811,7 +813,7 @@ def _overlap_score(query: str, content: str) -> float:
 
 
 def _normalize_text(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", str(value).lower()).strip()
+    return _RE_NON_ALNUM_TO_SPACE.sub(" ", str(value).lower()).strip()
 
 
 def _utc_now_iso() -> str:

--- a/seocho/local_engine.py
+++ b/seocho/local_engine.py
@@ -13,6 +13,8 @@ from .query.executor import GraphQueryExecutor
 from .query.planner import DeterministicQueryPlanner
 from .query.run_metadata import build_local_query_metadata
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+
 logger = logging.getLogger(__name__)
 _FOUR_DIGIT_YEAR_RE = re.compile(r"\b(20\d{2})\b")
 
@@ -750,8 +752,8 @@ class _LocalEngine:
     def _company_match_score(self, company: str, anchor: str) -> int:
         if not anchor:
             return 0
-        company_norm = re.sub(r"[^a-z0-9]+", " ", company.lower())
-        anchor_norm = re.sub(r"[^a-z0-9]+", " ", anchor.lower())
+        company_norm = _RE_NON_ALNUM_TO_SPACE.sub(" ", company.lower())
+        anchor_norm = _RE_NON_ALNUM_TO_SPACE.sub(" ", anchor.lower())
         anchor_tokens = [token for token in anchor_norm.split() if token]
         return sum(2 for token in anchor_tokens if token in company_norm)
 

--- a/seocho/query/answering.py
+++ b/seocho/query/answering.py
@@ -10,6 +10,12 @@ from .intent import build_evidence_bundle, infer_question_intent
 _FOUR_DIGIT_YEAR_RE = re.compile(r"\b(20\d{2})\b")
 
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+_RE_PRIOR_YEAR_1 = re.compile(r"\bthe prior year\b", flags=re.IGNORECASE)
+_RE_PRIOR_YEAR_2 = re.compile(r"\bprior year\b", flags=re.IGNORECASE)
+_RE_PREVIOUS_YEAR_1 = re.compile(r"\bthe previous year\b", flags=re.IGNORECASE)
+_RE_PREVIOUS_YEAR_2 = re.compile(r"\bprevious year\b", flags=re.IGNORECASE)
+
 class QueryAnswerSynthesizer:
     """Canonical answer synthesis for local deterministic query execution."""
 
@@ -389,10 +395,10 @@ class QueryAnswerSynthesizer:
         if len(ordered_years) < 2:
             return text
         earlier_year = ordered_years[0]
-        normalized = re.sub(r"\bthe prior year\b", earlier_year, text, flags=re.IGNORECASE)
-        normalized = re.sub(r"\bprior year\b", earlier_year, normalized, flags=re.IGNORECASE)
-        normalized = re.sub(r"\bthe previous year\b", earlier_year, normalized, flags=re.IGNORECASE)
-        normalized = re.sub(r"\bprevious year\b", earlier_year, normalized, flags=re.IGNORECASE)
+        normalized = _RE_PRIOR_YEAR_1.sub(earlier_year, text)
+        normalized = _RE_PRIOR_YEAR_2.sub(earlier_year, normalized)
+        normalized = _RE_PREVIOUS_YEAR_1.sub(earlier_year, normalized)
+        normalized = _RE_PREVIOUS_YEAR_2.sub(earlier_year, normalized)
         return normalized
 
     @staticmethod
@@ -463,8 +469,8 @@ class QueryAnswerSynthesizer:
     def _company_match_score(self, company: str, anchor: str) -> int:
         if not anchor:
             return 0
-        company_norm = re.sub(r"[^a-z0-9]+", " ", company.lower())
-        anchor_norm = re.sub(r"[^a-z0-9]+", " ", anchor.lower())
+        company_norm = _RE_NON_ALNUM_TO_SPACE.sub(" ", company.lower())
+        anchor_norm = _RE_NON_ALNUM_TO_SPACE.sub(" ", anchor.lower())
         anchor_tokens = [token for token in anchor_norm.split() if token]
         return sum(2 for token in anchor_tokens if token in company_norm)
 

--- a/seocho/query/constraints.py
+++ b/seocho/query/constraints.py
@@ -36,6 +36,8 @@ COMMON_ALLOWED_PROPERTIES = {
 }
 
 
+_RE_NON_ALNUM_TO_EMPTY = re.compile(r"[^a-z0-9]+")
+
 @dataclass(frozen=True)
 class _CanonicalGraphTarget:
     graph_id: str
@@ -45,11 +47,11 @@ class _CanonicalGraphTarget:
 
 
 def _normalize_symbol(value: Any) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM_TO_EMPTY.sub("", str(value).lower())
 
 
 def _slugify_symbol(value: Any) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+    slug = _RE_NON_ALNUM_TO_EMPTY.sub("-", str(value).lower()).strip("-")
     return slug or "term"
 
 

--- a/seocho/query/cypher_builder.py
+++ b/seocho/query/cypher_builder.py
@@ -66,13 +66,16 @@ _GENERIC_METRIC_TOKENS = {
 }
 
 
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_TRAILING_AMPERSAND = re.compile(r"\s*&\s*$")
+
 def normalize_entity(name: str) -> str:
     """Normalize an entity name for fuzzy matching."""
     text = name.strip()
     text = text.replace("\u2019s", "").replace("'s", "")
     text = _ENTITY_SUFFIXES.sub("", text).strip()
-    text = re.sub(r"\s*&\s*$", "", text)
-    text = re.sub(r"\s+", " ", text).strip()
+    text = _RE_TRAILING_AMPERSAND.sub("", text)
+    text = _RE_WHITESPACE.sub(" ", text).strip()
     return text
 
 

--- a/seocho/query/cypher_validator.py
+++ b/seocho/query/cypher_validator.py
@@ -20,11 +20,13 @@ FORBIDDEN_CYPHER_TOKENS = (
 )
 
 
+_RE_WHITESPACE = re.compile(r"\s+")
+
 class CypherQueryValidator:
     """Validate constrained Cypher plans before execution."""
 
     def validate(self, plan: CypherPlan, constraint_slice: Dict[str, Any]) -> Dict[str, Any]:
-        normalized_query = " " + re.sub(r"\s+", " ", plan.query.upper()) + " "
+        normalized_query = " " + _RE_WHITESPACE.sub(" ", plan.query.upper()) + " "
         violations: List[str] = []
         if "$node_id" not in plan.query:
             violations.append("missing_node_binding")

--- a/seocho/query/intent.py
+++ b/seocho/query/intent.py
@@ -38,6 +38,8 @@ INTENT_CATALOG: tuple[IntentSpec, ...] = (
 )
 
 
+_RE_NON_ALNUM_TO_EMPTY = re.compile(r"[^a-z0-9]+")
+
 def infer_question_intent(question: str, entities: Sequence[str]) -> Dict[str, Any]:
     normalized = question.lower()
     best_spec = INTENT_CATALOG[-1]
@@ -200,13 +202,13 @@ def _entity_name(payload: Dict[str, Any]) -> str:
 
 
 def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_targets: Set[str]) -> str:
-    normalized_target_keys = {re.sub(r"[^a-z0-9]+", "", item.lower()) for item in normalized_targets}
+    normalized_target_keys = {_RE_NON_ALNUM_TO_EMPTY.sub("", item.lower()) for item in normalized_targets}
     for entity in entities:
         labels = entity.get("labels", [])
         if not isinstance(labels, list):
             continue
         normalized_labels = {
-            re.sub(r"[^a-z0-9]+", "", str(label).lower())
+            _RE_NON_ALNUM_TO_EMPTY.sub("", str(label).lower())
             for label in labels
         }
         if normalized_labels & normalized_target_keys:

--- a/seocho/query/semantic_agents.py
+++ b/seocho/query/semantic_agents.py
@@ -18,6 +18,12 @@ from .query_proxy import QueryExecutionError, coerce_query_records
 from .run_registry import RunMetadataRegistry
 from .strategy_chooser import ExecutionStrategyChooser, IntentSupportValidator
 
+_RE_NON_ALNUM_TO_SPACE = re.compile(r"[^a-z0-9]+")
+_RE_NON_ALNUM_TO_EMPTY = re.compile(r"[^a-z0-9]+")
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_POSSESSIVE = re.compile(r"'s\b", flags=re.IGNORECASE)
+_RE_COMPANY_SUFFIX = re.compile(r"\b(corporation|corp|company|co|incorporated)\b\.?", flags=re.IGNORECASE)
+
 logger = logging.getLogger(__name__)
 
 RDF_HINTS = {
@@ -113,11 +119,11 @@ QUERY_CONTRACT_FAILURE_CODE = "query_execution_failed_or_contract_error"
 
 
 def _normalize(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return _RE_NON_ALNUM_TO_SPACE.sub(" ", value.lower()).strip()
 
 
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM_TO_EMPTY.sub("", str(value).lower())
 
 
 def _query_rows(
@@ -943,9 +949,9 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _clean_span(value: str) -> str:
-        cleaned = re.sub(r"\s+", " ", value.strip())
+        cleaned = _RE_WHITESPACE.sub(" ", value.strip())
         cleaned = cleaned.strip(".,:;!?()[]{}")
-        cleaned = re.sub(r"'s\b", "", cleaned, flags=re.IGNORECASE)
+        cleaned = _RE_POSSESSIVE.sub("", cleaned)
         tokens = cleaned.split()
         while len(tokens) > 1 and tokens[0].lower() in LEADING_ENTITY_WRAPPER_TOKENS:
             tokens = tokens[1:]
@@ -967,7 +973,7 @@ class SemanticEntityResolver:
             terms.append(cleaned)
 
         for raw in (resolved_text, entity_text):
-            compact = re.sub(r"\b(corporation|corp|company|co|incorporated)\b\.?", "", raw, flags=re.IGNORECASE)
+            compact = _RE_COMPANY_SUFFIX.sub("", raw)
             compact = cls._clean_span(compact)
             if not compact:
                 continue
@@ -980,7 +986,7 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _normalize(value: str) -> str:
-        return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+        return _RE_NON_ALNUM_TO_SPACE.sub(" ", value.lower()).strip()
 
     @staticmethod
     def _lexical_similarity(a: str, b: str) -> float:
@@ -1001,8 +1007,8 @@ class SemanticEntityResolver:
     def _label_boost(labels: Sequence[str], label_hints: Set[str]) -> float:
         if not labels or not label_hints:
             return 0.0
-        normalized_labels = {re.sub(r"[^a-z0-9]+", "", str(label).lower()) for label in labels}
-        normalized_hints = {re.sub(r"[^a-z0-9]+", "", hint.lower()) for hint in label_hints}
+        normalized_labels = {_RE_NON_ALNUM_TO_EMPTY.sub("", str(label).lower()) for label in labels}
+        normalized_hints = {_RE_NON_ALNUM_TO_EMPTY.sub("", hint.lower()) for hint in label_hints}
         if normalized_labels & normalized_hints:
             return 0.15
         return 0.0

--- a/seocho/query/strategy_chooser.py
+++ b/seocho/query/strategy_chooser.py
@@ -6,8 +6,10 @@ from typing import Any, Dict, List, Sequence
 from .contracts import CypherPlan, InsufficiencyAssessment
 
 
+_RE_NON_ALNUM_TO_EMPTY = re.compile(r"[^a-z0-9]+")
+
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM_TO_EMPTY.sub("", str(value).lower())
 
 
 class IntentSupportValidator:

--- a/seocho/store/graph.py
+++ b/seocho/store/graph.py
@@ -29,6 +29,8 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from seocho.ontology import Ontology
 
+_RE_NON_ALNUM_TO_EMPTY = re.compile(r"[^a-z0-9]+")
+
 logger = logging.getLogger(__name__)
 
 _LABEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -134,7 +136,7 @@ def sanitize_database_name(raw: str) -> str:
     - Ensures minimum length
     - Prepends 'db' if starts with digit
     """
-    name = re.sub(r"[^a-z0-9]", "", raw.lower())
+    name = _RE_NON_ALNUM_TO_EMPTY.sub("", raw.lower())
     if not name:
         name = "seocho"
     if name[0].isdigit():


### PR DESCRIPTION
## What
Pre-compiled heavily used regular expressions for text tokenization and normalization into module-level constants across the semantic querying and indexing layers (e.g., `seocho/query/semantic_agents.py`, `extraction/semantic_query_flow.py`, `seocho/query/answering.py`, etc.). Replaced inline `re.sub(r"...", ...)` calls with corresponding `.sub(...)` methods on these pre-compiled constants.

## Why
Inline `re.sub(r"...", ...)` inside hot paths—such as iterating over all records, rows, and candidate entities during semantic resolution—incurs unnecessary regex recompilation/cache-lookup overhead. Pre-compiling to module-level constants speeds up these tight loops by caching the state machine once per module.

## Expected Impact
Small, bounded performance improvement in query resolution and text-matching hot paths without any behavioral changes. This is a low-risk optimization focused on reducing loop overhead.

## Validation
- Validated with `bash scripts/ci/run_basic_ci.sh`.
- Passed non-Python checks.
- Performed syntax-level validation (`python3 -m py_compile ...`) for the updated Python scripts to ensure correctness in the absence of full test dependency availability in the restricted environment.
- Preserved existing logic, flags (`re.IGNORECASE`), and behaviors.

## Risks
Very low risk. The logic is identical; it simply moves the pattern compilation from invocation time to module import time.

---
*PR created automatically by Jules for task [10334164816086873761](https://jules.google.com/task/10334164816086873761) started by @tteon*