### PR TITLE
Draft: Refactor reset trace button inline styles to CSS

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,3 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+Log entry: Moving inline styles and JS handlers to CSS classes improves maintainability and ensures better adherence to Content Security Policies (CSP).

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-trace-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,18 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+.reset-trace-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-trace-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
## What
Refactored the "Reset Trace" button in the Evaluation UI (`evaluation/static/index.html`) by extracting its inline CSS styles and inline JavaScript event handlers (`onmouseover`, `onmouseout`) into a dedicated `.reset-trace-btn` CSS class in `evaluation/static/styles.css`.

## Why
Using inline styles and JavaScript event handlers for styling is difficult to maintain and goes against modern frontend best practices. Moving these rules to a central CSS file makes the styles reusable, keeps the HTML semantic and clean, and paves the way for easier compliance with strict Content Security Policies (CSP).

## Accessibility / UX Impact
- **UX Impact:** Minor visual improvement by adding a smooth `transition: color 0.2s` rule, making the hover effect less abrupt.
- **Accessibility Impact:** The button retains its standard `<button>` behavior and keyboard focusability. Relying on CSS pseudo-classes (`:hover`) rather than JS events ensures style changes work consistently across all browsing contexts without relying on JavaScript execution for basic styling.

## Validation
- Verified the UI changes visually by capturing a screenshot using Playwright; the button renders correctly in the top bar.
- Confirmed the ID `resetSessionBtn` remained intact so existing JS logic won't break.
- Ran the core repository CI tests via `bash scripts/ci/run_basic_ci.sh`, which passed successfully.

## Risks
Minimal risk. This is a purely visual/structural refactor of a single UI button. No backend logic or functional Javascript behavior was altered.

---
*PR created automatically by Jules for task [8133761024784950338](https://jules.google.com/task/8133761024784950338) started by @tteon*