### PR TITLE
perf: precompile regex patterns in hot paths

### DIFF
--- a/seocho/query/answering.py
+++ b/seocho/query/answering.py
@@ -8,6 +8,14 @@ from .intent import build_evidence_bundle, infer_question_intent
 
 
 _FOUR_DIGIT_YEAR_RE = re.compile(r"\b(20\d{2})\b")
+_RE_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_RE_ALNUM_TOKEN = re.compile(r"[a-z0-9]+")
+_RE_NUMERIC = re.compile(r"\d+(?:\.\d+)?")
+_RE_THE_PRIOR_YEAR = re.compile(r"\bthe prior year\b", flags=re.IGNORECASE)
+_RE_PRIOR_YEAR = re.compile(r"\bprior year\b", flags=re.IGNORECASE)
+_RE_THE_PREVIOUS_YEAR = re.compile(r"\bthe previous year\b", flags=re.IGNORECASE)
+_RE_PREVIOUS_YEAR = re.compile(r"\bprevious year\b", flags=re.IGNORECASE)
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
 
 
 class QueryAnswerSynthesizer:
@@ -318,7 +326,7 @@ class QueryAnswerSynthesizer:
             return ""
         sentences = [
             sentence.strip()
-            for sentence in re.split(r"(?<=[.!?])\s+", supporting_fact)
+            for sentence in _RE_SENTENCE_SPLIT.split(supporting_fact)
             if sentence.strip()
         ]
         if not sentences:
@@ -326,13 +334,13 @@ class QueryAnswerSynthesizer:
 
         question_terms = {
             token
-            for token in re.findall(r"[a-z0-9]+", question.lower())
+            for token in _RE_ALNUM_TOKEN.findall(question.lower())
             if len(token) > 1
         }
         priority_tokens = {
             token
             for term in priority_terms
-            for token in re.findall(r"[a-z0-9]+", str(term).lower())
+            for token in _RE_ALNUM_TOKEN.findall(str(term).lower())
             if len(token) > 1
         }
         if not question_terms:
@@ -357,9 +365,9 @@ class QueryAnswerSynthesizer:
             )
 
         def score(sentence: str) -> tuple[int, int, int, int]:
-            terms = set(re.findall(r"[a-z0-9]+", sentence.lower()))
+            terms = set(_RE_ALNUM_TOKEN.findall(sentence.lower()))
             priority_hits = len(terms & priority_tokens)
-            numeric_hits = len(set(re.findall(r"\d+(?:\.\d+)?", sentence.lower())) & question_terms)
+            numeric_hits = len(set(_RE_NUMERIC.findall(sentence.lower())) & question_terms)
             return (priority_hits, len(terms & question_terms), numeric_hits, len(sentence))
 
         scored_sentences = [(index, sentence, score(sentence)) for index, sentence in enumerate(sentences)]
@@ -389,10 +397,10 @@ class QueryAnswerSynthesizer:
         if len(ordered_years) < 2:
             return text
         earlier_year = ordered_years[0]
-        normalized = re.sub(r"\bthe prior year\b", earlier_year, text, flags=re.IGNORECASE)
-        normalized = re.sub(r"\bprior year\b", earlier_year, normalized, flags=re.IGNORECASE)
-        normalized = re.sub(r"\bthe previous year\b", earlier_year, normalized, flags=re.IGNORECASE)
-        normalized = re.sub(r"\bprevious year\b", earlier_year, normalized, flags=re.IGNORECASE)
+        normalized = _RE_THE_PRIOR_YEAR.sub(earlier_year, text)
+        normalized = _RE_PRIOR_YEAR.sub(earlier_year, normalized)
+        normalized = _RE_THE_PREVIOUS_YEAR.sub(earlier_year, normalized)
+        normalized = _RE_PREVIOUS_YEAR.sub(earlier_year, normalized)
         return normalized
 
     @staticmethod
@@ -463,8 +471,8 @@ class QueryAnswerSynthesizer:
     def _company_match_score(self, company: str, anchor: str) -> int:
         if not anchor:
             return 0
-        company_norm = re.sub(r"[^a-z0-9]+", " ", company.lower())
-        anchor_norm = re.sub(r"[^a-z0-9]+", " ", anchor.lower())
+        company_norm = _RE_NON_ALNUM.sub(" ", company.lower())
+        anchor_norm = _RE_NON_ALNUM.sub(" ", anchor.lower())
         anchor_tokens = [token for token in anchor_norm.split() if token]
         return sum(2 for token in anchor_tokens if token in company_norm)
 

--- a/seocho/query/cypher_builder.py
+++ b/seocho/query/cypher_builder.py
@@ -14,6 +14,18 @@ classify the user question.
 from __future__ import annotations
 
 import re
+
+_RE_TRAILING_AMP = re.compile(r"\s*&\s*$")
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_ALNUM_UNDERSCORE = re.compile(r"[a-z][a-z0-9_]+")
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_ALNUM = re.compile(r"[a-z][a-z0-9]+")
+_RE_DELTA_IN = re.compile(r"delta in (.+?) from \d{4}")
+_RE_CHANGE_IN = re.compile(r"change in (.+?) from \d{4}")
+_RE_COMPARE_BETWEEN = re.compile(r"compare (.+?) between \d{4}")
+_RE_WHAT_WAS = re.compile(r"what was (.+?) in \d{4}")
+_RE_HOW_MUCH = re.compile(r"how much was (.+?) in \d{4}")
+
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from ..ontology import Ontology
@@ -77,8 +89,8 @@ def normalize_entity(name: str) -> str:
     text = name.strip()
     text = text.replace("\u2019s", "").replace("'s", "")
     text = _ENTITY_SUFFIXES.sub("", text).strip()
-    text = re.sub(r"\s*&\s*$", "", text)
-    text = re.sub(r"\s+", " ", text).strip()
+    text = _RE_TRAILING_AMP.sub("", text)
+    text = _RE_WHITESPACE.sub(" ", text).strip()
     return text
 
 
@@ -308,7 +320,7 @@ class CypherBuilder:
         normalized_blob = " ".join(self._normalize_hint_text(text) for text in raw_texts if str(text).strip())
         topic_terms: List[str] = []
         for text in raw_texts:
-            for token in re.findall(r"[a-z][a-z0-9_]+", str(text).lower().replace("&", " and ")):
+            for token in _RE_ALNUM_UNDERSCORE.findall(str(text).lower().replace("&", " and ")):
                 if token in _SCHEMA_HINT_STOPWORDS or token in _METRIC_TOKEN_STOPWORDS:
                     continue
                 if token not in topic_terms:
@@ -682,7 +694,7 @@ class CypherBuilder:
 
     @staticmethod
     def _normalize_hint_text(value: str) -> str:
-        return re.sub(r"[^a-z0-9]+", " ", str(value).lower()).strip()
+        return _RE_NON_ALNUM.sub(" ", str(value).lower()).strip()
 
     def _hint_match_score(self, normalized_blob: str, candidates: Sequence[Any]) -> int:
         score = 0
@@ -720,14 +732,14 @@ class CypherBuilder:
     def _extract_metric_phrase(self, question: str) -> str:
         lower = question.lower()
         patterns = [
-            r"delta in (.+?) from \d{4}",
-            r"change in (.+?) from \d{4}",
-            r"compare (.+?) between \d{4}",
-            r"what was (.+?) in \d{4}",
-            r"how much was (.+?) in \d{4}",
+            _RE_DELTA_IN,
+            _RE_CHANGE_IN,
+            _RE_COMPARE_BETWEEN,
+            _RE_WHAT_WAS,
+            _RE_HOW_MUCH,
         ]
         for pattern in patterns:
-            match = re.search(pattern, lower)
+            match = pattern.search(lower)
             if match:
                 candidate = match.group(1).strip(" .?")
                 if candidate:
@@ -756,16 +768,16 @@ class CypherBuilder:
         anchor_entity: str = "",
     ) -> List[str]:
         lower = text.lower().replace("&", " and ")
-        tokens = re.findall(r"[a-z][a-z0-9]+", lower)
+        tokens = _RE_ALNUM.findall(lower)
         anchor_tokens = {
             token
-            for token in re.findall(r"[a-z][a-z0-9]+", normalize_entity(anchor_entity).lower())
+            for token in _RE_ALNUM.findall(normalize_entity(anchor_entity).lower())
             if token
         }
         alias_tokens = {
             token
             for alias in metric_aliases
-            for token in re.findall(r"[a-z][a-z0-9]+", str(alias).lower())
+            for token in _RE_ALNUM.findall(str(alias).lower())
             if token
         }
         result: List[str] = []

--- a/seocho/query/intent.py
+++ b/seocho/query/intent.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 import re
+
+_RE_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_COMMA_OR_AND = re.compile(r",|\bor\b|\band\b|/|;", flags=re.IGNORECASE)
+
 from typing import Any, Dict, List, Optional, Sequence, Set
 
 from .contracts import IntentSpec
@@ -374,7 +380,7 @@ def extract_tradeoff_points_from_text(text: str) -> Dict[str, List[str]]:
 
     sentences = [
         sentence.strip()
-        for sentence in re.split(r"(?<=[.!?])\s+|\n+", text)
+        for sentence in _RE_SENTENCE_SPLIT.split(text)
         if sentence.strip()
     ]
     if not limitation_points:
@@ -445,13 +451,13 @@ def extract_tradeoff_points_from_triples(
 
 
 def _first_entity_with_labels(entities: Sequence[Dict[str, Any]], normalized_targets: Set[str]) -> str:
-    normalized_target_keys = {re.sub(r"[^a-z0-9]+", "", item.lower()) for item in normalized_targets}
+    normalized_target_keys = {_RE_NON_ALNUM.sub("", item.lower()) for item in normalized_targets}
     for entity in entities:
         labels = entity.get("labels", [])
         if not isinstance(labels, list):
             continue
         normalized_labels = {
-            re.sub(r"[^a-z0-9]+", "", str(label).lower())
+            _RE_NON_ALNUM.sub("", str(label).lower())
             for label in labels
         }
         if normalized_labels & normalized_target_keys:
@@ -491,10 +497,10 @@ def _tradeoff_points_from_entities(entities: Sequence[Dict[str, Any]]) -> Dict[s
 
 
 def _split_compact_points(raw: str) -> List[str]:
-    cleaned = re.sub(r"\s+", " ", str(raw).strip(" .,:;")).strip()
+    cleaned = _RE_WHITESPACE.sub(" ", str(raw).strip(" .,:;")).strip()
     if not cleaned:
         return []
-    parts = re.split(r",|\bor\b|\band\b|/|;", cleaned, flags=re.IGNORECASE)
+    parts = _RE_COMMA_OR_AND.split(cleaned)
     return [
         _canonicalize_point_text(part)
         for part in parts
@@ -503,14 +509,14 @@ def _split_compact_points(raw: str) -> List[str]:
 
 
 def _compact_sentence(sentence: str) -> str:
-    compact = re.sub(r"\s+", " ", sentence.strip())
+    compact = _RE_WHITESPACE.sub(" ", sentence.strip())
     if len(compact) <= 160:
         return compact
     return compact[:157].rsplit(" ", 1)[0].rstrip() + "..."
 
 
 def _canonicalize_point_text(value: str) -> str:
-    compact = re.sub(r"\s+", " ", str(value).strip(" .,:;")).strip()
+    compact = _RE_WHITESPACE.sub(" ", str(value).strip(" .,:;")).strip()
     if not compact:
         return ""
     if compact.lower() in {"gil", "the gil", "global interpreter lock"}:
@@ -534,4 +540,4 @@ def _dedupe_points(values: Sequence[str]) -> List[str]:
 
 
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM.sub("", str(value).lower())

--- a/seocho/query/semantic_agents.py
+++ b/seocho/query/semantic_agents.py
@@ -4,6 +4,19 @@ import json
 import logging
 import os
 import re
+
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_DOUBLE_QUOTES = re.compile(r'"([^"]+)"')
+_RE_SINGLE_QUOTES = re.compile(r"'([^']+)'")
+_RE_CAPS = re.compile(r"\b(?:[A-Z][a-zA-Z0-9&.-]{1,}|[A-Z]{2,})(?:\s+[A-Z][a-zA-Z0-9&.-]{1,})*\b")
+_RE_ALNUM_DASH = re.compile(r"[A-Za-z0-9][A-Za-z0-9&._-]{2,}")
+_RE_WHITESPACE = re.compile(r"\s+")
+_RE_S_BOUNDARY = re.compile(r"'s\b", flags=re.IGNORECASE)
+_RE_CORP_SUFFIX = re.compile(r"\b(corporation|corp|company|co|incorporated)\b\.?", flags=re.IGNORECASE)
+_RE_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_RE_ALNUM_TOKEN = re.compile(r"[a-z0-9]+")
+_RE_NUMERIC = re.compile(r"\d+(?:\.\d+)?")
+
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
@@ -114,11 +127,11 @@ QUERY_CONTRACT_FAILURE_CODE = "query_execution_failed_or_contract_error"
 
 
 def _normalize(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+    return _RE_NON_ALNUM.sub(" ", value.lower()).strip()
 
 
 def _normalize_symbol(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+    return _RE_NON_ALNUM.sub("", str(value).lower())
 
 
 def _query_rows(
@@ -639,14 +652,11 @@ class SemanticEntityResolver:
         self._query_diagnostics: List[Dict[str, Any]] = []
 
     def extract_question_entities(self, question: str) -> List[str]:
-        quoted = [m.group(1).strip() for m in re.finditer(r'"([^"]+)"', question)]
-        single_quoted = [m.group(1).strip() for m in re.finditer(r"'([^']+)'", question)]
+        quoted = [m.group(1).strip() for m in _RE_DOUBLE_QUOTES.finditer(question)]
+        single_quoted = [m.group(1).strip() for m in _RE_SINGLE_QUOTES.finditer(question)]
         caps = [
             m.group(0).strip()
-            for m in re.finditer(
-                r"\b(?:[A-Z][a-zA-Z0-9&.-]{1,}|[A-Z]{2,})(?:\s+[A-Z][a-zA-Z0-9&.-]{1,})*\b",
-                question,
-            )
+            for m in _RE_CAPS.finditer(question)
         ]
 
         entities: List[str] = []
@@ -662,7 +672,7 @@ class SemanticEntityResolver:
             entities.append(cleaned)
 
         if not entities:
-            for token in re.findall(r"[A-Za-z0-9][A-Za-z0-9&._-]{2,}", question):
+            for token in _RE_ALNUM_DASH.findall(question):
                 key = token.lower()
                 if key in STOPWORDS or key.isdigit():
                     continue
@@ -964,9 +974,9 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _clean_span(value: str) -> str:
-        cleaned = re.sub(r"\s+", " ", value.strip())
+        cleaned = _RE_WHITESPACE.sub(" ", value.strip())
         cleaned = cleaned.strip(".,:;!?()[]{}")
-        cleaned = re.sub(r"'s\b", "", cleaned, flags=re.IGNORECASE)
+        cleaned = _RE_S_BOUNDARY.sub("", cleaned)
         tokens = cleaned.split()
         while len(tokens) > 1 and tokens[0].lower() in LEADING_ENTITY_WRAPPER_TOKENS:
             tokens = tokens[1:]
@@ -988,7 +998,7 @@ class SemanticEntityResolver:
             terms.append(cleaned)
 
         for raw in (resolved_text, entity_text):
-            compact = re.sub(r"\b(corporation|corp|company|co|incorporated)\b\.?", "", raw, flags=re.IGNORECASE)
+            compact = _RE_CORP_SUFFIX.sub("", raw)
             compact = cls._clean_span(compact)
             if not compact:
                 continue
@@ -1001,7 +1011,7 @@ class SemanticEntityResolver:
 
     @staticmethod
     def _normalize(value: str) -> str:
-        return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+        return _RE_NON_ALNUM.sub(" ", value.lower()).strip()
 
     @staticmethod
     def _lexical_similarity(a: str, b: str) -> float:
@@ -1022,8 +1032,8 @@ class SemanticEntityResolver:
     def _label_boost(labels: Sequence[str], label_hints: Set[str]) -> float:
         if not labels or not label_hints:
             return 0.0
-        normalized_labels = {re.sub(r"[^a-z0-9]+", "", str(label).lower()) for label in labels}
-        normalized_hints = {re.sub(r"[^a-z0-9]+", "", hint.lower()) for hint in label_hints}
+        normalized_labels = {_RE_NON_ALNUM.sub("", str(label).lower()) for label in labels}
+        normalized_hints = {_RE_NON_ALNUM.sub("", hint.lower()) for hint in label_hints}
         if normalized_labels & normalized_hints:
             return 0.15
         return 0.0
@@ -2037,7 +2047,7 @@ class AnswerGenerationAgent:
             return ""
         sentences = [
             sentence.strip()
-            for sentence in re.split(r"(?<=[.!?])\s+", supporting_fact)
+            for sentence in _RE_SENTENCE_SPLIT.split(supporting_fact)
             if sentence.strip()
         ]
         if not sentences:
@@ -2045,7 +2055,7 @@ class AnswerGenerationAgent:
 
         question_terms = {
             token
-            for token in re.findall(r"[a-z0-9]+", question.lower())
+            for token in _RE_ALNUM_TOKEN.findall(question.lower())
             if token not in STOPWORDS and len(token) > 1
         }
         if not question_terms:
@@ -2055,8 +2065,8 @@ class AnswerGenerationAgent:
             question_terms.update({"ceo", "cfo", "chairman", "board", "director", "officer"})
 
         def score(sentence: str) -> tuple[int, int, int]:
-            terms = set(re.findall(r"[a-z0-9]+", sentence.lower()))
-            numeric_hits = len(set(re.findall(r"\d+(?:\.\d+)?", sentence.lower())) & question_terms)
+            terms = set(_RE_ALNUM_TOKEN.findall(sentence.lower()))
+            numeric_hits = len(set(_RE_NUMERIC.findall(sentence.lower())) & question_terms)
             return (len(terms & question_terms), numeric_hits, len(sentence))
 
         best_sentence = max(sentences, key=score)


### PR DESCRIPTION
## What
Precompiled all regular expression patterns used in hot paths for tokenization and normalization inside `seocho/query/` into module-level `_RE_` constants.

## Why
Uncompiled `re.sub`, `re.findall`, and `re.split` calls inside loops cause unnecessary repeated compilation overhead, which is a key bottleneck in the semantic query hot paths. This adheres to the specific repository constraint regarding regex precompilation.

## Expected Impact
Reduced latency and lower CPU overhead during query execution (quantitative improvement in loop execution speed, and qualitative improvement in code maintainability).

## Validation
Ran `uv run pytest seocho/tests/` locally with all tests passing.

## Risks
Low risk. The semantic behavior of the regular expressions is unchanged. The only change is when the pattern compilation happens.

---
*PR created automatically by Jules for task [1395738068351410606](https://jules.google.com/task/1395738068351410606) started by @tteon*