### PR TITLE
Refactor reset trace button hover styles to use native CSS

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,2 +1,3 @@
 - Ensure all interactive elements like select, input, textarea have 'box-shadow: 0 0 0 1px var(--accent-blue);' on :focus and buttons have 'button:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }' for proper keyboard accessibility.
 - All form controls (<input>, <select>, <textarea>) in the evaluation UI must have explicit `aria-label` attributes to satisfy strict accessibility requirements, even when implicitly wrapped inside a `<label>` element.
+\n- Avoid inline styles and inline JavaScript event handlers (e.g., onmouseover) in HTML for UI components. Use dedicated CSS classes and standard pseudo-classes like :hover or :focus-visible for better maintainability and proper keyboard accessibility.

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -160,6 +160,22 @@ body {
   color: var(--text-muted);
 }
 
+
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-btn:hover {
+  color: #fff;
+}
+
 .status-wrap {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### What
Replaced inline CSS styles and inline JavaScript event handlers (`onmouseover` and `onmouseout`) on the "Reset Trace" button in the workflow console UI with a dedicated `.reset-btn` CSS class and standard `:hover` pseudo-class.

### Why
Inline JavaScript event handlers for styling create poor separation of concerns, are harder to maintain, and can sometimes interfere with assistive technologies or strict Content Security Policies. Moving styling to CSS improves code clarity and ensures consistent browser rendering.

### Accessibility / UX Impact
Improves code maintainability and ensures hover states are handled natively by the browser CSS engine rather than via JavaScript, providing a slightly more robust visual response and aligning with standard web accessibility practices for interactive components.

### Validation
- Local execution of Playwright test script (`test_focus.py`) successfully identified the button, focused it, and generated a screenshot and recorded video showing proper layout and focus states without any regression.
- Local CI test suite (`bash scripts/ci/run_basic_ci.sh`) passed, verifying no unintended breakages across runtime contracts.

### Risks
Low risk. The change is isolated to the evaluation UI's `index.html` and `styles.css`. No backend routing, semantics, or multi-agent behavior was modified.

---
*PR created automatically by Jules for task [14752509051550817284](https://jules.google.com/task/14752509051550817284) started by @tteon*