### PR TITLE
fix(security): enforce authz on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1057,13 +1057,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** Insecure Direct Object Reference (IDOR) / Missing Authorization. The `platform_chat_session_get` and `platform_chat_session_reset` endpoints lacked any access control checks. An attacker could potentially retrieve or delete chat history data belonging to other users simply by guessing or brute-forcing a `session_id`.
**Impact:** Unauthorized access and modification of sensitive conversational data, leading to a loss of confidentiality and integrity of the user's platform session history.
**Fix:** Added the standard `require_runtime_permission` check to both endpoints. It uses the `session_id` to retrieve the raw session history and extracts the associated `workspace_id` from the metadata. It defaults to the `"default"` workspace if the metadata is missing or the session hasn't been initialized yet. If the authorization fails, it cleanly raises an `HTTPException` with status code 403.
**Validation:** Validated locally using standard unit testing suites via `bash scripts/ci/run_basic_ci.sh` as well as the docs linter `bash scripts/pm/lint-agent-docs.sh`. Code functionality manually verified via Python scripts during execution.
**Risks:** Very low. The fallback mechanism correctly addresses situations where `metadata` is unavailable in the historical row data without raising exceptions, ensuring stable behavior.

---
*PR created automatically by Jules for task [4901892124978427823](https://jules.google.com/task/4901892124978427823) started by @tteon*