### PR TITLE
perf: stream JSONL to CSV in trace export to fix memory bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 When logging history, traces, or metadata (such as prompt history), prefer append-only `.jsonl` format over reading and rewriting full JSON arrays to prevent O(N^2) file I/O scaling bottlenecks.
+When exporting or processing large .jsonl files (e.g., in tracing or logging), stream the data iteratively line-by-line rather than loading the entire file into memory (e.g., via readlines() or full list appends) to prevent O(N) memory scaling bottlenecks.

--- a/seocho/tracing.py
+++ b/seocho/tracing.py
@@ -744,41 +744,41 @@ def export_traces_csv(
             "elapsed_seconds",
         ]
 
-    records = []
-    with open(jsonl_path, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                raw = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            out = raw.get("output", {})
-            meta = raw.get("metadata", {})
-            usage = meta.get("usage", {})
-
-            record = {
-                "timestamp": raw.get("timestamp", ""),
-                "name": raw.get("name", ""),
-                "model": meta.get("model", raw.get("input", {}).get("model", "")),
-                "input_tokens": usage.get("prompt_tokens", ""),
-                "output_tokens": usage.get("completion_tokens", ""),
-                "total_tokens": usage.get("total_tokens", ""),
-                "nodes": out.get("nodes", ""),
-                "relationships": out.get("relationships", ""),
-                "score": out.get("score", ""),
-                "validation_errors": out.get("validation_errors", ""),
-                "result_count": out.get("result_count", ""),
-                "reasoning_attempts": out.get("reasoning_attempts", ""),
-                "elapsed_seconds": meta.get("elapsed_seconds", ""),
-            }
-            records.append(record)
-
-    with open(csv_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv_mod.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+    exported_count = 0
+    with open(csv_path, "w", newline="", encoding="utf-8") as f_out:
+        writer = csv_mod.DictWriter(f_out, fieldnames=fields, extrasaction="ignore")
         writer.writeheader()
-        writer.writerows(records)
 
-    return len(records)
+        with open(jsonl_path, "r", encoding="utf-8") as f_in:
+            for line in f_in:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    raw = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                out = raw.get("output", {})
+                meta = raw.get("metadata", {})
+                usage = meta.get("usage", {})
+
+                record = {
+                    "timestamp": raw.get("timestamp", ""),
+                    "name": raw.get("name", ""),
+                    "model": meta.get("model", raw.get("input", {}).get("model", "")),
+                    "input_tokens": usage.get("prompt_tokens", ""),
+                    "output_tokens": usage.get("completion_tokens", ""),
+                    "total_tokens": usage.get("total_tokens", ""),
+                    "nodes": out.get("nodes", ""),
+                    "relationships": out.get("relationships", ""),
+                    "score": out.get("score", ""),
+                    "validation_errors": out.get("validation_errors", ""),
+                    "result_count": out.get("result_count", ""),
+                    "reasoning_attempts": out.get("reasoning_attempts", ""),
+                    "elapsed_seconds": meta.get("elapsed_seconds", ""),
+                }
+                writer.writerow(record)
+                exported_count += 1
+
+    return exported_count


### PR DESCRIPTION
**What**
Refactored `export_traces_csv` in `seocho/tracing.py` to stream JSONL records one line at a time and write them immediately to the destination CSV, rather than reading all records into an in-memory list first. Added a learning regarding streaming JSONL parsing to `.jules/bolt.md`.

**Why**
The original implementation accumulated the entire `.jsonl` trace file in a Python list (`records.append(record)`) before writing anything to the output CSV. This constitutes an avoidable file I/O and JSONL parsing O(N) memory scaling bottleneck for large trace artifacts, conflicting with the repository's performance guidelines.

**Expected Impact**
O(1) memory footprint during trace exports regardless of the size of the `.jsonl` file. Time complexity remains linear. No behavioral change to the output CSV formatting or parsing logic.

**Validation**
- `uv run pytest seocho/tests/test_tracing.py` passed.
- `bash scripts/ci/run_basic_ci.sh` passed.
- Manually created a test script that instantiated a mock jsonl trace file and confirmed that the generated CSV output was identical after the patch.

**Risks**
Extremely low risk as the parsing and mapping logic is identical, only the storage mechanics were changed from buffering a list to directly writing rows. No public or remote APIs are affected.

---
*PR created automatically by Jules for task [10674909671559295053](https://jules.google.com/task/10674909671559295053) started by @tteon*