### PR TITLE
docs(cli): clarify search command help text

### DIFF
--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -33,7 +33,7 @@ def build_parser() -> argparse.ArgumentParser:
     get_parser.add_argument("--database", help="Target database override")
     _add_client_options(get_parser, include_scope=False, include_json=True)
 
-    search_parser = subparsers.add_parser("search", help="Search memories")
+    search_parser = subparsers.add_parser("search", help="Semantic search across graph memories")
     search_parser.add_argument("query", help="Search query")
     search_parser.add_argument("--limit", type=int, default=5, help="Max number of results")
     search_parser.add_argument("--graph-id", action="append", dest="graph_ids", default=[], help="Graph routing hint")


### PR DESCRIPTION
**What**
Updated the CLI help text for the `search` subcommand in `src/seocho/cli.py` from the generic "Search memories" to the more explicit "Semantic search across graph memories".

**Why**
The original description ("Search memories") was vague and didn't clearly communicate that the command performs semantic (vector/graph) search rather than just a simple keyword search.

**Accessibility / UX Impact**
Improves developer UX and documentation clarity by providing a more accurate description of the command's behavior, fulfilling the "CLI help text clarity" focus area.

**Validation**
- Manual inspection: Ran `uv run python -c "from seocho.cli import build_parser; print(build_parser().parse_args(['search', '-h']).format_help())"` to visually confirm the updated help text output.
- CI tests: Executed `bash scripts/ci/run_basic_ci.sh` to ensure no functionality regressions.
- Documentation linting: Executed `bash scripts/pm/lint-agent-docs.sh` to ensure documentation contracts are satisfied.

**Risks**
Extremely low. This is a strictly visual/informational change to the argparse help string. It does not alter any execution logic or introduce regressions.

---
*PR created automatically by Jules for task [10396575021371197080](https://jules.google.com/task/10396575021371197080) started by @tteon*