### PR TITLE
Draft: perf(ontology): optimize coverage stats n+1 query

### DIFF
--- a/seocho/ontology.py
+++ b/seocho/ontology.py
@@ -2362,19 +2362,44 @@ class Ontology:
             print(stats["overall_score"])        # 0.75
             print(stats["unused"]["node_types"]) # ["OldEntity"]
         """
+        try:
+            schema = graph_store.get_schema(database=database)
+            existing_labels = set(schema.get("labels", []))
+            existing_rtypes = set(schema.get("relationship_types", []))
+        except Exception:
+            existing_labels = None
+            existing_rtypes = None
+
         node_stats: List[Dict[str, Any]] = []
         total_defined_nodes = len(self.nodes)
         populated_nodes = 0
 
+        node_counts = {}
+        labels_to_count = []
         for label in self.nodes:
+            if existing_labels is not None and label not in existing_labels:
+                node_counts[label] = 0
+            else:
+                labels_to_count.append(label)
+
+        chunk_size = 50
+        for i in range(0, len(labels_to_count), chunk_size):
+            chunk = labels_to_count[i:i + chunk_size]
+            queries = [
+                f"MATCH (n:`{label}`) RETURN '{label}' AS key, count(n) AS cnt"
+                for label in chunk
+            ]
+            union_query = " UNION ALL ".join(queries)
             try:
-                result = graph_store.query(
-                    f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                result = graph_store.query(union_query, database=database)
+                chunk_counts = {row["key"]: int(row["cnt"]) for row in result}
             except Exception:
-                count = 0
+                chunk_counts = {}
+            for label in chunk:
+                node_counts[label] = chunk_counts.get(label, 0)
+
+        for label in self.nodes:
+            count = node_counts.get(label, 0)
             node_stats.append({"label": label, "count": count})
             if count > 0:
                 populated_nodes += 1
@@ -2383,15 +2408,31 @@ class Ontology:
         total_defined_rels = len(self.relationships)
         populated_rels = 0
 
+        rel_counts = {}
+        rtypes_to_count = []
         for rtype in self.relationships:
+            if existing_rtypes is not None and rtype not in existing_rtypes:
+                rel_counts[rtype] = 0
+            else:
+                rtypes_to_count.append(rtype)
+
+        for i in range(0, len(rtypes_to_count), chunk_size):
+            chunk = rtypes_to_count[i:i + chunk_size]
+            queries = [
+                f"MATCH ()-[r:`{rtype}`]->() RETURN '{rtype}' AS key, count(r) AS cnt"
+                for rtype in chunk
+            ]
+            union_query = " UNION ALL ".join(queries)
             try:
-                result = graph_store.query(
-                    f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                result = graph_store.query(union_query, database=database)
+                chunk_counts = {row["key"]: int(row["cnt"]) for row in result}
             except Exception:
-                count = 0
+                chunk_counts = {}
+            for rtype in chunk:
+                rel_counts[rtype] = chunk_counts.get(rtype, 0)
+
+        for rtype in self.relationships:
+            count = rel_counts.get(rtype, 0)
             rel_stats.append({"type": rtype, "count": count})
             if count > 0:
                 populated_rels += 1

--- a/seocho/tests/test_ontology_artifact_promotion.py
+++ b/seocho/tests/test_ontology_artifact_promotion.py
@@ -40,8 +40,35 @@ class FakeGraphStore:
         self._node_counts = node_counts or {}
         self._rel_counts = rel_counts or {}
 
+    def get_schema(self, *, database: str = "neo4j"):
+        return {
+            "labels": list(self._node_counts.keys()),
+            "relationship_types": list(self._rel_counts.keys()),
+            "property_keys": []
+        }
+
     def query(self, cypher: str, *, params=None, database="neo4j") -> List[Dict[str, Any]]:
-        # Parse label/type from the Cypher MATCH pattern
+        # Handle UNION ALL style multi-queries added for optimization
+        if "UNION ALL" in cypher:
+            result = []
+            for part in cypher.split(" UNION ALL "):
+                if "MATCH (n:`" in part:
+                    label = part.split("MATCH (n:`")[1].split("`)")[0]
+                    result.append({"key": label, "cnt": self._node_counts.get(label, 0)})
+                elif "MATCH ()-[r:`" in part:
+                    rtype = part.split("MATCH ()-[r:`")[1].split("`]->()")[0]
+                    result.append({"key": rtype, "cnt": self._rel_counts.get(rtype, 0)})
+            return result
+        # Handle single count queries matching the optimized format
+        if "RETURN '" in cypher and "AS key" in cypher:
+            if "MATCH (n:`" in cypher:
+                label = cypher.split("MATCH (n:`")[1].split("`)")[0]
+                return [{"key": label, "cnt": self._node_counts.get(label, 0)}]
+            elif "MATCH ()-[r:`" in cypher:
+                rtype = cypher.split("MATCH ()-[r:`")[1].split("`]->()")[0]
+                return [{"key": rtype, "cnt": self._rel_counts.get(rtype, 0)}]
+
+        # Legacy individual query parsing fallback
         for label, count in self._node_counts.items():
             if f"`{label}`" in cypher and "count(n)" in cypher:
                 return [{"cnt": count}]


### PR DESCRIPTION
## What
Optimized `coverage_stats()` in `seocho/ontology.py` to stop issuing an individual database query for every single node label and relationship type defined in the schema.

## Why
The previous implementation suffered from an N+1 query problem, making schema coverage reporting extremely slow when evaluating massive ontology schemas against remote DozerDB instances. 

## Expected Impact
Dramatically faster coverage metric calculations. Reduces N queries to roughly `(N / 50) + 1` queries by batching them using `UNION ALL`.

## Validation
- `FakeGraphStore` query mock format heavily modified in `test_ontology_artifact_promotion.py` to support testing `UNION ALL` statements.
- `bash scripts/ci/run_basic_ci.sh` passes fully without issue on the new optimization logic. 
- Core coverage metrics are mathematically identical to before (tests verify exact equality).

## Risks
If the backend doesn't support complex `UNION ALL` statements, queries might fail. However, neo4j syntax broadly permits this optimization, and try/except logic safely falls back to returning 0 for missing data if arbitrary database exceptions happen.

---
*PR created automatically by Jules for task [18277287775739534136](https://jules.google.com/task/18277287775739534136) started by @tteon*