### PR TITLE
perf: stream jsonl to csv line-by-line in tracing.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,3 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+
+When exporting or processing large .jsonl files, stream the data iteratively line-by-line rather than loading the entire file into memory to prevent O(N) memory scaling bottlenecks.

--- a/seocho/tracing.py
+++ b/seocho/tracing.py
@@ -744,41 +744,41 @@ def export_traces_csv(
             "elapsed_seconds",
         ]
 
-    records = []
-    with open(jsonl_path, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                raw = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            out = raw.get("output", {})
-            meta = raw.get("metadata", {})
-            usage = meta.get("usage", {})
-
-            record = {
-                "timestamp": raw.get("timestamp", ""),
-                "name": raw.get("name", ""),
-                "model": meta.get("model", raw.get("input", {}).get("model", "")),
-                "input_tokens": usage.get("prompt_tokens", ""),
-                "output_tokens": usage.get("completion_tokens", ""),
-                "total_tokens": usage.get("total_tokens", ""),
-                "nodes": out.get("nodes", ""),
-                "relationships": out.get("relationships", ""),
-                "score": out.get("score", ""),
-                "validation_errors": out.get("validation_errors", ""),
-                "result_count": out.get("result_count", ""),
-                "reasoning_attempts": out.get("reasoning_attempts", ""),
-                "elapsed_seconds": meta.get("elapsed_seconds", ""),
-            }
-            records.append(record)
-
-    with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv_mod.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+    record_count = 0
+    with open(csv_path, "w", newline="", encoding="utf-8") as out_f:
+        writer = csv_mod.DictWriter(out_f, fieldnames=fields, extrasaction="ignore")
         writer.writeheader()
-        writer.writerows(records)
 
-    return len(records)
+        with open(jsonl_path, "r", encoding="utf-8") as in_f:
+            for line in in_f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                out = raw.get("output", {})
+                meta = raw.get("metadata", {})
+                usage = meta.get("usage", {})
+
+                record = {
+                    "timestamp": raw.get("timestamp", ""),
+                    "name": raw.get("name", ""),
+                    "model": meta.get("model", raw.get("input", {}).get("model", "")),
+                    "input_tokens": usage.get("prompt_tokens", ""),
+                    "output_tokens": usage.get("completion_tokens", ""),
+                    "total_tokens": usage.get("total_tokens", ""),
+                    "nodes": out.get("nodes", ""),
+                    "relationships": out.get("relationships", ""),
+                    "score": out.get("score", ""),
+                    "validation_errors": out.get("validation_errors", ""),
+                    "result_count": out.get("result_count", ""),
+                    "reasoning_attempts": out.get("reasoning_attempts", ""),
+                    "elapsed_seconds": meta.get("elapsed_seconds", ""),
+                }
+                writer.writerow(record)
+                record_count += 1
+
+    return record_count


### PR DESCRIPTION
**What**
Refactored `export_traces_csv` in `seocho/tracing.py` to stream data from `.jsonl` directly to the `.csv` file instead of accumulating all rows in a memory list.

**Why**
The previous implementation buffered the entire dataset into memory before writing to the CSV. This presents an `O(N)` memory scaling bottleneck, which can lead to application failure or severe memory bloat when tracing logs grow large over time.

**Expected Impact**
- Memory footprint during CSV trace export becomes `O(1)`.
- Prevents out-of-memory errors on large trace dumps.

**Validation**
- Validated via `uv run pytest seocho/tests/test_tracing.py` and `bash scripts/ci/run_basic_ci.sh`, confirming no functionality or schema differences.
- Explicitly maintained backward-compatible logic for JSON schema parsing. 

**Risks**
- Extremely low risk. The input/output formats are perfectly matched, and error handling for bad JSON lines has been accurately ported.

---
*PR created automatically by Jules for task [15346682930699010910](https://jules.google.com/task/15346682930699010910) started by @tteon*