### PR TITLE
[DRAFT] fix: use explicit focus outline for inputs

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -584,5 +584,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
**What**
Replaced `outline: none;` with an explicit `outline: 2px solid var(--accent-blue);` (and offset) for globally styled inputs, selects, and textareas in `evaluation/static/styles.css`. Also appended learning to `.jules/palette.md`.

**Why**
The default browser outline was being suppressed without a sufficient fallback, making keyboard navigation difficult.

**Accessibility / UX Impact**
This is a small accessibility fix. Users navigating via keyboard (or screen readers relying on focus state) can now clearly see which input is active due to the high-contrast blue outline.

**Validation**
- Spun up UI via uvicorn and ran a Playwright script targeting `#workspaceInput`.
- Generated and visually confirmed screenshot: the blue outline and offset appear correctly when focused.
- `bash scripts/ci/run_basic_ci.sh` passed.

**Risks**
- Visual risk: Might conflict with container borders, but outline-offset mitigates this. Low overall risk.

---
*PR created automatically by Jules for task [14109764181392472693](https://jules.google.com/task/14109764181392472693) started by @tteon*