### PR TITLE
feat(bench): FinDER agent isolation & cooperation over the common backbone (seocho-vet)

### DIFF
--- a/scripts/benchmarks/finder_agent_isolation_cooperation.py
+++ b/scripts/benchmarks/finder_agent_isolation_cooperation.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""FinDER agent isolation & cooperation over the common backbone (seocho-vet).
+
+The synthesis of the whole line of work: WITHIN a tenant, category-specialist
+agents (Financials / Company overview / Footnotes) COOPERATE over a shared
+Company x FiscalYear backbone to answer cross-category questions no single
+specialist can; ACROSS tenants they stay ISOLATED (zero cross-tenant evidence
+bleed) even under concurrent multi-agent activity.
+
+Operationalizes seocho-x42 (supervisor + 3 category specialists; here as
+deterministic graph-querying specialists — the canonical OpenAI-Agents-SDK
+version is a follow-up) and seocho-8zh (deterministic Tier-1 metrics). The
+LLM-answering arms (qog) + MARA judge (8mr) are the secondary confirmatory
+layer, left as follow-ups; both reviewers held that the deterministic
+retrieval-layer metric is the primary, reproducible result.
+
+Conditions (per prior design): SHARED backbone (one Company/CIK, categories
+attached via CompanyYear) vs per-category-ISOLATED (per-_case_id islands).
+Two tenant logical DBs hold disjoint company sets — the isolation boundary
+(the worktree-isolated runtime model, seocho-6q9.3).
+
+Metrics (LIVE DozerDB, no LLM):
+  COOPERATION  cross_category_composition_success — multi-category companies
+               whose specialists fill >=2 categories bound to ONE company node
+  COOPERATION  grounding_precision — composed evidence matches gold references
+  ISOLATION    cross_tenant_contamination — evidence a tenant's agents retrieve
+               that belongs to another tenant's company (must be 0)
+  IDENTITY     entity_identity_consistency — 1 Company node per CIK
+
+Claim scope: data isolation + typed cross-category cooperation, NOT recall.
+
+Run: PYTHONPATH=src python3 scripts/benchmarks/finder_agent_isolation_cooperation.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, List
+
+from neo4j import GraphDatabase
+
+from finder_backbone import Case, select_xcat_cases  # reuse seocho-88b selector
+from seocho.semantic_layer.identity import EntityResolver
+
+CONTAINER = "seocho-agentcoop-neo4j"
+PASSWORD = "seocho-dev"
+IMAGE = "graphstack/dozerdb:5.26.3.0"
+BOLT = "bolt://localhost:7693"
+
+# Two tenants with DISJOINT company sets — the isolation boundary.
+TENANTS: Dict[str, List[str]] = {
+    "tenanta": ["UAL", "BBWI", "SYK", "VRTX"],
+    "tenantb": ["AON", "CNC", "RMD", "CE", "SYY"],
+}
+CATEGORIES = ["Financials", "Company overview", "Footnotes"]
+
+
+# --------------------------------------------------------------------------
+# Live DozerDB (neo4j driver)
+# --------------------------------------------------------------------------
+def boot():
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", CONTAINER,
+         "-e", f"NEO4J_AUTH=neo4j/{PASSWORD}", "-p", "7480:7474", "-p", "7693:7687", IMAGE],
+        capture_output=True, text=True,
+    )
+    for _ in range(60):
+        try:
+            drv = GraphDatabase.driver(BOLT, auth=("neo4j", PASSWORD))
+            with drv.session(database="system") as s:
+                s.run("SHOW DATABASES YIELD name RETURN count(name) AS n").single()
+                for t in TENANTS:
+                    s.run(f"CREATE DATABASE `{t}` IF NOT EXISTS").consume()
+            time.sleep(3)
+            return drv
+        except Exception:
+            time.sleep(2)
+    return None
+
+
+def _rows(cases: List[Case]) -> List[dict]:
+    return [{"cik": c.cik, "ticker": c.ticker, "cat": c.category,
+             "years": c.years or [0], "case": c.case_id,
+             "ev": [e[:400] for e in c.evidence]} for c in cases]
+
+
+def build(drv, db: str, cases: List[Case], shared: bool) -> None:
+    with drv.session(database=db) as s:
+        s.run("MATCH (n) DETACH DELETE n").consume()
+        if shared:
+            s.run(
+                "UNWIND $rows AS r MERGE (co:Company {cik:r.cik}) SET co.ticker=r.ticker "
+                "WITH r, co UNWIND r.years AS fy "
+                "MERGE (cy:CompanyYear {cy_id:'cy:'+r.cik+':'+toString(fy)}) SET cy.cik=r.cik "
+                "MERGE (co)-[:FOR_YEAR]->(cy) "
+                "MERGE (fs:FilingSection {fs_id:cy.cy_id+':'+r.cat}) SET fs.kind=r.cat, fs.cik=r.cik "
+                "MERGE (cy)-[:HAS_SECTION]->(fs)", rows=_rows(cases)).consume()
+            s.run(
+                "UNWIND $rows AS r WITH r, "
+                "'cy:'+r.cik+':'+toString(coalesce(r.years[0],0))+':'+r.cat AS fsid "
+                "MATCH (fs:FilingSection {fs_id:fsid}) UNWIND range(0,size(r.ev)-1) AS i "
+                "MERGE (e:Evidence {ev_id:r.case+':'+toString(i)}) "
+                "  SET e.category=r.cat, e.cik=r.cik, e.text=r.ev[i] "
+                "MERGE (fs)-[:CONTAINS]->(e)", rows=_rows(cases)).consume()
+        else:
+            s.run(
+                "UNWIND $rows AS r "
+                "MERGE (co:Company {cik:r.cik, _case_id:r.case}) SET co.ticker=r.ticker "
+                "MERGE (fs:FilingSection {fs_id:r.case+':'+r.cat}) SET fs.kind=r.cat, fs.cik=r.cik "
+                "MERGE (co)-[:HAS_SECTION]->(fs) WITH r, fs UNWIND range(0,size(r.ev)-1) AS i "
+                "MERGE (e:Evidence {ev_id:r.case+':'+toString(i)}) "
+                "  SET e.category=r.cat, e.cik=r.cik, e.text=r.ev[i] "
+                "MERGE (fs)-[:CONTAINS]->(e)", rows=_rows(cases)).consume()
+
+
+# --------------------------------------------------------------------------
+# Agents: a category specialist retrieves its slot from the tenant backbone.
+# --------------------------------------------------------------------------
+def specialist_retrieve(drv, db: str, cik: str, category: str, shared: bool,
+                        entry_case: str = "") -> List[dict]:
+    """One category specialist agent: fetch evidence for (company, category)
+    from its tenant DB. Anchors on Company{cik} — never names another company.
+
+    Backbone: one Company node per CIK reaches every category via CompanyYear.
+    Isolated: there is no shared hub, so the supervisor can only enter via a
+    single case-island (entry_case); from it, only that island's own category
+    is reachable — cross-category composition is structurally impossible."""
+    with drv.session(database=db) as s:
+        if shared:
+            q = ("MATCH (co:Company {cik:$cik})-[:FOR_YEAR]->(:CompanyYear)"
+                 "-[:HAS_SECTION]->(fs:FilingSection {kind:$cat})-[:CONTAINS]->(e:Evidence) "
+                 "RETURN e.cik AS cik, e.category AS category, e.text AS text")
+            params = {"cik": cik, "cat": category}
+        else:
+            q = ("MATCH (co:Company {cik:$cik, _case_id:$entry})"
+                 "-[:HAS_SECTION]->(fs:FilingSection {kind:$cat})-[:CONTAINS]->(e:Evidence) "
+                 "RETURN e.cik AS cik, e.category AS category, e.text AS text")
+            params = {"cik": cik, "cat": category, "entry": entry_case}
+        return [dict(r) for r in s.run(q, **params).data()]
+
+
+def supervisor_answer(drv, db: str, cik: str, shared: bool, entry_case: str = "") -> dict:
+    """Supervisor dispatches all 3 category specialists over the SAME backbone
+    and composes: which categories were filled, bound to one company node."""
+    bundles = {cat: specialist_retrieve(drv, db, cik, cat, shared, entry_case)
+               for cat in CATEGORIES}
+    filled = [cat for cat, ev in bundles.items() if ev]
+    all_ev = [e for ev in bundles.values() for e in ev]
+    return {"cik": cik, "categories_filled": filled, "evidence": all_ev}
+
+
+# --------------------------------------------------------------------------
+# Metrics
+# --------------------------------------------------------------------------
+def run_condition(drv, cases: List[Case], shared: bool) -> Dict[str, float]:
+    # partition cases by tenant
+    tenant_of = {tk: t for t, tks in TENANTS.items() for tk in tks}
+    by_tenant: Dict[str, List[Case]] = defaultdict(list)
+    for c in cases:
+        t = tenant_of.get(c.ticker)
+        if t:
+            by_tenant[t].append(c)
+    for t, cs in by_tenant.items():
+        build(drv, t, cs, shared)
+
+    # categories each company actually has (ground truth) + a single entry case
+    # per company (the isolated supervisor's only entry point — no shared hub).
+    cats_by_cik: Dict[str, set] = defaultdict(set)
+    cik_tenant: Dict[str, str] = {}
+    entry_case: Dict[str, str] = {}
+    for c in cases:
+        if c.ticker in tenant_of:
+            cats_by_cik[c.cik].add(c.category)
+            cik_tenant[c.cik] = tenant_of[c.ticker]
+            entry_case.setdefault(c.cik, c.case_id)
+    multi = [k for k, v in cats_by_cik.items() if len(v) >= 2]
+
+    # COOPERATION + ISOLATION measured under CONCURRENT multi-agent activity
+    results: Dict[str, dict] = {}
+    lock = threading.Lock()
+
+    def agent_job(cik: str) -> None:
+        ans = supervisor_answer(drv, cik_tenant[cik], cik, shared, entry_case.get(cik, ""))
+        with lock:
+            results[cik] = ans
+
+    threads = [threading.Thread(target=agent_job, args=(k,)) for k in cik_tenant]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    # cooperation: multi-category companies whose specialists filled >=2 categories
+    coop = sum(1 for k in multi if len(results[k]["categories_filled"]) >= 2) / len(multi)
+    # isolation: any retrieved evidence whose cik belongs to a different company
+    contamination = 0
+    for k, ans in results.items():
+        contamination += sum(1 for e in ans["evidence"] if e["cik"] != k)
+    # identity: 1 Company node per cik within its tenant
+    ident_ok = 0
+    for k in cik_tenant:
+        with drv.session(database=cik_tenant[k]) as s:
+            n = s.run("MATCH (co:Company {cik:$c}) RETURN count(co) AS n", c=k).single()["n"]
+        ident_ok += 1 if n == 1 else 0
+    return {
+        "cross_category_composition_success": coop,
+        "cross_tenant_or_company_contamination": float(contamination),
+        "entity_identity_consistency": ident_ok / len(cik_tenant),
+        "multi_category_companies": float(len(multi)),
+    }
+
+
+def isolation_probe(drv, cases: List[Case]) -> float:
+    """Direct cross-TENANT probe: can tenant A's DB see any tenant B company?
+    (the hard isolation boundary, independent of agent behavior)."""
+    tenant_of = {tk: t for t, tks in TENANTS.items() for tk in tks}
+    resolver = EntityResolver.from_frozen()
+    leaks = 0
+    for t in TENANTS:
+        # CIKs that belong to OTHER tenants
+        foreign = [resolver.resolve(tk) for ot, otk in TENANTS.items() if ot != t for tk in otk]
+        with drv.session(database=t) as s:
+            for cik in foreign:
+                n = s.run("MATCH (co:Company {cik:$c}) RETURN count(co) AS n", c=cik).single()["n"]
+                leaks += n
+    return float(leaks)
+
+
+def main() -> int:
+    resolver = EntityResolver.from_frozen()
+    if resolver is None:
+        print("FATAL: frozen CIK table not found", file=sys.stderr)
+        return 1
+    cases = select_xcat_cases(resolver)
+    drv = boot()
+    if drv is None:
+        print("FATAL: throwaway DozerDB not ready", file=sys.stderr)
+        subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+        return 1
+    try:
+        print("=" * 86)
+        print("FinDER agent isolation & cooperation — LIVE DozerDB (2 tenants, 3 category agents)")
+        print(f"  tenants: " + " | ".join(f"{t}={tks}" for t, tks in TENANTS.items()))
+        print("=" * 86)
+        rows = {}
+        for shared in (False, True):
+            rows["backbone" if shared else "isolated"] = run_condition(drv, cases, shared)
+        xtenant = isolation_probe(drv, cases)  # boundary holds regardless of arm
+        keys = ["entity_identity_consistency", "cross_category_composition_success",
+                "cross_tenant_or_company_contamination", "multi_category_companies"]
+        print(f"\n  {'metric':<42} {'ISOLATED':>10} {'BACKBONE':>10}")
+        print("  " + "-" * 64)
+        for k in keys:
+            print(f"  {k:<42} {rows['isolated'][k]:>10.2f} {rows['backbone'][k]:>10.2f}")
+        print(f"\n  cross-TENANT company visibility probe (want 0): {xtenant:.0f}")
+        print("\n  COOPERATION: on the backbone, specialists fill multiple categories for one")
+        print("  company (composition succeeds); isolated, each agent reaches only its island.")
+        print("  ISOLATION: agents never retrieve another company/tenant's evidence (contam=0),")
+        print("  and tenant DBs cannot see each other's companies — even under concurrent agents.")
+    finally:
+        try:
+            with drv.session(database="system") as s:
+                for t in TENANTS:
+                    s.run(f"DROP DATABASE `{t}` IF EXISTS").consume()
+            drv.close()
+        except Exception:
+            pass
+        subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+        print("\nthrowaway DozerDB removed; running stack untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Synthesis of the worktree-isolation + common-backbone work. **WITHIN a tenant**, category-specialist agents (Financials/Overview/Footnotes) **cooperate** over a shared Company × FiscalYear backbone to compose cross-category answers no single specialist can; **across tenants** they stay **isolated** with zero evidence bleed — even under concurrent multi-agent activity.

Operationalizes **seocho-x42** (supervisor + 3 category specialists; deterministic graph-querying form) and **seocho-8zh** (deterministic Tier-1 metrics). Two tenant logical DBs hold disjoint company sets — the isolation boundary from seocho-6q9.3.

### Verified live (DozerDB, 2 tenants, 9 cross-category companies, concurrent agents)
| metric | ISOLATED | BACKBONE |
|---|---|---|
| entity_identity_consistency | 0.00 | 1.00 |
| **cross_category_composition_success** | **0.00** | **1.00** |
| cross_tenant_or_company_contamination | 0.00 | 0.00 |
| cross-TENANT company visibility probe | — | **0** |

**COOPERATION** succeeds only on the shared backbone (isolated islands reach one category each). **ISOLATION** holds across tenants/companies under concurrency.

Reuses `finder_backbone.select_xcat_cases` (seocho-88b) + the frozen `EntityResolver`. Boots/drops a throwaway DozerDB on isolated ports — the running stack is untouched.

**Scope:** data isolation + typed cross-category cooperation, **not** recall. The LLM-answer arms (qog) + MARA judge (8mr) are the secondary confirmatory layer, left as follow-ups (the deterministic retrieval-layer metric is primary).