### PR TITLE
Draft: Refactor focus styles to use global element selectors for improved accessibility

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -209,12 +209,6 @@ body {
   outline: none;
 }
 
-.control select:focus,
-.control input:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
-}
-
 .ingest-controls {
   padding: 0.6rem 1.5rem;
   background-color: var(--bg-app);
@@ -242,11 +236,6 @@ body {
   font-size: 0.8rem;
   outline: none;
   resize: vertical;
-}
-
-.ingest-grow textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 #ingestBtn {
@@ -358,11 +347,6 @@ body {
   font-family: var(--font-sans);
   font-size: 0.9rem;
   outline: none;
-}
-
-.composer textarea:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 1px var(--accent-blue);
 }
 
 .composer button {
@@ -580,4 +564,12 @@ button:focus-visible {
   to {
     stroke-dashoffset: -16;
   }
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 1px var(--accent-blue);
+  outline: none;
 }


### PR DESCRIPTION
### What
Updated `evaluation/static/styles.css` to remove class-scoped focus selectors (e.g., `.control select:focus`, `.ingest-grow textarea:focus`) and replaced them with standard global element selectors (`input:focus`, `select:focus`, `textarea:focus`) appended to the end of the stylesheet.

### Why
To ensure that all form controls throughout the application consistently receive a visible focus indicator without relying on specific container classes. This prevents future accessibility regressions when new form elements are added, as they will inherit the focus state automatically.

### Accessibility / UX Impact
Improves accessibility by ensuring robust keyboard focus visibility across all input surfaces, aiding users who navigate via keyboard. Reduces the risk of missing focus outlines on newly developed UI components.

### Validation
- **Visual Validation**: Verified locally using Playwright to focus an input and a textarea, capturing a screenshot confirming the blue (`var(--accent-blue)`) focus ring appears correctly.
- **Automated Validation**: Ran `bash scripts/ci/run_basic_ci.sh`. All tests pass, no functionality broken.

### Risks
Low risk. The focus outline styling is identical to what existed before; it is just applied more universally. No `!important` tags were used, as the rules were correctly placed at the end of the CSS file to manage specificity.

---
*PR created automatically by Jules for task [9536446023589647532](https://jules.google.com/task/9536446023589647532) started by @tteon*