### PR TITLE
perf: incremental loading for JSONLResponseCache

### DIFF
--- a/seocho/response_cache.py
+++ b/seocho/response_cache.py
@@ -115,20 +115,42 @@ class JSONLResponseCache(ResponseCache):
         self._path = path
         self._lock = threading.RLock()
         os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+        self._index: Dict[CacheKey, CachedResponse] = {}
+        self._last_offset = 0
 
     def _load_index(self) -> Dict[CacheKey, CachedResponse]:
-        index: Dict[CacheKey, CachedResponse] = {}
         if not os.path.exists(self._path):
-            return index
+            self._index.clear()
+            self._last_offset = 0
+            return self._index
         try:
+            current_size = os.path.getsize(self._path)
+            if current_size < self._last_offset:
+                self._index.clear()
+                self._last_offset = 0
+
+            if current_size == self._last_offset:
+                return self._index
+
             with open(self._path, "r", encoding="utf-8") as fh:
-                for line in fh:
-                    line = line.strip()
+                fh.seek(self._last_offset)
+                while True:
+                    line = fh.readline()
                     if not line:
+                        break
+
+                    if not line.endswith("\n"):
+                        # Partial write, stop here and wait for next read
+                        break
+
+                    stripped = line.strip()
+                    if not stripped:
+                        self._last_offset = fh.tell()
                         continue
                     try:
-                        rec = json.loads(line)
+                        rec = json.loads(stripped)
                     except json.JSONDecodeError:
+                        self._last_offset = fh.tell()
                         continue
                     key = (
                         str(rec.get("workspace_id", "")),
@@ -136,14 +158,15 @@ class JSONLResponseCache(ResponseCache):
                         str(rec.get("ontology_identity_hash", "")),
                         str(rec.get("question", "")),
                     )
-                    index[key] = CachedResponse(
+                    self._index[key] = CachedResponse(
                         answer=str(rec.get("answer", "")),
                         written_at=float(rec.get("written_at", 0.0)),
                         metadata=dict(rec.get("metadata") or {}),
                     )
+                    self._last_offset = fh.tell()
         except OSError:
             pass
-        return index
+        return self._index
 
     def get(self, key: CacheKey) -> Optional[CachedResponse]:
         with self._lock:
@@ -169,3 +192,5 @@ class JSONLResponseCache(ResponseCache):
                 os.unlink(self._path)
             except FileNotFoundError:
                 pass
+            self._index.clear()
+            self._last_offset = 0


### PR DESCRIPTION
**What**
Refactored `JSONLResponseCache._load_index` to tail the append-only `.jsonl` cache file using `_last_offset` and an in-memory dictionary.

**Why**
Previously, `_load_index` read and decoded the entire JSONL file line-by-line into a new dictionary every time `get()` was called (which could happen repeatedly during agent sessions). As the cache grew, this caused an $O(N^2)$ file I/O and CPU overhead. By keeping the index in memory and tracking the byte offset, we avoid re-parsing older cache records.

**Expected Impact**
Significant performance improvement for long-running workflows with large response caches. It drops the cache lookup time from $O(N)$ (where $N$ is cache size) down to an amortized $O(1)$. 

**Validation**
- `uv run pytest seocho/tests/test_response_cache.py` (passes all checks for edge cases, missing files, truncations, overwrites)
- `bash scripts/ci/run_basic_ci.sh` (all canonical CI rules pass locally)

**Risks**
The implementation handles partial writes using `endswith("\n")` checks and resets on file truncation/compaction. There is a small theoretical risk if the cache file is manually manipulated in a way that breaks append-only semantics, but the code falls back gracefully if JSON decode fails.

---
*PR created automatically by Jules for task [13955174773299511532](https://jules.google.com/task/13955174773299511532) started by @tteon*