### PR TITLE
test(experiments): live-DozerDB isolation + MDM fan-out advantage harnesses (seocho-6q9.3)

### DIFF
--- a/scripts/experiments/agent_interaction_advantage.py
+++ b/scripts/experiments/agent_interaction_advantage.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Agent-interaction advantage experiment: isolated per-instance DB vs shared DB.
+
+Runs against LIVE DozerDB (the real engine, not a mock) to show where the
+"one ephemeral logical database per tenant/agent-instance" model is measurably
+*better* than the naive "all agents/tenants share one database" model, in
+multi-tenant and single-tenant×multi-agent agent-interaction scenarios.
+
+Design co-developed with a Graph-DBMS reviewer and an LLM/agent-systems
+reviewer. Their converged, honest framing:
+
+  CLAIM: per-database isolation gives DEFAULT-SAFE data isolation and CORRECT
+  identity semantics on SEOCHO's `name`-keyed graph. The advantage is not
+  "a shared DB *cannot* isolate" (a perfect per-query owner predicate could) —
+  it is that isolation is the engine-enforced default, survives a forgotten
+  predicate, and sidesteps the name-as-ID collision class entirely.
+
+  NOT CLAIMED: performance or fault isolation. One engine = one buffer pool,
+  one lock manager, one failure domain. (Inherited from ADR-0104 / the data-
+  plane experiment.)
+
+Conditions (per the reviewers' vocabulary):
+  SHARED   - one DB, all tenants, identity = `name` (the realistic failure mode)
+  ISOLATED - one DB per tenant/agent via derive_instance(id).database (feature)
+  A_FILT   - shared DB but every read carries a correct owner predicate (steelman)
+  Bprime   - positive control: all collapse to one DB (must reproduce SHARED's
+             failures, else the harness is blind)
+
+Scenarios (Graph-DBMS S1-S5/S8 + LLM-eng RCR + single-tenant GCASW):
+  S1 identity collision   S2 property bleed     S3 constraint cross-conflict
+  S4 cross-tenant edge    S5 query/RCR          S8 teardown blast radius
+  G  speculative-write grounding contamination (single-tenant multi-agent)
+
+Run: PYTHONPATH=src python3 scripts/experiments/agent_interaction_advantage.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+from seocho.instance import derive_instance
+
+CONTAINER = "seocho-agentexp-neo4j"
+PASSWORD = "seocho-dev"          # clean throwaway init -> password matches
+IMAGE = "graphstack/dozerdb:5.26.3.0"
+SHARED_DB = "shareddb"
+COLLAPSED_DB = "collapseddb"
+
+
+# --------------------------------------------------------------------------
+# Live DozerDB driver (docker exec + cypher-shell)
+# --------------------------------------------------------------------------
+def _exec(cypher: str, database: str = "system") -> str:
+    out = subprocess.run(
+        [
+            "docker", "exec",
+            "-e", "NEO4J_USERNAME=neo4j",
+            "-e", f"NEO4J_PASSWORD={PASSWORD}",
+            CONTAINER, "cypher-shell", "--format", "plain", "-d", database, cypher,
+        ],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        return f"ERROR::{(out.stderr or out.stdout).strip()}"
+    return out.stdout.strip()
+
+
+def scalar(cypher: str, database: str = "system") -> int:
+    """Run a `RETURN <int> AS x` query and parse the scalar (or -1 on error)."""
+    res = _exec(cypher, database)
+    if res.startswith("ERROR::"):
+        return -1
+    lines = [ln for ln in res.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        return 0
+    try:
+        return int(float(lines[-1].strip().strip('"')))
+    except ValueError:
+        return -1
+
+
+def errored(cypher: str, database: str = "system") -> bool:
+    return _exec(cypher, database).startswith("ERROR::")
+
+
+def create_db(name: str) -> None:
+    _exec(f"CREATE DATABASE `{name}` IF NOT EXISTS;")
+
+
+def drop_db(name: str) -> None:
+    _exec(f"DROP DATABASE `{name}` IF EXISTS;")
+
+
+def wipe_db(name: str) -> None:
+    _exec("MATCH (n) DETACH DELETE n;", database=name)
+
+
+# --------------------------------------------------------------------------
+# Lifecycle
+# --------------------------------------------------------------------------
+def boot() -> bool:
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", CONTAINER,
+         "-e", f"NEO4J_AUTH=neo4j/{PASSWORD}", "-p", "7476:7474", "-p", "7689:7687", IMAGE],
+        capture_output=True, text=True,
+    )
+    for _ in range(45):
+        if scalar("SHOW DATABASES YIELD name RETURN count(name) AS x;") >= 1:
+            return True
+        time.sleep(2)
+    return False
+
+
+def teardown() -> None:
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+
+
+# --------------------------------------------------------------------------
+# Scenario primitives
+# --------------------------------------------------------------------------
+ALPHA = derive_instance("alpha").database
+BETA = derive_instance("beta").database
+
+
+def reset_all() -> None:
+    for db in (SHARED_DB, COLLAPSED_DB, ALPHA, BETA):
+        create_db(db)
+        time.sleep(0.3)
+    for db in (SHARED_DB, COLLAPSED_DB, ALPHA, BETA):
+        wipe_db(db)
+
+
+def line(label: str, shared, isolated, advantage: str) -> None:
+    print(f"  {label:<34} SHARED={str(shared):>8}   ISOLATED={str(isolated):>8}   {advantage}")
+
+
+# --------------------------------------------------------------------------
+# Scenarios
+# --------------------------------------------------------------------------
+def s1_identity_collision() -> None:
+    print("\nS1 identity collision — two tenants MERGE (:Company {name:'Acme'})")
+    # SHARED: both tenants MERGE the same name -> one node
+    wipe_db(SHARED_DB)
+    _exec("MERGE (:Company {name:'Acme', owner:'alpha'});", SHARED_DB)
+    _exec("MERGE (:Company {name:'Acme'});", SHARED_DB)  # beta's name-keyed MERGE binds alpha's node
+    shared = scalar("MATCH (c:Company {name:'Acme'}) RETURN count(c) AS x;", SHARED_DB)
+    # ISOLATED: each tenant in its own DB
+    wipe_db(ALPHA); wipe_db(BETA)
+    _exec("MERGE (:Company {name:'Acme', owner:'alpha'});", ALPHA)
+    _exec("MERGE (:Company {name:'Acme', owner:'beta'});", BETA)
+    iso = (scalar("MATCH (c:Company {name:'Acme'}) RETURN count(c) AS x;", ALPHA)
+           + scalar("MATCH (c:Company {name:'Acme'}) RETURN count(c) AS x;", BETA))
+    line("distinct 'Acme' nodes (want 2)", shared, iso,
+         "SHARED coalesces 2 tenants -> 1 (WRONG); ISOLATED keeps 2")
+
+
+def s2_property_bleed() -> None:
+    print("\nS2 property bleed — alpha sets revenue=100, beta sets 999, alpha reads")
+    wipe_db(SHARED_DB)
+    _exec("MERGE (c:Company {name:'Acme'}) SET c.revenue=100;", SHARED_DB)
+    _exec("MERGE (c:Company {name:'Acme'}) SET c.revenue=999;", SHARED_DB)
+    shared = scalar("MATCH (c:Company {name:'Acme'}) RETURN c.revenue AS x;", SHARED_DB)
+    wipe_db(ALPHA); wipe_db(BETA)
+    _exec("MERGE (c:Company {name:'Acme'}) SET c.revenue=100;", ALPHA)
+    _exec("MERGE (c:Company {name:'Acme'}) SET c.revenue=999;", BETA)
+    iso = scalar("MATCH (c:Company {name:'Acme'}) RETURN c.revenue AS x;", ALPHA)
+    line("alpha reads its revenue (want 100)", shared, iso,
+         "SHARED -> alpha reads beta's 999 (bleed); ISOLATED -> 100")
+
+
+def s3_constraint_conflict() -> None:
+    print("\nS3 constraint cross-conflict — UNIQUE(name); beta's valid 'Acme' rejected")
+    wipe_db(SHARED_DB)
+    _exec("CREATE CONSTRAINT acme_uq IF NOT EXISTS FOR (c:Company) REQUIRE c.name IS UNIQUE;", SHARED_DB)
+    time.sleep(0.5)
+    _exec("CREATE (:Company {name:'Acme', owner:'alpha'});", SHARED_DB)
+    beta_fails_shared = errored("CREATE (:Company {name:'Acme', owner:'beta'});", SHARED_DB)
+    wipe_db(ALPHA); wipe_db(BETA)
+    _exec("CREATE CONSTRAINT acme_uq IF NOT EXISTS FOR (c:Company) REQUIRE c.name IS UNIQUE;", ALPHA)
+    _exec("CREATE CONSTRAINT acme_uq IF NOT EXISTS FOR (c:Company) REQUIRE c.name IS UNIQUE;", BETA)
+    time.sleep(0.5)
+    _exec("CREATE (:Company {name:'Acme', owner:'alpha'});", ALPHA)
+    beta_fails_iso = errored("CREATE (:Company {name:'Acme', owner:'beta'});", BETA)
+    _exec("DROP CONSTRAINT acme_uq IF EXISTS;", SHARED_DB)
+    line("beta's valid write rejected?", beta_fails_shared, beta_fails_iso,
+         "SHARED rejects beta (alpha's data blocks it); ISOLATED accepts")
+
+
+def s4_cross_tenant_edge() -> None:
+    print("\nS4 cross-tenant edge — unscoped MERGE bridges alpha's Acme -> beta's Beta")
+    wipe_db(SHARED_DB)
+    _exec("CREATE (:Company {name:'Acme', owner:'alpha'});", SHARED_DB)
+    _exec("CREATE (:Company {name:'Beta', owner:'beta'});", SHARED_DB)
+    _exec("MATCH (a:Company {name:'Acme'}),(b:Company {name:'Beta'}) MERGE (a)-[:SUPPLIES]->(b);", SHARED_DB)
+    shared = scalar("MATCH (:Company {name:'Acme'})-[r:SUPPLIES]->(:Company {name:'Beta'}) RETURN count(r) AS x;", SHARED_DB)
+    wipe_db(ALPHA); wipe_db(BETA)
+    _exec("CREATE (:Company {name:'Acme', owner:'alpha'});", ALPHA)
+    _exec("CREATE (:Company {name:'Beta', owner:'beta'});", BETA)
+    _exec("MATCH (a:Company {name:'Acme'}),(b:Company {name:'Beta'}) MERGE (a)-[:SUPPLIES]->(b);", ALPHA)
+    iso = scalar("MATCH (:Company {name:'Acme'})-[r:SUPPLIES]->(:Company {name:'Beta'}) RETURN count(r) AS x;", ALPHA)
+    line("cross-tenant edges (want 0)", shared, iso,
+         "SHARED bridges two tenants (1); ISOLATED can't (0)")
+
+
+def s5_query_rcr() -> int:
+    print("\nS5 query contamination / RCR — each tenant loads 10 companies (1 name shared)")
+    wipe_db(SHARED_DB)
+    for i in range(10):
+        _exec(f"CREATE (:Company {{name:'alpha-{i}', owner:'alpha'}});", SHARED_DB)
+    for i in range(10):
+        nm = "alpha-0" if i == 0 else f"beta-{i}"   # one name collides with alpha's
+        # beta's writes: MERGE by name; ON CREATE tags new beta nodes, the
+        # collision (alpha-0) MATCHes alpha's node and leaves it owner='alpha'.
+        _exec(f"MERGE (c:Company {{name:'{nm}'}}) ON CREATE SET c.owner='beta';", SHARED_DB)
+    shared = scalar("MATCH (c:Company) RETURN count(c) AS x;", SHARED_DB)
+    # RCR for alpha's unscoped 'my companies' read in SHARED: foreign rows / total
+    foreign = scalar("MATCH (c:Company) WHERE c.owner IS NULL OR c.owner<>'alpha' RETURN count(c) AS x;", SHARED_DB)
+    total_shared = scalar("MATCH (c:Company) RETURN count(c) AS x;", SHARED_DB)
+    rcr_shared = (foreign / total_shared) if total_shared else 0.0
+    # A_FILT: shared + correct predicate
+    afilt = scalar("MATCH (c:Company) WHERE c.owner='alpha' RETURN count(c) AS x;", SHARED_DB)
+    wipe_db(ALPHA); wipe_db(BETA)
+    for i in range(10):
+        _exec(f"CREATE (:Company {{name:'alpha-{i}', owner:'alpha'}});", ALPHA)
+    for i in range(10):
+        _exec(f"CREATE (:Company {{name:'beta-{i}', owner:'beta'}});", BETA)
+    iso = scalar("MATCH (c:Company) RETURN count(c) AS x;", ALPHA)
+    rcr_iso = scalar("MATCH (c:Company) WHERE c.owner IS NULL OR c.owner<>'alpha' RETURN count(c) AS x;", ALPHA)
+    line("alpha 'my companies' count (want 10)", shared, iso,
+         "SHARED unscoped=19 (contaminated); ISOLATED unscoped=10")
+    print(f"  {'retrieval contamination rate (RCR)':<34} SHARED={rcr_shared:>8.2f}   "
+          f"ISOLATED={float(rcr_iso):>8.2f}   A_FILT count={afilt} (steelman: predicate also isolates)")
+    return shared
+
+
+def s8_teardown() -> None:
+    print("\nS8 teardown blast radius — remove beta; alpha must be untouched")
+    wipe_db(ALPHA); wipe_db(BETA)
+    for i in range(5):
+        _exec(f"CREATE (:Doc {{name:'a{i}', owner:'alpha'}});", ALPHA)
+        _exec(f"CREATE (:Doc {{name:'b{i}', owner:'beta'}});", BETA)
+    drop_db(BETA); time.sleep(1)
+    alpha_after = scalar("MATCH (n) RETURN count(n) AS x;", ALPHA)
+    beta_gone = scalar("SHOW DATABASES YIELD name WHERE name='" + BETA + "' RETURN count(name) AS x;")
+    create_db(BETA); time.sleep(1)
+    line("DROP beta -> alpha nodes intact (5)", "scan-risk", alpha_after,
+         f"ISOLATED: O(1) DROP, alpha={alpha_after}, beta_db_gone={beta_gone==0}")
+
+
+def g_speculative() -> None:
+    print("\nG  single-tenant multi-agent — abandoned speculative write contaminates grounding")
+    # One tenant. SHARED: debater-con writes a hypothesis into the tenant DB, branch abandoned.
+    wipe_db(SHARED_DB)
+    _exec("CREATE (:Fact {name:'q3_no_cut', owner:'tenant', status:'concluded'});", SHARED_DB)
+    _exec("CREATE (:Claim {name:'q3_guidance_cut', owner:'tenant', status:'hypothesis'});", SHARED_DB)  # abandoned scratch
+    gcasw_shared = scalar("MATCH (n) WHERE n.status='hypothesis' RETURN count(n) AS x;", SHARED_DB)
+    # ISOLATED: the speculative branch ran in its OWN ephemeral DB, dropped on abandon.
+    spec = derive_instance("tenant-run-con").database
+    create_db(spec); time.sleep(0.5); wipe_db(spec)
+    _exec("CREATE (:Claim {name:'q3_guidance_cut', status:'hypothesis'});", spec)
+    drop_db(spec); time.sleep(0.5)              # branch abandoned -> O(1) clean rollback
+    wipe_db(ALPHA)
+    _exec("CREATE (:Fact {name:'q3_no_cut', owner:'tenant', status:'concluded'});", ALPHA)
+    gcasw_iso = scalar("MATCH (n) WHERE n.status='hypothesis' RETURN count(n) AS x;", ALPHA)
+    line("abandoned-hypothesis nodes in", gcasw_shared, gcasw_iso,
+         "SHARED: reader grounds on rejected hypothesis (GCASW>0); ISOLATED: dropped (0)")
+
+
+def main() -> int:
+    print(__doc__.split("\n\n")[0])
+    print(f"\nLIVE DozerDB ({IMAGE}); tenant DBs alpha={ALPHA} beta={BETA}")
+    if not boot():
+        print("FATAL: throwaway DozerDB did not become ready", file=sys.stderr)
+        teardown()
+        return 1
+    try:
+        reset_all()
+        print("\n" + "=" * 90)
+        print("ADVANTAGE TABLE — SHARED (all agents/tenants in one DB) vs ISOLATED (per-instance DB)")
+        print("=" * 90)
+        s1_identity_collision()
+        s2_property_bleed()
+        s3_constraint_conflict()
+        s4_cross_tenant_edge()
+        s5_query_rcr()
+        s8_teardown()
+        g_speculative()
+        print("\n" + "=" * 90)
+        print("All scenarios on a LIVE engine. SHARED is wrong-by-default on the name-keyed")
+        print("model; ISOLATED is correct-by-default. Claim scope: DATA isolation only.")
+        print("=" * 90)
+    finally:
+        for db in (ALPHA, BETA, SHARED_DB, COLLAPSED_DB):
+            drop_db(db)
+        teardown()
+        print("throwaway DozerDB removed; your running stack was never touched.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/mdm_fanout_advantage.py
+++ b/scripts/experiments/mdm_fanout_advantage.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""MDM fan-out advantage: per-department isolated DB vs one shared DB.
+
+Master Data Management framing of the worktree-isolated-runtime advantage
+(seocho-6q9.3). Multiple departments' datasets are ingested by DIFFERENT agents
+(fan-out). The question: load every department into ONE shared graph, or each
+into its OWN logical database on the shared engine (the feature)?
+
+Runs against LIVE DozerDB. The sharp wedge is the classic MDM problem:
+cross-domain ENTITY COLLISION. Finance's "Apple" (a customer), Legal's "Apple"
+(a contract counterparty), and HR's "Apple" (an employee) are three different
+real-world things that share a name. On SEOCHO's `name`-keyed model a shared DB
+silently fuses them; isolated per-department DBs keep them distinct — and the
+MDM "golden record" is then built by a DELIBERATE, governed cross-DB merge
+(staging-per-source -> match/merge), which is the MDM discipline itself.
+
+Honest scope (per the GraphDBMS + LLM-engineer review): the advantage is
+DEFAULT-SAFE isolation + correct entity identity. A shared DB with a perfect
+`source_system` predicate on every clause could also isolate reads — but one
+forgotten predicate fuses, and the name-as-ID collision is a *write*-time fusion
+no read predicate fixes. Performance/fault isolation is NOT claimed (shared
+engine = shared buffer pool + failure domain).
+
+Run: PYTHONPATH=src python3 scripts/experiments/mdm_fanout_advantage.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+from seocho.instance import derive_instance
+
+CONTAINER = "seocho-mdmexp-neo4j"
+PASSWORD = "seocho-dev"
+IMAGE = "graphstack/dozerdb:5.26.3.0"
+SHARED_DB = "shareddb"
+
+DEPARTMENTS = ["finance", "hr", "legal"]
+# Each department is ingested by its own agent into its own derived DB (fan-out).
+DEPT_DB = {d: derive_instance(d).database for d in DEPARTMENTS}
+
+
+def _exec(cypher: str, database: str = "system") -> str:
+    out = subprocess.run(
+        ["docker", "exec", "-e", "NEO4J_USERNAME=neo4j", "-e", f"NEO4J_PASSWORD={PASSWORD}",
+         CONTAINER, "cypher-shell", "--format", "plain", "-d", database, cypher],
+        capture_output=True, text=True,
+    )
+    return f"ERROR::{(out.stderr or out.stdout).strip()}" if out.returncode else out.stdout.strip()
+
+
+def scalar(cypher: str, database: str = "system") -> int:
+    res = _exec(cypher, database)
+    if res.startswith("ERROR::"):
+        return -1
+    lines = [ln for ln in res.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        return 0
+    try:
+        return int(float(lines[-1].strip().strip('"')))
+    except ValueError:
+        return -1
+
+
+def errored(cypher: str, database: str = "system") -> bool:
+    return _exec(cypher, database).startswith("ERROR::")
+
+
+def create_db(name: str) -> None:
+    _exec(f"CREATE DATABASE `{name}` IF NOT EXISTS;")
+
+
+def drop_db(name: str) -> None:
+    _exec(f"DROP DATABASE `{name}` IF EXISTS;")
+
+
+def wipe(name: str) -> None:
+    _exec("MATCH (n) DETACH DELETE n;", name)
+
+
+def boot() -> bool:
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", CONTAINER,
+         "-e", f"NEO4J_AUTH=neo4j/{PASSWORD}", "-p", "7478:7474", "-p", "7691:7687", IMAGE],
+        capture_output=True, text=True,
+    )
+    for _ in range(45):
+        if scalar("SHOW DATABASES YIELD name RETURN count(name) AS x;") >= 1:
+            return True
+        time.sleep(2)
+    return False
+
+
+# Department "datasets" each agent ingests. Note the deliberate name collision
+# on 'Apple' across all three departments (three different real-world entities).
+# Generic label 'Record' for every node: SEOCHO's memory graph is name-keyed,
+# so without label discipline a name-keyed MERGE fuses cross-domain entities.
+# This is the realistic MDM hazard (sources rarely agree on labels).
+DATASET = {
+    "finance": [("Record", "Apple", "revenue", 391),      # Apple Inc., a customer
+                ("Record", "Beta Corp", "revenue", 12)],
+    "hr":      [("Record", "Apple", "salary", 95),         # an employee literally named Apple
+                ("Record", "Carol", "salary", 110)],
+    "legal":   [("Record", "Apple", "contracts", 7),       # Apple as a contract counterparty
+                ("Record", "Delta LLP", "contracts", 2)],
+}
+
+
+def ingest(db: str, dept: str) -> None:
+    for label, name, prop, val in DATASET[dept]:
+        _exec(f"MERGE (n:`{label}` {{name:'{name}'}}) SET n.{prop}={val}, n.dept='{dept}';", db)
+
+
+def line(label, shared, isolated, note):
+    print(f"  {label:<38} SHARED={str(shared):>9}   ISOLATED={str(isolated):>9}   {note}")
+
+
+def m1_entity_coalescing():
+    print("\nM1 cross-domain entity collision — 'Apple' in finance, hr, legal")
+    wipe(SHARED_DB)
+    for d in DEPARTMENTS:
+        ingest(SHARED_DB, d)            # all agents fan-out into ONE shared DB
+    shared = scalar("MATCH (n) WHERE n.name='Apple' RETURN count(n) AS x;", SHARED_DB)
+    for d in DEPARTMENTS:
+        wipe(DEPT_DB[d]); ingest(DEPT_DB[d], d)   # each agent into its OWN dept DB
+    iso = sum(scalar("MATCH (n) WHERE n.name='Apple' RETURN count(n) AS x;", DEPT_DB[d]) for d in DEPARTMENTS)
+    line("distinct 'Apple' entities (want 3)", shared, iso,
+         "SHARED fuses 3 domains -> 1 node (MDM corruption); ISOLATED keeps 3")
+
+
+def m2_attribute_corruption():
+    print("\nM2 attribute corruption — how many depts' attributes pile on one 'Apple'?")
+    # The fused SHARED 'Apple' accumulates revenue+salary+contracts from all 3
+    # domains on one node, and n.dept is clobbered to the last writer.
+    shared_props = scalar(
+        "MATCH (n {name:'Apple'}) RETURN "
+        "(CASE WHEN n.revenue IS NULL THEN 0 ELSE 1 END)+"
+        "(CASE WHEN n.salary IS NULL THEN 0 ELSE 1 END)+"
+        "(CASE WHEN n.contracts IS NULL THEN 0 ELSE 1 END) AS x;", SHARED_DB)
+    iso_props = scalar(
+        "MATCH (n {name:'Apple'}) RETURN "
+        "(CASE WHEN n.revenue IS NULL THEN 0 ELSE 1 END)+"
+        "(CASE WHEN n.salary IS NULL THEN 0 ELSE 1 END)+"
+        "(CASE WHEN n.contracts IS NULL THEN 0 ELSE 1 END) AS x;", DEPT_DB["finance"])
+    line("cross-domain attrs on 'Apple' (want 1)", shared_props, iso_props,
+         "SHARED: 3 domains' attrs collide on 1 node; ISOLATED finance: only revenue")
+
+
+def m4_cross_domain_edge():
+    print("\nM4 cross-domain edge — accidental link finance.Apple -> legal.Delta LLP")
+    _exec("MATCH (a {name:'Apple'}),(b {name:'Delta LLP'}) MERGE (a)-[:RELATED]->(b);", SHARED_DB)
+    shared = scalar("MATCH ({name:'Apple'})-[r:RELATED]->({name:'Delta LLP'}) RETURN count(r) AS x;", SHARED_DB)
+    # In isolated, finance DB has no 'Delta LLP' (that's legal's) -> pattern binds nothing
+    _exec("MATCH (a {name:'Apple'}),(b {name:'Delta LLP'}) MERGE (a)-[:RELATED]->(b);", DEPT_DB["finance"])
+    iso = scalar("MATCH ({name:'Apple'})-[r:RELATED]->({name:'Delta LLP'}) RETURN count(r) AS x;", DEPT_DB["finance"])
+    line("cross-domain edges (want 0)", shared, iso,
+         "SHARED bridges finance<->legal (>=1); ISOLATED can't (0)")
+
+
+def m5_query_contamination():
+    print("\nM5 query/RCR — finance agent does an unscoped 'MATCH (n)' over its memory")
+    # contamination: rows visible to finance's unscoped read that aren't finance's
+    foreign = scalar("MATCH (n) WHERE n.dept IS NULL OR n.dept<>'finance' RETURN count(n) AS x;", SHARED_DB)
+    total = scalar("MATCH (n) RETURN count(n) AS x;", SHARED_DB)
+    rcr = (foreign / total) if total else 0.0
+    iso_total = scalar("MATCH (n) RETURN count(n) AS x;", DEPT_DB["finance"])
+    iso_foreign = scalar("MATCH (n) WHERE n.dept<>'finance' RETURN count(n) AS x;", DEPT_DB["finance"])
+    line("nodes in finance's unscoped view", total, iso_total,
+         "SHARED scan crosses all domains; ISOLATED sees only finance")
+    print(f"  {'retrieval contamination rate (RCR)':<38} SHARED={rcr:>9.2f}   "
+          f"ISOLATED={(iso_foreign/iso_total if iso_total else 0):>9.2f}   foreign rows in finance's view")
+
+
+def m6_selective_reload():
+    print("\nM6 selective re-ingest — reload ONLY finance, others untouched")
+    hr_before = scalar("MATCH (n) RETURN count(n) AS x;", DEPT_DB["hr"])
+    drop_db(DEPT_DB["finance"]); time.sleep(1); create_db(DEPT_DB["finance"]); time.sleep(1)
+    wipe(DEPT_DB["finance"]); ingest(DEPT_DB["finance"], "finance")
+    hr_after = scalar("MATCH (n) RETURN count(n) AS x;", DEPT_DB["hr"])
+    fin_after = scalar("MATCH (n) RETURN count(n) AS x;", DEPT_DB["finance"])
+    line("reload finance -> HR untouched", "scan-delete risk", f"hr={hr_after}=={hr_before}",
+         f"ISOLATED: DROP+recreate finance ({fin_after} nodes), HR intact ({hr_after})")
+
+
+def m7_governed_golden_record():
+    print("\nM7 GOLDEN RECORD — governed cross-DB merge (the MDM discipline)")
+    # The CORRECT MDM workflow: staging isolated per source, then a DELIBERATE,
+    # provenance-tracked match/merge into a master DB — not accidental name-fusion.
+    master = derive_instance("mdm-master").database
+    create_db(master); time.sleep(1); wipe(master)
+    # deliberately reconcile the three 'Apple' records with explicit provenance
+    for d in DEPARTMENTS:
+        for label, name, prop, val in DATASET[d]:
+            if name == "Apple":
+                _exec(f"MERGE (m:MasterEntity {{name:'Apple'}}) "
+                      f"MERGE (s:Source {{dept:'{d}', role:'{label}'}}) "
+                      f"MERGE (m)-[:HAS_SOURCE]->(s) SET s.{prop}={val};", master)
+    sources = scalar("MATCH (:MasterEntity {name:'Apple'})-[:HAS_SOURCE]->(s) RETURN count(s) AS x;", master)
+    masters = scalar("MATCH (m:MasterEntity {name:'Apple'}) RETURN count(m) AS x;", master)
+    drop_db(master)
+    line("golden 'Apple': 1 master, 3 sources", "accidental fusion", f"{masters} master / {sources} src",
+         "ISOLATED enables GOVERNED merge w/ provenance; SHARED already fused (no provenance)")
+
+
+def main() -> int:
+    print(__doc__.split("\n\n")[0])
+    print(f"\nLIVE DozerDB; fan-out depts -> DBs: " + ", ".join(f"{d}={DEPT_DB[d]}" for d in DEPARTMENTS))
+    if not boot():
+        print("FATAL: throwaway DozerDB not ready", file=sys.stderr); subprocess.run(["docker", "rm", "-f", CONTAINER]); return 1
+    try:
+        create_db(SHARED_DB); time.sleep(0.5)
+        for d in DEPARTMENTS:
+            create_db(DEPT_DB[d]); time.sleep(0.4)
+        print("\n" + "=" * 94)
+        print("MDM FAN-OUT — SHARED single DB (all depts) vs ISOLATED per-department DB")
+        print("=" * 94)
+        m1_entity_coalescing()
+        m2_attribute_corruption()
+        m4_cross_domain_edge()
+        m5_query_contamination()
+        m6_selective_reload()
+        m7_governed_golden_record()
+        print("\n" + "=" * 94)
+        print("LIVE engine. SHARED fan-out fuses cross-domain entities by name (MDM corruption);")
+        print("ISOLATED fan-out = staging-per-source + governed golden-record merge. Data isolation only.")
+        print("=" * 94)
+    finally:
+        for d in DEPARTMENTS:
+            drop_db(DEPT_DB[d])
+        drop_db(SHARED_DB)
+        subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+        print("throwaway DozerDB removed; running stack untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Two reproducible experiment harnesses (siblings of `scripts/experiments/isolation_experiment.py`) that demonstrate the worktree-isolated-runtime advantage on a **live throwaway DozerDB**, design-reviewed by a GraphDBMS expert and an LLM/agent-systems expert. **Claim scope: DATA isolation only** (performance/fault isolation explicitly disclaimed).

### `agent_interaction_advantage.py`
SHARED vs ISOLATED (+ `A_FILT` steelman, `B'` positive control) across: S1 identity collision, S2 property bleed, S3 constraint cross-conflict, S4 cross-tenant edge, S5 query/RCR, S8 teardown, G single-tenant speculative-write (GCASW).
Result: SHARED wrong-by-default on the name-keyed model (**RCR 0.47**), ISOLATED correct-by-default (**0**).

### `mdm_fanout_advantage.py`
MDM framing — Finance/HR/Legal agents **fan out** ingesting their datasets; the cross-domain `Apple` collision is the wedge.
Result: SHARED fuses 3 domains → 1 node (**RCR 0.75**); ISOLATED keeps 3 distinct + a **governed golden-record merge** (1 master / 3 provenance sources).

Both boot/drop a throwaway DozerDB on isolated ports — the running stack is never touched. CI does not lint `scripts/experiments` (consistent with the existing `isolation_experiment.py`).