### PR TITLE
fix(ui): enforce explicit focus outlines on inputs for accessibility

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -571,5 +571,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
**What**
Removed explicit `outline: none;` from input elements (`<input>`, `<select>`, `<textarea>`) in the evaluation UI (`evaluation/static/styles.css`) and standardized the global focus state to use a clearly visible `2px solid var(--accent-blue)` outline with an offset.

**Why**
The previous CSS utilized `outline: none;` for focused inputs and only relied on a border and box-shadow color change. This resulted in low visibility for keyboard navigation and violated basic accessibility standards (WCAG 2.1 Focus Visible).

**Accessibility / UX Impact**
Greatly improves keyboard navigation visibility across the workflow console by providing a standard, high-contrast, explicit focus outline matching the existing button focus paradigm.

**Validation**
- Manual/Playwright visual verification: A Playwright script programmatically focused the input elements and verified the CSS properties rendered the updated outline via screenshot.
- CI Validation: `bash scripts/ci/run_basic_ci.sh` passed, proving no runtime regressions.

**Risks**
Very low risk. Scoped entirely to a CSS file (`evaluation/static/styles.css`) and strictly applies global element focus styling. No behavioral or structural DOM changes.

---
*PR created automatically by Jules for task [98354900479281918](https://jules.google.com/task/98354900479281918) started by @tteon*