### PR TITLE
perf(ontology): batch coverage stats queries to reduce database roundtrips

### DIFF
--- a/seocho/ontology.py
+++ b/seocho/ontology.py
@@ -2366,35 +2366,49 @@ class Ontology:
         total_defined_nodes = len(self.nodes)
         populated_nodes = 0
 
-        for label in self.nodes:
+        node_labels = list(self.nodes.keys())
+        for i in range(0, len(node_labels), 50):
+            chunk = node_labels[i:i + 50]
+            queries = [
+                f"MATCH (n:`{label}`) RETURN '{label}' AS element, count(n) AS cnt"
+                for label in chunk
+            ]
+            combined_query = " UNION ALL ".join(queries)
             try:
-                result = graph_store.query(
-                    f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                results = graph_store.query(combined_query, database=database)
+                for row in results:
+                    label = row.get("element")
+                    count = int(row.get("cnt", 0))
+                    node_stats.append({"label": label, "count": count})
+                    if count > 0:
+                        populated_nodes += 1
             except Exception:
-                count = 0
-            node_stats.append({"label": label, "count": count})
-            if count > 0:
-                populated_nodes += 1
+                for label in chunk:
+                    node_stats.append({"label": label, "count": 0})
 
         rel_stats: List[Dict[str, Any]] = []
         total_defined_rels = len(self.relationships)
         populated_rels = 0
 
-        for rtype in self.relationships:
+        rel_types = list(self.relationships.keys())
+        for i in range(0, len(rel_types), 50):
+            chunk = rel_types[i:i + 50]
+            queries = [
+                f"MATCH ()-[r:`{rtype}`]->() RETURN '{rtype}' AS element, count(r) AS cnt"
+                for rtype in chunk
+            ]
+            combined_query = " UNION ALL ".join(queries)
             try:
-                result = graph_store.query(
-                    f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                results = graph_store.query(combined_query, database=database)
+                for row in results:
+                    rtype = row.get("element")
+                    count = int(row.get("cnt", 0))
+                    rel_stats.append({"type": rtype, "count": count})
+                    if count > 0:
+                        populated_rels += 1
             except Exception:
-                count = 0
-            rel_stats.append({"type": rtype, "count": count})
-            if count > 0:
-                populated_rels += 1
+                for rtype in chunk:
+                    rel_stats.append({"type": rtype, "count": 0})
 
         node_score = populated_nodes / total_defined_nodes if total_defined_nodes else 1.0
         rel_score = populated_rels / total_defined_rels if total_defined_rels else 1.0

--- a/seocho/tests/test_ontology_artifact_promotion.py
+++ b/seocho/tests/test_ontology_artifact_promotion.py
@@ -41,14 +41,31 @@ class FakeGraphStore:
         self._rel_counts = rel_counts or {}
 
     def query(self, cypher: str, *, params=None, database="neo4j") -> List[Dict[str, Any]]:
-        # Parse label/type from the Cypher MATCH pattern
+        if "UNION ALL" in cypher:
+            results = []
+            for q in cypher.split(" UNION ALL "):
+                results.extend(self.query(q, params=params, database=database))
+            return results
+
+        element = None
+        m = __import__('re').search(r"RETURN '([^']+)' AS element", cypher)
+        if m:
+            element = m.group(1)
+
         for label, count in self._node_counts.items():
             if f"`{label}`" in cypher and "count(n)" in cypher:
-                return [{"cnt": count}]
+                res = {"cnt": count}
+                if element: res["element"] = element
+                return [res]
         for rtype, count in self._rel_counts.items():
             if f"`{rtype}`" in cypher and "count(r)" in cypher:
-                return [{"cnt": count}]
-        return [{"cnt": 0}]
+                res = {"cnt": count}
+                if element: res["element"] = element
+                return [res]
+
+        res = {"cnt": 0}
+        if element: res["element"] = element
+        return [res]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**What:**
Optimizes `coverage_stats` in `seocho/ontology.py` by grouping label and relationship count queries into chunks of 50 and using `UNION ALL`. Test mock `FakeGraphStore` is updated to correctly parse the batched queries.

**Why:**
Computing ontology coverage statistics previously required `N` database queries for `N` labels and `M` queries for `M` relationship types. In schemas with large numbers of distinct elements, this caused significant network overhead. Batching via `UNION ALL` reduces database roundtrips by a factor of 50.

**Expected Impact:**
Qualitative optimization in environments computing ontology coverage over schemas with numerous entity and relationship types, significantly improving runtime speed and lowering database connection load. 

**Validation:**
Verified by running `uv run pytest seocho/tests/test_ontology_artifact_promotion.py` and `bash scripts/ci/run_basic_ci.sh`, passing cleanly.

**Risks:**
Negligible. Cypher string construction wraps labels safely. Fallback to zero is maintained if a specific chunk query fails.

---
*PR created automatically by Jules for task [7504448885081155326](https://jules.google.com/task/7504448885081155326) started by @tteon*