### PR TITLE
Draft: ui: Apply global focus styles to evaluation form controls

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,8 +209,9 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
+input:focus,
+select:focus,
+textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
 }
@@ -244,10 +245,7 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +358,7 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 .composer button {
   align-self: flex-end;


### PR DESCRIPTION
### What
Replaced class-scoped focus rules in `evaluation/static/styles.css` with generic global selectors (`input:focus`, `select:focus`, `textarea:focus`) for interactive form elements.

### Why
Previously, only specific elements with classes like `.control` or `.composer` received a visible focus state. Standardizing this behavior globally guarantees that any newly added input field or unclassed control in the UI correctly inherits a visible focus indicator without requiring developers to apply a wrapper class.

### Accessibility / UX Impact
- **Positive**: All form input elements across the evaluation UI now reliably receive a highly visible blue outline and box-shadow upon receiving keyboard focus, meeting WCAG focus visibility standards and preventing regressions on newly added form components.

### Validation
- **CI**: Executed `bash scripts/ci/run_basic_ci.sh`, which passed successfully.
- **Frontend Verifications**: Wrote a Playwright script to verify focus states visually. Manually verified the screenshot and video outputs, confirming that the `#modeSelect`, `#ingestInput`, and `#chatInput` elements all displayed the correct focus style (`border-color` and `box-shadow`) under the global rule.

### Risks
- **Low**: The specific focus colors and styles were preserved entirely. The only change was broadening the CSS selectors. It is unlikely to cause visual issues unless an element intentionally suppresses a focus ring, which is an anti-pattern.

### Note
Draft PR conforming to the persona constraint of limiting to ONE small, cohesive, and safe UX/accessibility fix.

---
*PR created automatically by Jules for task [4128600455146619581](https://jules.google.com/task/4128600455146619581) started by @tteon*