### PR TITLE
fix: enforce workspace authorization on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1080,13 +1080,27 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
This PR addresses a missing authorization check on the platform chat session read (`GET /platform/chat/session`) and delete (`DELETE /platform/chat/session`) endpoints in `runtime/agent_server.py`. 

**Severity**: High
**Vulnerability**: Insecure Direct Object Reference (IDOR) / Missing Authorization
**Impact**: Previously, the API did not verify if the caller had the necessary workspace permissions to access or clear a given `session_id`. An attacker could potentially retrieve or delete another user's chat session histories by guessing or iterating through session IDs.
**Fix**: Modified the endpoints to first retrieve the raw history and securely extract the `workspace_id` from the session metadata (with a safe fallback to "default" if missing/empty). The endpoints now successfully enforce `require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)` and return an `HTTP 403 Forbidden` if unauthorized.
**Validation**: Verified via `bash scripts/ci/run_basic_ci.sh`. All internal tests pass. 
**Risks**: Empty or legacy sessions lacking a `workspace_id` in their metadata will default to the `"default"` workspace context, which is the pre-existing fallback logic used throughout the platform.

---
*PR created automatically by Jules for task [1340855488659100610](https://jules.google.com/task/1340855488659100610) started by @tteon*