### PR TITLE
[Draft] perf: extract `re.compile` to module-level constant in guards

### DIFF
--- a/seocho/query/guards.py
+++ b/seocho/query/guards.py
@@ -98,6 +98,10 @@ _TEMPORAL_FILTER_RE = re.compile(
     r"\b(temporal_range|valid_from|valid_until|extracted_at|published_at)\b",
     re.IGNORECASE,
 )
+_WRONG_DIRECTION_RE = re.compile(
+    r"\(\s*[^()]*?:(\w+)[^()]*?\)\s*-\[[^\]]*:\s*(\w+)[^\]]*\]\s*->\s*\(\s*[^()]*?:(\w+)",
+    re.IGNORECASE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -174,11 +178,7 @@ def detect_wrong_direction(
         return []
     bad: List[str] = []
     # Pattern with explicit direction: (lbl1)-[:REL]->(lbl2)
-    pattern = re.compile(
-        r"\(\s*[^()]*?:(\w+)[^()]*?\)\s*-\[[^\]]*:\s*(\w+)[^\]]*\]\s*->\s*\(\s*[^()]*?:(\w+)",
-        re.IGNORECASE,
-    )
-    for left, rel, right in pattern.findall(cypher):
+    for left, rel, right in _WRONG_DIRECTION_RE.findall(cypher):
         spec = ontology_relationships.get(rel)
         if spec is None:
             continue


### PR DESCRIPTION
**What**
Extracted the inline `re.compile` inside `detect_wrong_direction` within `seocho/query/guards.py` to a module-level constant named `_WRONG_DIRECTION_RE`.

**Why**
`re.compile` called inside a function that is executing a hot loop (like a string validator) incurs compilation overhead on every invocation. By pre-compiling the regex once at module load time, we eliminate this repeated overhead, which addresses one of the primary performance goals (micro-optimizations and validation overhead).

**Expected Impact**
A small, qualitative improvement in text-to-Cypher guard validation speed, specifically when processing output that passes through `detect_wrong_direction`. The impact is largely to CPU overhead rather than I/O.

**Validation**
- Verified tests via `bash scripts/ci/run_basic_ci.sh`

**Risks**
No functionality or behavioral changes were made; the compiled pattern acts equivalently to the inline one. Thus, risks are essentially zero.

---
*PR created automatically by Jules for task [8015275863663257582](https://jules.google.com/task/8015275863663257582) started by @tteon*