### PR TITLE
Fix: enforce authorization on list endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1656,6 +1656,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1668,6 +1672,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1683,6 +1691,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** Missing authorization on list endpoints (`list_databases`, `list_graphs`, `list_agents`).
**Impact:** Unauthenticated or unauthorized users could theoretically enumerate active environments and configurations, disclosing internal setup data.
**Fix:** Explicitly integrated `require_runtime_permission(role="user", action="run_agent")` checks matching the other system behaviors within the same domain. Unhandled `PermissionError`s are captured and correctly translated to `HTTPException(403)`.
**Validation:** Ran the canonical CI sequence locally (`bash scripts/ci/run_basic_ci.sh`) ensuring tests and runtime shells are stable.
**Risks:** Low risk. Standard `try/except` pattern matching other endpoints in the same module. Client-facing API responses remain unimpacted.

---
*PR created automatically by Jules for task [3426973644714612874](https://jules.google.com/task/3426973644714612874) started by @tteon*