### PR TITLE
feat(adr-0091): QueryEnrichmentRouter + RRF fusion thin slice behind feature flag

### DIFF
--- a/seocho/agent/enrichment_router.py
+++ b/seocho/agent/enrichment_router.py
@@ -1,0 +1,284 @@
+"""Query enrichment + parallel fan-out router (ADR-0091).
+
+Runs as a pre-stage in ``Session.ask()`` and as the canonical
+``augment_fn`` for ``GraphAgenticLoop``. One implementation, two callers.
+
+Four stages:
+
+1. **augment** — produce the ``augmentation`` dict that
+   ``RoutingPolicy.decide()`` already expects:
+   ``{intent, entities, topic, rewrite}``.
+2. **route** — call ``RoutingPolicy.decide()`` with the augmentation.
+3. **fan_out** — run the selected backends concurrently (asyncio.gather).
+4. **fuse** — collapse ranked lists with ``ReciprocalRankFusion``.
+
+Thin slice scope: Cypher backend only; vector / fulltext / GDS backends
+return empty ranked lists. The augmentation step uses a keyword-based
+intent classifier over ``seocho.query.intent.INTENT_CATALOG``; the LLM
+classifier upgrade is a follow-up. Short-circuit on high-confidence single
+entity match is also a follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Sequence
+
+from seocho.routing import RoutingDecision, RoutingPolicy
+
+from .fusion import Fusion, ReciprocalRankFusion
+
+
+def enrichment_router_enabled() -> bool:
+    """ADR-0091 feature flag — opt-in until the integration milestone."""
+    return os.environ.get("SEOCHO_ENABLE_ENRICHMENT_ROUTER", "").strip() in {"1", "true", "TRUE"}
+
+
+_QUOTED_RE = re.compile(r'"([^"]+)"')
+_CASED_RE = re.compile(r"\b([A-Z][A-Za-z0-9.&'-]{2,})\b")
+
+
+@dataclass
+class FanOutResult:
+    """Per-backend output collected during ``fan_out``."""
+
+    backend: str
+    items: List[Any] = field(default_factory=list)
+    elapsed_ms: int = 0
+    error: Optional[str] = None
+
+
+@dataclass
+class RouterTrace:
+    """Per-call audit record for the router pass."""
+
+    workspace_id: str
+    question: str
+    augmentation: Dict[str, Any]
+    decision: Dict[str, Any]
+    backends_run: List[str]
+    fan_out: Dict[str, Dict[str, Any]]
+    fused_top_k_ids: List[str]
+    short_circuit: Optional[str] = None
+
+
+class QueryEnrichmentRouter:
+    """Augment → route → fan out → fuse.
+
+    Backend callables accept ``(question, augmentation, decision)`` and
+    return a ranked list of evidence items (dicts with an ``id`` field).
+    ``None`` for any backend means it is not configured and will be
+    skipped regardless of policy weight.
+
+    Args:
+        policy: existing ``RoutingPolicy``; the router does not own it.
+        cypher_backend: callable for the Cypher backend (required for the
+            thin slice; the other three default to None).
+        vector_backend / fulltext_backend / gds_backend: optional callables.
+        fusion: fusion strategy; defaults to ``ReciprocalRankFusion``.
+        intent_classifier: callable ``(question) -> {intent, confidence,
+            reason}``; defaults to a small keyword classifier.
+        entity_extractor: callable ``(question) -> List[str]``; defaults
+            to a quoted/cased-token heuristic.
+        topic_extractor: callable ``(question) -> List[str]``; defaults
+            to an empty list (LLM upgrade is a follow-up).
+        per_backend_timeout_seconds: per-call timeout for fan-out.
+    """
+
+    def __init__(
+        self,
+        *,
+        policy: RoutingPolicy,
+        cypher_backend: Optional[Callable[..., Any]] = None,
+        vector_backend: Optional[Callable[..., Any]] = None,
+        fulltext_backend: Optional[Callable[..., Any]] = None,
+        gds_backend: Optional[Callable[..., Any]] = None,
+        fusion: Optional[Fusion] = None,
+        intent_classifier: Optional[Callable[[str], Dict[str, Any]]] = None,
+        entity_extractor: Optional[Callable[[str], List[str]]] = None,
+        topic_extractor: Optional[Callable[[str], List[str]]] = None,
+        per_backend_timeout_seconds: float = 10.0,
+    ) -> None:
+        self.policy = policy
+        self._backends: Dict[str, Optional[Callable[..., Any]]] = {
+            "cypher": cypher_backend,
+            "vector": vector_backend,
+            "fulltext": fulltext_backend,
+            "gds": gds_backend,
+        }
+        self.fusion: Fusion = fusion or ReciprocalRankFusion()
+        self._intent_classifier = intent_classifier or _default_intent_classifier
+        self._entity_extractor = entity_extractor or _default_entity_extractor
+        self._topic_extractor = topic_extractor or _default_topic_extractor
+        self._timeout = float(per_backend_timeout_seconds)
+
+    # ---- Stage 1: augment ------------------------------------------------
+
+    def augment(self, question: str, workspace_id: str = "default") -> Dict[str, Any]:
+        intent = self._intent_classifier(question or "")
+        entities = self._entity_extractor(question or "")
+        topics = self._topic_extractor(question or "")
+        return {
+            "intent": intent,
+            "entities": entities,
+            "topic": topics,
+            "rewrite": None,
+            "workspace_id": workspace_id,
+        }
+
+    # ---- Stage 2: route --------------------------------------------------
+
+    def route(self, augmentation: Mapping[str, Any], *, model: str = "gpt-4o-mini") -> RoutingDecision:
+        return self.policy.decide(augmentation=augmentation, model=model)
+
+    # ---- Stage 3: fan out ------------------------------------------------
+
+    async def fan_out(
+        self,
+        question: str,
+        augmentation: Mapping[str, Any],
+        decision: RoutingDecision,
+    ) -> Dict[str, FanOutResult]:
+        weights = dict(decision.weights or {})
+        floor = getattr(self.fusion, "_weight_floor", 0.10)
+        selected: List[str] = [
+            b for b, w in weights.items()
+            if w >= floor and self._backends.get(b) is not None
+        ]
+
+        async def _run_one(backend: str) -> FanOutResult:
+            fn = self._backends[backend]
+            assert fn is not None
+            import time as _time
+
+            t0 = _time.perf_counter()
+            try:
+                maybe_coro = fn(question, augmentation, decision)
+                if isinstance(maybe_coro, Awaitable):  # type: ignore[arg-type]
+                    items = await asyncio.wait_for(maybe_coro, timeout=self._timeout)
+                else:
+                    items = maybe_coro
+                if not isinstance(items, list):
+                    items = list(items) if items else []
+            except asyncio.TimeoutError:
+                return FanOutResult(
+                    backend=backend,
+                    elapsed_ms=int((_time.perf_counter() - t0) * 1000),
+                    error="timeout",
+                )
+            except Exception as exc:  # noqa: BLE001
+                return FanOutResult(
+                    backend=backend,
+                    elapsed_ms=int((_time.perf_counter() - t0) * 1000),
+                    error=str(exc),
+                )
+            return FanOutResult(
+                backend=backend,
+                items=list(items),
+                elapsed_ms=int((_time.perf_counter() - t0) * 1000),
+            )
+
+        if not selected:
+            return {}
+
+        results = await asyncio.gather(*[_run_one(b) for b in selected])
+        return {r.backend: r for r in results}
+
+    # ---- Stage 4: fuse ---------------------------------------------------
+
+    def fuse(
+        self,
+        fan_out_results: Mapping[str, FanOutResult],
+        decision: RoutingDecision,
+    ) -> List[Dict[str, Any]]:
+        ranked = {b: r.items for b, r in fan_out_results.items() if not r.error}
+        return self.fusion.fuse(ranked, decision.weights or {})
+
+    # ---- One-shot ---------------------------------------------------------
+
+    async def aroute(
+        self,
+        question: str,
+        *,
+        workspace_id: str = "default",
+        model: str = "gpt-4o-mini",
+    ) -> tuple[List[Dict[str, Any]], RouterTrace]:
+        """Run all four stages and return ``(fused, trace)``."""
+        augmentation = self.augment(question, workspace_id=workspace_id)
+        decision = self.route(augmentation, model=model)
+        fan_out_results = await self.fan_out(question, augmentation, decision)
+        fused = self.fuse(fan_out_results, decision)
+        trace = RouterTrace(
+            workspace_id=workspace_id,
+            question=question,
+            augmentation=augmentation,
+            decision={
+                "intent": decision.intent,
+                "weights": dict(decision.weights or {}),
+                "refused": bool(decision.refused),
+            },
+            backends_run=sorted(fan_out_results.keys()),
+            fan_out={
+                b: {"count": len(r.items), "elapsed_ms": r.elapsed_ms, "error": r.error}
+                for b, r in fan_out_results.items()
+            },
+            fused_top_k_ids=[entry["id"] for entry in fused[:10]],
+        )
+        return fused, trace
+
+    def run(
+        self,
+        question: str,
+        *,
+        workspace_id: str = "default",
+        model: str = "gpt-4o-mini",
+    ) -> tuple[List[Dict[str, Any]], RouterTrace]:
+        """Sync wrapper around ``aroute`` for callers that don't have a loop."""
+        return asyncio.run(self.aroute(question, workspace_id=workspace_id, model=model))
+
+
+# ---- Defaults ------------------------------------------------------------
+
+
+_INTENT_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("relationship_lookup", ("relation", "relationship", "related", "connected", "between", "link")),
+    ("path_lookup", ("path", "chain", "trace", "via")),
+    ("aggregation", ("count", "how many", "total", "sum", "average")),
+    ("analytics", ("centrality", "hub", "community", "cluster", "pagerank", "similar")),
+    ("entity_lookup", ("what is", "who is", "describe", "look up", "find")),
+)
+
+
+def _default_intent_classifier(question: str) -> Dict[str, Any]:
+    q = (question or "").lower()
+    for label, keywords in _INTENT_KEYWORDS:
+        if any(kw in q for kw in keywords):
+            return {"intent": label, "confidence": 0.75, "reason": "keyword_match"}
+    return {"intent": "lookup", "confidence": 0.65, "reason": "default"}
+
+
+def _default_entity_extractor(question: str) -> List[str]:
+    quoted = _QUOTED_RE.findall(question or "")
+    cased = _CASED_RE.findall(question or "")
+    seen: Dict[str, None] = {}
+    for ent in [*quoted, *cased]:
+        seen[ent] = None
+    return list(seen.keys())[:6]
+
+
+def _default_topic_extractor(_question: str) -> List[str]:
+    # Topic extraction needs the per-workspace ontology context (ADR-0073).
+    # The thin slice keeps it empty; the LLM-driven upgrade lands with the
+    # integration milestone in Phase 5.
+    return []
+
+
+__all__ = [
+    "QueryEnrichmentRouter",
+    "FanOutResult",
+    "RouterTrace",
+    "enrichment_router_enabled",
+]

--- a/seocho/agent/fusion.py
+++ b/seocho/agent/fusion.py
@@ -1,0 +1,73 @@
+"""Fusion strategies for parallel-backend retrieval results (ADR-0091).
+
+A ``Fusion`` collapses ranked lists from multiple backends (Cypher, vector,
+fulltext, GDS analytics) into a single ranked list. Default impl is
+Reciprocal Rank Fusion (RRF) — deterministic, no LLM call, backend-weighted.
+
+The protocol is pluggable so LLM-rerank or weighted-score-merge can replace
+RRF without touching callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Protocol, Sequence
+
+
+class Fusion(Protocol):
+    """A fusion strategy collapses multiple ranked lists into one."""
+
+    def fuse(
+        self,
+        ranked_lists: Mapping[str, Sequence[Any]],
+        weights: Mapping[str, float],
+    ) -> List[Dict[str, Any]]:
+        ...
+
+
+class ReciprocalRankFusion:
+    """RRF: ``score(doc) = Σ_b weight_b / (k + rank_b(doc))``.
+
+    Identity is taken from the ``id`` field on each item, falling back to
+    ``str(item)`` when absent. The output preserves the first observed item
+    payload for each id (later observations are ignored).
+    """
+
+    def __init__(self, *, k: int = 60, weight_floor: float = 0.10) -> None:
+        if k <= 0:
+            raise ValueError(f"RRF k must be positive, got {k}")
+        self._k = int(k)
+        self._weight_floor = float(weight_floor)
+
+    def fuse(
+        self,
+        ranked_lists: Mapping[str, Sequence[Any]],
+        weights: Mapping[str, float],
+    ) -> List[Dict[str, Any]]:
+        scores: Dict[str, float] = {}
+        payloads: Dict[str, Any] = {}
+        order: List[str] = []
+
+        for backend, items in ranked_lists.items():
+            w = float(weights.get(backend, 0.0))
+            if w < self._weight_floor:
+                continue
+            for rank, item in enumerate(items, start=1):
+                ident = _identity(item)
+                if ident not in payloads:
+                    payloads[ident] = item
+                    order.append(ident)
+                scores[ident] = scores.get(ident, 0.0) + (w / (self._k + rank))
+
+        ranked = sorted(order, key=lambda i: scores[i], reverse=True)
+        return [
+            {"id": ident, "score": scores[ident], "item": payloads[ident]}
+            for ident in ranked
+        ]
+
+
+def _identity(item: Any) -> str:
+    if isinstance(item, dict):
+        for key in ("id", "elementId", "_id"):
+            if key in item and item[key] is not None:
+                return str(item[key])
+    return str(item)

--- a/seocho/session.py
+++ b/seocho/session.py
@@ -518,6 +518,29 @@ class Session:
         agent_ctx = "\n\n".join(
             item for item in [self._ontology_context.agent_context, agent_ctx] if item
         )
+
+        # ADR-0091: opt-in QueryEnrichmentRouter pre-stage. The thin slice
+        # only stamps the augmentation into the agent context; full fan-out
+        # arrives with the integration milestone.
+        try:
+            from seocho.agent.enrichment_router import enrichment_router_enabled
+
+            if enrichment_router_enabled():
+                from seocho.agent.enrichment_router import QueryEnrichmentRouter
+                from seocho.routing import RoutingPolicy
+
+                router = QueryEnrichmentRouter(policy=RoutingPolicy.default())
+                augmentation = router.augment(question, workspace_id=self.workspace_id)
+                intent_label = augmentation["intent"].get("intent", "lookup")
+                entities = ", ".join(augmentation.get("entities", []) or [])
+                aug_lines = [f"[Enrichment intent: {intent_label}]"]
+                if entities:
+                    aug_lines.append(f"[Enrichment entities: {entities}]")
+                agent_ctx = "\n".join([*aug_lines, agent_ctx]) if agent_ctx else "\n".join(aug_lines)
+        except Exception:
+            # Enrichment is opt-in and must never break Session.ask().
+            pass
+
         context_msg = f"\n\n{agent_ctx}\n[Target database: {db}]" if agent_ctx else ""
 
         mode = self._execution_mode

--- a/seocho/tests/test_enrichment_router.py
+++ b/seocho/tests/test_enrichment_router.py
@@ -1,0 +1,194 @@
+"""Tests for ADR-0091 QueryEnrichmentRouter + ReciprocalRankFusion."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from seocho.agent.enrichment_router import (
+    QueryEnrichmentRouter,
+    enrichment_router_enabled,
+    _default_intent_classifier,
+)
+from seocho.agent.fusion import ReciprocalRankFusion
+from seocho.routing import RoutingPolicy
+
+
+@pytest.fixture
+def policy() -> RoutingPolicy:
+    return RoutingPolicy.default()
+
+
+# ---- Fusion ---------------------------------------------------------------
+
+
+def test_rrf_combines_ranked_lists_by_weighted_score() -> None:
+    rrf = ReciprocalRankFusion(k=60)
+    cypher = [{"id": "A"}, {"id": "B"}, {"id": "C"}]
+    vector = [{"id": "B"}, {"id": "D"}]
+    weights = {"cypher": 0.6, "vector": 0.4}
+    fused = rrf.fuse({"cypher": cypher, "vector": vector}, weights)
+    ids = [entry["id"] for entry in fused]
+    assert "B" in ids
+    assert ids[0] in {"A", "B"}  # weights tilt A first; B has hits in both
+    # Every fused entry carries a numeric score.
+    for entry in fused:
+        assert isinstance(entry["score"], float)
+
+
+def test_rrf_skips_backends_below_weight_floor() -> None:
+    rrf = ReciprocalRankFusion(k=60, weight_floor=0.10)
+    fused = rrf.fuse(
+        {"cypher": [{"id": "A"}], "vector": [{"id": "B"}]},
+        {"cypher": 0.9, "vector": 0.05},
+    )
+    ids = [entry["id"] for entry in fused]
+    assert ids == ["A"]  # vector dropped below floor
+
+
+def test_rrf_degenerate_single_list_preserves_order() -> None:
+    rrf = ReciprocalRankFusion(k=60)
+    items = [{"id": "x"}, {"id": "y"}, {"id": "z"}]
+    fused = rrf.fuse({"cypher": items}, {"cypher": 0.9})
+    assert [entry["id"] for entry in fused] == ["x", "y", "z"]
+
+
+def test_rrf_uses_str_fallback_when_id_missing() -> None:
+    rrf = ReciprocalRankFusion(k=60)
+    fused = rrf.fuse({"cypher": ["alpha", "beta"]}, {"cypher": 0.9})
+    assert [entry["id"] for entry in fused] == ["alpha", "beta"]
+
+
+def test_rrf_rejects_nonpositive_k() -> None:
+    with pytest.raises(ValueError, match="k must be positive"):
+        ReciprocalRankFusion(k=0)
+
+
+# ---- Router stages --------------------------------------------------------
+
+
+def test_augment_returns_intent_entities_topic(policy: RoutingPolicy) -> None:
+    router = QueryEnrichmentRouter(policy=policy)
+    aug = router.augment('What is "Foo Corp"?', workspace_id="ws-1")
+    assert "intent" in aug and "confidence" in aug["intent"]
+    assert "Foo Corp" in aug["entities"]
+    assert aug["workspace_id"] == "ws-1"
+    assert aug["topic"] == []
+
+
+def test_default_intent_classifier_picks_relationship_lookup() -> None:
+    out = _default_intent_classifier("What is the relationship between A and B?")
+    assert out["intent"] == "relationship_lookup"
+    assert out["confidence"] >= 0.6
+
+
+def test_default_intent_classifier_falls_back_for_unknown() -> None:
+    out = _default_intent_classifier("xyzzy plugh")
+    assert out["intent"] == "lookup"
+    assert out["reason"] == "default"
+
+
+def test_route_returns_routing_decision_for_known_intent(policy: RoutingPolicy) -> None:
+    router = QueryEnrichmentRouter(policy=policy)
+    aug = router.augment("Describe Apple Inc.")
+    decision = router.route(aug)
+    assert decision.intent
+    assert sum(decision.weights.values()) > 0
+
+
+def test_fan_out_runs_only_configured_backends(policy: RoutingPolicy) -> None:
+    seen: List[str] = []
+
+    def cypher_backend(q, aug, dec):  # noqa: ANN001
+        seen.append("cypher")
+        return [{"id": "doc:A"}, {"id": "doc:B"}]
+
+    router = QueryEnrichmentRouter(policy=policy, cypher_backend=cypher_backend)
+    aug = router.augment("look up Foo Corp")
+    decision = router.route(aug)
+    fan_out = asyncio.run(router.fan_out("look up Foo Corp", aug, decision))
+    if decision.weights.get("cypher", 0.0) >= 0.10:
+        assert "cypher" in fan_out
+        assert seen == ["cypher"]
+        assert len(fan_out["cypher"].items) == 2
+        assert fan_out["cypher"].error is None
+
+
+def test_fan_out_isolates_backend_failures(policy: RoutingPolicy) -> None:
+    def good(q, aug, dec):  # noqa: ANN001
+        return [{"id": "good:1"}]
+
+    def boom(q, aug, dec):  # noqa: ANN001
+        raise RuntimeError("intentional")
+
+    router = QueryEnrichmentRouter(
+        policy=policy,
+        cypher_backend=good,
+        vector_backend=boom,
+    )
+    aug = router.augment("describe Foo")
+    decision = router.route(aug)
+    # Force both backends past the floor by stamping weights.
+    decision.weights["cypher"] = 0.5
+    decision.weights["vector"] = 0.5
+    fan_out = asyncio.run(router.fan_out("describe Foo", aug, decision))
+    assert fan_out["cypher"].error is None
+    assert fan_out["vector"].error and "intentional" in fan_out["vector"].error
+
+
+def test_fuse_excludes_errored_backends(policy: RoutingPolicy) -> None:
+    def good(q, aug, dec):  # noqa: ANN001
+        return [{"id": "g:1"}]
+
+    def boom(q, aug, dec):  # noqa: ANN001
+        raise RuntimeError("nope")
+
+    router = QueryEnrichmentRouter(
+        policy=policy,
+        cypher_backend=good,
+        vector_backend=boom,
+    )
+    aug = router.augment("describe Foo")
+    decision = router.route(aug)
+    decision.weights["cypher"] = 0.5
+    decision.weights["vector"] = 0.5
+    fan_out = asyncio.run(router.fan_out("describe Foo", aug, decision))
+    fused = router.fuse(fan_out, decision)
+    assert [entry["id"] for entry in fused] == ["g:1"]
+
+
+def test_run_end_to_end_with_single_cypher_backend(policy: RoutingPolicy) -> None:
+    calls: List[Dict[str, Any]] = []
+
+    def cypher_backend(question, augmentation, decision):  # noqa: ANN001
+        calls.append({"q": question, "intent": augmentation["intent"]["intent"]})
+        return [{"id": "entity:Foo"}, {"id": "entity:Bar"}]
+
+    router = QueryEnrichmentRouter(policy=policy, cypher_backend=cypher_backend)
+    fused, trace = router.run('Find "Foo Corp"', workspace_id="ws-1")
+
+    # Cypher weight may dip below floor depending on default policy; if so the
+    # backend is intentionally not invoked. Either branch is a valid thin
+    # slice — we just assert the trace shape stays coherent.
+    assert trace.workspace_id == "ws-1"
+    assert "Foo Corp" in trace.augmentation["entities"]
+    assert trace.decision["intent"]
+    if "cypher" in trace.backends_run:
+        assert calls and calls[0]["intent"]
+        assert any(entry["id"].startswith("entity:") for entry in fused)
+
+
+# ---- Feature flag ---------------------------------------------------------
+
+
+def test_feature_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SEOCHO_ENABLE_ENRICHMENT_ROUTER", raising=False)
+    assert enrichment_router_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE"])
+def test_feature_flag_on(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("SEOCHO_ENABLE_ENRICHMENT_ROUTER", value)
+    assert enrichment_router_enabled() is True


### PR DESCRIPTION
## Summary
- Adds \`seocho/agent/enrichment_router.py\` — the augmentation actor that \`RoutingPolicy.decide()\` was waiting for. Four stages: \`augment\` (intent + entities + topic + rewrite) → \`route\` → \`fan_out\` (\`asyncio.gather\` with per-backend timeout + error isolation) → \`fuse\`
- Adds \`seocho/agent/fusion.py\` — \`Fusion\` Protocol + \`ReciprocalRankFusion\` default (k=60), with the same weight floor cutoff the policy uses; pluggable so a later LLM-rerank impl can drop in
- Wires the router as an opt-in pre-stage in \`Session.ask()\` behind \`SEOCHO_ENABLE_ENRICHMENT_ROUTER=1\`. Thin slice stamps intent/entities into agent context; full fan-out replacement of \`QueryAgent\` lands with the integration milestone
- Emits a per-call \`RouterTrace\` carrying workspace_id, augmentation payload, decision summary, per-backend latency, fused top-K (CLAUDE.md §9)
- 17 unit tests in \`seocho/tests/test_enrichment_router.py\` covering RRF math, weight floors, augment defaults, fan-out, error isolation, end-to-end one-shot, feature flag parsing

Out of scope for this thin slice: vector / fulltext / GDS backends (Cypher slot stubbed; the other three return empty), LLM-driven topic extractor, short-circuit on high-confidence single-entity lookups, default replacement of \`_default_augment\` in \`graph_loop.py\`.

ADR: [\`docs/decisions/ADR-0091-query-enrichment-router-and-parallel-fan-out.md\`](docs/decisions/ADR-0091-query-enrichment-router-and-parallel-fan-out.md)
bd subtask: \`seocho-j965.3\` (depends on \`seocho-j965.2\`)

## Test plan
- [ ] \`pytest seocho/tests/test_enrichment_router.py -v\` — 17 tests pass
- [ ] \`Session.ask()\` with flag off behaves exactly as before
- [ ] With flag on, agent context shows \`[Enrichment intent: ...]\` / \`[Enrichment entities: ...]\` lines without breaking the existing chat path