### PR TITLE
feat(bench/finder_judge): skip LLM judge on empty candidates

### DIFF
--- a/scripts/benchmarks/finder_judge.py
+++ b/scripts/benchmarks/finder_judge.py
@@ -115,6 +115,22 @@ def _parse_judge(text: str) -> dict:
 
 
 def judge_one(llm, query: str, gold: str, candidate: str) -> dict:
+    # Sanity guard - an empty candidate is incorrect by definition, so skip
+    # the judge call. LLM judges (especially same-vendor as the generator)
+    # tend to return a plausible-sounding correct/partial on empty answers; a
+    # cross-vendor recheck of 38 such cells flipped all 38 to incorrect.
+    # Deliberately empty-only: terse-but-correct answers ("8.4%", "$5B") must
+    # still be judged, never auto-failed.
+    if not _safe_str(candidate).strip():
+        return {
+            "verdict": "incorrect",
+            "score": 0.0,
+            "rationale": "empty candidate answer (sanity guard, no judge call)",
+            "matched": [],
+            "missing_or_wrong": [],
+            "parse_error": False,
+            "sanity_skipped": True,
+        }
     user = (f"QUESTION:\n{_safe_str(query)}\n\n"
             f"GOLD ANSWER (ground truth):\n{_safe_str(gold)}\n\n"
             f"CANDIDATE ANSWER:\n{_safe_str(candidate)}")

--- a/tests/seocho/test_finder_judge.py
+++ b/tests/seocho/test_finder_judge.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _BENCH = Path(__file__).resolve().parents[2] / "scripts" / "benchmarks"
 _spec = importlib.util.spec_from_file_location("finder_judge", _BENCH / "finder_judge.py")
 assert _spec and _spec.loader
@@ -105,3 +107,29 @@ def test_paired_analysis_pairs_by_case():
     assert rec["lane_wins"] == 1 and rec["vector_wins"] == 1
     # x1: +0.5 (graph 1.0 - vector 0.5), x2: -1.0 (graph 0.0 - vector 1.0) -> mean -0.25
     assert rec["mean_delta"] == -0.25
+
+
+# ---- sanity guard: empty candidates skip the judge entirely ----------------
+
+class _NeverCalledLLM:
+    """Judge stub that fails the test if the LLM is reached at all."""
+
+    def complete(self, *args, **kwargs):
+        raise AssertionError("judge LLM must not be called on an empty candidate")
+
+
+@pytest.mark.parametrize("candidate", ["", "   ", "\n\t ", None, float("nan")])
+def test_judge_one_skips_llm_on_empty_candidate(candidate):
+    out = JUDGE.judge_one(_NeverCalledLLM(), "Q", "gold", candidate)
+    assert out["verdict"] == "incorrect" and out["score"] == 0.0
+    assert out["sanity_skipped"] is True
+
+
+@pytest.mark.parametrize("candidate", ["8.4%", "$5B", "12.7", "Apple Inc."])
+def test_judge_one_judges_terse_candidates(candidate):
+    """Terse-but-correct FinDER numerics must reach the judge, not auto-fail."""
+    llm = _FakeJudgeLLM('{"verdict":"correct","score":1.0}')
+    out = JUDGE.judge_one(llm, "Q", "gold", candidate)
+    assert llm.calls, "terse candidate was not sent to the judge"
+    assert out["verdict"] == "correct"
+    assert "sanity_skipped" not in out


### PR DESCRIPTION
## Problem
`judge_one()` sent every candidate to the judge, including empty ones. An empty answer is `incorrect` by definition, but the judge was still asked to rule on it, nd when the generator and the judge are the same vendor it **agrees with itself**:
38 empty-candidate cells came back `correct` or `partial`.          
A cross-vendor recheck of those same 38 cells (DeepSeek → `gpt-4o-mini`) returned `incorrect` on all 38, so the verdicts were judge artefacts rather than scores. Each one also cost a model call.    
<br/>


## Fix

- Return `incorrect` / `score=0.0` with `sanity_skipped=True` at the top of   `judge_one()` when the candidate is empty or whitespace-only, before any model call.
- `_safe_str` already normalises `None` and `NaN` to `""`, so null answers in the   saved partial JSONs take the same branch - no separate null check.

The guard is deliberately empty-only. An earlier revision of this PR auto-failed candidates under 3 meaningful tokens ; per review that was too aggressive, and the `<1 meaningful token` alternative does not fix it either - the tokenizer splits
`"8.4%"` on the `.`, leaving `8` and `4`, both dropped as single characters, so the count is 0 under either rule.         
Terse-but-correct FinDER numerics reach the judge unchanged.    
<br/>    


## Tests (`test_finder_judge.py`)

- `""`, `"   "`, `"\n\t "`, `None` and `NaN` return `incorrect` with `sanity_skipped=True`; the stub judge raises `AssertionError` if it is reached at all.
- `"8.4%"`, `"$5B"`, `"12.7"` and `"Apple Inc."` still reach the judge rather than   being auto-failed.

`pytest tests/seocho/test_finder_judge.py tests/seocho/test_finder_eval_helpers.py` → 28 passed (both modules load `finder_judge.py`). The two pre-existing `judge_one` wiring tests are byte-identical to `main`.     
<br/>    