### PR TITLE
fix: enforce workspace authz on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_rows:
+        workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in history_rows]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_rows:
+        workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
**Severity**: High
**Vulnerability**: Missing authorization checks on `platform_chat_session_get` and `platform_chat_session_reset` API endpoints. The endpoints returned or modified session history without validating that the caller had access to the workspace associated with the session.
**Impact**: Potential Insecure Direct Object Reference (IDOR). A caller could theoretically read or delete other users' platform chat session history by supplying arbitrary session IDs.
**Fix**: 
- Modified the endpoints to look up the session history first.
- Securely extracted the `workspace_id` from the metadata of the session's first turn (defaulting to `"default"`).
- Called `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` to enforce the runtime policy.
**Validation**: 
- Validated via `bash scripts/ci/run_basic_ci.sh` to ensure no runtime shell contracts or dependencies were broken.
- Tested using `pytest tests/` and `pytest runtime/` checks.
**Risks**: Minor risk of HTTP 403 on older stateless test sessions if metadata was improperly formed, but falls back cleanly to the `"default"` workspace.

---
*PR created automatically by Jules for task [13857204151867709470](https://jules.google.com/task/13857204151867709470) started by @tteon*