### PR TITLE
Security: Add missing authorization checks to chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1039,12 +1039,23 @@ async def platform_chat_send(request: PlatformChatRequest):
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
     history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    workspace_id = (history[0].metadata or {}).get("workspace_id", "default") if history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    workspace_id = (history[0].metadata or {}).get("workspace_id", "default") if history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
### Severity
High

### Vulnerability
Missing authorization checks (IDOR-like) on `platform_chat_session_get` and `platform_chat_session_reset` endpoints. These endpoints were allowing session retrieval and deletion without verifying if the user had permission to access the workspace associated with the session.

### Impact
An attacker could potentially read or reset chat sessions belonging to other users or workspaces if they knew or guessed a valid `session_id`.

### Fix
Added `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` to both endpoints. The `workspace_id` is securely extracted from the `metadata` field of the first turn in the session history, defaulting to `"default"` if the history is empty or the metadata is missing. 

### Validation
- Validated via `bash scripts/ci/run_basic_ci.sh` to ensure no syntax/contract breakages.
- Validated via `uv run pytest extraction/tests/test_api_endpoints.py` and full suite test (`uv run pytest seocho/tests/`) to ensure no new regressions were introduced by the exception handling logic.

### Risks
Low risk. The fallback logic correctly handles edge cases for new sessions (empty history) by using the `"default"` workspace, mirroring behavior seen in other parts of the runtime. No schema changes were made.

---
*PR created automatically by Jules for task [2533637705603135221](https://jules.google.com/task/2533637705603135221) started by @tteon*