### PR TITLE
feat(observability): trace read/query API + 'seocho traces' CLI (seocho-6q9.1)

### DIFF
--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -318,10 +318,40 @@ def build_parser() -> argparse.ArgumentParser:
     serve_http_parser.add_argument("--port", type=int, default=8010, help="Bind port")
     serve_http_parser.add_argument("--reload", action="store_true", help="Enable uvicorn reload mode")
 
+    traces_parser = subparsers.add_parser(
+        "traces",
+        help="Query trace spans from a JSONL file (read-safe, no server)",
+    )
+    traces_parser.add_argument(
+        "--path",
+        default=None,
+        help="JSONL trace file (default: $SEOCHO_TRACE_JSONL_PATH or ./traces/seocho.jsonl)",
+    )
+    traces_parser.add_argument(
+        "--min-latency-ms", type=float, default=None,
+        help="Keep only spans at/above this latency (ms)",
+    )
+    traces_parser.add_argument("--name", default=None, help="Exact span-name match")
+    traces_parser.add_argument("--name-contains", default=None, help="Substring match on span name")
+    traces_parser.add_argument(
+        "--tag", action="append", dest="tags", default=None,
+        help="Require this tag (repeatable)",
+    )
+    traces_parser.add_argument("--since", default=None, help="ISO timestamp lower bound (UTC)")
+    traces_parser.add_argument(
+        "--limit", type=int, default=50,
+        help="Max spans to print (0 = all)",
+    )
+    traces_parser.add_argument(
+        "--sort-latency", action="store_true",
+        help="Sort by latency descending",
+    )
+    traces_parser.add_argument("--output-json", action="store_true", help="Emit JSON")
+
     return parser
 
 
-LOCAL_COMMANDS = {"init", "index", "local-ask", "status", "compare", "experiment", "bundle", "ontology", "serve-http"}
+LOCAL_COMMANDS = {"init", "index", "local-ask", "status", "compare", "experiment", "bundle", "ontology", "serve-http", "traces"}
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -756,7 +786,53 @@ def _dispatch_local(args: argparse.Namespace) -> int:
         return _cmd_ontology(args)
     if args.command == "serve-http":
         return _cmd_serve_http(args)
+    if args.command == "traces":
+        return _cmd_traces(args)
     raise SeochoError(f"Unknown local command: {args.command}")
+
+
+def _cmd_traces(args: argparse.Namespace) -> int:
+    """Query trace spans from a JSONL file (read side of the observe loop)."""
+    from .tracing import default_jsonl_path, read_jsonl
+
+    path = args.path or default_jsonl_path()
+    try:
+        spans = read_jsonl(
+            path,
+            min_latency_ms=args.min_latency_ms,
+            name=args.name,
+            name_contains=args.name_contains,
+            tags=args.tags,
+            since=args.since,
+        )
+    except FileNotFoundError:
+        print(
+            f"No trace file at {path}. Enable JSONL tracing with "
+            f"SEOCHO_TRACE_BACKEND=jsonl (or pass --path).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.sort_latency:
+        spans.sort(key=lambda r: (r.get("latency_ms") if r.get("latency_ms") is not None else -1.0), reverse=True)
+    if args.limit and args.limit > 0:
+        spans = spans[: args.limit]
+
+    if getattr(args, "output_json", False):
+        print(json.dumps(spans, indent=2, default=str))
+        return 0
+
+    if not spans:
+        print("No matching spans.")
+        return 0
+
+    for record in spans:
+        latency = record.get("latency_ms")
+        latency_str = f"{latency:.0f}ms" if latency is not None else "-"
+        tags = ",".join(record.get("tags") or [])
+        print(f"{record.get('timestamp', '')}  {latency_str:>8}  {record.get('name', '')}  [{tags}]")
+    print(f"\n{len(spans)} span(s).")
+    return 0
 
 
 def _cmd_init(args: argparse.Namespace) -> int:

--- a/src/seocho/tracing.py
+++ b/src/seocho/tracing.py
@@ -746,6 +746,119 @@ def traced(name: str) -> Callable:
 
 
 # ---------------------------------------------------------------------------
+# Trace read / query (closes the observe loop — seocho-6q9.1)
+# ---------------------------------------------------------------------------
+
+def default_jsonl_path() -> str:
+    """Resolve the canonical JSONL trace path from the env contract.
+
+    Returns ``$SEOCHO_TRACE_JSONL_PATH`` when set, else the conventional
+    ``./traces/seocho.jsonl``. This is the same default the JSONL backend
+    writes to, so ``read_jsonl(default_jsonl_path())`` round-trips.
+    """
+    return os.getenv(TRACE_JSONL_PATH_ENV) or "./traces/seocho.jsonl"
+
+
+def span_latency_ms(record: Dict[str, Any]) -> Optional[float]:
+    """Best-effort latency for one JSONL span, in milliseconds.
+
+    The SDK loggers stamp ``metadata.elapsed_seconds`` (seconds); StageTimer
+    output lands as ``*_ms`` keys. Prefer the canonical seconds field, then
+    fall back to common millisecond keys. Returns ``None`` when no timing is
+    present (e.g. session.start markers).
+    """
+    meta = record.get("metadata") or {}
+    secs = meta.get("elapsed_seconds")
+    if secs is not None:
+        try:
+            return float(secs) * 1000.0
+        except (TypeError, ValueError):
+            pass
+    for key in ("elapsed_ms", "total_ms", "latency_ms"):
+        val = meta.get(key)
+        if val is not None:
+            try:
+                return float(val)
+            except (TypeError, ValueError):
+                pass
+    return None
+
+
+def read_jsonl(
+    path: Union[str, Path],
+    *,
+    min_latency_ms: Optional[float] = None,
+    name: Optional[str] = None,
+    name_contains: Optional[str] = None,
+    tags: Optional[Sequence[str]] = None,
+    since: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Read and filter spans from a JSONL trace file.
+
+    This is the read side of the otherwise write-only tracing layer: it lets
+    an agent ask "show spans over 2s" or "did this run breach a budget" by
+    reading back the canonical JSONL artifact. Read-safe — no side effects.
+
+    Each returned record is the raw span dict augmented with a derived
+    ``latency_ms`` field (see :func:`span_latency_ms`), so callers can sort or
+    assert on it directly.
+
+    Parameters
+    ----------
+    path:
+        JSONL trace file (one span per line).
+    min_latency_ms:
+        Keep only spans whose derived ``latency_ms`` is >= this. Spans with no
+        timing are dropped when this filter is set.
+    name:
+        Exact span-name match.
+    name_contains:
+        Substring match on the span name.
+    tags:
+        Require every listed tag to be present on the span.
+    since:
+        ISO-8601 lower bound on ``timestamp`` (UTC strings sort lexically).
+
+    Raises
+    ------
+    FileNotFoundError:
+        When ``path`` does not exist.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"trace file not found: {p}")
+
+    want_tags = set(tags) if tags else None
+    out: List[Dict[str, Any]] = []
+    with open(p, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            latency = span_latency_ms(record)
+            record["latency_ms"] = latency
+
+            if name is not None and record.get("name") != name:
+                continue
+            if name_contains is not None and name_contains not in (record.get("name") or ""):
+                continue
+            if want_tags is not None and not want_tags.issubset(set(record.get("tags") or [])):
+                continue
+            if since is not None and str(record.get("timestamp", "")) < since:
+                continue
+            if min_latency_ms is not None and (latency is None or latency < min_latency_ms):
+                continue
+
+            out.append(record)
+    return out
+
+
+# ---------------------------------------------------------------------------
 # CSV Export
 # ---------------------------------------------------------------------------
 

--- a/tests/seocho/test_tracing.py
+++ b/tests/seocho/test_tracing.py
@@ -53,3 +53,84 @@ def test_configure_tracing_from_env_rejects_invalid_backend(monkeypatch) -> None
         assert current_backend_names() == []
     finally:
         disable_tracing()
+
+
+# ---------------------------------------------------------------------------
+# Trace read / query (seocho-6q9.1)
+# ---------------------------------------------------------------------------
+
+import json
+
+import pytest
+
+from seocho.tracing import default_jsonl_path, read_jsonl, span_latency_ms
+
+
+def _write_spans(path: Path, spans) -> None:
+    path.write_text("\n".join(json.dumps(s) for s in spans) + "\n", encoding="utf-8")
+
+
+def test_span_latency_ms_prefers_elapsed_seconds() -> None:
+    assert span_latency_ms({"metadata": {"elapsed_seconds": 2.5}}) == 2500.0
+    assert span_latency_ms({"metadata": {"total_ms": 800}}) == 800.0
+    assert span_latency_ms({"metadata": {}}) is None
+    assert span_latency_ms({}) is None
+
+
+def test_read_jsonl_filters_by_latency_name_and_tags(tmp_path: Path) -> None:
+    path = tmp_path / "seocho.jsonl"
+    _write_spans(path, [
+        {"timestamp": "2026-06-05T00:00:01", "name": "sdk.query", "tags": ["query"], "metadata": {"elapsed_seconds": 3.0}},
+        {"timestamp": "2026-06-05T00:00:02", "name": "sdk.query", "tags": ["query"], "metadata": {"elapsed_seconds": 0.1}},
+        {"timestamp": "2026-06-05T00:00:03", "name": "sdk.session.start", "tags": ["session"], "metadata": {}},
+    ])
+
+    slow = read_jsonl(path, min_latency_ms=2000)
+    assert len(slow) == 1
+    assert slow[0]["name"] == "sdk.query"
+    assert slow[0]["latency_ms"] == 3000.0
+
+    by_tag = read_jsonl(path, tags=["session"])
+    assert [s["name"] for s in by_tag] == ["sdk.session.start"]
+
+    by_name = read_jsonl(path, name="sdk.query")
+    assert len(by_name) == 2
+
+
+def test_read_jsonl_since_and_name_contains(tmp_path: Path) -> None:
+    path = tmp_path / "seocho.jsonl"
+    _write_spans(path, [
+        {"timestamp": "2026-06-04T23:59:00", "name": "sdk.extraction", "tags": [], "metadata": {}},
+        {"timestamp": "2026-06-05T00:00:05", "name": "sdk.query", "tags": [], "metadata": {}},
+    ])
+
+    recent = read_jsonl(path, since="2026-06-05T00:00:00")
+    assert [s["name"] for s in recent] == ["sdk.query"]
+
+    matched = read_jsonl(path, name_contains="extra")
+    assert [s["name"] for s in matched] == ["sdk.extraction"]
+
+
+def test_read_jsonl_skips_malformed_lines(tmp_path: Path) -> None:
+    path = tmp_path / "seocho.jsonl"
+    path.write_text(
+        '{"name": "ok", "metadata": {}}\n'
+        "not-json\n"
+        "\n"
+        '{"name": "ok2", "metadata": {}}\n',
+        encoding="utf-8",
+    )
+    spans = read_jsonl(path)
+    assert [s["name"] for s in spans] == ["ok", "ok2"]
+
+
+def test_read_jsonl_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        read_jsonl(tmp_path / "nope.jsonl")
+
+
+def test_default_jsonl_path_honours_env(monkeypatch) -> None:
+    monkeypatch.delenv("SEOCHO_TRACE_JSONL_PATH", raising=False)
+    assert default_jsonl_path() == "./traces/seocho.jsonl"
+    monkeypatch.setenv("SEOCHO_TRACE_JSONL_PATH", "/tmp/custom.jsonl")
+    assert default_jsonl_path() == "/tmp/custom.jsonl"


### PR DESCRIPTION
## Feature

Read/query side for the SDK tracing layer. Adds `seocho.tracing.read_jsonl()`,
`span_latency_ms()`, `default_jsonl_path()`, and a read-safe `seocho traces`
CLI subcommand that filters trace spans from a JSONL file by latency, name,
tags, and time.

## Why

`tracing.py` was write-only (jsonl/opik/console + `export_traces_csv`) — there
was no way to read spans back. An agent could emit telemetry but could not
assert on it: questions like "show spans over 2s" or "did startup exceed 800ms"
were unanswerable from the SDK. This closes the observe loop (SEOCHO's LogQL
analog) and is the foundation the perf/behavioral budget gate (seocho-6q9.2)
builds on.

## Design

- `read_jsonl(path, *, min_latency_ms, name, name_contains, tags, since)` reads
  the canonical JSONL artifact and returns each span augmented with a derived
  `latency_ms`. Read-safe, no side effects. Malformed lines skipped; missing
  file raises `FileNotFoundError`.
- `span_latency_ms()` prefers `metadata.elapsed_seconds` (the loggers' canonical
  field), falling back to `*_ms` keys (StageTimer output).
- `default_jsonl_path()` reuses the existing `SEOCHO_TRACE_JSONL_PATH` env
  contract so `read_jsonl(default_jsonl_path())` round-trips with the writer.
- `seocho traces` is registered as a LOCAL command (no HTTP client) and
  delegates entirely to the SDK reader.

Canonical logic lives in `src/seocho/` (data-plane), per CLAUDE.md boundaries.

## Expected Effect

Agents and operators can query trace spans locally to verify behavior and
latency without standing up Opik or a server.

## Impact Results

- `seocho traces --min-latency-ms 2000 --sort-latency` lists only slow spans,
  latency-sorted.
- `seocho traces --tag session --output-json` emits structured JSON.
- Missing trace file exits non-zero with a remediation hint.
- 26 CLI subcommands (was 25).

## Validation

- `python -m pytest tests/seocho/test_tracing.py -q` → 17 passed (6 new).
- CLI smoke over a fixture JSONL: latency filter, tag filter, name-contains,
  JSON output, missing-file exit=1 — all verified.
- `py_compile` OK; `import seocho.cli, seocho.tracing` OK; `git diff --check`
  clean.
- Skipped: ruff (not installed in this venv).

## Risks

Low. Additive and read-only — no change to write paths, runtime APIs, or Cypher.
JSONL timestamp `since` filter relies on UTC ISO strings sorting lexically
(documented).
