### PR TITLE
feat: add missing authz checks to runtime agent server endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1057,13 +1057,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 
@@ -1570,6 +1582,7 @@ async def run_debate(request: QueryRequest):
 async def runtime_health(
     workspace_id: str = Query(default="runtime-health", pattern=WORKSPACE_ID_PATTERN),
 ):
+    # Skip authz on health endpoints to allow load balancers / readiness probes
     components: List[HealthComponent] = [
         HealthComponent(name="api", status="ready", detail="agent_server reachable"),
     ]
@@ -1656,6 +1669,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1668,6 +1685,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1683,6 +1704,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
### Severity
Medium

### Vulnerability
Several sensitive endpoints in the runtime agent server (`platform_chat_session_get`, `platform_chat_session_reset`, `list_databases`, `list_graphs`, `list_agents`) lacked authorization checks. While some list endpoints are meant to be uniform, session fetching without authz allows unprivileged retrieval of other users' session histories if a session ID is guessed or leaked.

### Impact
Unauthenticated or under-privileged actors could list databases/agents/graphs, and more importantly, read or reset active chat sessions belonging to other workspaces or users.

### Fix
Added `require_runtime_permission` to all identified sensitive endpoints:
- Session endpoints now securely extract the `workspace_id` from the existing session metadata (or default to "default") and require the `run_platform` action.
- List endpoints require the `run_agent` action.
- Explicitly documented that `runtime_health` intentionally skips authz for load balancer probes.
Any `PermissionError` is gracefully caught and re-raised as an `HTTPException(status_code=403)` to integrate with FastAPI's error handling.

### Validation
Ran `bash scripts/ci/run_basic_ci.sh` which executed the complete test suite successfully. 

### Risks
Low risk. The authorization check matches existing patterns in the file and relies on robust fallback logic for missing metadata when fetching sessions.

---
*PR created automatically by Jules for task [12338942726245159044](https://jules.google.com/task/12338942726245159044) started by @tteon*