### PR TITLE
feat(adr-0090): tiered NL→Cypher tools + Tier-1/2/3 system prompt

### DIFF
--- a/seocho/agent/factory.py
+++ b/seocho/agent/factory.py
@@ -41,22 +41,36 @@ answer questions by building and executing graph queries.
 
 {ctx.get('graph_schema', '')}
 
-## Workflow
+## Workflow (ADR-0090 tiered NL→Cypher)
 
 1. Analyze the user's question to determine intent:
-   - entity_lookup: find info about a specific entity
-   - relationship_lookup: find relationships between entities
-   - neighbors: find connected entities
-   - path: find paths between entities
-   - count: count entities/relationships
-   - list_all: list entities of a type
+   - entity_lookup, relationship_lookup, neighbors, path, count, list_all
 
-2. Call `text2cypher` with the structured intent (DO NOT write Cypher yourself)
-3. Call `execute_cypher` with the generated query
-4. If results are empty:
-   - Try a broader query (e.g., neighbors instead of specific relationship)
-   - Try fuzzy matching on entity names
-5. Synthesize a clear answer from the results
+2. **Tier 1 — template lookup (cheap, deterministic).**
+   Call `text2cypher` (a.k.a. cypher_template_lookup) with the structured
+   intent. If it returns a non-empty Cypher template, go to Tier-validate.
+
+3. **Tier 2 — schema-grounded generation (only on Tier-1 miss).**
+   - Call `similar_query_search` to retrieve up to k validated past
+     (NL, Cypher) examples for this workspace as few-shot context.
+   - Call `schema_introspect` to read the live workspace schema
+     (labels / relationship types / property keys).
+   - Use those signals to assemble a Cypher plan grounded in the actual
+     workspace state. Never hallucinate labels or properties.
+
+4. **Tier-validate.** Always call `validate_cypher` before
+   `execute_cypher`. Pass the cypher, parameters, and the allow-lists you
+   read from `schema_introspect`. If `ok=false`, fix the listed
+   violations and re-validate once.
+
+5. **Tier-execute.** Call `execute_cypher`.
+
+6. **Tier 3 — single repair on validate or execute error.** If the
+   previous step failed, feed the error text back and regenerate the
+   Cypher once. After two failures total, return a clear refusal with
+   the diagnostic — do not loop further.
+
+7. Synthesize a concise answer from the records.
 
 ## Query hints
 
@@ -64,10 +78,15 @@ answer questions by building and executing graph queries.
 
 ## Rules
 
-- NEVER write Cypher directly — always use `text2cypher`
+- NEVER write Cypher directly without `text2cypher` or `validate_cypher`.
+- `text2cypher` is preferred for known intents — it produces deterministic,
+  ontology-grounded queries.
+- `schema_introspect` is the source of truth for what labels / rels /
+  properties exist in the active workspace.
+- `validate_cypher` MUST run before any `execute_cypher`.
 - Available node types: {ctx.get('node_types', '')}
 - Available relationships: {ctx.get('relationship_types', '')}
-- If no results found after retries, say so clearly
+- If no results found after the single Tier-3 repair, say so clearly.
 """
 
 

--- a/seocho/store/vector.py
+++ b/seocho/store/vector.py
@@ -402,3 +402,77 @@ def create_vector_store(
             region=region,
         )
     raise ValueError(f"Unsupported vector store kind '{kind}'. Known kinds: faiss, lancedb")
+
+
+# ======================================================================
+# NL→Cypher example store (ADR-0090)
+# ======================================================================
+
+
+@dataclass(frozen=True)
+class NLCypherExample:
+    """A previously-validated (question, Cypher) pair for few-shot reuse."""
+
+    question: str
+    cypher: str
+    success: bool = True
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class NLCypherExampleStore:
+    """Per-workspace store of validated (NL, Cypher) pairs.
+
+    Thin slice: in-memory dict, no embeddings, no eviction. ADR-0090
+    follow-up replaces this with a real per-workspace vector index keyed by
+    question embedding and gated on ``success == True``.
+
+    The Protocol is intentionally narrow:
+
+    - ``add(workspace_id, question, cypher, success, metadata)`` writes a
+      new validated pair. No-op when ``success`` is False (the ADR-0090
+      contract forbids poisoning the store with failed examples).
+    - ``search(workspace_id, question, k)`` returns the top-k examples.
+      Thin slice: returns up to ``k`` most-recent successful entries for
+      this workspace; embedding-based ranking is a follow-up.
+    """
+
+    def __init__(self) -> None:
+        self._by_workspace: Dict[str, List[NLCypherExample]] = {}
+
+    def add(
+        self,
+        *,
+        workspace_id: str,
+        question: str,
+        cypher: str,
+        success: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not success:
+            return
+        if not question or not cypher:
+            return
+        bucket = self._by_workspace.setdefault(workspace_id, [])
+        bucket.append(
+            NLCypherExample(
+                question=question.strip(),
+                cypher=cypher.strip(),
+                success=True,
+                metadata=dict(metadata or {}),
+            )
+        )
+
+    def search(
+        self,
+        *,
+        workspace_id: str,
+        question: str,
+        k: int = 5,
+    ) -> List[NLCypherExample]:
+        if k <= 0:
+            return []
+        bucket = self._by_workspace.get(workspace_id) or []
+        return list(reversed(bucket))[:k]
+
+    def __len__(self) -> int:
+        return sum(len(v) for v in self._by_workspace.values())

--- a/seocho/tests/test_session_agent.py
+++ b/seocho/tests/test_session_agent.py
@@ -213,7 +213,10 @@ class TestToolCreation:
             ontology_context=context,
             workspace_id="acme",
         )
-        assert len(tools) == 2  # text2cypher, execute_cypher
+        # ADR-0090 adds schema_introspect, validate_cypher, similar_query_search
+        # alongside the original text2cypher and execute_cypher.
+        names = {getattr(t, "name", getattr(t, "__name__", "")) for t in tools}
+        assert {"text2cypher", "execute_cypher", "schema_introspect", "validate_cypher", "similar_query_search"} <= names
 
     def test_create_query_tools_with_vector_store(self, monkeypatch):
         self._patch_agents(monkeypatch)
@@ -224,7 +227,10 @@ class TestToolCreation:
         vstore = MagicMock()
 
         tools = create_query_tools(ontology=onto, graph_store=store, vector_store=vstore)
-        assert len(tools) == 3  # text2cypher, execute_cypher, search_similar
+        names = {getattr(t, "name", getattr(t, "__name__", "")) for t in tools}
+        # ADR-0090 tier-1/2/3 tools plus the optional document-corpus search_similar.
+        assert "search_similar" in names
+        assert {"text2cypher", "execute_cypher", "schema_introspect", "validate_cypher", "similar_query_search"} <= names
 
     @staticmethod
     def _patch_agents(monkeypatch):
@@ -454,7 +460,9 @@ class TestAgentCreation:
             ontology=onto, graph_store=store, llm=llm,
         )
         assert agent.name == "QueryAgent"
-        assert len(agent.tools) == 2
+        # ADR-0090: QueryAgent now carries the tier-1/2/3 tool set.
+        names = {getattr(t, "name", getattr(t, "__name__", "")) for t in agent.tools}
+        assert {"text2cypher", "execute_cypher", "schema_introspect", "validate_cypher", "similar_query_search"} <= names
 
     def test_indexing_agent_system_prompt_contains_ontology(self):
         onto = _make_test_ontology()

--- a/seocho/tests/test_tiered_nl2cypher.py
+++ b/seocho/tests/test_tiered_nl2cypher.py
@@ -1,0 +1,281 @@
+"""Tests for ADR-0090 tiered NL→Cypher tools + NLCypherExampleStore.
+
+The function tools are decorated with ``@function_tool`` from the OpenAI
+Agents SDK. We stub ``agents`` so ``function_tool`` returns the callable
+unchanged (matching the test pattern used elsewhere in this repo, e.g.
+test_agent_contract.py), then invoke the tools as plain functions.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+
+import pytest
+
+
+def _stub_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = types.SimpleNamespace(
+        Agent=type("_StubAgent", (), {}),
+        function_tool=lambda fn: fn,
+        RunContextWrapper=type("_StubCtx", (), {}),
+        Runner=type("_StubRunner", (), {}),
+        ModelSettings=type("_StubSettings", (), {}),
+        handoff=lambda *_a, **_kw: None,
+        trace=lambda *_a, **_k: None,
+    )
+    monkeypatch.setitem(sys.modules, "agents", fake)
+    if "seocho.tools" in sys.modules:
+        del sys.modules["seocho.tools"]
+
+
+# ---- NLCypherExampleStore (no Agents SDK dependency) ---------------------
+
+
+def test_example_store_is_empty_by_default() -> None:
+    from seocho.store.vector import NLCypherExampleStore
+
+    store = NLCypherExampleStore()
+    assert len(store) == 0
+    assert store.search(workspace_id="ws", question="anything", k=5) == []
+
+
+def test_example_store_adds_successful_pair() -> None:
+    from seocho.store.vector import NLCypherExampleStore
+
+    store = NLCypherExampleStore()
+    store.add(
+        workspace_id="ws",
+        question="Find Apple",
+        cypher="MATCH (e:Entity {name:'Apple'}) RETURN e",
+    )
+    assert len(store) == 1
+    out = store.search(workspace_id="ws", question="Find Apple", k=5)
+    assert len(out) == 1
+    assert out[0].question == "Find Apple"
+    assert "Apple" in out[0].cypher
+
+
+def test_example_store_ignores_failed_pair() -> None:
+    from seocho.store.vector import NLCypherExampleStore
+
+    store = NLCypherExampleStore()
+    store.add(workspace_id="ws", question="q", cypher="c", success=False)
+    assert len(store) == 0
+
+
+def test_example_store_is_workspace_scoped() -> None:
+    from seocho.store.vector import NLCypherExampleStore
+
+    store = NLCypherExampleStore()
+    store.add(workspace_id="ws-A", question="qA", cypher="cypher A")
+    store.add(workspace_id="ws-B", question="qB", cypher="cypher B")
+    assert [ex.question for ex in store.search(workspace_id="ws-A", question="x", k=5)] == ["qA"]
+    assert [ex.question for ex in store.search(workspace_id="ws-B", question="x", k=5)] == ["qB"]
+
+
+def test_example_store_returns_most_recent_first() -> None:
+    from seocho.store.vector import NLCypherExampleStore
+
+    store = NLCypherExampleStore()
+    for i in range(3):
+        store.add(workspace_id="ws", question=f"q{i}", cypher=f"c{i}")
+    out = store.search(workspace_id="ws", question="x", k=2)
+    assert [ex.question for ex in out] == ["q2", "q1"]
+
+
+def test_example_store_search_with_k_zero_returns_empty() -> None:
+    from seocho.store.vector import NLCypherExampleStore
+
+    store = NLCypherExampleStore()
+    store.add(workspace_id="ws", question="q", cypher="c")
+    assert store.search(workspace_id="ws", question="q", k=0) == []
+
+
+# ---- Tool factories (with agents stub) -----------------------------------
+
+
+def test_schema_introspect_tool_returns_graph_store_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    class FakeStore:
+        def get_schema(self, *, database: str, workspace_id: str):
+            assert database == "neo4j"
+            assert workspace_id == "ws-1"
+            return {"labels": ["Entity"], "relationship_types": ["MENTIONS"], "property_keys": ["name"]}
+
+    tool = tools.make_schema_introspect_tool(FakeStore(), workspace_id="ws-1")
+    payload = json.loads(tool(database=""))
+    assert payload == {
+        "labels": ["Entity"],
+        "relationship_types": ["MENTIONS"],
+        "property_keys": ["name"],
+    }
+
+
+def test_schema_introspect_tool_swallows_store_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    class BoomStore:
+        def get_schema(self, *, database: str, workspace_id: str):
+            raise RuntimeError("bolt down")
+
+    tool = tools.make_schema_introspect_tool(BoomStore())
+    payload = json.loads(tool(database=""))
+    assert payload["labels"] == []
+    assert "bolt down" in payload["error"]
+
+
+def test_validate_cypher_tool_rejects_forbidden_keywords(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    tool = tools.make_validate_cypher_tool(workspace_id="ws-1")
+    payload = json.loads(
+        tool(
+            cypher="MATCH (n {id:$node_id}) DETACH DELETE n RETURN n",
+            params_json='{"node_id":"x"}',
+        )
+    )
+    assert payload["ok"] is False
+    assert any("forbidden_token" in v for v in payload["violations"])
+
+
+def test_validate_cypher_tool_flags_missing_node_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    tool = tools.make_validate_cypher_tool(workspace_id="ws-1")
+    payload = json.loads(tool(cypher="MATCH (n) RETURN n", params_json="{}"))
+    assert payload["ok"] is False
+    assert "missing_node_binding" in payload["violations"]
+
+
+def test_validate_cypher_tool_passes_clean_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    tool = tools.make_validate_cypher_tool(workspace_id="ws-1")
+    payload = json.loads(
+        tool(
+            cypher="MATCH (n:Entity {id:$node_id}) RETURN n",
+            params_json='{"node_id":"x"}',
+            allowed_labels_csv="Entity",
+            allowed_properties_csv="id",
+        )
+    )
+    assert payload["ok"] is True
+    assert payload["labels"] == ["Entity"]
+    assert payload["workspace_id"] == "ws-1"
+
+
+def test_similar_query_search_tool_returns_empty_without_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    tool = tools.make_similar_query_search_tool(None, workspace_id="ws-1")
+    payload = json.loads(tool(question="anything", k=5))
+    assert payload == {"examples": [], "count": 0}
+
+
+def test_similar_query_search_tool_returns_store_hits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    from seocho.store.vector import NLCypherExampleStore
+
+    tools = importlib.import_module("seocho.tools")
+
+    store = NLCypherExampleStore()
+    store.add(workspace_id="ws-1", question="Find Apple", cypher="MATCH (a) RETURN a")
+
+    tool = tools.make_similar_query_search_tool(store, workspace_id="ws-1")
+    payload = json.loads(tool(question="Find Apple", k=5))
+    assert payload["count"] == 1
+    assert payload["examples"][0]["question"] == "Find Apple"
+
+
+# ---- create_query_tools wiring -------------------------------------------
+
+
+def test_create_query_tools_returns_tiered_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    tools = importlib.import_module("seocho.tools")
+
+    class FakeOntology:
+        graph_model = "lpg"
+        name = "test"
+        namespace = "test"
+        nodes: dict = {}
+        relations: dict = {}
+        property_types: dict = {}
+
+        def to_query_context(self):
+            return {"ontology_name": "test"}
+
+    class FakeStore:
+        def get_schema(self, *, database: str, workspace_id: str):
+            return {"labels": [], "relationship_types": [], "property_keys": []}
+
+        def query(self, *_a, **_kw):
+            return []
+
+    out = tools.create_query_tools(
+        ontology=FakeOntology(),
+        graph_store=FakeStore(),
+        workspace_id="ws-1",
+    )
+    names = {getattr(t, "__name__", None) for t in out}
+    assert "text2cypher" in names
+    assert "execute_cypher" in names
+    assert "schema_introspect" in names
+    assert "validate_cypher" in names
+    assert "similar_query_search" in names
+
+
+# ---- factory.py system prompt covers tiered policy ------------------------
+
+
+def test_query_system_prompt_documents_tiered_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_agents(monkeypatch)
+    if "seocho.agent.factory" in sys.modules:
+        del sys.modules["seocho.agent.factory"]
+    factory = importlib.import_module("seocho.agent.factory")
+
+    class FakeOntology:
+        def to_query_context(self):
+            return {
+                "ontology_name": "test",
+                "graph_schema": "schema",
+                "query_hints": "hints",
+                "node_types": "Entity",
+                "relationship_types": "MENTIONS",
+            }
+
+    prompt = factory.query_system_prompt(FakeOntology())
+    assert "Tier 1" in prompt
+    assert "Tier 2" in prompt
+    assert "Tier 3" in prompt
+    assert "schema_introspect" in prompt
+    assert "validate_cypher" in prompt
+    assert "similar_query_search" in prompt

--- a/seocho/tools.py
+++ b/seocho/tools.py
@@ -384,6 +384,157 @@ def make_search_similar_tool(vector_store: Any):
 
 
 # ======================================================================
+# ADR-0090: tiered NL→Cypher support tools
+# ======================================================================
+
+
+def make_schema_introspect_tool(
+    graph_store: Any,
+    *,
+    workspace_id: str = "default",
+    default_database: str = "neo4j",
+):
+    """Wrap ``graph_store.get_schema()`` as a function tool (ADR-0090).
+
+    Returns ``{labels, relationship_types, property_keys}`` for the active
+    workspace. The tool lets the agent ground Cypher generation in the
+    live schema instead of hallucinating labels.
+    """
+    from agents import function_tool
+
+    @function_tool
+    def schema_introspect(database: str = "") -> str:
+        """Return the live label / relationship / property keys for the workspace.
+
+        Args:
+            database: Optional database name; defaults to the configured one.
+
+        Returns:
+            JSON string with ``labels``, ``relationship_types``, ``property_keys``.
+        """
+        db = database.strip() or default_database
+        try:
+            schema = graph_store.get_schema(database=db, workspace_id=workspace_id)
+            return json.dumps(schema, default=str)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("schema_introspect failed: %s", exc)
+            return json.dumps(
+                {"labels": [], "relationship_types": [], "property_keys": [], "error": str(exc)}
+            )
+
+    return schema_introspect
+
+
+def make_validate_cypher_tool(*, workspace_id: str = "default"):
+    """Wrap ``CypherQueryValidator.validate()`` as a function tool (ADR-0090).
+
+    Lets the agent pre-flight a generated query (forbidden keywords +
+    label/relationship/property allow-lists) before calling
+    ``execute_cypher``. Thin slice: agent supplies allow-lists explicitly
+    via the tool args; the integration milestone wires them automatically
+    from ``schema_introspect`` output.
+    """
+    from agents import function_tool
+
+    from .query.contracts import CypherPlan
+    from .query.cypher_validator import CypherQueryValidator
+
+    validator = CypherQueryValidator()
+
+    @function_tool
+    def validate_cypher(
+        cypher: str,
+        params_json: str = "{}",
+        allowed_labels_csv: str = "",
+        allowed_relationship_types_csv: str = "",
+        allowed_properties_csv: str = "",
+    ) -> str:
+        """Validate a Cypher plan against forbidden tokens + workspace allow-lists.
+
+        Args:
+            cypher: The Cypher query text.
+            params_json: JSON-encoded parameter dict (must include ``$node_id``).
+            allowed_labels_csv: Comma-separated labels permitted in the query.
+            allowed_relationship_types_csv: Comma-separated rel-type allow-list.
+            allowed_properties_csv: Comma-separated property allow-list.
+
+        Returns:
+            JSON with ``ok``, ``violations``, observed ``labels`` / ``relation_types`` / ``properties``.
+        """
+        try:
+            params = json.loads(params_json) if params_json else {}
+        except json.JSONDecodeError:
+            params = {}
+
+        plan = CypherPlan(
+            database="",
+            query=cypher,
+            params=params if isinstance(params, dict) else {},
+            strategy="agent_validate",
+            anchor_entity="",
+        )
+        constraint_slice = {
+            "allowed_labels": [s for s in allowed_labels_csv.split(",") if s.strip()],
+            "allowed_relationship_types": [
+                s for s in allowed_relationship_types_csv.split(",") if s.strip()
+            ],
+            "allowed_properties": [s for s in allowed_properties_csv.split(",") if s.strip()],
+        }
+        try:
+            result = validator.validate(plan, constraint_slice)
+            result["workspace_id"] = workspace_id
+            return json.dumps(result, default=str)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("validate_cypher failed: %s", exc)
+            return json.dumps({"ok": False, "violations": ["validator_error"], "error": str(exc)})
+
+    return validate_cypher
+
+
+def make_similar_query_search_tool(
+    example_store: Any = None,
+    *,
+    workspace_id: str = "default",
+):
+    """Wrap ``NLCypherExampleStore.search()`` as a function tool (ADR-0090).
+
+    Thin slice: returns an empty list when no store is configured; when a
+    store is configured, returns up to ``k`` most-recent successful
+    examples for this workspace. The embedding-based retrieval upgrade is
+    a follow-up.
+    """
+    from agents import function_tool
+
+    @function_tool
+    def similar_query_search(question: str, k: int = 5) -> str:
+        """Retrieve previously-validated (question, Cypher) pairs as few-shot context.
+
+        Args:
+            question: The user's NL question.
+            k: Maximum number of past examples to return.
+
+        Returns:
+            JSON with ``examples`` (list of ``{question, cypher}``) and ``count``.
+        """
+        if example_store is None:
+            return json.dumps({"examples": [], "count": 0})
+        try:
+            examples = example_store.search(workspace_id=workspace_id, question=question, k=k)
+            payload = {
+                "examples": [
+                    {"question": ex.question, "cypher": ex.cypher} for ex in examples
+                ],
+                "count": len(examples),
+            }
+            return json.dumps(payload, default=str)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("similar_query_search failed: %s", exc)
+            return json.dumps({"examples": [], "count": 0, "error": str(exc)})
+
+    return similar_query_search
+
+
+# ======================================================================
 # Tool collection factory
 # ======================================================================
 
@@ -418,13 +569,33 @@ def create_query_tools(
     vector_store: Any = None,
     ontology_context: Any = None,
     workspace_id: str = "default",
+    nl_cypher_example_store: Any = None,
+    default_database: str = "neo4j",
 ) -> List[Any]:
-    """Create the full set of query tools."""
+    """Create the full set of query tools.
+
+    ADR-0090: the tiered NL→Cypher policy gets three additional support
+    tools (``schema_introspect``, ``validate_cypher``,
+    ``similar_query_search``) alongside the existing ``text2cypher`` and
+    ``execute_cypher``. The latter two are unchanged; the new tools are
+    additive and safe to expose even when the agent prompt is the
+    pre-ADR-0090 version.
+    """
     tools = [
         make_text2cypher_tool(ontology),
         make_execute_cypher_tool(
             graph_store,
             ontology_context=ontology_context,
+            workspace_id=workspace_id,
+        ),
+        make_schema_introspect_tool(
+            graph_store,
+            workspace_id=workspace_id,
+            default_database=default_database,
+        ),
+        make_validate_cypher_tool(workspace_id=workspace_id),
+        make_similar_query_search_tool(
+            nl_cypher_example_store,
             workspace_id=workspace_id,
         ),
     ]


### PR DESCRIPTION
## Summary
- Three new \`@function_tool\` factories in \`seocho/tools.py\`:
  - \`make_schema_introspect_tool\` wraps \`Neo4jGraphStore.get_schema()\` with workspace_id propagation — agent reads the live workspace schema before generating Cypher
  - \`make_validate_cypher_tool\` wraps \`CypherQueryValidator.validate()\` (forbidden-token blocklist + label/relationship/property allow-lists) — agent pre-flights every generated query
  - \`make_similar_query_search_tool\` reads the new \`NLCypherExampleStore\` for few-shot (NL, Cypher) examples; returns empty when no store is configured
- \`create_query_tools()\` now wires all five tools (text2cypher, execute_cypher, schema_introspect, validate_cypher, similar_query_search) plus the existing optional \`search_similar\`
- Adds \`NLCypherExample\` + \`NLCypherExampleStore\` to \`seocho/store/vector.py\` — in-memory, workspace-scoped, ignores failed pairs (no poisoning), most-recent-first retrieval. Persistent FAISS/LanceDB backing is a follow-up.
- Rewrites the \`QueryAgent\` system prompt (\`seocho/agent/factory.py:35-71\`) for the tiered policy: **Tier 1** template lookup → **Tier 2** \`similar_query_search\` + \`schema_introspect\` + generate → **Tier-validate** → **Tier-execute** → **Tier 3** single repair on error, then refuse.
- 15 unit tests in \`seocho/tests/test_tiered_nl2cypher.py\` covering the store, the three tool factories (forbidden tokens, missing node binding, clean pass-through, schema introspection success and error paths, store hit/miss), \`create_query_tools\` wiring, and the prompt text contract.

Out of scope for this thin slice: persistent vector backing for the example store, the cache write-back loop on successful execute, end-to-end LLM-driven Tier-2/3 generation. The prompt documents them; runtime behavior remains the existing text2cypher path until the integration milestone.

ADR: [\`docs/decisions/ADR-0090-tiered-nl2cypher-query-agent.md\`](docs/decisions/ADR-0090-tiered-nl2cypher-query-agent.md)
bd subtask: \`seocho-j965.1\`

## Test plan
- [ ] \`pytest seocho/tests/test_tiered_nl2cypher.py -v\` — 15 tests pass
- [ ] Existing query-agent tests still pass: \`pytest seocho/tests/test_agent_contract.py seocho/tests/test_agent_factory_cache.py\`
- [ ] Manual smoke: \`QueryAgent\` with the new prompt resolves a known-entity question via the Tier-1 template path (no behavioral regression)