### PR TITLE
fix: add authorization to platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1057,13 +1057,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
### Severity
High

### Vulnerability
The `platform_chat_session_get` and `platform_chat_session_reset` endpoints in `runtime/agent_server.py` lacked authorization checks, allowing unauthenticated users to potentially view or manipulate arbitrary chat session histories. This is an Insecure Direct Object Reference (IDOR) vulnerability.

### Impact
An attacker could guess or iterate session IDs to read sensitive platform chat history or destructively clear sessions belonging to other users or workspaces.

### Fix
Added explicit authorization checks using `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` to both endpoints. The `workspace_id` is securely extracted from the session history metadata, with a fallback to the `"default"` workspace if the history is empty or metadata is missing. Unauthorized access throws a 403 Forbidden `HTTPException`.

### Validation
Validated locally by successfully running all API endpoint integration tests via `bash scripts/ci/run_basic_ci.sh`. The CI passed and confirmed no existing contracts or behaviors were inadvertently broken.

### Risks
The fix introduces an authorization dependency. If legacy or misconfigured clients attempt to access valid sessions but lack the `"run_platform"` permission on the associated `workspace_id`, they will encounter a 403 Forbidden error. This strictly enforces expected behavior but may surface latent integration bugs in the client.

---
*PR created automatically by Jules for task [726170930436327294](https://jules.google.com/task/726170930436327294) started by @tteon*