### PR TITLE
fix(ui): use global element selectors for interactive focus states

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,8 +209,9 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
+input:focus,
+select:focus,
+textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
 }
@@ -244,10 +245,6 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +357,6 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 .composer button {
   align-self: flex-end;


### PR DESCRIPTION
### What
Replaced tightly scoped CSS focus classes (e.g. `.control select:focus`, `.ingest-grow textarea:focus`) in `evaluation/static/styles.css` with generic global element selectors (`input:focus, select:focus, textarea:focus`).

### Why
By relying on component-specific wrappers, new form elements added to the evaluation console risked missing focus styles entirely. Using standard global selectors ensures any input, select, or textarea naturally inherits the correct accessibility focus ring without requiring manual CSS updates for each new UI section.

### Accessibility / UX Impact
- Increases keyboard navigation reliability across the UI.
- Future-proofs the console against simple HTML accessibility regressions.
- Simplifies the stylesheet.

### Validation
- Validated via Playwright screenshot targeting `#workspaceInput` and `#chatInput` focus.
- Verified `scripts/ci/run_basic_ci.sh` passes successfully.

### Risks
- Very low. This change safely normalizes an existing standard focus style `var(--accent-blue)` and box-shadow across the form controls without introducing any new visual paradigms or layout shifts.

---
*PR created automatically by Jules for task [4553489034766661898](https://jules.google.com/task/4553489034766661898) started by @tteon*