### PR TITLE
feat(adr-0092): Graph-CoT PropertyShaper thin slice behind feature flag

### DIFF
--- a/seocho/index/pipeline.py
+++ b/seocho/index/pipeline.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import uuid
 from dataclasses import dataclass, field
@@ -42,6 +43,12 @@ logger = logging.getLogger(__name__)
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 from .extraction_engine import CanonicalExtractionEngine
+from .property_shaper import PropertyShaper
+
+
+def _graph_cot_properties_enabled() -> bool:
+    """ADR-0092 feature flag — opt-in until the integration milestone."""
+    return os.environ.get("SEOCHO_GRAPH_COT_PROPERTIES", "").strip() in {"1", "true", "TRUE"}
 
 
 # ---------------------------------------------------------------------------
@@ -642,6 +649,21 @@ class IndexingPipeline:
                     all_rels,
                     ontology_context,
                 )
+
+                if _graph_cot_properties_enabled():
+                    shaper = PropertyShaper()
+                    for node in all_nodes:
+                        props = node.get("properties") or {}
+                        props.setdefault("id", node.get("id"))
+                        props.setdefault("name", props.get("name") or node.get("id"))
+                        node["properties"] = shaper.shape_node(props)
+                    for rel in all_rels:
+                        edge_type = str(rel.get("type") or "MENTIONS")
+                        rel["properties"] = shaper.shape_edge(
+                            rel.get("properties") or {},
+                            edge_type=edge_type,
+                        )
+
                 summary = self.graph_store.write(
                     all_nodes, all_rels,
                     database=database,

--- a/seocho/index/property_shaper.py
+++ b/seocho/index/property_shaper.py
@@ -1,0 +1,311 @@
+"""Graph-CoT-oriented property shaping for indexed nodes and relationships.
+
+Implements the property schema defined by ADR-0092. Properties are treated as
+an agent control surface (claim / useWhen / reasoningRole / confidence /
+sourceRefs / embeddingText), not just descriptive metadata.
+
+Thin-slice scope: enforce required fields with safe defaults, validate fixed
+enums, compose ``embeddingText`` deterministically, and detect promotion
+candidates without emitting them. Persistent index creation (fulltext /
+vector / property) is out of scope for this slice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+
+SEMANTIC_ROLE_ENUM: frozenset[str] = frozenset(
+    {
+        "concept",
+        "claim",
+        "definition",
+        "method",
+        "example",
+        "risk",
+        "metric",
+        "source",
+        "decision",
+        "evidence",
+        "constraint",
+    }
+)
+
+
+REASONING_ROLE_ENUM: frozenset[str] = frozenset(
+    {
+        "premise",
+        "bridge",
+        "constraint",
+        "evidence",
+        "counterEvidence",
+        "hypothesis",
+        "answerCandidate",
+        "nextStepHint",
+        "strategy",
+    }
+)
+
+
+RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        "SUPPORTS",
+        "CONTRADICTS",
+        "REQUIRES",
+        "CAUSES",
+        "IMPLEMENTS",
+        "EXAMPLE_OF",
+        "PART_OF",
+        "ALTERNATIVE_TO",
+        "EVIDENCED_BY",
+        "SUPPORTED_BY",
+        "MENTIONS",
+    }
+)
+
+
+REQUIRED_NODE_FIELDS: tuple[str, ...] = (
+    "id",
+    "title",
+    "claim",
+    "agentSummary",
+    "semanticRole",
+    "reasoningRole",
+    "answers",
+    "useWhen",
+    "confidence",
+    "sourceRefs",
+    "embeddingText",
+)
+
+
+RECOMMENDED_NODE_FIELDS: tuple[str, ...] = (
+    "doNotUseWhen",
+    "domainScope",
+    "validFrom",
+    "validTo",
+    "importance",
+    "graphCotUtility",
+    "preferredNextRelations",
+    "extractionConfidence",
+)
+
+
+REQUIRED_EDGE_FIELDS: tuple[str, ...] = (
+    "relationSummary",
+    "reasoningRole",
+    "confidence",
+    "sourceRefs",
+)
+
+
+_AGENT_SUMMARY_MAX_CHARS = 200
+_EMBEDDING_TEXT_LIST_JOIN = " "
+_PROMOTE_LIST_LENGTH = 5
+_PROMOTE_STRING_LENGTH = 512
+
+
+@dataclass(frozen=True)
+class PromotionRequest:
+    """A field value that should become a separate node + relationship."""
+
+    field: str
+    reason: str
+    payload: Any
+
+
+class PropertyShaper:
+    """Shape node/edge properties per ADR-0092.
+
+    The shaper is deliberately tolerant: missing required fields get safe
+    defaults instead of raising, so existing extraction outputs can flow
+    through the pipeline once the feature flag is enabled. Enum violations
+    raise ``ValueError`` because they would silently corrupt agent prompts.
+    """
+
+    def __init__(
+        self,
+        *,
+        default_semantic_role: str = "concept",
+        default_reasoning_role: str = "premise",
+        default_confidence: float = 0.5,
+    ) -> None:
+        if default_semantic_role not in SEMANTIC_ROLE_ENUM:
+            raise ValueError(
+                f"default_semantic_role={default_semantic_role!r} not in "
+                f"SEMANTIC_ROLE_ENUM"
+            )
+        if default_reasoning_role not in REASONING_ROLE_ENUM:
+            raise ValueError(
+                f"default_reasoning_role={default_reasoning_role!r} not in "
+                f"REASONING_ROLE_ENUM"
+            )
+        self._default_semantic_role = default_semantic_role
+        self._default_reasoning_role = default_reasoning_role
+        self._default_confidence = float(default_confidence)
+
+    def shape_node(self, raw_props: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of ``raw_props`` with the ADR-0092 required fields.
+
+        Existing keys are preserved. Required keys that are missing are
+        filled with safe defaults. Enum-typed keys are validated.
+        """
+        shaped: Dict[str, Any] = dict(raw_props or {})
+
+        node_id = shaped.get("id") or shaped.get("name") or ""
+        if not node_id:
+            raise ValueError("shape_node requires either 'id' or 'name' in raw_props")
+        shaped["id"] = str(node_id)
+
+        shaped.setdefault("title", shaped.get("name") or shaped["id"])
+
+        claim = shaped.get("claim") or shaped.get("description") or shaped["title"]
+        shaped["claim"] = str(claim)
+
+        shaped.setdefault("agentSummary", _truncate(shaped["claim"], _AGENT_SUMMARY_MAX_CHARS))
+
+        semantic_role = shaped.get("semanticRole", self._default_semantic_role)
+        if semantic_role not in SEMANTIC_ROLE_ENUM:
+            raise ValueError(
+                f"semanticRole={semantic_role!r} not in SEMANTIC_ROLE_ENUM"
+            )
+        shaped["semanticRole"] = semantic_role
+
+        reasoning_role = shaped.get("reasoningRole", self._default_reasoning_role)
+        if reasoning_role not in REASONING_ROLE_ENUM:
+            raise ValueError(
+                f"reasoningRole={reasoning_role!r} not in REASONING_ROLE_ENUM"
+            )
+        shaped["reasoningRole"] = reasoning_role
+
+        shaped["answers"] = _coerce_str_list(shaped.get("answers"))
+        shaped["useWhen"] = _coerce_str_list(shaped.get("useWhen"))
+
+        confidence = shaped.get("confidence", self._default_confidence)
+        shaped["confidence"] = _clip_unit(float(confidence))
+
+        shaped["sourceRefs"] = _coerce_str_list(shaped.get("sourceRefs"))
+
+        shaped["embeddingText"] = self.compose_embedding_text(shaped)
+        return shaped
+
+    def shape_edge(
+        self,
+        raw_props: Dict[str, Any],
+        *,
+        edge_type: str,
+    ) -> Dict[str, Any]:
+        """Return a copy of ``raw_props`` with required edge fields filled.
+
+        Rejects relationship types that are not in the canonical vocabulary.
+        """
+        if edge_type not in RELATIONSHIP_TYPES:
+            raise ValueError(
+                f"edge_type={edge_type!r} not in RELATIONSHIP_TYPES"
+            )
+
+        shaped: Dict[str, Any] = dict(raw_props or {})
+
+        shaped.setdefault(
+            "relationSummary",
+            f"{edge_type.lower().replace('_', ' ')} relation",
+        )
+
+        reasoning_role = shaped.get("reasoningRole", self._default_reasoning_role)
+        if reasoning_role not in REASONING_ROLE_ENUM:
+            raise ValueError(
+                f"edge reasoningRole={reasoning_role!r} not in REASONING_ROLE_ENUM"
+            )
+        shaped["reasoningRole"] = reasoning_role
+
+        confidence = shaped.get("confidence", self._default_confidence)
+        shaped["confidence"] = _clip_unit(float(confidence))
+
+        shaped["sourceRefs"] = _coerce_str_list(shaped.get("sourceRefs"))
+        return shaped
+
+    @staticmethod
+    def compose_embedding_text(node: Dict[str, Any]) -> str:
+        """Deterministic ``embeddingText`` composition.
+
+        Concatenates ``title + claim + agentSummary + answers + useWhen``
+        with single-space separation. Existing ``embeddingText`` value is
+        respected when explicitly provided (non-empty).
+        """
+        existing = node.get("embeddingText")
+        if isinstance(existing, str) and existing.strip():
+            return existing.strip()
+
+        parts: List[str] = []
+        for field in ("title", "claim", "agentSummary"):
+            value = node.get(field)
+            if isinstance(value, str) and value.strip():
+                parts.append(value.strip())
+        for list_field in ("answers", "useWhen"):
+            values = _coerce_str_list(node.get(list_field))
+            if values:
+                parts.append(_EMBEDDING_TEXT_LIST_JOIN.join(values))
+        return _EMBEDDING_TEXT_LIST_JOIN.join(parts)
+
+    @staticmethod
+    def promotion_candidates(node: Dict[str, Any]) -> List[PromotionRequest]:
+        """Detect properties that should be promoted to standalone nodes.
+
+        Thin-slice: report only. Emission of the promoted nodes is out of
+        scope and will land in a follow-up slice.
+        """
+        candidates: List[PromotionRequest] = []
+        for field, value in (node or {}).items():
+            if isinstance(value, list) and len(value) > _PROMOTE_LIST_LENGTH:
+                if field in {"sourceRefs", "assumptions"}:
+                    candidates.append(
+                        PromotionRequest(
+                            field=field,
+                            reason=f"list length {len(value)} > {_PROMOTE_LIST_LENGTH}",
+                            payload=value,
+                        )
+                    )
+            elif isinstance(value, str) and len(value) > _PROMOTE_STRING_LENGTH:
+                if field in {"evidenceText", "assumptions"}:
+                    candidates.append(
+                        PromotionRequest(
+                            field=field,
+                            reason=f"string length {len(value)} > {_PROMOTE_STRING_LENGTH}",
+                            payload=value,
+                        )
+                    )
+        return candidates
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    text = (value or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _coerce_str_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    if isinstance(value, Sequence):
+        out: List[str] = []
+        for item in value:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                out.append(text)
+        return out
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _clip_unit(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return float(value)

--- a/seocho/tests/test_property_shaper.py
+++ b/seocho/tests/test_property_shaper.py
@@ -1,0 +1,165 @@
+"""Tests for ADR-0092 PropertyShaper."""
+
+import pytest
+
+from seocho.index.property_shaper import (
+    PromotionRequest,
+    PropertyShaper,
+    REASONING_ROLE_ENUM,
+    RELATIONSHIP_TYPES,
+    REQUIRED_EDGE_FIELDS,
+    REQUIRED_NODE_FIELDS,
+    SEMANTIC_ROLE_ENUM,
+)
+
+
+@pytest.fixture
+def shaper() -> PropertyShaper:
+    return PropertyShaper()
+
+
+def test_shape_node_fills_all_required_fields(shaper: PropertyShaper) -> None:
+    out = shaper.shape_node({"id": "ent:foo", "name": "Foo Corp"})
+    for field in REQUIRED_NODE_FIELDS:
+        assert field in out, f"missing required field: {field}"
+    assert out["id"] == "ent:foo"
+    assert out["title"] == "Foo Corp"
+    assert out["claim"] == "Foo Corp"
+    assert out["agentSummary"].startswith("Foo Corp")
+    assert out["semanticRole"] in SEMANTIC_ROLE_ENUM
+    assert out["reasoningRole"] in REASONING_ROLE_ENUM
+    assert out["answers"] == []
+    assert out["useWhen"] == []
+    assert out["confidence"] == 0.5
+    assert out["sourceRefs"] == []
+    assert "Foo Corp" in out["embeddingText"]
+
+
+def test_shape_node_preserves_explicit_values(shaper: PropertyShaper) -> None:
+    raw = {
+        "id": "claim:graphcot:iterative_traversal",
+        "title": "Graph-CoT iterative traversal",
+        "claim": "Graph-CoT reasons through iterative graph traversal.",
+        "semanticRole": "method",
+        "reasoningRole": "strategy",
+        "answers": ["How should an agent use a knowledge graph?"],
+        "useWhen": ["question asks about Graph-CoT design"],
+        "confidence": 0.86,
+        "sourceRefs": ["paper:graph-cot-2024"],
+    }
+    out = shaper.shape_node(raw)
+    assert out["semanticRole"] == "method"
+    assert out["reasoningRole"] == "strategy"
+    assert out["confidence"] == 0.86
+    assert out["answers"] == ["How should an agent use a knowledge graph?"]
+    assert out["sourceRefs"] == ["paper:graph-cot-2024"]
+    embedding_text = out["embeddingText"]
+    assert "Graph-CoT iterative traversal" in embedding_text
+    assert "iterative graph traversal" in embedding_text
+    assert "Graph-CoT design" in embedding_text
+
+
+def test_shape_node_rejects_unknown_semantic_role(shaper: PropertyShaper) -> None:
+    with pytest.raises(ValueError, match="semanticRole"):
+        shaper.shape_node({"id": "x", "name": "x", "semanticRole": "made-up-role"})
+
+
+def test_shape_node_rejects_unknown_reasoning_role(shaper: PropertyShaper) -> None:
+    with pytest.raises(ValueError, match="reasoningRole"):
+        shaper.shape_node({"id": "x", "name": "x", "reasoningRole": "made-up"})
+
+
+def test_shape_node_requires_id_or_name(shaper: PropertyShaper) -> None:
+    with pytest.raises(ValueError, match="requires either 'id' or 'name'"):
+        shaper.shape_node({})
+
+
+def test_shape_node_clips_confidence_to_unit_interval(shaper: PropertyShaper) -> None:
+    over = shaper.shape_node({"id": "x", "name": "x", "confidence": 1.7})
+    under = shaper.shape_node({"id": "y", "name": "y", "confidence": -0.4})
+    assert over["confidence"] == 1.0
+    assert under["confidence"] == 0.0
+
+
+def test_compose_embedding_text_is_deterministic(shaper: PropertyShaper) -> None:
+    raw = {
+        "id": "n",
+        "name": "Node",
+        "claim": "A claim.",
+        "answers": ["q1", "q2"],
+        "useWhen": ["c1"],
+    }
+    a = shaper.shape_node(dict(raw))
+    b = shaper.shape_node(dict(raw))
+    assert a["embeddingText"] == b["embeddingText"]
+    assert a["embeddingText"] == "Node A claim. A claim. q1 q2 c1"
+
+
+def test_compose_embedding_text_respects_explicit_value(shaper: PropertyShaper) -> None:
+    raw = {"id": "n", "name": "Node", "embeddingText": "  explicit text  "}
+    out = shaper.shape_node(raw)
+    assert out["embeddingText"] == "explicit text"
+
+
+def test_shape_edge_accepts_canonical_types(shaper: PropertyShaper) -> None:
+    for edge_type in RELATIONSHIP_TYPES:
+        out = shaper.shape_edge({}, edge_type=edge_type)
+        for field in REQUIRED_EDGE_FIELDS:
+            assert field in out, f"missing edge field: {field} for {edge_type}"
+        assert out["confidence"] == 0.5
+        assert out["sourceRefs"] == []
+
+
+def test_shape_edge_rejects_unknown_type(shaper: PropertyShaper) -> None:
+    with pytest.raises(ValueError, match="edge_type"):
+        shaper.shape_edge({}, edge_type="MENTIONS_NOT_REAL")
+
+
+def test_shape_edge_rejects_unknown_reasoning_role(shaper: PropertyShaper) -> None:
+    with pytest.raises(ValueError, match="reasoningRole"):
+        shaper.shape_edge({"reasoningRole": "bogus"}, edge_type="MENTIONS")
+
+
+def test_promotion_candidates_flags_long_lists(shaper: PropertyShaper) -> None:
+    node = {
+        "id": "n",
+        "name": "Node",
+        "sourceRefs": [f"src:{i}" for i in range(7)],
+    }
+    candidates = shaper.promotion_candidates(node)
+    assert any(c.field == "sourceRefs" for c in candidates)
+    assert all(isinstance(c, PromotionRequest) for c in candidates)
+
+
+def test_promotion_candidates_flags_long_evidence_string(shaper: PropertyShaper) -> None:
+    node = {
+        "id": "n",
+        "name": "Node",
+        "evidenceText": "x" * 600,
+    }
+    candidates = shaper.promotion_candidates(node)
+    assert any(c.field == "evidenceText" for c in candidates)
+
+
+def test_promotion_candidates_returns_empty_for_small_node(shaper: PropertyShaper) -> None:
+    assert shaper.promotion_candidates({"id": "n", "name": "Node"}) == []
+
+
+def test_shaper_default_role_validation() -> None:
+    with pytest.raises(ValueError, match="default_semantic_role"):
+        PropertyShaper(default_semantic_role="not-a-role")
+    with pytest.raises(ValueError, match="default_reasoning_role"):
+        PropertyShaper(default_reasoning_role="not-a-role")
+
+
+def test_shape_node_accepts_mixed_iterable_in_answers(shaper: PropertyShaper) -> None:
+    out = shaper.shape_node(
+        {
+            "id": "n",
+            "name": "Node",
+            "answers": ("q1", "", None, "q2"),
+            "useWhen": "single string",
+        }
+    )
+    assert out["answers"] == ["q1", "q2"]
+    assert out["useWhen"] == ["single string"]


### PR DESCRIPTION
## Summary
- Adds \`seocho/index/property_shaper.py\` — the agent-control-surface property schema from ADR-0092 (5 groups, 11 required node fields, canonical 11-type relationship vocabulary, fixed \`semanticRole\` / \`reasoningRole\` enums)
- \`PropertyShaper.shape_node\` fills missing required fields with safe defaults, validates enums (raises on violation), composes \`embeddingText\` deterministically; \`shape_edge\` enforces the relationship vocabulary; \`promotion_candidates\` detects long-list / long-string fields without emitting them
- Integrates into \`seocho/index/pipeline.py\` between \`apply_ontology_context_to_graph_payload\` and \`graph_store.write\`, gated by \`SEOCHO_GRAPH_COT_PROPERTIES=1\` — default off so prod behavior is preserved
- 16 unit tests in \`seocho/tests/test_property_shaper.py\` covering enum validation, default fill, embeddingText determinism, edge type enforcement, promotion detection, confidence clamping, sequence coercion

Out of scope for this thin slice: persistent fulltext/vector/property index creation, extraction prompt extensions, backfill for legacy workspaces, promoted-node emission. Tracked as follow-ups under \`seocho-j965.2\`.

ADR: [\`docs/decisions/ADR-0092-graph-cot-lpg-property-schema.md\`](docs/decisions/ADR-0092-graph-cot-lpg-property-schema.md)
bd subtask: \`seocho-j965.2\` (blocks \`seocho-j965.3\`)

## Test plan
- [ ] \`pytest seocho/tests/test_property_shaper.py -v\` — 16 tests pass
- [ ] Existing indexing tests still pass with flag off (default): \`pytest seocho/tests/test_extraction_engine.py\`
- [ ] With flag on, an \`Entity\` node written through the pipeline carries all 11 required properties (manual fixture run)