### PR TITLE
Standardize Evaluation UI Keyboard Focus States Globally

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,11 +209,6 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 .ingest-controls {
   padding: 0.6rem 1.5rem;
@@ -244,10 +239,6 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +351,6 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 .composer button {
   align-self: flex-end;
@@ -528,6 +515,14 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #484f58;
+}
+
+select:focus,
+input:focus,
+textarea:focus {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
+  outline: none;
 }
 
 button:focus-visible {


### PR DESCRIPTION
**What**
Replaced element-specific focus ring styles (`.control select:focus`, `.composer textarea:focus`, etc.) with global CSS rules (`select:focus`, `input:focus`, `textarea:focus`) in `evaluation/static/styles.css`.

**Why**
Previously, accessibility focus rings were inconsistently scoped to specific form control classes. If new form elements were added to the UI without those exact wrapper classes, they would fail to render visible focus states, leading to keyboard accessibility regressions. Standardizing this via global rules resolves the fragility.

**Accessibility / UX Impact**
Guarantees a reliable, distinct focus state (`box-shadow: 0 0 0 1px var(--accent-blue)`) for all current and future inputs, selects, and textareas across the entire evaluation UI without relying on ad-hoc utility classes.

**Validation**
- Visually verified via Playwright screenshot automation for keyboard-focused states (`#workspaceInput`).
- Grepped `styles.css` output to ensure complete removal of previously localized overrides and clean insertion of the global rule.
- Checked UI element styling in local rendering scripts.
- Completed standard repository CI shell, Python, and docs checks (`run_basic_ci.sh`) to guarantee zero collateral test failure.

**Risks**
Minimal. Because this change is confined to focus styling in `styles.css`, the chance of structural breakage is nonexistent. The focus style replaces identical specific rules, so existing elements should look completely identical upon receiving focus, while future elements are protected automatically.

---
*PR created automatically by Jules for task [3629998342713162079](https://jules.google.com/task/3629998342713162079) started by @tteon*