### PR TITLE
Draft: UX/A11y: Standardize Global Focus States in Evaluation UI

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,11 +209,7 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 .ingest-controls {
   padding: 0.6rem 1.5rem;
@@ -244,10 +240,7 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +353,7 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
+
 
 .composer button {
   align-self: flex-end;
@@ -580,4 +570,11 @@ button:focus-visible {
   to {
     stroke-dashoffset: -16;
   }
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
 }


### PR DESCRIPTION
### What
Consolidated individual, scoped focus state CSS rules (e.g., `.control select:focus`, `.ingest-grow textarea:focus`) into a single global selector (`input:focus, select:focus, textarea:focus`) in `evaluation/static/styles.css`.

### Why
Applying focus styles using explicit global element selectors instead of specific control classes prevents accessibility regressions on newly added form elements, ensuring that every interactive input surface receives a standard focus indicator by default.

### Accessibility / UX Impact
- **Impact**: Positive. Guarantees keyboard navigability and clear visual focus for all current and future inputs, textareas, and selects within the UI without relying on developers to remember specific class names.

### Validation
- **Automated**: `bash scripts/ci/run_basic_ci.sh` passed.
- **Visual**: Wrote a local Playwright script to verify focus styling triggers cleanly. Captured screenshot confirming proper standard blue border and shadow.

### Risks
- **Risk**: Very low. Only touches CSS for focus states. There are no cascading functional changes. The duplicate global block issue raised in code review was cleaned up locally prior to commit.

---
*PR created automatically by Jules for task [5735852941886440077](https://jules.google.com/task/5735852941886440077) started by @tteon*