### PR TITLE
fix: missing authz check on chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1039,12 +1039,23 @@ async def platform_chat_send(request: PlatformChatRequest):
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    workspace_id = history[0].metadata.get("workspace_id", "default") if history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    workspace_id = history[0].metadata.get("workspace_id", "default") if history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
## Severity
High

## Vulnerability
Insecure Direct Object Reference (IDOR) / Missing Authorization. The session endpoints (`platform_chat_session_get` and `platform_chat_session_reset`) in `runtime/agent_server.py` lacked authorization checks on the incoming request. They retrieved or deleted chat history strictly based on the provided `session_id`, bypassing runtime permission enforcement for the relevant workspace.

## Impact
Any user could read or delete the chat session history of any other user in the platform, simply by knowing or guessing the `session_id`.

## Fix
The `workspace_id` is now securely extracted from the `metadata` of the first item in the platform session's turn history (`history[0].metadata.get("workspace_id", "default")`). If the session has no history, we fall back to "default". This extracted `workspace_id` is then used to enforce the `run_platform` permission via `require_runtime_permission`. 

## Validation
- Executed `bash scripts/ci/run_basic_ci.sh`, which passed all checks with no regressions.
- Evaluated unit testing suite through `uv run pytest tests/`, successfully passing all 9 tests.

## Risks
None identified. The changes are tightly scoped to the specific vulnerable endpoints and provide safe fallbacks for edge cases (e.g. empty history).

---
*PR created automatically by Jules for task [16884443324811603258](https://jules.google.com/task/16884443324811603258) started by @tteon*