### PR TITLE
fix(security): Enforce RBAC on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1057,13 +1057,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
Severity: High
Vulnerability: Insecure Direct Object Reference (IDOR) / Missing Authorization. The `platform_chat_session_get` and `platform_chat_session_reset` endpoints in `runtime/agent_server.py` lacked proper `workspace_id` extraction and access control, allowing potential cross-tenant session access.
Impact: An attacker could potentially retrieve or delete interactive platform session histories belonging to other tenants.
Fix: Updated both endpoints to properly extract the `workspace_id` from the session history metadata and enforce `require_runtime_permission` with action `run_platform`, falling back to the `"default"` workspace if no history exists.
Validation: Basic CI suite (`bash scripts/ci/run_basic_ci.sh`) passes cleanly.
Risks: Minimal. Gracefully handles missing metadata and gracefully translates `PermissionError`s into `403 Forbidden` API responses.

---
*PR created automatically by Jules for task [11726405501518050651](https://jules.google.com/task/11726405501518050651) started by @tteon*