### PR TITLE
Draft: Fix missing focus state on evaluation UI inputs

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -571,5 +571,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
### What
Updated global input focus styles in evaluation UI to use an explicit outline.

### Why
`outline: none;` on input focus causes accessibility regressions for keyboard navigation, as users cannot see which element is currently active.

### Accessibility / UX Impact
Explicit focus outlines (2px solid blue with a 2px offset) improve keyboard navigation and visibility of active elements, meeting accessibility requirements.

### Validation
Passed `scripts/ci/run_basic_ci.sh` and manually verified the visual focus state with a Playwright screenshot.

### Risks
Low. Only modifies visual focus state in the evaluation UI.

---
*PR created automatically by Jules for task [5846128435090422551](https://jules.google.com/task/5846128435090422551) started by @tteon*