### PR TITLE
Fix missing authorization on session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,29 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_rows:
+        workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default")
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in history_rows]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_rows:
+        workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default")
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
Severity: High

Vulnerability: Missing authorization (IDOR-like) on session retrieve and reset endpoints in `runtime/agent_server.py`. The endpoints trusted that any caller with a session ID was authorized to view or reset the history.

Impact: A user could potentially access or reset other users' interactive sessions by guessing or brute-forcing session IDs, bypassing isolation and leading to data leakage or denial of service.

Fix: Extract the `workspace_id` from the session history's `metadata` and explicitly require the `run_platform` permission via `require_runtime_permission`. The logic safely handles cases where history is empty or metadata is missing.

Validation: 
- Ran an isolated mock script (`test_authz_local.py`) to verify extraction and permission calls.
- Ran basic CI checks (`scripts/ci/run_basic_ci.sh`) to ensure syntax, shell contracts, and agent docs remain intact.

Risks: Minor overhead on fetching the session array to extract the `workspace_id` prior to the main logic flow. Edge cases where the session history has no elements cleanly default to `"default"` workspace.

---
*PR created automatically by Jules for task [13933193287019359865](https://jules.google.com/task/13933193287019359865) started by @tteon*