### PR TITLE
style(ui): refactor reset trace button styles to CSS

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -581,3 +581,18 @@ button:focus-visible {
     stroke-dashoffset: -16;
   }
 }
+
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+}


### PR DESCRIPTION
**What:**
Refactored the "Reset Trace" button in the workflow evaluation UI (`evaluation/static/index.html`) to use a dedicated CSS class (`.reset-session-btn`) instead of inline styles and JavaScript event handlers (`onmouseover`/`onmouseout`).

**Why:**
This change improves the maintainability and cleanliness of the UI code. It removes inline event handlers, aligning with better security and maintainability practices, and moves styling to a single source of truth in `styles.css`.

**Accessibility / UX Impact:**
This provides a subtle UX improvement by introducing a CSS transition for the hover color change, making the interaction feel slightly smoother. It also improves keyboard accessibility conceptually, as focus management and hover states are more reliably handled by native CSS pseudo-classes.

**Validation:**
- Local UI inspection and Playwright programmatic testing verified the button maintains its intended visual state and behavior.
- Playwright screenshot captured and verified.
- `bash scripts/ci/run_basic_ci.sh` passed successfully.

**Risks:**
Extremely low risk. This is an isolated styling refactor on a single element and introduces no functional backend or runtime changes.

---
*PR created automatically by Jules for task [8895413454697989857](https://jules.google.com/task/8895413454697989857) started by @tteon*