### PR TITLE
[DRAFT] perf: fix N+1 query overhead in ontology coverage stats

### DIFF
--- a/seocho/ontology.py
+++ b/seocho/ontology.py
@@ -2356,15 +2356,27 @@ class Ontology:
         total_defined_nodes = len(self.nodes)
         populated_nodes = 0
 
-        for label in self.nodes:
+        # Batch nodes counting
+        nodes_list = list(self.nodes)
+        node_counts = {lbl: 0 for lbl in nodes_list}
+        chunk_size = 50
+        for i in range(0, len(nodes_list), chunk_size):
+            chunk = nodes_list[i : i + chunk_size]
+            queries = []
+            for lbl in chunk:
+                safe_lbl = lbl.replace('\n', '').replace('\r', '').replace('`', '')
+                queries.append(f"MATCH (n:`{safe_lbl}`) RETURN '{safe_lbl}' AS element, count(n) AS cnt")
+            union_query = " UNION ALL ".join(queries)
             try:
-                result = graph_store.query(
-                    f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                if union_query:
+                    results = graph_store.query(union_query, database=database)
+                    for r in results:
+                        node_counts[r["element"]] = int(r["cnt"])
             except Exception:
-                count = 0
+                pass
+
+        for label in nodes_list:
+            count = node_counts.get(label, 0)
             node_stats.append({"label": label, "count": count})
             if count > 0:
                 populated_nodes += 1
@@ -2373,15 +2385,26 @@ class Ontology:
         total_defined_rels = len(self.relationships)
         populated_rels = 0
 
-        for rtype in self.relationships:
+        # Batch rels counting
+        rels_list = list(self.relationships)
+        rel_counts = {rtype: 0 for rtype in rels_list}
+        for i in range(0, len(rels_list), chunk_size):
+            chunk = rels_list[i : i + chunk_size]
+            queries = []
+            for rtype in chunk:
+                safe_rtype = rtype.replace('\n', '').replace('\r', '').replace('`', '')
+                queries.append(f"MATCH ()-[r:`{safe_rtype}`]->() RETURN '{safe_rtype}' AS element, count(r) AS cnt")
+            union_query = " UNION ALL ".join(queries)
             try:
-                result = graph_store.query(
-                    f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                if union_query:
+                    results = graph_store.query(union_query, database=database)
+                    for r in results:
+                        rel_counts[r["element"]] = int(r["cnt"])
             except Exception:
-                count = 0
+                pass
+
+        for rtype in rels_list:
+            count = rel_counts.get(rtype, 0)
             rel_stats.append({"type": rtype, "count": count})
             if count > 0:
                 populated_rels += 1

--- a/seocho/tests/test_ontology_artifact_promotion.py
+++ b/seocho/tests/test_ontology_artifact_promotion.py
@@ -41,7 +41,22 @@ class FakeGraphStore:
         self._rel_counts = rel_counts or {}
 
     def query(self, cypher: str, *, params=None, database="neo4j") -> List[Dict[str, Any]]:
-        # Parse label/type from the Cypher MATCH pattern
+        if "UNION ALL" in cypher or "AS element" in cypher:
+            results = []
+            for part in cypher.split("UNION ALL"):
+                element = None
+                if "RETURN '" in part:
+                    element = part.split("RETURN '")[1].split("'")[0]
+
+                count = 0
+                if "count(n)" in part:
+                    count = self._node_counts.get(element, 0)
+                elif "count(r)" in part:
+                    count = self._rel_counts.get(element, 0)
+                results.append({"element": element, "cnt": count})
+            return results
+
+        # Fallback for single query
         for label, count in self._node_counts.items():
             if f"`{label}`" in cypher and "count(n)" in cypher:
                 return [{"cnt": count}]


### PR DESCRIPTION
**What:** 
Updated `Ontology.coverage_stats()` in `seocho/ontology.py` to use `UNION ALL` to batch Cypher count queries into chunks of 50, rather than issuing separate N+1 queries for every single node label and relationship type defined in the ontology. Updated `FakeGraphStore` in tests to support this query pattern.

**Why:** 
For very large ontologies, loading schema counts creates an N+1 query problem that repeatedly hits the graph database for individual `MATCH (n:\`Label\`) RETURN count(n)` calls, causing severe and unnecessary network round-trip overhead.

**Expected Impact:** 
Significant reduction in wait times (latency) when executing schema/coverage queries against live graph instances with large ontology definitions.

**Validation:** 
- Updated `FakeGraphStore` in test suite to correctly parse `UNION ALL` chunks.
- Verified test suite passes via `uv run pytest seocho/tests/test_ontology.py` and `seocho/tests/test_ontology_artifact_promotion.py`.
- Ran full repository CI (`bash scripts/ci/run_basic_ci.sh`) and confirmed everything passed without issue.

**Risks:** 
- If an individual query within a batched `UNION ALL` group were to fail due to a syntax issue (e.g., malformed label escaping), the entire batch (up to 50 types) would fail and report 0 counts. To mitigate this, label sanitization (stripping newlines and backticks) is applied prior to construction.

*(Draft PR as requested by constraints)*

---
*PR created automatically by Jules for task [2117800069781823317](https://jules.google.com/task/2117800069781823317) started by @tteon*