### PR TITLE
Draft: Fix focus outlines accessibility for inputs

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -206,7 +206,6 @@ body {
   border-radius: 4px;
   font-family: var(--font-sans);
   font-size: 0.8rem;
-  outline: none;
 }
 
 .ingest-controls {
@@ -234,7 +233,6 @@ body {
   border-radius: 4px;
   font-family: var(--font-sans);
   font-size: 0.8rem;
-  outline: none;
   resize: vertical;
 }
 
@@ -346,7 +344,6 @@ body {
   resize: none;
   font-family: var(--font-sans);
   font-size: 0.9rem;
-  outline: none;
 }
 
 .composer button {
@@ -571,5 +568,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
What: Removed `outline: none;` and added solid outlines to input, select, and textarea elements.
Why: `outline: none;` on focus removes the visible focus indicator which is a severe accessibility issue. 
Accessibility / UX Impact: Keyboard users will now be able to see which field has focus.
Validation: Verified via visual testing using Playwright.
Risks: Minimal risk. No functional logic changed.

---
*PR created automatically by Jules for task [908348608944997846](https://jules.google.com/task/908348608944997846) started by @tteon*