### PR TITLE
fix: add missing authz check to platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
**Severity**: High
**Vulnerability**: Broken Object Level Authorization (BOLA/IDOR). The `platform_chat_session_get` and `platform_chat_session_reset` endpoints did not check if the requesting user had permission to access the requested `session_id`.
**Impact**: An attacker could read or delete chat histories of any session just by knowing or guessing the `session_id`.
**Fix**: Added `require_runtime_permission` checks to both endpoints. The check securely extracts the `workspace_id` from the target session's history metadata, safely defaulting to "default" if absent, and verifies the "run_platform" action for the "user" role.
**Validation**: Verified locally via `bash scripts/ci/run_basic_ci.sh`. All runtime and core tests pass, and ownership contracts remain intact.
**Risks**: Low. The fallback logic guarantees that legacy or malformed sessions without metadata will fall back to the "default" workspace, ensuring backwards compatibility.

---
*PR created automatically by Jules for task [11105493736291919463](https://jules.google.com/task/11105493736291919463) started by @tteon*