### PR TITLE
fix(security): Add missing authorization checks to session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
### Severity
High

### Vulnerability
Missing authorization checks (IDOR) on session retrieval (`platform_chat_session_get`) and reset (`platform_chat_session_reset`) endpoints.

### Impact
Any user could view or clear another user's active session history by guessing or brute-forcing the `session_id`, bypassing tenant isolation.

### Fix
Added explicit `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` checks to `platform_chat_session_get` and `platform_chat_session_reset`. The `workspace_id` is securely extracted from the session history's metadata rather than trusting an arbitrary client parameter. Fallbacks are included for empty histories and missing metadata.

### Validation
- Validated via `bash scripts/ci/run_basic_ci.sh` (tests and shell contract checks pass).
- Validated via `uv run pytest tests/` (tests pass).
- The patch logic was applied safely without breaking existing valid sessions.

### Risks
Sessions that somehow lack a workspace ID will default to the `"default"` workspace, which may result in incorrect access evaluation if the requesting user lacks access to the `"default"` workspace. However, this is better than failing completely or allowing unauthorized access.

---
*PR created automatically by Jules for task [7076437644614200252](https://jules.google.com/task/7076437644614200252) started by @tteon*