### PR TITLE
fix(security): enforce authorization on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1080,13 +1080,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
Severity: High
Vulnerability: Broken Access Control / IDOR
Impact: Any user could retrieve or clear chat session histories belonging to other users simply by providing the session ID, bypassing all authorization checks.
Fix: Implemented `require_runtime_permission` checks on `platform_chat_session_get` and `platform_chat_session_reset`. The `workspace_id` is derived from the session's metadata.
Validation: Wrote test scripts leveraging FastAPIs TestClient and `unittest.mock` to ensure an unauthorized access request throws a 403 `HTTPException`. Validated entire test suite via `scripts/ci/run_basic_ci.sh`.
Risks: Minimal. The `workspace_id` defaults to "default" gracefully if none is provided in the history's metadata, preventing application crashes.

---
*PR created automatically by Jules for task [8819395827280936](https://jules.google.com/task/8819395827280936) started by @tteon*