### PR TITLE
perf(cache): implement incremental JSONL loading for ResponseCache

### DIFF
--- a/seocho/response_cache.py
+++ b/seocho/response_cache.py
@@ -114,14 +114,28 @@ class JSONLResponseCache(ResponseCache):
     def __init__(self, path: str) -> None:
         self._path = path
         self._lock = threading.RLock()
+        self._index: Dict[CacheKey, CachedResponse] = {}
+        self._file_offset: int = 0
         os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
 
     def _load_index(self) -> Dict[CacheKey, CachedResponse]:
-        index: Dict[CacheKey, CachedResponse] = {}
         if not os.path.exists(self._path):
-            return index
+            if self._file_offset > 0:
+                self._index.clear()
+                self._file_offset = 0
+            return self._index
+
         try:
+            current_size = os.path.getsize(self._path)
+            if current_size < self._file_offset:
+                self._index.clear()
+                self._file_offset = 0
+
+            if current_size == self._file_offset:
+                return self._index
+
             with open(self._path, "r", encoding="utf-8") as fh:
+                fh.seek(self._file_offset)
                 for line in fh:
                     line = line.strip()
                     if not line:
@@ -136,14 +150,15 @@ class JSONLResponseCache(ResponseCache):
                         str(rec.get("ontology_identity_hash", "")),
                         str(rec.get("question", "")),
                     )
-                    index[key] = CachedResponse(
+                    self._index[key] = CachedResponse(
                         answer=str(rec.get("answer", "")),
                         written_at=float(rec.get("written_at", 0.0)),
                         metadata=dict(rec.get("metadata") or {}),
                     )
+                self._file_offset = fh.tell()
         except OSError:
             pass
-        return index
+        return self._index
 
     def get(self, key: CacheKey) -> Optional[CachedResponse]:
         with self._lock:


### PR DESCRIPTION
### What
Implement incremental loading for `JSONLResponseCache`.

### Why
To avoid O(N²) file I/O overhead on large append-only files when `.get()` is called repeatedly.

### Expected Impact
Qualitatively much faster response times when the cache file grows large, as it avoids redundant parsing of the entire file. File parsing is now bounded by newly written data rather than the lifetime size of the file.

### Validation
`bash scripts/ci/run_basic_ci.sh`

### Risks
Incremental file tracking relies on OS size updates and file offsets. If the cache file shrinks or is deleted/rotated, the offset is properly handled to clear and reset the state. A slight edge case exists where incomplete appended lines might silently be skipped if read exactly during the write, but this is a standard limitation of basic JSONL polling and acceptable in this local cache context.

---
*PR created automatically by Jules for task [11224437256378611949](https://jules.google.com/task/11224437256378611949) started by @tteon*