### PR TITLE
UX/A11y: Use global focus selectors in evaluation UI CSS

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,8 +209,9 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
+input:focus,
+select:focus,
+textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
 }
@@ -244,10 +245,6 @@ body {
   resize: vertical;
 }
 
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 #ingestBtn {
   background: var(--accent-green);
@@ -360,10 +357,6 @@ body {
   outline: none;
 }
 
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
 
 .composer button {
   align-self: flex-end;


### PR DESCRIPTION
### What
Updated `evaluation/static/styles.css` to use global focus selectors (`input:focus`, `select:focus`, `textarea:focus`) instead of scoping them within specific classes (like `.control` or `.composer`). 

### Why
To ensure a consistent and visible focus outline for all form elements in the evaluation UI. Previously, new inputs added outside of the `.control` or `.composer` classes would not receive the blue focus outline, causing potential accessibility regressions.

### Accessibility / UX Impact
- **Accessibility:** Improves keyboard navigation and visibility by guaranteeing a high-contrast focus state for any input, select, or textarea added to the UI, regardless of its parent container.
- **UX:** Simplifies the stylesheet and ensures consistent interactive feedback for users.

### Validation
- Validated the focus styles manually via a Playwright script taking a screenshot of an input receiving focus.
- Verified the evaluation server starts successfully.
- Ran `bash scripts/ci/run_basic_ci.sh` to confirm no breakage in the existing tests.
- Reviewed and applied codebase-specific learnings by appending to `.jules/palette.md`.

### Risks
- **Low Risk:** This is purely a CSS presentation change. There is no impact to the backend orchestration, orchestration models, or external workflows. It strictly applies to the evaluation shell UI.

---
*PR created automatically by Jules for task [7949341971735996213](https://jules.google.com/task/7949341971735996213) started by @tteon*