### PR TITLE
feat(bench): add MARA provider to FinDER llm_io (seocho-eju)

### DIFF
--- a/examples/finder/lib/llm_io.py
+++ b/examples/finder/lib/llm_io.py
@@ -123,6 +123,15 @@ _PROVIDER_PRESETS: dict[str, dict] = {
         "forced_temperature": None,
         "supports_response_format_json": True,  # deepseek docs document JSON Output mode
     },
+    # MARA cloud — OpenAI-compatible endpoint serving MiniMax-class models.
+    # Mirrors src/seocho/store/llm.py's "mara" ProviderSpec (the SDK default).
+    "mara": {
+        "default_model": "MiniMax-M2.5",
+        "base_url": "https://api.cloud.mara.com/v1",
+        "api_key_env": "MARA_API_KEY",
+        "forced_temperature": None,
+        "supports_response_format_json": False,
+    },
 }
 
 


### PR DESCRIPTION
First step of the FinDER LLM-answer confirmatory layer (seocho-eju). The benchmark's `examples/finder/lib/llm_io.py` provider presets lacked a MARA entry, so the MARA-first arms/judge couldn't be selected despite `MARA_API_KEY` being set.

Adds a `mara` preset mirroring the SDK's `src/seocho/store/llm.py` ProviderSpec: **MiniMax-M2.5** over the OpenAI-compatible endpoint `https://api.cloud.mara.com/v1`.

**Verified live:** `parse_llm_spec("mara/")` → `mara/MiniMax-M2.5`, and a chat completion returns content. Note: a bare `mara` is parsed as the kimi model `mara` (the bare-string convention) — select MARA as `mara/` or `mara/<model>`.

Unblocks the rest of seocho-eju (LLM-answer arms + MARA judge + Spearman bridge).