### PR TITLE
perf: batch graph count queries via UNION ALL

### DIFF
--- a/seocho/ontology.py
+++ b/seocho/ontology.py
@@ -2403,35 +2403,85 @@ class Ontology:
         total_defined_nodes = len(self.nodes)
         populated_nodes = 0
 
-        for label in self.nodes:
+        nodes_list = list(self.nodes)
+        for i in range(0, len(nodes_list), 50):
+            chunk = nodes_list[i:i+50]
+            if not chunk: continue
+
+            queries = []
+            for label in chunk:
+                safe_label = label.replace("`", "``").replace("\n", "").replace("\r", "")
+                safe_literal = safe_label.replace("'", "''")
+                queries.append(f"MATCH (n:`{safe_label}`) RETURN '{safe_literal}' AS element, count(n) AS cnt")
+
             try:
-                result = graph_store.query(
-                    f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                batched_query = " UNION ALL ".join(queries)
+                results = graph_store.query(batched_query, database=database)
+                count_map = {row["element"]: int(row["cnt"]) for row in results} if results else {}
             except Exception:
-                count = 0
-            node_stats.append({"label": label, "count": count})
-            if count > 0:
-                populated_nodes += 1
+                # Fallback to individual queries if the batch fails (e.g. missing table in strict graph DBs)
+                count_map = {}
+                for label in chunk:
+                    safe_label = label.replace("`", "``").replace("\n", "").replace("\r", "")
+                    safe_literal = safe_label.replace("'", "''")
+                    try:
+                        results = graph_store.query(
+                            f"MATCH (n:`{safe_label}`) RETURN '{safe_literal}' AS element, count(n) AS cnt",
+                            database=database,
+                        )
+                        count_map[safe_literal] = int(results[0]["cnt"]) if results else 0
+                    except Exception:
+                        pass
+
+            for label in chunk:
+                safe_label = label.replace("`", "``").replace("\n", "").replace("\r", "")
+                safe_literal = safe_label.replace("'", "''")
+                count = count_map.get(safe_label, 0)
+                node_stats.append({"label": label, "count": count})
+                if count > 0:
+                    populated_nodes += 1
 
         rel_stats: List[Dict[str, Any]] = []
         total_defined_rels = len(self.relationships)
         populated_rels = 0
 
-        for rtype in self.relationships:
+        rels_list = list(self.relationships)
+        for i in range(0, len(rels_list), 50):
+            chunk = rels_list[i:i+50]
+            if not chunk: continue
+
+            queries = []
+            for rtype in chunk:
+                safe_rtype = rtype.replace("`", "``").replace("\n", "").replace("\r", "")
+                safe_literal = safe_rtype.replace("'", "''")
+                queries.append(f"MATCH ()-[r:`{safe_rtype}`]->() RETURN '{safe_literal}' AS element, count(r) AS cnt")
+
             try:
-                result = graph_store.query(
-                    f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                batched_query = " UNION ALL ".join(queries)
+                results = graph_store.query(batched_query, database=database)
+                count_map = {row["element"]: int(row["cnt"]) for row in results} if results else {}
             except Exception:
-                count = 0
-            rel_stats.append({"type": rtype, "count": count})
-            if count > 0:
-                populated_rels += 1
+                # Fallback to individual queries
+                count_map = {}
+                for rtype in chunk:
+                    safe_rtype = rtype.replace("`", "``").replace("\n", "").replace("\r", "")
+                    safe_literal = safe_rtype.replace("'", "''")
+                    try:
+                        results = graph_store.query(
+                            f"MATCH ()-[r:`{safe_rtype}`]->() RETURN '{safe_literal}' AS element, count(r) AS cnt",
+                            database=database,
+                        )
+                        count_map[safe_literal] = int(results[0]["cnt"]) if results else 0
+                    except Exception:
+                        pass
+
+            for rtype in chunk:
+                safe_rtype = rtype.replace("`", "``").replace("\n", "").replace("\r", "")
+                safe_literal = safe_rtype.replace("'", "''")
+                count = count_map.get(safe_label, 0)
+                rel_stats.append({"type": rtype, "count": count})
+                if count > 0:
+                    populated_rels += 1
 
         node_score = populated_nodes / total_defined_nodes if total_defined_nodes else 1.0
         rel_score = populated_rels / total_defined_rels if total_defined_rels else 1.0

--- a/seocho/store/graph.py
+++ b/seocho/store/graph.py
@@ -1615,16 +1615,36 @@ class LadybugGraphStore(GraphStore):
         node_total = 0
         relationship_total = 0
 
-        for label in self._declared_node_tables:
+        declared_nodes = list(self._declared_node_tables)
+        for i in range(0, len(declared_nodes), 50):
+            chunk = declared_nodes[i:i+50]
+            if not chunk: continue
+
+            queries = []
+            for label in chunk:
+                safe_label = label.replace("`", "``").replace("\n", "").replace("\r", "")
+                safe_literal = safe_label.replace("'", "''")
+                queries.append(f"MATCH (n:`{safe_label}`) WHERE n._source_id = $sid RETURN '{safe_literal}' AS element, count(n) AS cnt")
+
             try:
-                result = self._locked_execute(
-                    f"MATCH (n:`{label}`) WHERE n._source_id = $sid RETURN count(n)",
-                    {"sid": source_id},
-                )
+                batched_query = " UNION ALL ".join(queries)
+                result = self._locked_execute(batched_query, {"sid": source_id})
                 for row in result:
-                    node_total += int(row[0] if isinstance(row, list) else list(row)[0])
+                    cnt_val = row[1] if isinstance(row, list) else (row["cnt"] if isinstance(row, dict) else list(row)[1])
+                    node_total += int(cnt_val)
             except Exception:
-                pass
+                # Fallback to individual queries
+                for label in chunk:
+                    safe_label = label.replace("`", "``").replace("\n", "").replace("\r", "")
+                    try:
+                        result = self._locked_execute(
+                            f"MATCH (n:`{safe_label}`) WHERE n._source_id = $sid RETURN count(n)",
+                            {"sid": source_id},
+                        )
+                        for row in result:
+                            node_total += int(row[0] if isinstance(row, list) else list(row)[0])
+                    except Exception:
+                        pass
 
         try:
             result = self._locked_execute(


### PR DESCRIPTION
What:
Batched individual node and relationship counting queries during schema validation and metadata population using Cypher's `UNION ALL` feature, chunking them in groups of 50.

Why:
Previously, the system would issue an independent database query (e.g. `MATCH (n:\`Label\`) RETURN count(n) AS cnt`) for every single node label and relationship type defined in an ontology or graph schema. For complex ontologies, this N+1 querying approach introduced massive linear overhead due to database round-trips.

Expected Impact:
Significantly faster query latency when analyzing ontology coverage and graph size against Neo4j and DozerDB databases, reducing O(N) round-trips to O(N/50).

Validation:
- Tested with dummy batch implementations
- Ran `bash scripts/ci/run_basic_ci.sh` with 100% pass rate

Risks:
- Some graph databases strictly fail queries referencing undefined node or edge tables. We included a fallback to individual queries if the batched chunk throws an exception, mitigating this risk.

---
*PR created automatically by Jules for task [18164767895162284909](https://jules.google.com/task/18164767895162284909) started by @tteon*