### PR TITLE
fix(security): Enforce authorization on agent and platform endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1057,13 +1057,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    history_raw = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_raw:
+        workspace_id = (history_raw[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in history_raw]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history_raw = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_raw:
+        workspace_id = (history_raw[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 
@@ -1656,6 +1676,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1668,6 +1692,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1683,6 +1711,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
Severity: Medium
Vulnerability: Missing authorization checks on sensitive runtime endpoints. The `list_databases`, `list_graphs`, `list_agents`, and platform session read/reset endpoints lacked runtime permission enforcement, potentially allowing unauthorized read access to backend environment configurations and session histories.
Impact: Unauthorized actors could map the database targets, available graph scopes, and access user session contexts if they bypass network perimeters.
Fix: Added explicit `require_runtime_permission` logic mapping to `run_agent` and `run_platform` roles on the affected endpoints. It also gracefully handles the resolution of fallback workspace IDs during session access.
Validation: Successfully executed `uv run pytest extraction/tests/test_api_endpoints.py extraction/tests/test_policy.py extraction/tests/test_server_runtime.py`.
Risks: Minor regression risk for services legitimately calling these endpoints that lack the correct authorization scopes setup.

---
*PR created automatically by Jules for task [6046724785370084281](https://jules.google.com/task/6046724785370084281) started by @tteon*