### PR TITLE
perf: Batch graph index cardinality queries

### DIFF
--- a/seocho/store/graph.py
+++ b/seocho/store/graph.py
@@ -621,38 +621,47 @@ class Neo4jGraphStore(GraphStore):
                     logger.warning("SHOW INDEXES failed for '%s': %s", database, exc)
 
                 label_counts: Dict[str, int] = {}
-                for r in session.run("CALL db.labels()"):
-                    label = r["label"]
-                    if not is_valid_identifier(label):
-                        logger.warning("skipping non-identifier label '%s'", label)
-                        continue
-                    try:
-                        count_rec = session.run(
-                            f"MATCH (n:{label}) "
-                            "WHERE n._workspace_id = $workspace_id "
-                            "RETURN count(n) AS cnt",
-                            workspace_id=workspace_id,
-                        ).single()
-                        label_counts[label] = int(count_rec["cnt"]) if count_rec else 0
-                    except Exception as exc:
-                        logger.warning("label count failed for '%s': %s", label, exc)
+                schema = self.get_schema(database=database)
+                labels = [label for label in schema.get("labels", []) if is_valid_identifier(label)]
+
+                if labels:
+                    queries = []
+                    for label in labels:
+                        safe_label = label.replace("`", "").replace('\n', '').replace('\r', '')
+                        queries.append(
+                            f"MATCH (n:`{safe_label}`) WHERE n._workspace_id = $workspace_id "
+                            f"RETURN '{safe_label}' AS element, count(n) AS cnt"
+                        )
+
+                    for i in range(0, len(queries), 50):
+                        chunk = queries[i:i+50]
+                        union_query = " UNION ALL ".join(chunk)
+                        try:
+                            for r in session.run(union_query, workspace_id=workspace_id):
+                                label_counts[r["element"]] = r["cnt"]
+                        except Exception as exc:
+                            logger.warning("batched label count failed: %s", exc)
 
                 rel_counts: Dict[str, int] = {}
-                for r in session.run("CALL db.relationshipTypes()"):
-                    rt = r["relationshipType"]
-                    if not is_valid_identifier(rt):
-                        logger.warning("skipping non-identifier rel type '%s'", rt)
-                        continue
-                    try:
-                        count_rec = session.run(
-                            f"MATCH ()-[r:{rt}]->() "
-                            "WHERE r._workspace_id = $workspace_id "
-                            "RETURN count(r) AS cnt",
-                            workspace_id=workspace_id,
-                        ).single()
-                        rel_counts[rt] = int(count_rec["cnt"]) if count_rec else 0
-                    except Exception as exc:
-                        logger.warning("rel count failed for '%s': %s", rt, exc)
+                rel_types = [rt for rt in schema.get("relationship_types", []) if is_valid_identifier(rt)]
+
+                if rel_types:
+                    queries = []
+                    for rt in rel_types:
+                        safe_rt = rt.replace("`", "").replace('\n', '').replace('\r', '')
+                        queries.append(
+                            f"MATCH ()-[r:`{safe_rt}`]->() WHERE r._workspace_id = $workspace_id "
+                            f"RETURN '{safe_rt}' AS element, count(r) AS cnt"
+                        )
+
+                    for i in range(0, len(queries), 50):
+                        chunk = queries[i:i+50]
+                        union_query = " UNION ALL ".join(chunk)
+                        try:
+                            for r in session.run(union_query, workspace_id=workspace_id):
+                                rel_counts[r["element"]] = r["cnt"]
+                        except Exception as exc:
+                            logger.warning("batched rel count failed: %s", exc)
 
             payload = {
                 "indexes": indexes,


### PR DESCRIPTION
### What
Refactored `get_index_stats` in `seocho/store/graph.py` to eliminate N+1 schema cardinality queries by pre-filtering labels utilizing `get_schema()` and batching count queries into `UNION ALL` chunks of 50.

### Why
During graph initialization, cost model runs, and runtime cold-starts, `get_index_stats` was executing O(N) database queries by invoking a separate `count(n)` or `count(r)` query for each individual label and relationship type in the database. This caused substantial database load and overhead.

### Expected Impact
Significant reduction in the number of database queries and execution time during calls to `get_index_stats`, greatly speeding up schema loading, caching behavior, and test suites that depend on cardinality estimation.

### Validation
- `uv run pytest seocho/tests/test_cost_model.py` - passed
- `bash scripts/ci/run_basic_ci.sh` - passed
- Verified manually using codebase grep.

### Risks
- Minor: Handling of deeply invalid Cypher strings in labels could cause chunk failures. However, this is already guarded using `is_valid_identifier` check and query safety interpolation (`.replace("\`", "").replace('\n', '').replace('\r', '')`), and `UNION ALL` execution is wrapped in a `try...except` to log failures gracefully without breaking the payload.

---
*PR created automatically by Jules for task [14115117142515841620](https://jules.google.com/task/14115117142515841620) started by @tteon*