### PR TITLE
Fix IDOR vulnerability in platform session retrieval APIs

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,35 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        metadata = raw_history[0].get("metadata") or {}
+        workspace_id = metadata.get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        metadata = raw_history[0].get("metadata") or {}
+        workspace_id = metadata.get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
## Severity
High

## Vulnerability
Insecure Direct Object Reference (IDOR). The `platform_chat_session_get` and `platform_chat_session_reset` API endpoints accepted an unauthenticated `session_id` directly, completely bypassing `require_runtime_permission` checks applied to other sensitive paths.

## Impact
An attacker with no authentication could sequentially guess or directly specify `session_id`s to view private chat history (including traces and query payloads) or destructively wipe active sessions for other users.

## Fix
Added `require_runtime_permission` checks to both endpoints. The target `workspace_id` is securely extracted from the underlying session record's `metadata` using `platform_session_store.get(session_id)` to prevent trusting arbitrary query parameters for access control. If the session history is empty, it safely defaults to the "default" workspace namespace before running the RBAC check.

## Validation
*   Verified patches manually (`cat`).
*   Ran `bash scripts/ci/run_basic_ci.sh`. All runtime alias and contract checks continue to pass securely.

## Risks
If custom API clients pass malformed metadata missing a `workspace_id` entirely, the endpoints will safely default to checking the `"default"` scope. No architectural or ontology retrieval code was modified.

---
*PR created automatically by Jules for task [15764864596050750988](https://jules.google.com/task/15764864596050750988) started by @tteon*