### PR TITLE
Draft: perf(index): optimize read_jsonl_file memory usage with lazy iteration

### DIFF
--- a/src/seocho/index/file_reader.py
+++ b/src/seocho/index/file_reader.py
@@ -232,20 +232,21 @@ def read_json_file(path: Path) -> List[Dict[str, Any]]:
 def read_jsonl_file(path: Path) -> List[Dict[str, Any]]:
     """Read a .jsonl file — one JSON object per line."""
     records: List[Dict[str, Any]] = []
-    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            item = json.loads(line)
-            if isinstance(item, dict):
-                content = item.get("content", json.dumps(item))
-                meta = {k: v for k, v in item.items() if k != "content"}
-                meta["source_file"] = str(path)
-                meta["line_index"] = i
-                records.append({"content": content, "metadata": meta})
-        except json.JSONDecodeError:
-            logger.warning("Skipping malformed JSON at %s line %d", path, i)
+    with path.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+                if isinstance(item, dict):
+                    content = item.get("content", json.dumps(item))
+                    meta = {k: v for k, v in item.items() if k != "content"}
+                    meta["source_file"] = str(path)
+                    meta["line_index"] = i
+                    records.append({"content": content, "metadata": meta})
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed JSON at %s line %d", path, i)
     return records
 
 


### PR DESCRIPTION
**What**
Replaced `path.read_text().splitlines()` with lazy file iteration in `read_jsonl_file` (`src/seocho/index/file_reader.py`).

**Why**
Calling `.read_text().splitlines()` loads the entire file into memory as a list of strings before iterating. For large `.jsonl` files (like extensive logs, traces, or datasets), this causes an O(N) memory allocation spike and performance bottleneck. Lazy iteration (`for line in path.open(...)`) yields lines one by one, keeping the memory footprint minimal.

**Expected Impact**
- Reduced peak memory usage when indexing large `.jsonl` datasets.
- Faster processing of large `.jsonl` files due to eliminated overhead from `splitlines()` array allocation.
- No behavioral changes.

**Validation**
- `uv run pytest tests/seocho/test_file_indexer.py` passed successfully.
- `bash scripts/ci/run_basic_ci.sh` passed successfully.

**Risks**
- Negligible risk. `line.strip()` replicates the newline-stripping behavior of `splitlines()`, maintaining identical parsing behavior.

---
*PR created automatically by Jules for task [2286964789123484707](https://jules.google.com/task/2286964789123484707) started by @tteon*