### PR TITLE
Fix accessibility focus outlines in UI CSS

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -206,7 +206,6 @@ body {
   border-radius: 4px;
   font-family: var(--font-sans);
   font-size: 0.8rem;
-  outline: none;
 }
 
 .ingest-controls {
@@ -234,7 +233,6 @@ body {
   border-radius: 4px;
   font-family: var(--font-sans);
   font-size: 0.8rem;
-  outline: none;
   resize: vertical;
 }
 
@@ -346,7 +344,6 @@ body {
   resize: none;
   font-family: var(--font-sans);
   font-size: 0.9rem;
-  outline: none;
 }
 
 .composer button {
@@ -519,12 +516,9 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
-/* a11y: form controls strip the default outline above (outline: none) for
+/* a11y: form controls strip the default outline above for
    visual consistency; restore a visible keyboard-focus indicator via
    :focus-visible so mouse users see no ring but keyboard users do. */
-.control input:focus-visible,
-.control select:focus-visible,
-.ingest-grow textarea:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
@@ -584,5 +578,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## What
Removes `outline: none;` anti-patterns from specific input classes and standardizes a highly visible 2px solid focus outline across all form controls (`input`, `select`, `textarea`) in the evaluation UI CSS.

## Why
The previous CSS used `outline: none;` which strips the default browser focus ring, creating a severe accessibility barrier for keyboard users who rely on visible focus indicators to navigate the UI.

## Accessibility / UX Impact
Restores an explicit, high-contrast focus indicator for form controls, enabling accessible keyboard navigation and improving the experience for screen reader users by ensuring the current interaction target is visually distinct.

## Validation
- Checked file changes using `grep` and `cat`.
- Validated UI visually via Playwright verification script.
- Ran test suite using `bash scripts/ci/run_basic_ci.sh` with all tests passing.

## Risks
Low risk. This is a CSS-only change that affects focus pseudo-classes. It does not modify application logic, layout dimensions, or core components.

---
*PR created automatically by Jules for task [15801751758832944745](https://jules.google.com/task/15801751758832944745) started by @tteon*