### PR TITLE
feat(bench): cross-model judge removes self-preference (seocho-992 step 3)

### DIFF
--- a/scripts/benchmarks/finder_arms_xbrl.py
+++ b/scripts/benchmarks/finder_arms_xbrl.py
@@ -37,7 +37,7 @@ for _p in (_ROOT / "src", _ROOT, Path(__file__).resolve().parent):
         sys.path.insert(0, str(_p))
 
 from finder_backbone import Case, DATASET, select_xcat_cases  # noqa: E402
-from finder_arms import ANSWER_SPEC, CONTEXT_BUDGET, JUDGE_SPEC, answer, judge  # noqa: E402
+from finder_arms import ANSWER_SPEC, CONTEXT_BUDGET, answer, judge  # noqa: E402
 from finder_judge import token_f1  # noqa: E402
 from examples.finder.lib import llm_io  # noqa: E402
 from seocho.index.xbrl_ingest import companyfacts_to_observations, fetch_companyfacts  # noqa: E402
@@ -118,6 +118,10 @@ ARMS = {
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--n", type=int, default=6, help="number of Financials cases (0 = all)")
+    # CROSS-MODEL judge (step 3): different model than the MiniMax-M2.5 answerer,
+    # to remove the generator==judge self-preference that made closed_book ~0.8.
+    ap.add_argument("--judge", default="mara/gpt-oss-120b",
+                    help="judge LLM spec (default cross-model mara/gpt-oss-120b)")
     args = ap.parse_args()
 
     resolver = EntityResolver.from_frozen()
@@ -133,13 +137,13 @@ def main() -> int:
     sample = fin if args.n == 0 else fin[:args.n]
 
     aspec = llm_io.parse_llm_spec(ANSWER_SPEC)
-    jspec = llm_io.parse_llm_spec(JUDGE_SPEC)
+    jspec = llm_io.parse_llm_spec(args.judge)
     aclient = llm_io.make_chat_client(aspec)
     jclient = llm_io.make_chat_client(jspec)
 
     print("=" * 84)
-    print(f"FinDER arms + XBRL — MARA ({aspec.model}); {len(sample)} Financials cases, "
-          f"fixed {CONTEXT_BUDGET}-char budget")
+    print(f"FinDER arms + XBRL — answerer={aspec.model}, judge={jspec.model}; "
+          f"{len(sample)} Financials cases, fixed {CONTEXT_BUDGET}-char budget")
     print("=" * 84)
     agg: Dict[str, dict] = {a: {"f1": [], "judge": []} for a in ARMS}
     for i, case in enumerate(sample, 1):
@@ -161,15 +165,17 @@ def main() -> int:
         f1s, js = agg[arm]["f1"], agg[arm]["judge"]
         print(f"  {arm:<20} {sum(f1s)/len(f1s):>14.3f} {sum(js)/len(js):>12.3f}")
     print("\n  Findings (honest, smoke n=5):")
-    print("  - Judge is now INFORMATIVE (finder_arms judge max_tokens 400->1600 fixed a")
-    print("    truncation that scored every answer 0.0: MiniMax emits reasoning before the")
-    print("    JSON verdict). That fix is the real step-2 deliverable.")
-    print("  - structured XBRL numbers lift token_f1 over snippet-backbone (0.233 vs 0.208)")
-    print("    but the judge does NOT reward it; backbone_xbrl is not a clean win here.")
-    print("  - CONFOUND surfaced: MARA-judges-MARA is too LENIENT — closed_book (no context)")
-    print("    scores ~0.8. generator==judge self-preference (both reviewers flagged it) makes")
-    print("    the absolute judge untrustworthy. NEXT: use a DIFFERENT judge model than the")
-    print("    answerer. The deterministic metric (PR #195/#196) remains the headline.")
+    print("  - CROSS-MODEL judge (gpt-oss-120b judging MiniMax-M2.5 answers) removes the")
+    print("    self-preference confound: closed_book (no context) drops 0.80 (self-judge) ->")
+    print("    0.00 (cross-judge) — context-free answers are correctly scored unanswerable.")
+    print("    Always judge with a DIFFERENT model than the answerer.")
+    print("  - Under the trustworthy judge the arms separate: isolated 0.94 > backbone_snippet")
+    print("    0.80 > backbone_xbrl 0.50 > closed_book 0.00. On SINGLE-category questions the")
+    print("    focused (isolated) context still beats the backbone — cross-category breadth")
+    print("    dilutes; the backbone must be GATED to questions that need >=2 categories.")
+    print("  - structured XBRL lifts token_f1 (0.233 vs 0.208) but not judge here; the")
+    print("    deterministic metric (PR #195/#196) remains the headline. Step 4: cross-category")
+    print("    B-questions + Spearman rho(cross_category_success, judge_score).")
     return 0
 
 


### PR DESCRIPTION
Step 2 (#200) surfaced a severe confound: **MARA-judges-MARA scored `closed_book` (no context) ~0.80** — generator==judge self-preference made the absolute judge untrustworthy. MARA serves four models on one key (DeepSeek-V3.1, MiniMax-M2.5, MiniMax-M2.7, gpt-oss-120b), so the judge can be a **different model** than the answerer at zero extra cost.

`finder_arms_xbrl.py`: add `--judge` (default cross-model `mara/gpt-oss-120b`) judging the `MiniMax-M2.5` answers.

### Verified live (smoke n=5 Financials) — self-judge → cross-judge
| arm | token_f1 | self-judge (MiniMax) | **cross-judge (gpt-oss-120b)** |
|---|---|---|---|
| closed_book | 0.048 | 0.80 | **0.00** |
| isolated_snippet | 0.269 | 1.00 | 0.94 |
| backbone_snippet | 0.208 | 0.92 | 0.80 |
| backbone_xbrl | 0.233 | 0.60 | 0.50 |

The self-preference confound was **real and large** — context-free answers drop from 0.80 to a correct 0.00 under an independent judge. Under the trustworthy cross-model judge the arms **separate cleanly**, and the eju "dilution" finding holds: on **single-category** questions, focused (isolated) context beats the backbone → the backbone must be **gated** to ≥2-category questions.

The deterministic metric (PR #195/#196) stays the headline. **Step 4:** cross-category B-questions + Spearman ρ(cross_category_success, judge_score). Part of seocho-992.