### PR TITLE
fix: Enforce workspace_id authorization on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1057,13 +1057,27 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default") if history_rows else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in history_rows]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default") if history_rows else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** Insecure Direct Object Reference (IDOR) on session read/delete endpoints. The `platform_chat_session_get` and `platform_chat_session_reset` endpoints lacked proper `require_runtime_permission` checks, allowing any caller to read or reset any active session by ID.
**Impact:** A malicious actor or compromised agent could access sensitive past interactions (prompts, answers, metadata) from other workspaces or aggressively delete session history, violating single-tenant/multi-tenant boundaries.
**Fix:** Added policy enforcement in `runtime/agent_server.py` for both endpoints by retrieving the existing session data and extracting the `workspace_id` from the `metadata` context. If missing, defaults to "default". An HTTP 403 Forbidden is properly raised if the authorization fails.
**Validation:** Ran standard basic CI `bash scripts/ci/run_basic_ci.sh`, and local tests passed. Evaluated endpoints correctly handle the edge cases for empty lists or missing metadata. 
**Risks:** Low. Only targets specific backend endpoints correctly. Does not interfere with the semantic retrieval path or multi-agent boundaries. Safe fallback to default workspace prevents 500s on uninitialized sessions.

---
*PR created automatically by Jules for task [3524429811733905619](https://jules.google.com/task/3524429811733905619) started by @tteon*