### PR TITLE
Fix missing IDOR authorization checks on session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1039,12 +1039,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+
+    workspace_id = "default"
+    if history:
+        workspace_id = history[0].metadata.get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+
+    workspace_id = "default"
+    if history:
+        workspace_id = history[0].metadata.get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** Insecure Direct Object Reference (IDOR) via missing authorization checks.
**Impact:** A user could potentially interact with or reset the platform chat session histories of other workspaces by querying or deleting specific session IDs on the `PLATFORM_CHAT_SESSION` runtime endpoint, since the endpoint did not check if the workspace embedded in the chat history belonged to the authenticated user.
**Fix:** Added secure `require_runtime_permission` checks to the `platform_chat_session_get` and `platform_chat_session_reset` endpoints in `runtime/agent_server.py`. The `workspace_id` is now robustly extracted from the `metadata` payload of the queried session’s `PlatformTurn` history to enforce authorization, defaulting to `"default"` if the session is empty.
**Validation:** Verified the logic natively using `bash scripts/ci/run_basic_ci.sh`, which passed successfully for all relevant local tests and system boundaries, without regressions. Code review assessed logic safety.
**Risks:** Very low. The `PlatformTurn` schema explicitly guarantees fallback mechanisms if the list is empty, averting `IndexError` conditions.

---
*PR created automatically by Jules for task [11414416650384917295](https://jules.google.com/task/11414416650384917295) started by @tteon*