### PR TITLE
Fix missing authorization in platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1080,13 +1080,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
Severity: High
Vulnerability: Insecure Direct Object Reference (IDOR) / Missing Authorization
Impact: An attacker or unauthorized user could read or delete chat history for a session ID belonging to another workspace, leading to privacy violations or data loss.
Fix: Extracted `workspace_id` from the session metadata in `platform_session_store` and added `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` checks to both the `GET` and `DELETE` endpoints for `/platform/chat/session`.
Validation: Ran `bash scripts/ci/run_basic_ci.sh` locally. All CI checks and tests passed.
Risks: Minimal. Graceful fallbacks for missing histories and malformed metadata dictionaries prevent crashes. Standard FastAPI exception mapping covers `PermissionError`.

---
*PR created automatically by Jules for task [8159156858857630272](https://jules.google.com/task/8159156858857630272) started by @tteon*