### PR TITLE
fix(security): Add missing auth checks to platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1080,13 +1080,35 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        metadata = raw_history[0].get("metadata") or {}
+        workspace_id = metadata.get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if raw_history:
+        metadata = raw_history[0].get("metadata") or {}
+        workspace_id = metadata.get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
### Severity
Medium/High

### Vulnerability
Missing authorization checks on the `PLATFORM_CHAT_SESSION` endpoints (`GET` and `DELETE`). An attacker could supply an arbitrary `session_id` and read or delete chat sessions belonging to other workspaces or users, completely bypassing the single-tenant MVP controls intended by the `require_runtime_permission` architecture.

### Impact
Unauthorized data disclosure (reading sensitive chat history) and unauthorized data destruction (deleting chat histories).

### Fix
Added explicit `require_runtime_permission` calls to both endpoints. The fix reads the target session's history to extract the owning `workspace_id` from the initial turn's metadata. If the session doesn't exist, it defaults to `"default"` (safe for the MVP tenant model). It then validates the current user has the `run_platform` action for that specific workspace before returning or deleting the history.

### Validation
- `bash scripts/ci/run_basic_ci.sh` passes successfully.
- Endpoint logic defensively handles empty histories and missing metadata to prevent 500 errors.
- Adheres to `AGENTS.md` and repo memory rules regarding explicit workspace authorization.

### Risks
None anticipated. The logic matches the authorization pattern applied defensively across the rest of the runtime server. If a session somehow lacks a workspace ID in metadata, it correctly falls back to `"default"`, preventing locking users out of legacy sessions while still enforcing base permissions.

---
*PR created automatically by Jules for task [3803298584016464410](https://jules.google.com/task/3803298584016464410) started by @tteon*