### PR TITLE
chore(ui): enforce global focus styling for input accessibility

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,11 +209,6 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 .ingest-controls {
   padding: 0.6rem 1.5rem;
@@ -244,10 +239,6 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +351,6 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 .composer button {
   align-self: flex-end;
@@ -580,4 +567,13 @@ button:focus-visible {
   to {
     stroke-dashoffset: -16;
   }
+}
+
+/* Global Focus Styles for Accessibility */
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }


### PR DESCRIPTION
**What**
Replaced component-specific focus styling (`.control input:focus`, `.composer textarea:focus`, etc.) with a single, global focus rule for all form elements in `evaluation/static/styles.css`.

**Why**
Applying focus styles conditionally per-component creates a brittle accessibility foundation. If a developer adds a new input outside of a predefined `.control` wrapper, it may silently lack focus states. Transitioning to a global focus definition guarantees that any `input`, `select`, or `textarea` element will have a visible and consistent keyboard outline by default, aligning with the WCAG minimum contrast requirements for focus indicators without breaking the design.

**Accessibility / UX Impact**
This is a pure accessibility resilience fix. It does not alter the appearance of currently properly-styled elements, but it acts as a safeguard to ensure all future UI additions inherently receive a visible `var(--accent-blue)` focus ring, directly improving keyboard navigation safety.

**Validation**
- Spun up the evaluation server locally.
- Verified visual behavior via Playwright automated browser tests by programmatically injecting `.focus()` states onto inputs, selects, and textareas.
- Captured screenshots confirming the `var(--accent-blue)` focus ring renders correctly.
- Ran `bash scripts/ci/run_basic_ci.sh` to guarantee no structural breaks occurred.

**Risks**
Minimal. The global rule mirrors the exact styles (`border-color` and `box-shadow`) previously used, simply expanding their target surface area. The only risk is if an edge-case hidden or stylized element implicitly relied on having *no* focus state, but this is an antipattern that should be surfaced and fixed explicitly rather than hidden.

---
*PR created automatically by Jules for task [9879576746683364951](https://jules.google.com/task/9879576746683364951) started by @tteon*