### PR TITLE
Draft: Fix accessibility issue by explicitly setting focus outlines

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -584,5 +584,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
### What
Replaced `outline: none;` with `outline: 2px solid var(--accent-blue); outline-offset: 2px;` for focused inputs, textareas, and selects in the evaluation UI CSS.

### Why
Relying on `outline: none` paired with `:focus-visible` can result in inaccessible inputs if the user navigates via keyboard and the browser styling logic misinterprets the interaction, leading to invisible focus states. Explicit outlines ensure focus is always discernible.

### Accessibility / UX Impact
Improves keyboard navigation visibility significantly across the evaluation platform forms. Standard inputs now feature a clear, distinct 2px blue outline offset from the element, complying with WCAG visibility guidelines.

### Validation
- Local UI tested via Playwright. Visual focus outline on text inputs successfully rendered in verification screenshot and video.
- Standard CI executed (`bash scripts/ci/run_basic_ci.sh`) and passed.
- PM Docs lint executed and passed.

### Risks
Extremely low risk. The change is isolated to CSS pseudo-classes governing focus styles within the evaluation application. No backend or runtime impacts.

---
*PR created automatically by Jules for task [13920348681081316671](https://jules.google.com/task/13920348681081316671) started by @tteon*