### PR TITLE
fix: enforce runtime permission checks on list endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1656,6 +1656,10 @@ async def list_databases(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "databases": db_registry.list_databases()}
 
 
@@ -1668,6 +1672,10 @@ async def list_graphs(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_databases", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {
         "workspace_id": workspace_id,
         "graphs": [target.to_public_dict() for target in graph_registry.list_graphs()],
@@ -1683,6 +1691,10 @@ async def list_agents(
     ``workspace_id`` is accepted on the contract for tenancy uniformity;
     multi-tenant filtering is not yet enforced (single-tenant MVP).
     """
+    try:
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     return {"workspace_id": workspace_id, "agents": agent_factory.list_agents()}
 
 


### PR DESCRIPTION
### Severity
Medium

### Vulnerability
The `list_databases`, `list_graphs`, and `list_agents` endpoints in the runtime server were missing proper authorization and policy checks.

### Impact
Any user could access these endpoints without the required runtime permissions for `read_databases` or `read_agents`, potentially exposing metadata to unauthorized users.

### Fix
Added `require_runtime_permission` checks to the endpoints with the correct corresponding action policies (`read_databases` and `read_agents`). Properly handles exceptions as HTTP 403 Forbidden.

### Validation
Verified that basic tests and API route tests pass, specifically confirming the list endpoints return 403 if they receive an unauthorized hit or if the endpoint tests don't have authorization.

### Risks
Minor risk of regression if downstream systems depend on unauthenticated access to these list endpoints, but in an enterprise orchestration layer, authentication is strictly required.

---
*PR created automatically by Jules for task [15882471285242289517](https://jules.google.com/task/15882471285242289517) started by @tteon*