### PR TITLE
a11y: Restore focus outline to form controls to fix accessibility regression

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -584,5 +584,6 @@ select:focus,
 textarea:focus {
   border-color: var(--accent-blue);
   box-shadow: 0 0 0 1px var(--accent-blue);
-  outline: none;
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
### What
Replaced `outline: none;` with an explicit `outline: 2px solid var(--accent-blue);` for global input, select, and textarea focus styles.

### Why
The `outline: none;` rule broke accessibility by completely removing the focus ring for keyboard users, making it impossible to navigate the UI confidently.

### Accessibility / UX Impact
- **Impact:** Restores high-visibility focus rings for keyboard navigation while ensuring the aesthetic matches via the primary accent color.

### Validation
- **Visual:** Ran a local server and confirmed focus states via a Playwright test. Verified the blue ring appears.
- **Automated:** Executed `bash scripts/ci/run_basic_ci.sh`. All unrelated tests pass or have pre-existing issues.

### Risks
- Negligible risk. CSS specificity targets exactly the global input, select, and textarea elements which overrides default styles safely.

---
*PR created automatically by Jules for task [13601105993991797323](https://jules.google.com/task/13601105993991797323) started by @tteon*