### PR TITLE
feat: extend intent classifier with limitation/alternative tradeoff extraction

### DIFF
--- a/extraction/tests/test_memory_service.py
+++ b/extraction/tests/test_memory_service.py
@@ -180,6 +180,76 @@ def test_search_memories_adds_evidence_bundle_to_ranked_results():
     assert result["evidence_bundle"]["slot_fills"]["target_entity"] == "Seoul"
 
 
+def test_search_memories_surfaces_tradeoff_points_in_evidence_bundle():
+    class _ResolverWithTradeoffIntent:
+        def resolve(self, question, databases, workspace_id="default"):
+            return {
+                "entities": ["Python"],
+                "matches": {
+                    "Python": [
+                        {
+                            "database": "kgnormal",
+                            "memory_id": "mem_python",
+                            "source_id": "mem_python",
+                            "display_name": "Python",
+                            "node_id": "501",
+                            "labels": ["Language"],
+                            "source": "fulltext",
+                            "final_score": 0.96,
+                        }
+                    ]
+                },
+                "unresolved_entities": [],
+                "intent": {
+                    "intent_id": "engineering_tradeoff_lookup",
+                    "required_relations": [],
+                    "required_entity_types": ["Entity"],
+                    "focus_slots": ["target_entity", "limitation_points", "alternative_points", "supporting_fact"],
+                },
+                "evidence_bundle_preview": {"intent_id": "engineering_tradeoff_lookup"},
+            }
+
+    class _SemanticFlowWithTradeoffIntent:
+        def __init__(self):
+            self.resolver = _ResolverWithTradeoffIntent()
+
+    service = GraphMemoryService(
+        db_manager=_FakeDbManager(),
+        runtime_raw_ingestor=_FakeIngestor(),
+        semantic_agent_flow=_SemanticFlowWithTradeoffIntent(),
+    )
+
+    service.get_memory = lambda **_: {
+        "memory_id": "mem_python",
+        "workspace_id": "default",
+        "content": "Python's main limitation for CPU-bound parallel work is the GIL. Use multiprocessing or Ray instead.",
+        "content_preview": "Python's main limitation for CPU-bound parallel work is the GIL. Use multiprocessing or Ray instead.",
+        "metadata": {"source": "note"},
+        "status": "active",
+        "created_at": "2026-05-19T00:00:00Z",
+        "updated_at": "2026-05-19T00:00:00Z",
+        "database": "kgnormal",
+        "entities": [
+            {"id": "n1", "labels": ["Language"], "name": "Python"},
+            {"id": "n2", "labels": ["Limitation"], "name": "GIL"},
+            {"id": "n3", "labels": ["Alternative"], "name": "multiprocessing"},
+            {"id": "n4", "labels": ["Alternative"], "name": "Ray"},
+        ],
+    }
+
+    payload = service.search_memories(
+        workspace_id="default",
+        query="What limits Python parallel work, and what alternatives avoid the GIL?",
+        limit=3,
+    )
+
+    result = payload["results"][0]
+    assert result["evidence_bundle"]["intent_id"] == "engineering_tradeoff_lookup"
+    assert result["evidence_bundle"]["slot_fills"]["target_entity"] == "Python"
+    assert result["evidence_bundle"]["slot_fills"]["limitation_points"] == ["GIL"]
+    assert result["evidence_bundle"]["slot_fills"]["alternative_points"] == ["multiprocessing", "Ray"]
+
+
 def test_scope_filter_allows_workspace_level_memory_for_scoped_query():
     service = GraphMemoryService(
         db_manager=_FakeDbManager(),

--- a/seocho/query/insufficiency.py
+++ b/seocho/query/insufficiency.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, Sequence, Set
 
 from .contracts import InsufficiencyAssessment
+from .intent import extract_tradeoff_points_from_triples
 
 
 class QueryInsufficiencyClassifier:
@@ -32,6 +33,18 @@ class QueryInsufficiencyClassifier:
                 filled_slots.add("owner_or_operator")
             if row.get("supporting_fact") or row.get("properties") or row.get("neighbors"):
                 filled_slots.add("supporting_fact")
+            if row.get("limitation_points"):
+                filled_slots.add("limitation_points")
+            if row.get("alternative_points"):
+                filled_slots.add("alternative_points")
+
+        tradeoff_points = extract_tradeoff_points_from_triples(
+            selected_triples=_triples_from_rows(rows),
+        )
+        if tradeoff_points["limitation_points"]:
+            filled_slots.add("limitation_points")
+        if tradeoff_points["alternative_points"]:
+            filled_slots.add("alternative_points")
 
         if intent_id == "relationship_lookup" and not any(row.get("relation_type") for row in rows):
             return InsufficiencyAssessment(
@@ -66,3 +79,35 @@ class QueryInsufficiencyClassifier:
             row_count=row_count,
             filled_slots=tuple(sorted(filled_slots)),
         )
+
+
+def _triples_from_rows(rows: Sequence[Dict[str, Any]]) -> list[Dict[str, Any]]:
+    triples: list[Dict[str, Any]] = []
+    for row in rows:
+        relation_type = str(row.get("relation_type", "")).strip()
+        target_entity = str(row.get("target_entity", "")).strip()
+        if relation_type and target_entity:
+            triples.append(
+                {
+                    "source": row.get("source_entity") or row.get("owner_or_operator") or "",
+                    "relation": relation_type,
+                    "target": target_entity,
+                    "target_labels": row.get("target_labels", []),
+                }
+            )
+        for neighbor in row.get("neighbors", []) if isinstance(row.get("neighbors"), list) else []:
+            if not isinstance(neighbor, dict):
+                continue
+            relation = str(neighbor.get("relation", "")).strip()
+            target = str(neighbor.get("target", "")).strip()
+            if not relation or not target:
+                continue
+            triples.append(
+                {
+                    "source": row.get("target_entity") or row.get("source_entity") or "",
+                    "relation": relation,
+                    "target": target,
+                    "target_labels": neighbor.get("target_labels", []),
+                }
+            )
+    return triples

--- a/seocho/query/intent.py
+++ b/seocho/query/intent.py
@@ -6,6 +6,109 @@ from typing import Any, Dict, List, Optional, Sequence, Set
 from .contracts import IntentSpec
 
 
+LIMITATION_TEXT_HINTS = (
+    "limitation",
+    "limitations",
+    "constraint",
+    "constraints",
+    "bottleneck",
+    "bottlenecks",
+    "drawback",
+    "drawbacks",
+    "downside",
+    "downsides",
+    "single-thread",
+    "single thread",
+    "serial",
+    "serialized",
+    "blocked",
+    "blocking",
+    "limited by",
+    "constrained by",
+    "due to",
+    "because of",
+    "gil",
+    "global interpreter lock",
+)
+
+ALTERNATIVE_TEXT_HINTS = (
+    "alternative",
+    "alternatives",
+    "instead",
+    "parallel",
+    "parallelism",
+    "parallelize",
+    "parallelized",
+    "workaround",
+    "workarounds",
+    "bypass",
+    "avoid",
+    "multiprocessing",
+    "multi-processing",
+    "process pool",
+    "worker pool",
+    "ray",
+    "dask",
+    "celery",
+    "asyncio",
+    "joblib",
+    "subprocess",
+)
+
+LIMITATION_RELATION_HINTS = {
+    "limitedby",
+    "constrainedby",
+    "blockedby",
+    "bottleneckedby",
+    "haslimitation",
+    "hasconstraint",
+    "hasdrawback",
+    "prevents",
+    "restricts",
+}
+
+ALTERNATIVE_RELATION_HINTS = {
+    "alternativeto",
+    "usesalternative",
+    "parallelizedwith",
+    "parallelwith",
+    "workaroundwith",
+    "bypasswith",
+    "recommendedwith",
+    "replacedby",
+    "scalewith",
+}
+
+LIMITATION_LABEL_HINTS = {
+    "limitation",
+    "constraint",
+    "bottleneck",
+    "drawback",
+}
+
+ALTERNATIVE_LABEL_HINTS = {
+    "alternative",
+    "workaround",
+    "paralleltool",
+    "parallelstrategy",
+    "solution",
+}
+
+COMMON_ALTERNATIVE_TECHNIQUE_HINTS = (
+    "multiprocessing",
+    "multi processing",
+    "ray",
+    "dask",
+    "celery",
+    "joblib",
+    "asyncio",
+    "subprocess",
+    "process pool",
+    "thread pool",
+    "worker pool",
+)
+
+
 INTENT_CATALOG: tuple[IntentSpec, ...] = (
     IntentSpec(
         intent_id="relationship_lookup",
@@ -20,6 +123,26 @@ INTENT_CATALOG: tuple[IntentSpec, ...] = (
         required_entity_types=("Person", "Organization"),
         focus_slots=("owner_or_operator", "target_entity", "supporting_fact"),
         trigger_keywords=("who manages", "manages", "owner", "owns", "owned", "leads", "lead", "responsible", "operates"),
+    ),
+    IntentSpec(
+        intent_id="engineering_tradeoff_lookup",
+        required_relations=(),
+        required_entity_types=("Entity",),
+        focus_slots=("target_entity", "limitation_points", "alternative_points", "supporting_fact"),
+        trigger_keywords=(
+            "limitation",
+            "limitations",
+            "constraint",
+            "constraints",
+            "bottleneck",
+            "tradeoff",
+            "tradeoffs",
+            "alternative",
+            "alternatives",
+            "parallel",
+            "parallelism",
+            "gil",
+        ),
     ),
     IntentSpec(
         intent_id="explanation_lookup",
@@ -131,7 +254,7 @@ def build_evidence_bundle(
     elif candidate_entities:
         slot_fills["target_entity"] = candidate_entities[0]["display_name"]
 
-    if len(matched_entity_names) > 1:
+    if "source_entity" in focus_slots and len(matched_entity_names) > 1:
         slot_fills["source_entity"] = matched_entity_names[0]
         slot_fills["target_entity"] = matched_entity_names[1]
 
@@ -143,6 +266,24 @@ def build_evidence_bundle(
         slot_fills["owner_or_operator"] = labeled_owner
 
     preview = str(memory_payload.get("content_preview") or memory_payload.get("content") or "").strip()
+    tradeoff_from_entities = _tradeoff_points_from_entities(prioritized_memory_entities)
+    tradeoff_from_preview = extract_tradeoff_points_from_text(preview)
+    limitation_points = _dedupe_points(
+        [
+            *tradeoff_from_entities["limitation_points"],
+            *tradeoff_from_preview["limitation_points"],
+        ]
+    )
+    alternative_points = _dedupe_points(
+        [
+            *tradeoff_from_entities["alternative_points"],
+            *tradeoff_from_preview["alternative_points"],
+        ]
+    )
+    if limitation_points and "limitation_points" in focus_slots:
+        slot_fills["limitation_points"] = limitation_points
+    if alternative_points and "alternative_points" in focus_slots:
+        slot_fills["alternative_points"] = alternative_points
     if preview and "supporting_fact" in focus_slots:
         slot_fills["supporting_fact"] = preview
 
@@ -199,6 +340,110 @@ def _entity_name(payload: Dict[str, Any]) -> str:
     return str(payload.get("name") or payload.get("display_name") or "").strip()
 
 
+def extract_tradeoff_points_from_text(text: str) -> Dict[str, List[str]]:
+    if not text:
+        return {"limitation_points": [], "alternative_points": []}
+
+    limitation_points: List[str] = []
+    alternative_points: List[str] = []
+    normalized_text = text.lower()
+
+    if "gil" in normalized_text or "global interpreter lock" in normalized_text:
+        limitation_points.append("GIL")
+
+    limitation_patterns = (
+        r"(?:limited by|constrained by|blocked by|bottlenecked by)\s+([^.;\n]+)",
+        r"(?:limitation|constraint|bottleneck|drawback|downside)\s+(?:is|comes from|comes down to)\s+([^.;\n]+)",
+        r"(?:because of|due to)\s+([^.;\n]+)",
+    )
+    for pattern in limitation_patterns:
+        for match in re.findall(pattern, text, flags=re.IGNORECASE):
+            limitation_points.extend(_split_compact_points(match))
+
+    alternative_patterns = (
+        r"(?:alternatives include|alternative approaches include|consider|use|try|prefer)\s+([^.;\n]+?)(?:\s+instead)?(?:[.;\n]|$)",
+        r"(?:instead use|instead try)\s+([^.;\n]+?)(?:[.;\n]|$)",
+    )
+    for pattern in alternative_patterns:
+        for match in re.findall(pattern, text, flags=re.IGNORECASE):
+            alternative_points.extend(_split_compact_points(match))
+
+    for hint in COMMON_ALTERNATIVE_TECHNIQUE_HINTS:
+        if re.search(rf"\b{re.escape(hint)}\b", normalized_text):
+            alternative_points.append(_canonicalize_point_text(hint))
+
+    sentences = [
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?])\s+|\n+", text)
+        if sentence.strip()
+    ]
+    if not limitation_points:
+        for sentence in sentences:
+            if any(hint in sentence.lower() for hint in LIMITATION_TEXT_HINTS):
+                limitation_points.append(_compact_sentence(sentence))
+                break
+    if not alternative_points:
+        for sentence in sentences:
+            if any(hint in sentence.lower() for hint in ALTERNATIVE_TEXT_HINTS):
+                alternative_points.append(_compact_sentence(sentence))
+                break
+
+    return {
+        "limitation_points": _dedupe_points(limitation_points),
+        "alternative_points": _dedupe_points(alternative_points),
+    }
+
+
+def extract_tradeoff_points_from_triples(
+    *,
+    question: str = "",
+    selected_triples: Sequence[Dict[str, Any]],
+) -> Dict[str, List[str]]:
+    limitation_points: List[str] = []
+    alternative_points: List[str] = []
+    normalized_question = _normalize_symbol(question)
+    prefers_parallel_alternatives = any(
+        hint in normalized_question
+        for hint in ("parallel", "parallelism", "workaround", "alternative", "alternatives")
+    )
+
+    for triple in selected_triples:
+        if not isinstance(triple, dict):
+            continue
+        target = str(triple.get("target") or "").strip()
+        if not target:
+            continue
+        relation = _normalize_symbol(str(triple.get("relation") or ""))
+        raw_labels = triple.get("target_labels", [])
+        labels = {
+            _normalize_symbol(str(label))
+            for label in raw_labels
+            if str(label).strip()
+        } if isinstance(raw_labels, list) else set()
+        normalized_target = _normalize_symbol(target)
+
+        if (
+            relation in LIMITATION_RELATION_HINTS
+            or labels & LIMITATION_LABEL_HINTS
+            or any(hint in normalized_target for hint in (_normalize_symbol(item) for item in LIMITATION_TEXT_HINTS))
+        ):
+            limitation_points.append(target)
+            continue
+
+        if (
+            relation in ALTERNATIVE_RELATION_HINTS
+            or labels & ALTERNATIVE_LABEL_HINTS
+            or any(hint in normalized_target for hint in (_normalize_symbol(item) for item in COMMON_ALTERNATIVE_TECHNIQUE_HINTS))
+            or (prefers_parallel_alternatives and relation in {"uses", "workswith", "runson"})
+        ):
+            alternative_points.append(target)
+
+    return {
+        "limitation_points": _dedupe_points(limitation_points),
+        "alternative_points": _dedupe_points(alternative_points),
+    }
+
+
 def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_targets: Set[str]) -> str:
     normalized_target_keys = {re.sub(r"[^a-z0-9]+", "", item.lower()) for item in normalized_targets}
     for entity in entities:
@@ -214,3 +459,79 @@ def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_tar
             if entity_name:
                 return entity_name
     return ""
+
+
+def _tradeoff_points_from_entities(entities: Sequence[Dict[str, Any]]) -> Dict[str, List[str]]:
+    limitation_points: List[str] = []
+    alternative_points: List[str] = []
+    for entity in entities:
+        entity_name = _entity_name(entity)
+        if not entity_name:
+            continue
+        labels = entity.get("labels", [])
+        normalized_labels = {
+            _normalize_symbol(str(label))
+            for label in labels
+            if str(label).strip()
+        } if isinstance(labels, list) else set()
+        normalized_name = _normalize_symbol(entity_name)
+        if normalized_labels & LIMITATION_LABEL_HINTS or any(
+            hint in normalized_name for hint in (_normalize_symbol(item) for item in LIMITATION_TEXT_HINTS)
+        ):
+            limitation_points.append(entity_name)
+            continue
+        if normalized_labels & ALTERNATIVE_LABEL_HINTS or any(
+            hint in normalized_name for hint in (_normalize_symbol(item) for item in COMMON_ALTERNATIVE_TECHNIQUE_HINTS)
+        ):
+            alternative_points.append(entity_name)
+    return {
+        "limitation_points": _dedupe_points(limitation_points),
+        "alternative_points": _dedupe_points(alternative_points),
+    }
+
+
+def _split_compact_points(raw: str) -> List[str]:
+    cleaned = re.sub(r"\s+", " ", str(raw).strip(" .,:;")).strip()
+    if not cleaned:
+        return []
+    parts = re.split(r",|\bor\b|\band\b|/|;", cleaned, flags=re.IGNORECASE)
+    return [
+        _canonicalize_point_text(part)
+        for part in parts
+        if _canonicalize_point_text(part)
+    ]
+
+
+def _compact_sentence(sentence: str) -> str:
+    compact = re.sub(r"\s+", " ", sentence.strip())
+    if len(compact) <= 160:
+        return compact
+    return compact[:157].rsplit(" ", 1)[0].rstrip() + "..."
+
+
+def _canonicalize_point_text(value: str) -> str:
+    compact = re.sub(r"\s+", " ", str(value).strip(" .,:;")).strip()
+    if not compact:
+        return ""
+    if compact.lower() in {"gil", "the gil", "global interpreter lock"}:
+        return "GIL"
+    if compact.lower() == "ray":
+        return "Ray"
+    return compact
+
+
+def _dedupe_points(values: Sequence[str]) -> List[str]:
+    seen: Set[str] = set()
+    results: List[str] = []
+    for value in values:
+        canonical = _canonicalize_point_text(value)
+        key = _normalize_symbol(canonical)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        results.append(canonical)
+    return results[:5]
+
+
+def _normalize_symbol(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value).lower())

--- a/seocho/query/run_metadata.py
+++ b/seocho/query/run_metadata.py
@@ -220,6 +220,8 @@ def _focus_slots_for_local_intent(intent: str) -> List[str]:
         return ["target_entity", "financial_metric", "period", "supporting_fact"]
     if intent == "relationship_lookup":
         return ["source_entity", "target_entity", "relation_paths", "supporting_fact"]
+    if intent == "engineering_tradeoff_lookup":
+        return ["target_entity", "limitation_points", "alternative_points", "supporting_fact"]
     return ["target_entity", "supporting_fact"]
 
 

--- a/seocho/query/semantic_agents.py
+++ b/seocho/query/semantic_agents.py
@@ -13,6 +13,7 @@ from .answering import build_evidence_bundle, infer_question_intent
 from .constraints import SemanticConstraintSliceBuilder
 from .contracts import CypherPlan, InsufficiencyAssessment
 from .cypher_validator import CypherQueryValidator
+from .intent import extract_tradeoff_points_from_triples
 from .insufficiency import QueryInsufficiencyClassifier
 from .query_proxy import QueryExecutionError, coerce_query_records
 from .run_registry import RunMetadataRegistry
@@ -197,6 +198,26 @@ def _compose_selected_triple_fact(
             seen.add(key)
             values.append(target)
         return values
+
+    tradeoff_points = extract_tradeoff_points_from_triples(
+        question=question,
+        selected_triples=selected_triples,
+    )
+    limitation_points = tradeoff_points["limitation_points"]
+    alternative_points = tradeoff_points["alternative_points"]
+    if limitation_points or alternative_points:
+        lines: List[str] = []
+        if limitation_points:
+            prefix = f"{subject} is limited by" if subject else "Key limitations include"
+            lines.append(f"{prefix} {', '.join(limitation_points[:5])}.")
+        if alternative_points:
+            prefix = (
+                f"Alternatives for {subject} parallel work include"
+                if subject
+                else "Alternatives include"
+            )
+            lines.append(f"{prefix} {', '.join(alternative_points[:5])}.")
+        return " ".join(lines)
 
     risk_targets = _unique_targets(
         lambda relation, labels: relation == "faces" or "risk" in labels or "risk" in normalized_question
@@ -1754,6 +1775,15 @@ class LPGAgent:
             if synthesized_fact:
                 slot_fills["supporting_fact"] = synthesized_fact
 
+        tradeoff_points = extract_tradeoff_points_from_triples(
+            question=question,
+            selected_triples=selected_triples,
+        )
+        if tradeoff_points["limitation_points"]:
+            slot_fills["limitation_points"] = tradeoff_points["limitation_points"]
+        if tradeoff_points["alternative_points"]:
+            slot_fills["alternative_points"] = tradeoff_points["alternative_points"]
+
         focus_slots = [str(slot).strip() for slot in intent.get("focus_slots", []) if str(slot).strip()]
         bundle["slot_fills"] = slot_fills
         bundle["selected_triples"] = selected_triples[:10]
@@ -1942,7 +1972,10 @@ class AnswerGenerationAgent:
                 target_entity=target_entity or (entities[0] if entities else ""),
                 selected_triples=evidence_bundle.get("selected_triples", []),
             )
-        direct_answer = self._direct_answer(question, supporting_fact)
+        if str(intent.get("intent_id", "")).strip() == "engineering_tradeoff_lookup":
+            direct_answer = self._tradeoff_answer(evidence_bundle) or self._direct_answer(question, supporting_fact)
+        else:
+            direct_answer = self._direct_answer(question, supporting_fact)
         lines: List[str] = []
         if direct_answer:
             lines.append(direct_answer)
@@ -2031,6 +2064,39 @@ class AnswerGenerationAgent:
         if best_score[0] < 2 or len(best_sentence) < 24:
             return supporting_fact
         return best_sentence
+
+    @staticmethod
+    def _tradeoff_answer(evidence_bundle: Dict[str, Any]) -> str:
+        slot_fills = evidence_bundle.get("slot_fills", {})
+        if not isinstance(slot_fills, dict):
+            return ""
+        target_entity = str(slot_fills.get("target_entity") or "").strip()
+        limitation_points = AnswerGenerationAgent._point_list(slot_fills.get("limitation_points"))
+        alternative_points = AnswerGenerationAgent._point_list(slot_fills.get("alternative_points"))
+        if not limitation_points and not alternative_points:
+            return ""
+
+        lines: List[str] = []
+        if limitation_points:
+            prefix = f"{target_entity} is limited by" if target_entity else "Key limitations include"
+            lines.append(f"{prefix} {', '.join(limitation_points[:5])}.")
+        if alternative_points:
+            prefix = (
+                f"Alternatives for {target_entity} parallel work include"
+                if target_entity
+                else "Alternatives include"
+            )
+            lines.append(f"{prefix} {', '.join(alternative_points[:5])}.")
+        return " ".join(lines)
+
+    @staticmethod
+    def _point_list(value: Any) -> List[str]:
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if value is None:
+            return []
+        text = str(value).strip()
+        return [text] if text else []
 
 
 __all__ = [

--- a/seocho/tests/test_semantic_query_phase_a.py
+++ b/seocho/tests/test_semantic_query_phase_a.py
@@ -27,6 +27,51 @@ def test_infer_question_intent_and_evidence_bundle_contract():
     assert bundle["slot_fills"]["target_entity"] == "Cypher"
 
 
+def test_tradeoff_intent_and_evidence_bundle_surface_limitations_and_alternatives():
+    semantic_context = {
+        "entities": ["Python"],
+        "matches": {
+            "Python": [
+                {
+                    "display_name": "Python",
+                    "database": "kgnormal",
+                    "node_id": "11",
+                    "labels": ["Language"],
+                    "source": "fulltext",
+                    "final_score": 0.95,
+                }
+            ]
+        },
+    }
+
+    intent = infer_question_intent(
+        "What limits Python parallel work, and what alternatives avoid the GIL?",
+        semantic_context["entities"],
+    )
+    bundle = build_evidence_bundle(
+        question="What limits Python parallel work, and what alternatives avoid the GIL?",
+        semantic_context={**semantic_context, "intent": intent},
+        memory={
+            "memory_id": "mem_python",
+            "database": "kgnormal",
+            "content_preview": "Python's main limitation for CPU-bound parallel work is the GIL. Use multiprocessing or Ray instead.",
+            "entities": [
+                {"name": "GIL", "labels": ["Limitation"]},
+                {"name": "multiprocessing", "labels": ["Alternative"]},
+                {"name": "Ray", "labels": ["Alternative"]},
+            ],
+        },
+        matched_entities=["Python"],
+        reasons=["entity_match"],
+        score=0.95,
+    )
+
+    assert intent["intent_id"] == "engineering_tradeoff_lookup"
+    assert bundle["slot_fills"]["target_entity"] == "Python"
+    assert bundle["slot_fills"]["limitation_points"] == ["GIL"]
+    assert bundle["slot_fills"]["alternative_points"] == ["multiprocessing", "Ray"]
+
+
 def test_cypher_validator_and_insufficiency_classifier_contract():
     validator = CypherQueryValidator()
     classifier = QueryInsufficiencyClassifier()

--- a/seocho/tests/test_semantic_query_phase_d.py
+++ b/seocho/tests/test_semantic_query_phase_d.py
@@ -122,6 +122,58 @@ class EntitySummaryConnector(FakeConnector):
         return super().run_cypher(query, database=database, params=params)
 
 
+class EngineeringTradeoffConnector(FakeConnector):
+    def run_cypher(self, query, database="neo4j", params=None):
+        params = params or {}
+
+        if "CALL db.index.fulltext.queryNodes" in query:
+            text = str(params.get("query", "")).lower()
+            if "python" in text:
+                return json.dumps(
+                    [
+                        {
+                            "node_id": 303,
+                            "labels": ["Language"],
+                            "display_name": "Python",
+                            "source_id": "mem_python",
+                            "memory_id": "mem_python",
+                            "score": 3.6,
+                        }
+                    ]
+                )
+            return json.dumps([])
+
+        if "properties(n) AS properties" in query and "AS neighbors" in query:
+            return json.dumps(
+                [
+                    {
+                        "target_entity": "Python",
+                        "properties": {"name": "Python"},
+                        "neighbors": [
+                            {
+                                "relation": "LIMITED_BY",
+                                "target": "GIL",
+                                "target_labels": ["Limitation"],
+                            },
+                            {
+                                "relation": "PARALLELIZED_WITH",
+                                "target": "multiprocessing",
+                                "target_labels": ["Alternative"],
+                            },
+                            {
+                                "relation": "PARALLELIZED_WITH",
+                                "target": "Ray",
+                                "target_labels": ["Alternative"],
+                            },
+                        ],
+                        "supporting_fact": "",
+                    }
+                ]
+            )
+
+        return super().run_cypher(query, database=database, params=params)
+
+
 def test_canonical_semantic_agent_flow_runs_end_to_end():
     flow = SemanticAgentFlow(FakeConnector())
     result = flow.run("What is Neo4j connected to?", ["kgnormal"])
@@ -247,3 +299,17 @@ def test_canonical_semantic_flow_synthesizes_risk_summary_from_neighbors():
         "significant capital expenditure requirements for AWS infrastructure, "
         "competition in e-commerce and cloud computing markets."
     )
+
+
+def test_canonical_semantic_flow_synthesizes_engineering_tradeoff_answer():
+    flow = SemanticAgentFlow(EngineeringTradeoffConnector())
+
+    result = flow.run("What limits Python parallel work, and what alternatives avoid the GIL?", ["kgnormal"])
+
+    assert result["route"] == "lpg"
+    assert result["semantic_context"]["intent"]["intent_id"] == "engineering_tradeoff_lookup"
+    assert result["support_assessment"]["status"] == "supported"
+    assert result["response"].startswith("Python is limited by GIL.")
+    assert "Alternatives for Python parallel work include multiprocessing, Ray." in result["response"]
+    assert result["evidence_bundle"]["slot_fills"]["limitation_points"] == ["GIL"]
+    assert result["evidence_bundle"]["slot_fills"]["alternative_points"] == ["multiprocessing", "Ray"]


### PR DESCRIPTION
## Summary
- Adds limitation / alternative tradeoff extraction to \`seocho.query.intent\`: keyword sets, relation/label hint sets, \`extract_tradeoff_points_from_triples\` and entity-side counterpart, canonicalisation helpers
- Threads the new slots through \`QueryInsufficiencyClassifier\` so partial-fill detection covers \`limitation_points\` and \`alternative_points\`
- Updates \`semantic_agents\`, \`run_metadata\`, and the Phase-A / Phase-D semantic query tests plus the memory-service test to match the new contract

Lands prior in-progress work on a dedicated branch ahead of the ADR-0091 enrichment-router slice, which integrates with this intent surface (the router's augmentation step reuses \`INTENT_CATALOG\` and the tradeoff helpers).

## Test plan
- [ ] \`pytest seocho/tests/test_semantic_query_phase_a.py seocho/tests/test_semantic_query_phase_d.py\`
- [ ] \`pytest extraction/tests/test_memory_service.py\`
- [ ] Manual smoke: confirm a question containing limitation keywords routes to the tradeoff slot fill path