### PR TITLE
Refactor 'Reset Trace' button in evaluation UI to improve accessibility and code style

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,20 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+/* Reset Session Button */
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover,
+.reset-session-btn:focus-visible {
+  color: #fff;
+}


### PR DESCRIPTION
**What:**
Refactored the "Reset Trace" button in the Evaluation Console UI (`evaluation/static/index.html`) by removing inline styles and Javascript (`onmouseover`, `onmouseout`) and migrating them to a dedicated CSS class `.reset-session-btn` in `evaluation/static/styles.css`. Also added a `:focus-visible` CSS rule for the button.

**Why:**
To improve the maintainability of the frontend code and ensure better accessibility for users navigating the UI with a keyboard.

**Accessibility / UX Impact:**
Added a clear `color: #fff` styling via the `:focus-visible` pseudo-class. This ensures the "Reset Trace" button responds visually to keyboard focus, an accessibility requirement that was previously missing due to the button relying solely on mouse hover events.

**Validation:**
1. Manually verified changes to the HTML and CSS via `grep` and `tail`.
2. Started a local Uvicorn development server (`uv run uvicorn evaluation.server:app --port 8501`).
3. Executed a `playwright` script to hover over the newly styled button and captured a successful screenshot verifying layout and styling integrity.
4. Cleaned up the dev server and test scripts.
5. Successfully ran all backend shell and python test contracts via `bash scripts/ci/run_basic_ci.sh`.

**Risks:**
Very low risk. The change is isolated to a single button's visual presentation on the frontend and touches no backend or platform logic. Backward compatibility across browsers that support `:focus-visible` is widely standard.

---
*PR created automatically by Jules for task [10473614076716075500](https://jules.google.com/task/10473614076716075500) started by @tteon*