### PR TITLE
fix(runtime): forward neo4j creds into container + set instance env on teardown (seocho-oj9)

### DIFF
--- a/src/seocho/local.py
+++ b/src/seocho/local.py
@@ -201,7 +201,13 @@ def stop_local_runtime(
             database=layout.database if layout else "",
         )
 
-    _run_compose(command, root, os.environ.copy(), runner)
+    # `docker compose -f docker-compose.instance.yml down` still interpolates the
+    # file, whose required vars (SEOCHO_DATABASE, ports) must be present even for
+    # teardown — so apply the same instance env overrides as serve.
+    down_env = os.environ.copy()
+    if layout is not None:
+        down_env.update(layout.env_overrides())
+    _run_compose(command, root, down_env, runner)
     # Teardown removes only this instance's resources: its app project (above)
     # and its ephemeral logical database. The shared neo4j is left intact.
     if layout is not None:
@@ -287,11 +293,17 @@ def _run_compose(
         raise SeochoError(f"docker compose failed: {detail}") from exc
 
 
-def admin_database_command(database: str, *, action: str) -> List[str]:
+def admin_database_command(
+    database: str, *, action: str, user: str = "neo4j", password: str = ""
+) -> List[str]:
     """Build the docker/cypher-shell argv that creates or drops ``database``.
 
     ``database`` is re-validated against the runtime contract before it is
     interpolated into Cypher (defense in depth — derived names already comply).
+
+    cypher-shell runs *inside* the neo4j container, which does not inherit the
+    docker-compose client's environment, so the credentials are forwarded
+    explicitly with ``exec -e`` rather than relying on the client env.
     """
     if action not in ("create", "drop"):
         raise SeochoError(f"unknown database admin action: {action!r}")
@@ -304,19 +316,12 @@ def admin_database_command(database: str, *, action: str) -> List[str]:
         cypher = f"CREATE DATABASE `{database}` IF NOT EXISTS"
     else:
         cypher = f"DROP DATABASE `{database}` IF EXISTS"
-    return [
-        "docker",
-        "compose",
-        "-p",
-        SHARED_PROJECT_NAME,
-        "exec",
-        "-T",
-        "neo4j",
-        "cypher-shell",
-        "-d",
-        "system",
-        cypher,
-    ]
+    command = ["docker", "compose", "-p", SHARED_PROJECT_NAME, "exec", "-T"]
+    command += ["-e", f"NEO4J_USERNAME={user or 'neo4j'}"]
+    if password:
+        command += ["-e", f"NEO4J_PASSWORD={password}"]
+    command += ["neo4j", "cypher-shell", "-d", "system", cypher]
+    return command
 
 
 def _admin_database(
@@ -328,15 +333,13 @@ def _admin_database(
     runner: Callable[..., subprocess.CompletedProcess[str]],
 ) -> None:
     """Create/drop an ephemeral logical database on the shared neo4j."""
-    command = admin_database_command(database, action=action)
-    env = os.environ.copy()
-    user = settings.get("NEO4J_USER") or "neo4j"
-    password = settings.get("NEO4J_PASSWORD") or ""
-    # cypher-shell reads credentials from the environment to keep them off argv.
-    env["NEO4J_USERNAME"] = user
-    if password:
-        env["NEO4J_PASSWORD"] = password
-    _run_compose(command, project_dir, env, runner)
+    command = admin_database_command(
+        database,
+        action=action,
+        user=settings.get("NEO4J_USER") or "neo4j",
+        password=settings.get("NEO4J_PASSWORD") or "",
+    )
+    _run_compose(command, project_dir, os.environ.copy(), runner)
 
 
 def _wait_for_runtime_ready(

--- a/tests/seocho/test_instance.py
+++ b/tests/seocho/test_instance.py
@@ -112,6 +112,20 @@ def test_admin_database_command_create_and_drop():
     assert drop[-1] == "DROP DATABASE `wt522b276a356b` IF EXISTS"
 
 
+def test_admin_database_command_forwards_credentials_into_container():
+    # cypher-shell runs inside the neo4j container; creds must be injected with
+    # `exec -e`, not left on the docker-compose client env (the live-boot bug).
+    cmd = admin_database_command("wt522b276a356b", action="create", user="neo4j", password="s3cret")
+    assert "-e" in cmd
+    assert "NEO4J_USERNAME=neo4j" in cmd
+    assert "NEO4J_PASSWORD=s3cret" in cmd
+    # password must precede the `neo4j` service / cypher-shell tokens
+    assert cmd.index("NEO4J_PASSWORD=s3cret") < cmd.index("cypher-shell")
+    # no password -> no NEO4J_PASSWORD token (avoid an empty credential)
+    nopw = admin_database_command("wt522b276a356b", action="create")
+    assert not any(t.startswith("NEO4J_PASSWORD=") for t in nopw)
+
+
 def test_admin_database_command_rejects_injection():
     with pytest.raises(SeochoError):
         admin_database_command("wt`; DROP DATABASE neo4j; --", action="create")
@@ -161,9 +175,11 @@ class _Recorder:
 
     def __init__(self):
         self.calls: list[list[str]] = []
+        self.envs: list[dict] = []
 
     def __call__(self, command, **kwargs):
         self.calls.append(list(command))
+        self.envs.append(dict(kwargs.get("env") or {}))
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
 
@@ -209,5 +225,8 @@ def test_stop_with_instance_drops_database_after_compose_down():
     )
     # Compose down first (remove app tier), then drop only this ephemeral DB.
     assert "down" in recorder.calls[0]
+    # the down command must carry the instance env so the compose file (which has
+    # required vars like SEOCHO_DATABASE) interpolates even for teardown.
+    assert recorder.envs[0].get("SEOCHO_DATABASE") == "wt522b276a356b"
     assert recorder.calls[1][-1] == "DROP DATABASE `wt522b276a356b` IF EXISTS"
     assert status.status == "stopped"


### PR DESCRIPTION
Two bugs in worktree-isolated boot (seocho-6q9.3, #189) found during **live full-compose-boot** validation against a password-protected DozerDB. Both block `seocho serve/stop --instance` against any real neo4j; they slipped through because unit tests used a fake runner and the earlier data-plane smoke used `docker exec -e` directly.

### Bug 1 — credentials never reach cypher-shell
`admin_database_command` set `NEO4J_USERNAME/PASSWORD` on the docker-compose **client** env, but `docker compose exec -T neo4j cypher-shell` runs cypher-shell **inside the container**, which doesn't inherit client env → `The client is unauthorized`. Fix: forward with `exec -e NEO4J_USERNAME=.. -e NEO4J_PASSWORD=..`.

### Bug 2 — teardown can't interpolate the compose file
`stop_local_runtime` ran `docker compose -f docker-compose.instance.yml down` **without** the instance env, so compose interpolation of the file's required `SEOCHO_DATABASE`/`:?` vars failed before the `DROP DATABASE` step → teardown errored, leaving the ephemeral DB + app tier behind. Fix: apply `layout.env_overrides()` to the down command env.

### Live verification (real DozerDB, shared stack untouched)
- `finance` + `hr` instances booted **concurrently** via `make up INSTANCE=`: offset ports `8808`/`8844`, distinct ephemeral DBs `wta1cf62af599e`/`wt51bd95353aed`, `collides_with=False`, both `/health/runtime` → **200**.
- Scoped `make down INSTANCE=` dropped **only** the two `wt*` DBs (38 → 36), leaving the shared stack's other 36 databases (real benchmark DBs) intact.
- `tests/seocho/test_instance.py`: **21 pass** (added cred-forwarding + teardown-env assertions).
- `bash scripts/ci/run_basic_ci.sh` passes.

Closes seocho-oj9.