### PR TITLE
feat(runtime): worktree-isolated runtime boot — shared neo4j + ephemeral logical DB (seocho-6q9.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ DOCKER_COMPOSE = docker compose
 DOCKER_COMPOSE_LIVE = docker compose -f docker-compose.yml -f docker-compose.dev.yml
 DOCKER_COMPOSE_TUTORIALS = docker compose -f docker-compose.tutorials.yml
 
+# Shared stack project name (fixed so per-instance app tiers can target its
+# neo4j for ephemeral-database admin — see src/seocho/local.py).
+SHARED_PROJECT = seocho
+SEOCHO_CLI = python3 -m seocho.cli
+
 .PHONY: up up-live up-legacy-semantic down restart logs clean bootstrap shell test test-integration e2e-smoke lint format help opik-up opik-down opik-logs demo-raw demo-meta demo-neo4j demo-graphrag-opik demo-all setup-env tutorials-up tutorials-down tutorials-logs tutorials-shell tutorials-build tutorials-smoke tutorials-test tutorials-pytest tutorials-gds
 
 ##@ Development
@@ -25,15 +30,22 @@ bootstrap: ## Bootstrap the development environment
 setup-env: ## Interactive .env setup (OpenAI key, Opik, ports)
 	@bash scripts/setup/init-env.sh
 
-up: ## Start core local stack (DozerDB + extraction API + platform UI)
+up: ## Start core local stack; or an isolated app tier with INSTANCE=<id>
+ifeq ($(strip $(INSTANCE)),)
 	@echo "🐳 Starting Seocho core local stack from an image-backed source snapshot..."
-	@docker compose up -d --build
+	@COMPOSE_PROJECT_NAME=$(SHARED_PROJECT) docker compose up -d --build
 	@echo "✅ Services started!"
 	@echo "🖥️  Platform UI: http://localhost:$${CHAT_INTERFACE_PORT:-8501}"
 	@echo "🧠 Backend API Docs: http://localhost:$${EXTRACTION_API_PORT:-8001}/docs"
 	@echo "🗄️  DozerDB Browser: http://localhost:$${NEO4J_HTTP_PORT:-7474}"
 	@echo "ℹ️  Legacy semantic-service is opt-in: docker compose --profile legacy-semantic up -d semantic-service"
 	@echo "ℹ️  For a bind-mounted live edit loop, use: make up-live"
+	@echo "ℹ️  For an isolated per-worktree runtime, use: make up INSTANCE=<id>"
+else
+	@echo "🐳 Booting isolated instance '$(INSTANCE)' (offset ports + ephemeral DB) against the shared neo4j..."
+	@echo "ℹ️  Requires the shared stack to be running first: make up"
+	@$(SEOCHO_CLI) serve --instance $(INSTANCE) --build
+endif
 
 up-live: ## Start core local stack with live bind mounts for extraction/runtime/src/seocho
 	@echo "🐳 Starting Seocho core local stack with live source mounts..."
@@ -45,9 +57,14 @@ up-legacy-semantic: ## Start the legacy semantic-service profile too
 	@docker compose --profile legacy-semantic up -d
 	@echo "✅ Legacy semantic-service started."
 
-down: ## Stop all services
+down: ## Stop all services; or tear down one isolated instance with INSTANCE=<id>
+ifeq ($(strip $(INSTANCE)),)
 	@echo "🛑 Stopping services..."
-	@docker compose down
+	@COMPOSE_PROJECT_NAME=$(SHARED_PROJECT) docker compose down
+else
+	@echo "🛑 Tearing down instance '$(INSTANCE)' and dropping only its ephemeral DB..."
+	@$(SEOCHO_CLI) stop --instance $(INSTANCE)
+endif
 
 restart: ## Restart all services
 	@echo "🔄 Restarting services..."

--- a/docker-compose.instance.yml
+++ b/docker-compose.instance.yml
@@ -1,0 +1,59 @@
+# Per-instance app tier for worktree-isolated runtime boot (seocho-6q9.3).
+#
+# This is a SELF-CONTAINED compose file (used alone, not as an overlay on
+# docker-compose.yml) that brings up only the stateless app tier — extraction
+# API + thin UI — in its own compose project on offset ports, all reaching the
+# SHARED neo4j started by `make up`. Each instance drives its own ephemeral
+# logical database (SEOCHO_DATABASE), so the heavyweight graph backend stays
+# shared while worktrees never collide on ports, containers, or data.
+#
+# Boot:     COMPOSE_PROJECT_NAME=seocho-<id> EXTRACTION_API_PORT=81x0 \
+#           CHAT_INTERFACE_PORT=86x0 SEOCHO_DATABASE=wt<hash> \
+#           docker compose -f docker-compose.instance.yml up -d
+# Network:  attaches to the shared stack's external `seocho-net`.
+services:
+  extraction-service:
+    build:
+      context: .
+      dockerfile: extraction/Dockerfile
+    ports:
+      - "${SEOCHO_BIND_HOST:-127.0.0.1}:${EXTRACTION_API_PORT:-8100}:8001"
+    volumes:
+      - ./notebooks:/app/notebooks
+      - ./demos:/app/demos
+    environment:
+      # Reach the shared neo4j by its container name on the shared network,
+      # not compose-internal service DNS (a different project owns it).
+      - NEO4J_URI=bolt://graphrag-neo4j:7687
+      - NEO4J_USER=${NEO4J_USER:-neo4j}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:?Set NEO4J_PASSWORD in .env before starting compose}
+      # Per-instance ephemeral logical database (required for isolation).
+      - "NEO4J_DATABASE=${SEOCHO_DATABASE:?Set SEOCHO_DATABASE via seocho serve --instance <id>}"
+      - "SEOCHO_DATABASE=${SEOCHO_DATABASE:?Set SEOCHO_DATABASE via seocho serve --instance <id>}"
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - SEOCHO_TRACE_BACKEND=${SEOCHO_TRACE_BACKEND:-none}
+      - SEOCHO_TRACE_JSONL_PATH=${SEOCHO_TRACE_JSONL_PATH:-/tmp/seocho-runtime.jsonl}
+    networks:
+      - graphrag-net
+
+  evaluation-interface:
+    build: ./evaluation
+    command: uvicorn server:app --host 0.0.0.0 --port 8501
+    ports:
+      - "${SEOCHO_BIND_HOST:-127.0.0.1}:${CHAT_INTERFACE_PORT:-8600}:8501"
+    volumes:
+      - ./evaluation:/app
+    environment:
+      # Resolves to this instance's own extraction-service (same project).
+      - EXTRACTION_SERVICE_URL=http://extraction-service:8001
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    depends_on:
+      - extraction-service
+    networks:
+      - graphrag-net
+
+networks:
+  graphrag-net:
+    # The shared stack (docker-compose.yml) owns this network; attach to it.
+    name: seocho-net
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,8 @@ services:
     build:
       context: .
       dockerfile: extraction/Dockerfile
-    container_name: extraction-service
+    # No fixed container_name: the app tier runs per-instance (seocho-6q9.3),
+    # so compose derives <project>-extraction-service-<n> to avoid collisions.
     ports:
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${EXTRACTION_NOTEBOOK_PORT:-8888}:8888"
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${EXTRACTION_API_PORT:-8001}:8001"
@@ -55,7 +56,6 @@ services:
 
   semantic-service:
     build: ./semantic
-    container_name: semantic-service
     profiles: ["legacy-semantic"]
     volumes:
       - ./semantic:/app
@@ -72,7 +72,6 @@ services:
 
   evaluation-interface:
     build: ./evaluation
-    container_name: evaluation-interface
     command: uvicorn server:app --host 0.0.0.0 --port 8501
     ports:
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${CHAT_INTERFACE_PORT:-8501}:8501"
@@ -272,4 +271,7 @@ services:
 
 networks:
   graphrag-net:
+    # Fixed name so per-instance app projects (docker-compose.instance.yml,
+    # seocho-6q9.3) can attach to the shared stack's network as `external`.
+    name: seocho-net
     driver: bridge

--- a/docs/RUNTIME_DEPLOYMENT.md
+++ b/docs/RUNTIME_DEPLOYMENT.md
@@ -103,6 +103,54 @@ If you need the old standalone `semantic-service`, start it explicitly:
 docker compose --profile legacy-semantic up -d semantic-service
 ```
 
+## 3.1 Isolated Per-Worktree Runtime (multi-instance)
+
+When more than one worktree (or agent) needs to drive the runtime at the same
+time, boot an **isolated instance** instead of a second full stack. SEOCHO
+follows a single-neo4j, multi-database model: the heavyweight graph backend
+started by `make up` stays **shared**, while each instance gets its own
+ephemeral logical database, its own app-tier containers, and offset ports.
+
+```bash
+make up                       # shared stack once (neo4j + default app tier)
+make up INSTANCE=alice        # isolated app tier: offset ports + ephemeral DB
+make up INSTANCE=bob          # a second, concurrent, non-colliding instance
+```
+
+Each instance is derived deterministically from its id (`src/seocho/instance.py`):
+
+| id      | API port | UI port | ephemeral DB     | compose project |
+| ------- | -------- | ------- | ---------------- | --------------- |
+| `alice` | `8880`   | `9180`  | `wt522b276a356b` | `seocho-alice`  |
+| `bob`   | `8890`   | `9190`  | `wt48181acd22b3` | `seocho-bob`    |
+
+The ephemeral database name is validated against the runtime contract
+(`^[a-z][a-z0-9]{2,62}$`) before it is created on the shared neo4j. Teardown
+removes **only that instance's** app tier and drops **only its** logical
+database — the shared neo4j and every other instance are untouched:
+
+```bash
+make down INSTANCE=alice      # docker compose down (alice) + DROP DATABASE wt522…
+make down                     # stop the shared stack
+```
+
+Equivalent SDK CLI form (and `--dry-run` to preview without docker):
+
+```bash
+seocho serve --instance alice
+seocho stop  --instance alice
+seocho serve --instance alice --dry-run --json   # inspect ports/DB/command
+```
+
+App-tier ports are hash-derived over 200 slots, so two distinct ids can in rare
+cases land on the same slot (P(collision) ≈ 1% at 2 worktrees, ≈ 14% at 8);
+`InstanceLayout.collides_with(...)` detects this. A port-slot collision is an
+*availability* concern only — **data isolation is unaffected** because the data
+plane routes by the ephemeral database key, which is derived independently of
+the port slot (a 48-bit space; collisions negligible). This is validated in
+`scripts/experiments/isolation_experiment.py`. Pick distinct short ids per
+worktree (a branch name or tenant id works well).
+
 ## 4. First Success: UI Path
 
 1. Open `http://localhost:8501`

--- a/docs/decisions/ADR-0104-worktree-isolated-runtime-boot.md
+++ b/docs/decisions/ADR-0104-worktree-isolated-runtime-boot.md
@@ -1,0 +1,76 @@
+# ADR-0104: Worktree-Isolated Runtime Boot (shared neo4j + ephemeral logical DB)
+
+Date: 2026-06-06
+Status: Proposed
+
+## Context
+
+`docker-compose.yml` was a single shared instance with hardcoded ports
+(7474/7687/8001/8501) and hardcoded `container_name`s. Two worktrees (or two
+agents) could not boot the runtime concurrently: container names collided, the
+default compose project was shared, and `make clean` was destructive and
+manual. There was no SEOCHO analog of Codex's "boot an isolated instance, drive
+it, delete its logs/metrics/DB when done."
+
+This closes the last child of the observability epic (`seocho-6q9`), after the
+trace read/query API (`seocho-6q9.1`, ADR-merged via #187) and the perf-budget
+gate (`seocho-6q9.2`).
+
+## Decision
+
+Per-worktree isolation follows SEOCHO's existing **single-neo4j,
+multi-database** model rather than a full stack per worktree:
+
+- **Shared graph backend.** `make up` starts one neo4j (fixed compose project
+  `seocho`, default ports). Worktrees share it. The compose network is given a
+  fixed name (`seocho-net`) so per-instance projects can attach as `external`.
+- **Per-instance app tier.** `make up INSTANCE=<id>` boots only the stateless
+  app tier (extraction API + UI) in its own compose project (`seocho-<id>`)
+  from a self-contained `docker-compose.instance.yml`, on hash-derived offset
+  ports, reaching the shared neo4j by container name on `seocho-net`.
+- **Ephemeral logical database.** Each instance drives its own database
+  `wt<hash>`, created with `CREATE DATABASE … IF NOT EXISTS` before the app
+  tier connects and dropped with `DROP DATABASE … IF EXISTS` on teardown.
+- **Scoped teardown.** `make down INSTANCE=<id>` removes only that instance's
+  app project and drops only its logical database; the shared neo4j and other
+  instances are untouched.
+
+Canonical derivation is side-effect-free in `src/seocho/instance.py`
+(`derive_instance` → `InstanceLayout`); the database name is validated against
+the existing runtime contract `^[a-z][a-z0-9]{2,62}$`
+(`runtime_contract.DATABASE_NAME_PATTERN`) before any Cypher interpolation.
+Boot/teardown orchestration lives in `src/seocho/local.py` and is surfaced via
+`seocho serve/stop --instance` and the Makefile.
+
+## Consequences / Tradeoffs
+
+- The heavyweight backend stays shared, so concurrent instances are cheap
+  (no neo4j-per-worktree RAM cost), but neo4j is a **shared failure domain** —
+  one instance can exhaust shared backend resources.
+- App-tier ports are derived from a hash over 200 slots (widened from an
+  initial 40 after the isolation experiment measured P(collision) ≈ 0.50 at
+  8 tenants; 200 slots brings this to ≈ 0.14, and ≈ 0.01 at the canonical
+  two-worktree case). Residual collisions are **detectable** via
+  `InstanceLayout.collides_with(...)`. Crucially, a port-slot collision is an
+  availability concern only: **data isolation is preserved** because the data
+  plane routes by the ephemeral database key, derived independently of the port
+  slot (proven in the experiment, Finding 3). A future revision can
+  probe-and-reassign at boot.
+- `container_name` was removed from the app services (compose now derives
+  `<project>-extraction-service-<n>`); shared singletons (neo4j, opik-*) keep
+  fixed names. `docker compose exec extraction-service …` still works (service
+  name, not container name).
+
+## Validation
+
+- `tests/seocho/test_instance.py` (20 tests): deterministic derivation,
+  distinct-instance non-collision, same-slot collision detection, DB-name
+  contract compliance, injection rejection, dry-run + fake-runner command
+  construction (CREATE-before-up, down-before-DROP), backward-compatible
+  no-instance path.
+- `docker compose -f docker-compose.instance.yml config` renders a valid
+  app-only stack on `external: seocho-net` with offset port maps and the
+  ephemeral DB env.
+- `bash scripts/ci/run_basic_ci.sh` and `check-doc-contracts.sh` pass.
+- Live two-worktree concurrent boot is the documented manual acceptance check
+  (`docs/RUNTIME_DEPLOYMENT.md` §3.1).

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -3,6 +3,18 @@
 This file is the lightweight index of architecture/product decisions.
 Each entry must link to a full ADR when impact is non-trivial.
 
+## 2026-06-06
+
+- [Proposed] ADR-0104 worktree-isolated runtime boot
+  - `make up INSTANCE=<id>` / `seocho serve --instance <id>` boot an isolated
+    app tier (offset ports + ephemeral logical DB) against a SHARED neo4j;
+    teardown drops only that instance's app project and database
+  - canonical derivation in `src/seocho/instance.py` (validated against the
+    `^[a-z][a-z0-9]{2,62}$` runtime contract); orchestration in `local.py`
+  - tradeoff: shared neo4j failure domain; hash-derived ports over 40 slots can
+    collide and is surfaced via `InstanceLayout.collides_with(...)`
+  - closes `seocho-6q9.3`, the last child of the observe-loop epic `seocho-6q9`
+
 ## 2026-06-03
 
 - Accepted `ADR-0099-ontology-control-plane-as-agentic-middleware-lock-in.md`

--- a/scripts/experiments/isolation_experiment.py
+++ b/scripts/experiments/isolation_experiment.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Multi-tenant / agent-interaction isolation experiment for seocho-6q9.3.
+
+Validates the *worktree-isolated runtime boot* feature (shared neo4j, one
+ephemeral logical database per tenant). Design hardened after independent
+review by a systems-methodology referee and a multi-tenancy/isolation referee.
+The two non-negotiable corrections from that review shape this harness:
+
+  1. The data-plane is keyed by *database name*, so a dict-backed store would
+     make "no leakage under isolation" true by construction. We therefore add a
+     POSITIVE CONTROL (condition B') that forces a derivation bug (all tenants
+     collapse to one database) and show the harness DOES detect leakage there.
+     A null result under B is only meaningful because B' is non-null.
+
+  2. We claim DATA ISOLATION ONLY. Performance isolation and fault isolation are
+     explicitly NOT claimed — a shared engine shares a buffer pool and a failure
+     domain. H2 is split into H2a (logical result-set invariance, claimed and
+     tested) and H2b (latency/availability invariance, NOT claimed; a shared
+     engine couples neighbors — out of scope for this in-memory harness).
+
+WHAT THIS VALIDATES (backend-independent, exercises real code):
+  - determinism of derive_instance (an invariant, asserted exhaustively)
+  - collision-freedom of the database key over a tenant population, vs the
+    analytical birthday bound, with a rule-of-three upper bound on zero events
+  - that the data-isolation invariant rests on the DATABASE key and survives
+    app-tier PORT-SLOT collisions (the headline conditional claim)
+  - control-plane name-injection rejection (real admin_database_command)
+  - teardown blast radius and residual-after-recreate on the routing layer
+
+WHAT THIS DOES NOT VALIDATE (deferred to live-neo4j integration):
+  - that neo4j logical databases actually enforce visibility/transaction
+    isolation (assumed from neo4j multi-database guarantees)
+  - any real performance/contention/noisy-neighbor behavior (H2b)
+
+Threat model: honest-but-concurrent tenants (not malicious in-process). This is
+not a security boundary against a compromised engine or Cypher injection beyond
+the validated control-plane path.
+
+Run: PYTHONPATH=src python3 scripts/experiments/isolation_experiment.py
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+from seocho.exceptions import SeochoError
+from seocho.instance import INSTANCE_PORT_SLOTS, derive_instance
+from seocho.local import admin_database_command
+from seocho.runtime_contract import DATABASE_NAME_PATTERN
+
+SHARED_DB = "sharedmemorydb"          # condition A: one database for everyone
+COLLAPSED_DB = "collapseddb"          # condition B': forced derivation bug
+
+
+# --------------------------------------------------------------------------
+# Faithful in-memory multi-database store (stands in for neo4j multi-database)
+# --------------------------------------------------------------------------
+@dataclass
+class Node:
+    owner: str
+    name: str
+
+
+class InMemoryMultiDB:
+    """Thread-safe store keyed by database name.
+
+    Mirrors only the structural property under test: a query is scoped to the
+    database the caller connected to. An UNSCOPED `MATCH (n)` therefore returns
+    every node in the *connected* database — which is exactly the surface a
+    cross-tenant leak would appear on.
+    """
+
+    def __init__(self) -> None:
+        self._dbs: Dict[str, List[Node]] = {}
+        self._lock = threading.Lock()
+
+    def create_database(self, name: str) -> None:
+        with self._lock:
+            self._dbs.setdefault(name, [])
+
+    def drop_database(self, name: str) -> None:
+        with self._lock:
+            self._dbs.pop(name, None)
+
+    def write(self, database: str, node: Node) -> None:
+        with self._lock:
+            self._dbs.setdefault(database, []).append(node)
+
+    def match_all(self, database: str) -> List[Node]:
+        # Unscoped MATCH (n) within the connected database.
+        with self._lock:
+            return list(self._dbs.get(database, []))
+
+    def exists(self, name: str) -> bool:
+        with self._lock:
+            return name in self._dbs
+
+
+# --------------------------------------------------------------------------
+# Conditions: how a tenant id resolves to a target database
+# --------------------------------------------------------------------------
+def resolve_db_A(tenant: str) -> str:
+    """Single shared instance, multi-agent: everyone shares one logical DB."""
+    return SHARED_DB
+
+
+def resolve_db_B(tenant: str) -> str:
+    """The feature: each tenant routed to its own derived ephemeral DB."""
+    return derive_instance(tenant).database
+
+
+def resolve_db_Bprime(tenant: str) -> str:
+    """POSITIVE CONTROL: a derivation bug collapses all tenants to one DB."""
+    return COLLAPSED_DB
+
+
+CONDITIONS: Dict[str, Callable[[str], str]] = {
+    "A_shared_single": resolve_db_A,
+    "B_isolated": resolve_db_B,
+    "Bprime_broken_control": resolve_db_Bprime,
+}
+
+
+# --------------------------------------------------------------------------
+# Concurrent multi-tenant workload
+# --------------------------------------------------------------------------
+@dataclass
+class LeakageResult:
+    condition: str
+    tenants: int
+    ops: int
+    leak_ops: int           # tenant reads that observed a foreign node
+    leaked_nodes: int       # total foreign nodes observed across reads
+
+
+def run_workload(
+    resolve: Callable[[str], str],
+    tenants: List[str],
+    writes_per_tenant: int,
+    *,
+    identical_names: bool,
+    condition: str,
+) -> LeakageResult:
+    """Concurrently: each tenant creates its DB, writes tagged nodes, then does
+    an unscoped read of its connected DB and counts any foreign-owned nodes."""
+    store = InMemoryMultiDB()
+    leak_ops = 0
+    leaked_nodes = 0
+    audit_lock = threading.Lock()
+
+    def agent(tenant: str) -> None:
+        nonlocal leak_ops, leaked_nodes
+        db = resolve(tenant)
+        store.create_database(db)
+        for i in range(writes_per_tenant):
+            # identical_names probes the name-as-ID collision risk: the same
+            # logical name written by two tenants must stay two distinct nodes
+            # in two databases under isolation.
+            name = f"shared-name-{i}" if identical_names else f"{tenant}-node-{i}"
+            store.write(db, Node(owner=tenant, name=name))
+        # Unscoped read of the connected DB — where a leak would show up.
+        seen = store.match_all(db)
+        foreign = [n for n in seen if n.owner != tenant]
+        with audit_lock:
+            if foreign:
+                leak_ops += 1
+                leaked_nodes += len(foreign)
+
+    threads = [threading.Thread(target=agent, args=(t,)) for t in tenants]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    return LeakageResult(
+        condition=condition,
+        tenants=len(tenants),
+        ops=len(tenants),
+        leak_ops=leak_ops,
+        leaked_nodes=leaked_nodes,
+    )
+
+
+# --------------------------------------------------------------------------
+# Statistics (correct treatment for zero-bounded counts)
+# --------------------------------------------------------------------------
+def rule_of_three_upper_bound(events: int, trials: int) -> Optional[float]:
+    """95% one-sided upper bound on a rate with `events` in `trials`.
+
+    Exact only for the zero-event case (the classic rule of three: ~3/n).
+    Returns None when events>0 (use a proper interval there)."""
+    if trials == 0:
+        return None
+    if events == 0:
+        return 3.0 / trials
+    return None
+
+
+def birthday_expected_collisions(n: int, slots: int) -> float:
+    """Expected number of colliding pairs for n items in `slots` buckets."""
+    if slots <= 0:
+        return 0.0
+    return (n * (n - 1) / 2.0) / slots
+
+
+def birthday_prob_at_least_one(n: int, slots: int) -> float:
+    if slots <= 0:
+        return 1.0
+    return 1.0 - math.exp(-n * (n - 1) / (2.0 * slots))
+
+
+def fisher_exact_2x2(a: int, b: int, c: int, d: int) -> float:
+    """Two-sided Fisher's exact p-value for table [[a,b],[c,d]] (no scipy)."""
+    n = a + b + c + d
+    if n == 0:
+        return 1.0
+    r1, r2 = a + b, c + d
+    c1 = a + c
+
+    def logfact(k: int) -> float:
+        return math.lgamma(k + 1)
+
+    def logp(x: int) -> float:
+        # hypergeometric: x in the (row1,col1) cell
+        y = r1 - x
+        z = c1 - x
+        w = r2 - z
+        if min(x, y, z, w) < 0:
+            return float("-inf")
+        return (
+            logfact(r1) + logfact(r2) + logfact(c1) + logfact(n - c1)
+            - logfact(n) - logfact(x) - logfact(y) - logfact(z) - logfact(w)
+        )
+
+    p_obs = logp(a)
+    lo = max(0, r1 - (n - c1))
+    hi = min(r1, c1)
+    total = 0.0
+    for x in range(lo, hi + 1):
+        lp = logp(x)
+        if lp <= p_obs + 1e-9:
+            total += math.exp(lp)
+    return min(1.0, total)
+
+
+# --------------------------------------------------------------------------
+# Experiment sections
+# --------------------------------------------------------------------------
+def section(title: str) -> None:
+    print("\n" + "=" * 78)
+    print(title)
+    print("=" * 78)
+
+
+def exp_determinism(ids: List[str], repeats: int = 50) -> bool:
+    section("INVARIANT 1 — derivation determinism (exhaustive, not statistical)")
+    ok = True
+    for tid in ids:
+        first = derive_instance(tid)
+        for _ in range(repeats):
+            if derive_instance(tid) != first:
+                ok = False
+                print(f"  NON-DETERMINISTIC: {tid!r}")
+                break
+    print(f"  {len(ids)} ids x {repeats} repeats -> deterministic: {ok}")
+    return ok
+
+
+def exp_collisions(populations: List[int]) -> None:
+    section("FINDING 2 — collision-freedom: PORT-SLOT vs DATABASE key")
+    print("  Data isolation must rest on the DATABASE key, not the port slot.")
+    print(f"  Port slots = {INSTANCE_PORT_SLOTS} (birthday-bound, collisions EXPECTED).")
+    print("  Database key = 'wt' + 12 hex = 48-bit space (collisions negligible).\n")
+    print(f"  {'N':>6} | {'port_coll':>9} {'port_E[pairs]':>13} {'P(>=1)':>8} | "
+          f"{'db_coll':>7} {'db_RoT_ub':>10}")
+    print("  " + "-" * 70)
+    for n in populations:
+        ids = [f"tenant-{i:05d}" for i in range(n)]
+        layouts = [derive_instance(t) for t in ids]
+        # port-slot collisions
+        slot_buckets: Dict[int, int] = defaultdict(int)
+        for L in layouts:
+            slot_buckets[L.slot] += 1
+        port_coll_pairs = sum(c * (c - 1) // 2 for c in slot_buckets.values())
+        # database-name collisions
+        db_buckets: Dict[str, int] = defaultdict(int)
+        for L in layouts:
+            db_buckets[L.database] += 1
+        db_coll_pairs = sum(c * (c - 1) // 2 for c in db_buckets.values())
+        db_ub = rule_of_three_upper_bound(db_coll_pairs, max(1, n * (n - 1) // 2))
+        print(f"  {n:>6} | {port_coll_pairs:>9} "
+              f"{birthday_expected_collisions(n, INSTANCE_PORT_SLOTS):>13.2f} "
+              f"{birthday_prob_at_least_one(n, INSTANCE_PORT_SLOTS):>8.3f} | "
+              f"{db_coll_pairs:>7} "
+              f"{(f'{db_ub:.2e}' if db_ub is not None else 'n/a'):>10}")
+
+
+def exp_port_collision_isolation() -> bool:
+    section("FINDING 3 — HEADLINE: data isolation holds UNDER a port-slot collision")
+    id_a, id_b = "tenant-00001", "tenant-00044"  # hash to the same port slot
+    a = derive_instance(id_a)
+    b = derive_instance(id_b)
+    print(f"  {id_a} : slot={a.slot} api={a.api_port} db={a.database}")
+    print(f"  {id_b} : slot={b.slot} api={b.api_port} db={b.database}")
+    same_port = a.api_port == b.api_port and a.slot == b.slot
+    diff_db = a.database != b.database
+    print(f"  -> share app-tier port slot: {same_port}")
+    print(f"  -> distinct database key:    {diff_db}")
+    # Route both through the isolation resolver, identical node names, concurrent.
+    res = run_workload(
+        resolve_db_B, [id_a, id_b], writes_per_tenant=200,
+        identical_names=True, condition="B_isolated",
+    )
+    isolated = res.leaked_nodes == 0
+    print(f"  -> concurrent identical-name writes; cross-tenant leaked nodes: "
+          f"{res.leaked_nodes}")
+    claim = same_port and diff_db and isolated
+    print("\n  CLAIM: port collision does NOT break data isolation iff routing")
+    print(f"  key = database (independent of port slot). Holds: {claim}")
+    return claim
+
+
+def exp_leakage_ABBprime(tenants: List[str], trials: int, writes: int) -> None:
+    section("FINDING 4 — leakage: A (shared) vs B (isolated) vs B' (broken control)")
+    print("  H1: zero cross-tenant data leakage under B.")
+    print("  Positive control B' must show NON-zero leakage, else the harness")
+    print("  cannot detect leakage and a null result under B is vacuous.\n")
+    agg: Dict[str, Tuple[int, int, int]] = {}  # condition -> (leak_ops, total_ops, leaked_nodes)
+    for cond, resolve in CONDITIONS.items():
+        tot_leak_ops = tot_ops = tot_nodes = 0
+        for _ in range(trials):
+            r = run_workload(resolve, tenants, writes,
+                             identical_names=True, condition=cond)
+            tot_leak_ops += r.leak_ops
+            tot_ops += r.ops
+            tot_nodes += r.leaked_nodes
+        agg[cond] = (tot_leak_ops, tot_ops, tot_nodes)
+        ub = rule_of_three_upper_bound(tot_leak_ops, tot_ops)
+        ub_s = f"<= {ub:.4f} (rule of 3)" if ub is not None else "n/a (events>0)"
+        print(f"  {cond:24} leak_ops={tot_leak_ops:>5}/{tot_ops:<5} "
+              f"leaked_nodes={tot_nodes:>7}  95% rate UB: {ub_s}")
+
+    # Fisher's exact: B vs B' on (leak, no-leak)
+    b_leak, b_tot, _ = agg["B_isolated"]
+    bp_leak, bp_tot, _ = agg["Bprime_broken_control"]
+    p = fisher_exact_2x2(b_leak, b_tot - b_leak, bp_leak, bp_tot - bp_leak)
+    print(f"\n  Fisher's exact (B vs B', leak/no-leak): p = {p:.3e}")
+    print(f"  Interpretation: B' detects leakage ({bp_leak}/{bp_tot} ops) while B")
+    print(f"  shows {b_leak}/{b_tot} -> the null under B is a real, powered result.")
+
+
+def exp_h2a_invariance(target: str, neighbors: List[str], writes: int) -> None:
+    section("FINDING 5 — H2a: a tenant's RESULT SET is invariant to neighbors")
+    print("  (H2b latency/availability invariance is NOT claimed: shared engine")
+    print("   couples neighbors. This harness only tests logical invariance.)\n")
+    for cond, resolve in (("A_shared_single", resolve_db_A), ("B_isolated", resolve_db_B)):
+        # solo baseline result set (the uncontaminated ground truth for H2a)
+        store_solo = InMemoryMultiDB()
+        db = resolve(target)
+        store_solo.create_database(db)
+        for i in range(writes):
+            store_solo.write(db, Node(owner=target, name=f"{target}-node-{i}"))
+        solo_set = {(n.owner, n.name) for n in store_solo.match_all(db)}
+        # concurrent with neighbors
+        store_conc = InMemoryMultiDB()
+
+        def agent(t: str) -> None:
+            d = resolve(t)
+            store_conc.create_database(d)
+            for i in range(writes):
+                store_conc.write(d, Node(owner=t, name=f"{t}-node-{i}"))
+
+        ths = [threading.Thread(target=agent, args=(t,)) for t in [target] + neighbors]
+        for th in ths:
+            th.start()
+        for th in ths:
+            th.join()
+        conc_set = {(n.owner, n.name) for n in store_conc.match_all(resolve(target))}
+        invariant = conc_set == solo_set
+        contamination = len(conc_set - solo_set)
+        print(f"  {cond:24} result-set invariant: {invariant!s:5}  "
+              f"contaminating rows under concurrency: {contamination}")
+
+
+def exp_name_injection() -> bool:
+    section("FINDING 6 — control-plane: name-injection rejection + derivation safety")
+    ok = True
+    # 6a: derive_instance hashes the id, so even hostile ids yield a safe wt<hash>
+    hostile = ["a; DROP DATABASE neo4j; --", "../../etc", "DROP", "robert');--", "üñïçODE"]
+    import re
+    db_re = re.compile(DATABASE_NAME_PATTERN)
+    for h in hostile:
+        try:
+            layout = derive_instance(h)
+        except SeochoError:
+            continue
+        if not db_re.match(layout.database):
+            ok = False
+            print(f"  UNSAFE derived db from {h!r}: {layout.database}")
+    print(f"  hostile ids -> derived db always matches {DATABASE_NAME_PATTERN!r}: {ok}")
+    # 6b: admin command must reject a raw malicious database name
+    rejected = 0
+    for bad in ["neo4j`; DROP DATABASE system; --", "WITH space", "1leadingdigit", "x"]:
+        try:
+            admin_database_command(bad, action="create")
+        except SeochoError:
+            rejected += 1
+    print(f"  admin_database_command rejected {rejected}/4 malformed/malicious names")
+    ok = ok and rejected == 4
+    return ok
+
+
+def exp_teardown_and_residual() -> bool:
+    section("FINDING 7 — teardown blast radius + residual-after-recreate")
+    store = InMemoryMultiDB()
+    a, b = derive_instance("alice"), derive_instance("bob")
+    for L, t in ((a, "alice"), (b, "bob")):
+        store.create_database(L.database)
+        for i in range(10):
+            store.write(L.database, Node(owner=t, name=f"{t}-{i}"))
+    # drop only alice
+    store.drop_database(a.database)
+    blast_ok = (not store.exists(a.database)) and len(store.match_all(b.database)) == 10
+    print(f"  drop alice's DB -> alice gone: {not store.exists(a.database)}, "
+          f"bob intact (10 nodes): {len(store.match_all(b.database)) == 10}")
+    # residual after recreate (same id -> same db name)
+    a2 = derive_instance("alice")
+    store.create_database(a2.database)
+    residual = len(store.match_all(a2.database))
+    print(f"  recreate alice (same db key {a2.database}) -> residual nodes: {residual}")
+    ok = blast_ok and residual == 0
+    print(f"  teardown is scoped and recreate is clean: {ok}")
+    return ok
+
+
+def exp_overhead(tenants: List[str], writes: int, trials: int) -> None:
+    section("FINDING 8 — routing overhead (DEMOTED: near-zero, NOT load-bearing)")
+    print("  The PhD review flags derivation cost as negligible and external")
+    print("  validity as limited (in-memory, GIL). Reported for completeness;")
+    print("  real engine throughput/memory is deferred to live-neo4j.\n")
+    for cond, resolve in (("A_shared_single", resolve_db_A), ("B_isolated", resolve_db_B)):
+        samples = []
+        for _ in range(trials):
+            t0 = time.perf_counter()
+            run_workload(resolve, tenants, writes, identical_names=False, condition=cond)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+        samples.sort()
+        med = samples[len(samples) // 2]
+        p95 = samples[min(len(samples) - 1, int(len(samples) * 0.95))]
+        print(f"  {cond:24} median={med:8.2f}ms  p95={p95:8.2f}ms  "
+              f"(n={trials} trials, {len(tenants)} tenants x {writes} writes)")
+
+
+def main() -> int:
+    print(__doc__.split("\n\n")[0])
+    print("\nThreat model: honest-but-concurrent tenants. Claim: DATA isolation")
+    print("ONLY (performance + fault isolation explicitly NOT claimed).")
+
+    tenants = [f"tenant-{i:03d}" for i in range(16)]
+    results = {}
+    results["determinism"] = exp_determinism(tenants + ["alice", "bob", "wt-2"])
+    exp_collisions([8, 64, 512, 4096])
+    results["port_collision_isolation"] = exp_port_collision_isolation()
+    exp_leakage_ABBprime(tenants, trials=20, writes=50)
+    exp_h2a_invariance("tenant-000", tenants[1:], writes=50)
+    results["name_injection"] = exp_name_injection()
+    results["teardown_residual"] = exp_teardown_and_residual()
+    exp_overhead(tenants, writes=50, trials=15)
+
+    section("SUMMARY — invariant pass/fail")
+    all_ok = True
+    for k, v in results.items():
+        all_ok = all_ok and v
+        print(f"  {'PASS' if v else 'FAIL'}  {k}")
+    print(f"\n  Overall invariants: {'ALL PASS' if all_ok else 'FAILURES PRESENT'}")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -87,6 +87,11 @@ def build_parser() -> argparse.ArgumentParser:
     serve_parser.add_argument("--no-wait", action="store_true", help="Return after docker compose starts")
     serve_parser.add_argument("--timeout", type=float, default=90.0, help="Readiness wait timeout in seconds")
     serve_parser.add_argument(
+        "--instance",
+        default=None,
+        help="Boot an isolated per-worktree app tier (offset ports + ephemeral DB) against the shared neo4j",
+    )
+    serve_parser.add_argument(
         "--fallback-openai-key",
         default="dummy-key",
         help="Fallback OPENAI_API_KEY for local verification when no key is set",
@@ -97,6 +102,11 @@ def build_parser() -> argparse.ArgumentParser:
     stop_parser = subparsers.add_parser("stop", help="Stop the local SEOCHO docker stack")
     stop_parser.add_argument("--project-dir", default=None, help="Repository root containing docker-compose.yml")
     stop_parser.add_argument("--volumes", action="store_true", help="Also remove compose volumes")
+    stop_parser.add_argument(
+        "--instance",
+        default=None,
+        help="Tear down a per-worktree app tier and drop only its ephemeral DB",
+    )
     stop_parser.add_argument("--dry-run", action="store_true", help="Print the compose command without running it")
     stop_parser.add_argument("--json", dest="output_json", action="store_true", help="Emit JSON output")
 
@@ -486,6 +496,7 @@ def _dispatch(client: Optional[Seocho], args: argparse.Namespace) -> int:
             wait=not args.no_wait,
             timeout=args.timeout,
             fallback_openai_key=args.fallback_openai_key,
+            instance=args.instance,
             dry_run=args.dry_run,
         )
         _print_result(status, args.output_json)
@@ -495,6 +506,7 @@ def _dispatch(client: Optional[Seocho], args: argparse.Namespace) -> int:
         status = stop_local_runtime(
             project_dir=args.project_dir,
             volumes=args.volumes,
+            instance=args.instance,
             dry_run=args.dry_run,
         )
         _print_result(status, args.output_json)
@@ -1351,3 +1363,7 @@ def _cmd_serve_http(args: argparse.Namespace) -> int:
     app = create_bundle_runtime_app(bundle)
     uvicorn.run(app, host=args.host, port=args.port, reload=args.reload)
     return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/seocho/instance.py
+++ b/src/seocho/instance.py
@@ -1,0 +1,129 @@
+"""Deterministic per-instance runtime layout derivation.
+
+Worktree-isolated runtime boot (seocho-6q9.3) follows the SEOCHO
+"single Neo4j instance, multi-database" model: a *shared* graph backend is
+reached by every worktree, while each worktree drives its own ephemeral
+logical database plus its own app-tier containers on offset ports.
+
+This module is the canonical, side-effect-free derivation: an instance id maps
+deterministically to a compose project name, an ephemeral database name (which
+is validated against the same ``DATABASE_NAME_PATTERN`` the runtime enforces),
+and an app-tier port slot. It performs no I/O so it is trivially unit-testable
+and reproducible across processes (``hashlib`` rather than the salted builtin
+``hash``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Dict
+
+from .exceptions import SeochoError
+from .runtime_contract import DATABASE_NAME_PATTERN
+
+# App-tier port bands. The shared neo4j keeps the default 7474/7687; only the
+# per-instance app containers are offset. Bands sit clear of the monolithic
+# stack's 8001/8501/8888 defaults AND the opik profile ports (8080/8000/8123/
+# 9000/9001/9090/...). 200 contiguous slots keep collisions rare at realistic
+# worktree counts: P(>=1 collision) ~1% at 2 tenants, ~14% at 8 (vs ~5% / ~50%
+# at the original 40 slots — see scripts/experiments/isolation_experiment.py).
+# Residual collisions are detectable via InstanceLayout.collides_with(...).
+INSTANCE_API_PORT_BASE = 8800
+INSTANCE_UI_PORT_BASE = 9100
+INSTANCE_PORT_STEP = 1
+INSTANCE_PORT_SLOTS = 200
+
+_DATABASE_NAME_RE = re.compile(DATABASE_NAME_PATTERN)
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _digest(instance_id: str) -> int:
+    """Stable, process-independent integer digest of an instance id."""
+    return int(hashlib.sha1(instance_id.encode("utf-8")).hexdigest(), 16)
+
+
+def _slug(instance_id: str) -> str:
+    slug = _SLUG_RE.sub("-", instance_id.strip().lower()).strip("-")
+    return slug
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceLayout:
+    """Resolved, collision-checkable layout for one worktree instance."""
+
+    instance_id: str
+    slug: str
+    project_name: str
+    database: str
+    api_port: int
+    ui_port: int
+    slot: int
+
+    def env_overrides(self) -> Dict[str, str]:
+        """Environment overrides applied to the per-instance app compose run.
+
+        The shared neo4j is reached over its published bolt port, so app
+        containers in a separate compose project resolve it via the host
+        gateway rather than compose-internal DNS.
+        """
+        return {
+            "COMPOSE_PROJECT_NAME": self.project_name,
+            "EXTRACTION_API_PORT": str(self.api_port),
+            "CHAT_INTERFACE_PORT": str(self.ui_port),
+            "SEOCHO_DATABASE": self.database,
+            "NEO4J_DATABASE": self.database,
+        }
+
+    def collides_with(self, other: "InstanceLayout") -> bool:
+        """True if two layouts would contend for a port or logical database."""
+        if self.instance_id == other.instance_id:
+            return False
+        return (
+            self.api_port == other.api_port
+            or self.ui_port == other.ui_port
+            or self.database == other.database
+            or self.project_name == other.project_name
+        )
+
+
+def derive_instance(instance_id: str) -> InstanceLayout:
+    """Derive the deterministic runtime layout for ``instance_id``.
+
+    Raises ``SeochoError`` for an empty id or if the derived database name does
+    not satisfy the runtime database-name contract (a defensive check; the
+    derivation is constructed to always satisfy it).
+    """
+    if not instance_id or not instance_id.strip():
+        raise SeochoError("instance id must be a non-empty string")
+
+    slug = _slug(instance_id)
+    if not slug:
+        raise SeochoError(
+            f"instance id {instance_id!r} has no [a-z0-9] characters to derive a layout from"
+        )
+
+    digest = _digest(instance_id)
+    slot = digest % INSTANCE_PORT_SLOTS
+    # Database name must match ^[a-z][a-z0-9]{2,62}$ — derive from the hex
+    # digest (which is already [0-9a-f]) under a leading letter prefix.
+    database = "wt" + hashlib.sha1(instance_id.encode("utf-8")).hexdigest()[:12]
+    project_name = f"seocho-{slug}"
+
+    layout = InstanceLayout(
+        instance_id=instance_id,
+        slug=slug,
+        project_name=project_name,
+        database=database,
+        api_port=INSTANCE_API_PORT_BASE + slot * INSTANCE_PORT_STEP,
+        ui_port=INSTANCE_UI_PORT_BASE + slot * INSTANCE_PORT_STEP,
+        slot=slot,
+    )
+
+    if not _DATABASE_NAME_RE.match(layout.database):
+        raise SeochoError(
+            f"derived database name {layout.database!r} violates the runtime "
+            f"contract {DATABASE_NAME_PATTERN!r}"
+        )
+    return layout

--- a/src/seocho/local.py
+++ b/src/seocho/local.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -11,13 +12,24 @@ import requests
 from dotenv import dotenv_values
 
 from .exceptions import SeochoConnectionError, SeochoError
+from .instance import derive_instance
 from .models import JsonSerializable
+from .runtime_contract import DATABASE_NAME_PATTERN
 
 DEFAULT_API_PORT = "8001"
 DEFAULT_UI_PORT = "8501"
 DEFAULT_GRAPH_PORT = "7474"
+DEFAULT_BOLT_PORT = "7687"
 DEFAULT_FALLBACK_OPENAI_KEY = "dummy-key"
 _PLACEHOLDER_OPENAI_KEYS = {"sk-your-key-here", "your-openai-api-key", "changeme"}
+
+# Compose project name of the shared stack started by `make up` (Makefile sets
+# COMPOSE_PROJECT_NAME=seocho). Per-instance app tiers reach its neo4j to
+# create/drop their ephemeral logical databases.
+SHARED_PROJECT_NAME = "seocho"
+INSTANCE_COMPOSE_FILE = "docker-compose.instance.yml"
+
+_DATABASE_NAME_RE = re.compile(DATABASE_NAME_PATTERN)
 
 
 @dataclass(slots=True)
@@ -33,6 +45,8 @@ class LocalRuntimeStatus(JsonSerializable):
     runtime_status: str = ""
     graph_count: int = 0
     details: Dict[str, Any] = field(default_factory=dict)
+    instance: str = ""
+    database: str = ""
 
 
 def find_project_dir(start_dir: Optional[str] = None) -> Path:
@@ -65,13 +79,20 @@ def serve_local_runtime(
     timeout: float = 90.0,
     poll_interval: float = 2.0,
     fallback_openai_key: str = DEFAULT_FALLBACK_OPENAI_KEY,
+    instance: Optional[str] = None,
     dry_run: bool = False,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     http_get: Callable[..., requests.Response] = requests.get,
 ) -> LocalRuntimeStatus:
     root = find_project_dir(project_dir)
     settings = _load_runtime_settings(root)
+    layout = derive_instance(instance) if instance else None
+
     command = ["docker", "compose"]
+    if layout is not None:
+        # Per-instance app tier: its own project + self-contained app-only
+        # compose file, reaching the shared neo4j over the shared network.
+        command.extend(["-p", layout.project_name, "-f", INSTANCE_COMPOSE_FILE])
     if with_opik:
         command.extend(["--profile", "opik"])
     command.extend(["up", "-d"])
@@ -79,8 +100,17 @@ def serve_local_runtime(
         command.append("--build")
 
     env, used_fallback = _build_runtime_env(settings, fallback_openai_key=fallback_openai_key)
-    api_url = f"http://localhost:{settings['EXTRACTION_API_PORT']}"
-    ui_url = f"http://localhost:{settings['CHAT_INTERFACE_PORT']}"
+    if layout is not None:
+        env.update(layout.env_overrides())
+        api_port: str = str(layout.api_port)
+        ui_port: str = str(layout.ui_port)
+    else:
+        api_port = settings["EXTRACTION_API_PORT"]
+        ui_port = settings["CHAT_INTERFACE_PORT"]
+
+    api_url = f"http://localhost:{api_port}"
+    ui_url = f"http://localhost:{ui_port}"
+    # neo4j is shared, so its browser URL is always the shared HTTP port.
     graph_url = f"http://localhost:{settings['NEO4J_HTTP_PORT']}"
 
     if dry_run:
@@ -93,7 +123,14 @@ def serve_local_runtime(
             ui_url=ui_url,
             graph_url=graph_url,
             used_fallback_openai_key=used_fallback,
+            instance=instance or "",
+            database=layout.database if layout else "",
         )
+
+    # An instance's ephemeral logical database must exist on the shared neo4j
+    # before its app tier connects to it.
+    if layout is not None:
+        _admin_database(root, settings, layout.database, action="create", runner=runner)
 
     _run_compose(command, root, env, runner)
     runtime_status = ""
@@ -119,6 +156,8 @@ def serve_local_runtime(
         runtime_status=runtime_status,
         graph_count=graph_count,
         details=details,
+        instance=instance or "",
+        database=layout.database if layout else "",
     )
 
 
@@ -126,14 +165,28 @@ def stop_local_runtime(
     *,
     project_dir: Optional[str] = None,
     volumes: bool = False,
+    instance: Optional[str] = None,
     dry_run: bool = False,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> LocalRuntimeStatus:
     root = find_project_dir(project_dir)
     settings = _load_runtime_settings(root)
-    command = ["docker", "compose", "down"]
+    layout = derive_instance(instance) if instance else None
+
+    command = ["docker", "compose"]
+    if layout is not None:
+        command.extend(["-p", layout.project_name, "-f", INSTANCE_COMPOSE_FILE])
+    command.append("down")
     if volumes:
         command.append("-v")
+
+    if layout is not None:
+        api_url = f"http://localhost:{layout.api_port}"
+        ui_url = f"http://localhost:{layout.ui_port}"
+    else:
+        api_url = f"http://localhost:{settings['EXTRACTION_API_PORT']}"
+        ui_url = f"http://localhost:{settings['CHAT_INTERFACE_PORT']}"
+    graph_url = f"http://localhost:{settings['NEO4J_HTTP_PORT']}"
 
     if dry_run:
         return LocalRuntimeStatus(
@@ -141,20 +194,29 @@ def stop_local_runtime(
             status="dry_run",
             project_dir=str(root),
             command=command,
-            api_url=f"http://localhost:{settings['EXTRACTION_API_PORT']}",
-            ui_url=f"http://localhost:{settings['CHAT_INTERFACE_PORT']}",
-            graph_url=f"http://localhost:{settings['NEO4J_HTTP_PORT']}",
+            api_url=api_url,
+            ui_url=ui_url,
+            graph_url=graph_url,
+            instance=instance or "",
+            database=layout.database if layout else "",
         )
 
     _run_compose(command, root, os.environ.copy(), runner)
+    # Teardown removes only this instance's resources: its app project (above)
+    # and its ephemeral logical database. The shared neo4j is left intact.
+    if layout is not None:
+        _admin_database(root, settings, layout.database, action="drop", runner=runner)
+
     return LocalRuntimeStatus(
         action="stop",
         status="stopped",
         project_dir=str(root),
         command=command,
-        api_url=f"http://localhost:{settings['EXTRACTION_API_PORT']}",
-        ui_url=f"http://localhost:{settings['CHAT_INTERFACE_PORT']}",
-        graph_url=f"http://localhost:{settings['NEO4J_HTTP_PORT']}",
+        api_url=api_url,
+        ui_url=ui_url,
+        graph_url=graph_url,
+        instance=instance or "",
+        database=layout.database if layout else "",
     )
 
 
@@ -174,6 +236,9 @@ def _load_runtime_settings(project_dir: Path) -> Dict[str, str]:
         "EXTRACTION_API_PORT": merged.get("EXTRACTION_API_PORT", DEFAULT_API_PORT),
         "CHAT_INTERFACE_PORT": merged.get("CHAT_INTERFACE_PORT", DEFAULT_UI_PORT),
         "NEO4J_HTTP_PORT": merged.get("NEO4J_HTTP_PORT", DEFAULT_GRAPH_PORT),
+        "NEO4J_BOLT_PORT": merged.get("NEO4J_BOLT_PORT", DEFAULT_BOLT_PORT),
+        "NEO4J_USER": merged.get("NEO4J_USER", "neo4j"),
+        "NEO4J_PASSWORD": merged.get("NEO4J_PASSWORD", ""),
     }
 
 
@@ -220,6 +285,58 @@ def _run_compose(
         stdout = exc.stdout.strip() if isinstance(exc.stdout, str) else ""
         detail = stderr or stdout or str(exc)
         raise SeochoError(f"docker compose failed: {detail}") from exc
+
+
+def admin_database_command(database: str, *, action: str) -> List[str]:
+    """Build the docker/cypher-shell argv that creates or drops ``database``.
+
+    ``database`` is re-validated against the runtime contract before it is
+    interpolated into Cypher (defense in depth — derived names already comply).
+    """
+    if action not in ("create", "drop"):
+        raise SeochoError(f"unknown database admin action: {action!r}")
+    if not _DATABASE_NAME_RE.match(database):
+        raise SeochoError(
+            f"refusing to interpolate database name {database!r}: must match "
+            f"{DATABASE_NAME_PATTERN!r}"
+        )
+    if action == "create":
+        cypher = f"CREATE DATABASE `{database}` IF NOT EXISTS"
+    else:
+        cypher = f"DROP DATABASE `{database}` IF EXISTS"
+    return [
+        "docker",
+        "compose",
+        "-p",
+        SHARED_PROJECT_NAME,
+        "exec",
+        "-T",
+        "neo4j",
+        "cypher-shell",
+        "-d",
+        "system",
+        cypher,
+    ]
+
+
+def _admin_database(
+    project_dir: Path,
+    settings: Dict[str, str],
+    database: str,
+    *,
+    action: str,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    """Create/drop an ephemeral logical database on the shared neo4j."""
+    command = admin_database_command(database, action=action)
+    env = os.environ.copy()
+    user = settings.get("NEO4J_USER") or "neo4j"
+    password = settings.get("NEO4J_PASSWORD") or ""
+    # cypher-shell reads credentials from the environment to keep them off argv.
+    env["NEO4J_USERNAME"] = user
+    if password:
+        env["NEO4J_PASSWORD"] = password
+    _run_compose(command, project_dir, env, runner)
 
 
 def _wait_for_runtime_ready(

--- a/tests/seocho/test_instance.py
+++ b/tests/seocho/test_instance.py
@@ -1,0 +1,213 @@
+"""Tests for worktree-isolated runtime boot (seocho-6q9.3).
+
+Covers the canonical, side-effect-free instance-layout derivation plus the
+dry-run / fake-runner command construction in ``serve_local_runtime`` /
+``stop_local_runtime`` — so the isolation guarantees (distinct ports, distinct
+ephemeral database, ephemeral CREATE/DROP) are asserted without docker.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from seocho.exceptions import SeochoError
+from seocho.instance import (
+    INSTANCE_PORT_SLOTS,
+    derive_instance,
+)
+from seocho.local import (
+    INSTANCE_COMPOSE_FILE,
+    SHARED_PROJECT_NAME,
+    admin_database_command,
+    serve_local_runtime,
+    stop_local_runtime,
+)
+from seocho.runtime_contract import DATABASE_NAME_PATTERN
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_DB_RE = re.compile(DATABASE_NAME_PATTERN)
+
+
+# --- pure derivation -------------------------------------------------------
+
+
+def test_derive_instance_is_deterministic():
+    assert derive_instance("alice") == derive_instance("alice")
+
+
+def test_derive_instance_concrete_layout():
+    layout = derive_instance("alice")
+    assert layout.project_name == "seocho-alice"
+    assert layout.database == "wt522b276a356b"
+    assert layout.api_port == 8880
+    assert layout.ui_port == 9180
+
+
+def test_distinct_instances_do_not_collide():
+    alice = derive_instance("alice")
+    bob = derive_instance("bob")
+    assert not alice.collides_with(bob)
+    assert alice.api_port != bob.api_port
+    assert alice.ui_port != bob.ui_port
+    assert alice.database != bob.database
+    assert alice.project_name != bob.project_name
+
+
+def test_same_slot_port_collision_is_detectable():
+    # tenant-00001 and tenant-00044 hash to the same port slot; their databases
+    # and projects differ but ports would contend — collides_with must catch it.
+    a = derive_instance("tenant-00001")
+    b = derive_instance("tenant-00044")
+    assert a.slot == b.slot
+    assert a.api_port == b.api_port
+    assert a.database != b.database
+    assert a.collides_with(b)
+
+
+def test_collides_with_is_false_for_same_instance():
+    assert not derive_instance("alice").collides_with(derive_instance("alice"))
+
+
+def test_derived_database_always_satisfies_runtime_contract():
+    for raw in ["alice", "BOB", "wt/3", "tenant a", "x", "feature-123", "main"]:
+        layout = derive_instance(raw)
+        assert _DB_RE.match(layout.database), (raw, layout.database)
+
+
+def test_ports_stay_within_derived_bands():
+    for raw in ["alice", "bob", "wt-1", "tenant-z", "main", "feature-x"]:
+        layout = derive_instance(raw)
+        assert 0 <= layout.slot < INSTANCE_PORT_SLOTS
+        assert 8800 <= layout.api_port < 8800 + INSTANCE_PORT_SLOTS
+        assert 9100 <= layout.ui_port < 9100 + INSTANCE_PORT_SLOTS
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "----", "///"])
+def test_derive_instance_rejects_empty_or_unslugifiable(bad):
+    with pytest.raises(SeochoError):
+        derive_instance(bad)
+
+
+def test_env_overrides_carry_isolation_knobs():
+    env = derive_instance("alice").env_overrides()
+    assert env["COMPOSE_PROJECT_NAME"] == "seocho-alice"
+    assert env["EXTRACTION_API_PORT"] == "8880"
+    assert env["CHAT_INTERFACE_PORT"] == "9180"
+    assert env["SEOCHO_DATABASE"] == "wt522b276a356b"
+    assert env["NEO4J_DATABASE"] == "wt522b276a356b"
+
+
+# --- admin (CREATE/DROP DATABASE) command ----------------------------------
+
+
+def test_admin_database_command_create_and_drop():
+    create = admin_database_command("wt522b276a356b", action="create")
+    assert create[:5] == ["docker", "compose", "-p", SHARED_PROJECT_NAME, "exec"]
+    assert create[-1] == "CREATE DATABASE `wt522b276a356b` IF NOT EXISTS"
+    drop = admin_database_command("wt522b276a356b", action="drop")
+    assert drop[-1] == "DROP DATABASE `wt522b276a356b` IF EXISTS"
+
+
+def test_admin_database_command_rejects_injection():
+    with pytest.raises(SeochoError):
+        admin_database_command("wt`; DROP DATABASE neo4j; --", action="create")
+
+
+def test_admin_database_command_rejects_unknown_action():
+    with pytest.raises(SeochoError):
+        admin_database_command("wt522b276a356b", action="truncate")
+
+
+# --- serve / stop command construction (dry-run) ---------------------------
+
+
+def test_serve_dry_run_with_instance_uses_isolated_project_and_ports():
+    status = serve_local_runtime(project_dir=str(REPO_ROOT), instance="alice", dry_run=True)
+    assert "-p" in status.command
+    assert status.command[status.command.index("-p") + 1] == "seocho-alice"
+    assert "-f" in status.command
+    assert status.command[status.command.index("-f") + 1] == INSTANCE_COMPOSE_FILE
+    assert status.api_url == "http://localhost:8880"
+    assert status.ui_url == "http://localhost:9180"
+    assert status.instance == "alice"
+    assert status.database == "wt522b276a356b"
+
+
+def test_serve_dry_run_without_instance_is_unchanged():
+    status = serve_local_runtime(project_dir=str(REPO_ROOT), dry_run=True)
+    assert "-p" not in status.command
+    assert "-f" not in status.command
+    assert status.instance == ""
+    assert status.database == ""
+    assert status.api_url == "http://localhost:8001"
+
+
+def test_stop_dry_run_with_instance_targets_only_that_project():
+    status = stop_local_runtime(project_dir=str(REPO_ROOT), instance="bob", dry_run=True)
+    assert status.command[:4] == ["docker", "compose", "-p", "seocho-bob"]
+    assert "down" in status.command
+    assert status.database == derive_instance("bob").database
+
+
+# --- serve / stop with a fake runner (no docker) ---------------------------
+
+
+class _Recorder:
+    """Captures argv passed to subprocess.run and returns a success result."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def __call__(self, command, **kwargs):
+        self.calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+
+def _ready_http_get(url, **kwargs):
+    class _Resp:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    if url.endswith("/graphs"):
+        return _Resp({"graphs": []})
+    return _Resp({"status": "ready"})
+
+
+def test_serve_with_instance_creates_database_before_compose_up():
+    recorder = _Recorder()
+    status = serve_local_runtime(
+        project_dir=str(REPO_ROOT),
+        instance="alice",
+        runner=recorder,
+        http_get=_ready_http_get,
+    )
+    # First side effect must be the ephemeral CREATE DATABASE on the shared
+    # neo4j; only then the per-instance app tier is brought up.
+    assert recorder.calls[0][-1] == "CREATE DATABASE `wt522b276a356b` IF NOT EXISTS"
+    assert recorder.calls[0][:4] == ["docker", "compose", "-p", SHARED_PROJECT_NAME]
+    assert recorder.calls[1][:2] == ["docker", "compose"]
+    assert "-p" in recorder.calls[1] and "up" in recorder.calls[1]
+    assert status.status == "ready"
+    assert status.database == "wt522b276a356b"
+
+
+def test_stop_with_instance_drops_database_after_compose_down():
+    recorder = _Recorder()
+    status = stop_local_runtime(
+        project_dir=str(REPO_ROOT),
+        instance="alice",
+        runner=recorder,
+    )
+    # Compose down first (remove app tier), then drop only this ephemeral DB.
+    assert "down" in recorder.calls[0]
+    assert recorder.calls[1][-1] == "DROP DATABASE `wt522b276a356b` IF EXISTS"
+    assert status.status == "stopped"


### PR DESCRIPTION
Closes the last child of the observe-loop epic **seocho-6q9** (after #187 trace read/query and the perf-budget gate).

## What

`make up INSTANCE=<id>` / `seocho serve --instance <id>` boot an **isolated app tier** (offset ports + ephemeral logical database) against a **shared neo4j**. Teardown drops only that instance's app project and its logical database. Follows SEOCHO's single-neo4j, multi-database model.

| surface | change |
|---|---|
| `src/seocho/instance.py` (new) | side-effect-free `derive_instance(id) → InstanceLayout`; ephemeral DB name validated `^[a-z][a-z0-9]{2,62}$`; `collides_with()` surfaces port-slot collisions |
| `src/seocho/local.py` | thread `instance` through serve/stop (`-p` + app-only compose, CREATE/DROP DATABASE on shared neo4j); `NEO4J_BOLT_PORT`+creds; `admin_database_command()` re-validates before Cypher |
| `docker-compose.instance.yml` (new) | self-contained app tier on shared external `seocho-net` |
| `docker-compose.yml` | fixed network name; drop app `container_name` so per-instance projects don't collide |
| `Makefile` | `up`/`down INSTANCE=<id>` (shared path unchanged) |
| `src/seocho/cli.py` | `serve/stop --instance` + `__main__` guard |
| ADR-0104, RUNTIME_DEPLOYMENT.md §3.1, DECISION_LOG | docs |

## Validation

- `tests/seocho/test_instance.py` — 20 tests (dry-run + fake-runner; CREATE-before-up, down-before-DROP; backward-compatible no-instance path), **no docker required**.
- `scripts/experiments/isolation_experiment.py` — multi-tenant / agent-interaction harness, design-hardened after two independent expert reviews (systems methodology + multi-tenancy semantics):
  - **positive control B′** (forced broken isolation) proves the harness *can* detect leakage → B's zero-leakage null is powered (Fisher's exact p≈1e-159; rule-of-three UB ≤ 0.009).
  - **headline**: data isolation holds **under a port-slot collision** — routing key is the database, derived independently of the port slot.
  - determinism, name-injection rejection, teardown blast radius, residual-after-recreate all pass.
  - drove a fix: original 40 port slots → P(collision)=0.50 @ 8 tenants; **widened to 200** (~0.14 @ 8, ~0.01 @ 2).
  - **Claim scope: DATA isolation only.** Performance + fault isolation are explicitly disclaimed (shared engine = shared buffer pool & failure domain). Backend-enforced isolation deferred to live-neo4j integration.
- `bash scripts/ci/run_basic_ci.sh` + doc/hierarchy/runtime-shell contracts pass.