### PR TITLE
fix: secure agent_server list endpoints with authz checks

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1656,6 +1656,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1668,6 +1672,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1683,6 +1691,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
**Severity**: Medium  
**Vulnerability**: Missing authorization checks on sensitive list endpoints (`/databases`, `/graphs`, `/agents`). Previously, these endpoints returned the available resources uniformly without enforcing the `run_agent` policy role constraint, bypassing workspace isolation logic.  
**Impact**: Tenants or users within the platform could enumerate active graphs, databases, or agents assigned to different workspaces or broader system environments, potentially resulting in horizontal information disclosure.  
**Fix**: Added explicit `require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)` checks and integrated appropriate HTTP 403 fallback handling inside the `list_databases`, `list_graphs`, and `list_agents` GET endpoint handlers.  
**Validation**: Validation via `scripts/ci/run_basic_ci.sh` has successfully passed ensuring no broken aliases, route configurations, or core regressions were introduced. Evaluated manually checking `require_runtime_permission` definitions over the target methods.  
**Risks**: Minimal; endpoints previously lacked the auth checks, now they correctly throw 403 on missing context. Downstream components lacking context could encounter 403s but none observed in the standard test suite.

---
*PR created automatically by Jules for task [17942291695910455088](https://jules.google.com/task/17942291695910455088) started by @tteon*