### PR TITLE
perf(ontology): batch coverage_stats queries using UNION ALL

### DIFF
--- a/src/seocho/ontology.py
+++ b/src/seocho/ontology.py
@@ -2428,36 +2428,71 @@ class Ontology:
         node_stats: List[Dict[str, Any]] = []
         total_defined_nodes = len(self.nodes)
         populated_nodes = 0
+        chunk_size = 50
 
-        for label in self.nodes:
+        nodes_list = list(self.nodes)
+        for i in range(0, len(nodes_list), chunk_size):
+            chunk = nodes_list[i:i + chunk_size]
+            query = " UNION ALL ".join([
+                f"MATCH (n:`{label}`) RETURN count(n) AS cnt, '{label}' AS element"
+                for label in chunk
+            ])
             try:
-                result = graph_store.query(
-                    f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                results = graph_store.query(query, database=database)
+                counts = {r["element"]: int(r["cnt"]) for r in results}
             except Exception:
-                count = 0
-            node_stats.append({"label": label, "count": count})
-            if count > 0:
-                populated_nodes += 1
+                counts = {}
+
+            for label in chunk:
+                if label in counts:
+                    count = counts[label]
+                else:
+                    try:
+                        result = graph_store.query(
+                            f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
+                            database=database,
+                        )
+                        count = int(result[0]["cnt"]) if result else 0
+                    except Exception:
+                        count = 0
+
+                node_stats.append({"label": label, "count": count})
+                if count > 0:
+                    populated_nodes += 1
 
         rel_stats: List[Dict[str, Any]] = []
         total_defined_rels = len(self.relationships)
         populated_rels = 0
 
-        for rtype in self.relationships:
+        rels_list = list(self.relationships)
+        for i in range(0, len(rels_list), chunk_size):
+            chunk = rels_list[i:i + chunk_size]
+            query = " UNION ALL ".join([
+                f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt, '{rtype}' AS element"
+                for rtype in chunk
+            ])
             try:
-                result = graph_store.query(
-                    f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
-                    database=database,
-                )
-                count = int(result[0]["cnt"]) if result else 0
+                results = graph_store.query(query, database=database)
+                counts = {r["element"]: int(r["cnt"]) for r in results}
             except Exception:
-                count = 0
-            rel_stats.append({"type": rtype, "count": count})
-            if count > 0:
-                populated_rels += 1
+                counts = {}
+
+            for rtype in chunk:
+                if rtype in counts:
+                    count = counts[rtype]
+                else:
+                    try:
+                        result = graph_store.query(
+                            f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
+                            database=database,
+                        )
+                        count = int(result[0]["cnt"]) if result else 0
+                    except Exception:
+                        count = 0
+
+                rel_stats.append({"type": rtype, "count": count})
+                if count > 0:
+                    populated_rels += 1
 
         node_score = populated_nodes / total_defined_nodes if total_defined_nodes else 1.0
         rel_score = populated_rels / total_defined_rels if total_defined_rels else 1.0


### PR DESCRIPTION
### What
Refactored the `coverage_stats` method in `src/seocho/ontology.py` to batch node and relationship count queries. It now sends chunked `UNION ALL` Cypher requests containing up to 50 count queries per batch instead of individual `MATCH` queries for each label/type.

### Why
Previously, if an ontology defined 100 node labels and 200 relationship types, the coverage statistics logic would trigger 300 individual round-trip queries to the graph database. This sequential N+1 query pattern creates an avoidable performance bottleneck, especially over network boundaries.

### Expected Impact
Significant reduction in the number of database queries and execution time for the `coverage_stats` method. It scales linearly up with chunks of 50, reducing graph communication overhead by approximately ~98% for large ontologies.

### Validation
- Validated fallback mechanism ensures missing elements in batch degrade gracefully to original query behavior.
- Successfully ran `PYTHONPATH=. uv run pytest tests/seocho/test_ontology.py`.
- Ran and passed `bash scripts/ci/run_basic_ci.sh`.

### Risks
- Batched Cypher query length could theoretically hit upper limits if labels/types have extremely long names, though chunking limits this risk substantially.
- The `UNION ALL` parsing approach could potentially obscure specific syntax error locations, mitigated by the individual fallback query block on exceptions.

draft: true

---
*PR created automatically by Jules for task [17321775308573634281](https://jules.google.com/task/17321775308573634281) started by @tteon*