### PR TITLE
Draft: Fix evaluation UI form element focus states (A11Y)

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,8 +209,9 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
+select:focus,
+input:focus,
+textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
 }
@@ -244,10 +245,7 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +358,7 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 .composer button {
   align-self: flex-end;


### PR DESCRIPTION
### What
Updated `evaluation/static/styles.css` to use global CSS element selectors (`select:focus, input:focus, textarea:focus`) instead of container-scoped classes for applying focus styles.

### Why
Previously, form controls only received a visible focus outline if they were placed inside specific containers (like `.control`, `.ingest-grow`, or `.composer`). If a new form element was added without these exact wrapper classes, it would lack a focus outline, causing an accessibility failure for keyboard navigation. Applying this style globally ensures a safer accessibility baseline for the entire UI.

### Accessibility / UX Impact
- **Impact:** High positive impact for keyboard users.
- Ensures a high-contrast focus ring (`0 0 0 1px var(--accent-blue)`) is universally applied to all interactive form controls, preventing hidden focus states.
- Cleans up duplicate CSS rules, slightly reducing file size.

### Validation
1. **Visual Testing (Playwright):** Wrote a local Playwright script to launch the evaluation server locally and programmatically test `.focus()` on all key inputs (`#modeSelect`, `#workspaceInput`, `#chatInput`, etc.). Captured screenshots verifying the blue focus ring appeared consistently.
2. **Automated CI:** Ran `bash scripts/ci/run_basic_ci.sh`. All tests passed.

### Risks
- **Low Risk:** This is a purely CSS-based visual change that relies on standard pseudo-classes. It removes duplicate code and strictly enhances visual accessibility without touching any underlying javascript logic or backend constraints.

---
*PR created automatically by Jules for task [13850313257471108991](https://jules.google.com/task/13850313257471108991) started by @tteon*