### PR TITLE
refactor(store): unify Cypher identifier quoting into one helper (seocho-91s)

### DIFF
--- a/extraction/fulltext_index.py
+++ b/extraction/fulltext_index.py
@@ -5,15 +5,11 @@ Fulltext index discovery/bootstrap helpers for DozerDB/Neo4j-compatible backends
 from __future__ import annotations
 
 import json
-import re
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-
-_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def is_valid_identifier(value: str) -> bool:
-    return bool(_IDENT_RE.match(value))
+# Canonical identifier validation lives in the SDK; re-exported here so existing
+# ``from extraction.fulltext_index import is_valid_identifier`` callers keep working.
+from seocho.cypher_ident import IDENT_RE as _IDENT_RE, is_valid_identifier
 
 
 def validate_identifiers(values: Sequence[str], field_name: str) -> List[str]:

--- a/extraction/schema_manager.py
+++ b/extraction/schema_manager.py
@@ -6,6 +6,7 @@ from neo4j.exceptions import ServiceUnavailable, SessionExpired
 from config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
 from exceptions import Neo4jConnectionError
 from retry_utils import neo4j_retry
+from seocho.cypher_ident import is_valid_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +42,18 @@ class SchemaManager:
         try:
             with self.driver.session(database=database) as session:
                 for label, definition in nodes.items():
+                    # DDL identifiers can't be parameterized; reject anything that
+                    # isn't a simple identifier rather than interpolating it raw.
+                    if not is_valid_identifier(label):
+                        logger.warning("Skipping schema for invalid label %r", label)
+                        continue
                     props = definition.get('properties', {})
                     for prop_name, config in props.items():
+                        if not is_valid_identifier(prop_name):
+                            logger.warning(
+                                "Skipping invalid property %r on label %s", prop_name, label
+                            )
+                            continue
                         # 1. Unique Constraints
                         if config.get('constraint') == 'UNIQUE':
                             constraint_name = f"constraint_{label}_{prop_name}_unique"

--- a/src/seocho/cypher_ident.py
+++ b/src/seocho/cypher_ident.py
@@ -1,0 +1,61 @@
+"""Canonical Cypher identifier validation and quoting.
+
+Single source of truth for turning dynamic strings (labels, relationship
+types, property keys) into Cypher fragments. Before this module the same
+regex ``^[A-Za-z_][A-Za-z0-9_]*$`` was copied into three places
+(:mod:`seocho.store.graph`, :mod:`seocho.ontology`,
+``extraction.fulltext_index``) and :mod:`seocho.query.cypher_builder`
+hand-rolled a lossy ``.replace("`", "")`` quote. Two policies live here:
+
+* :func:`is_valid_identifier` / :data:`IDENT_RE` — strict whitelist. Use when
+  a non-simple identifier should be *rejected* (schema probes, DDL,
+  property keys read back from the graph).
+* :func:`quote_identifier` / :func:`label_clause` — lossless backtick
+  quoting. Use when the identifier is ontology-driven and may legitimately
+  contain characters outside the simple set (e.g. RDF labels with
+  namespaces). Injection-safe: inside a backtick-quoted identifier the only
+  character with syntactic meaning is the backtick, which Cypher escapes by
+  *doubling* — so this doubles it rather than stripping it (which would
+  silently corrupt the identifier instead of preserving it).
+
+This module imports only the stdlib so it can be pulled in from anywhere in
+the package without risking an import cycle.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["IDENT_RE", "is_valid_identifier", "quote_identifier", "label_clause"]
+
+# Neo4j simple identifier: a letter or underscore, then letters/digits/
+# underscores. Anything else must go through ``quote_identifier`` (or be
+# rejected up front with ``is_valid_identifier``).
+IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def is_valid_identifier(value: str) -> bool:
+    """Return True if ``value`` is a simple Cypher identifier needing no quoting."""
+    return bool(IDENT_RE.match(value))
+
+
+def quote_identifier(value: str) -> str:
+    """Backtick-quote ``value`` for safe interpolation into Cypher.
+
+    Embedded backticks are escaped by doubling (Cypher's own escape rule), so
+    the result cannot terminate the quoted identifier early — this is what
+    makes raw interpolation of the result injection-safe. Accepts any
+    non-empty string; raises :class:`ValueError` otherwise.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"Cypher identifier must be a non-empty string, got {value!r}"
+        )
+    return "`" + value.replace("`", "``") + "`"
+
+
+def label_clause(label: str) -> str:
+    """Return a quoted ``:`Label``` clause, or ``""`` when ``label`` is falsy."""
+    if not label:
+        return ""
+    return ":" + quote_identifier(label)

--- a/src/seocho/ontology.py
+++ b/src/seocho/ontology.py
@@ -49,11 +49,11 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Type, Union
 
 import yaml
 
+from seocho.cypher_ident import IDENT_RE as _LABEL_RE  # canonical identifier regex
+
 # ---------------------------------------------------------------------------
 # Enums
 # ---------------------------------------------------------------------------
-
-_LABEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 _PY_TO_GRAPH_TYPE: Dict[type, str] = {
     str: "STRING",

--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
+from ..cypher_ident import quote_identifier
 from ..ontology import Ontology
 
 _ENTITY_SUFFIXES = re.compile(
@@ -430,7 +431,7 @@ class CypherBuilder:
         return "\n".join(lines)
 
     def _entity_lookup(self, entity: str, label: str, workspace_id: str, limit: int) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":`{label.replace('`', '')}`" if label else ""
+        label_clause = f":{quote_identifier(label)}" if label else ""
         normalized = normalize_entity(entity)
         return (
             f"MATCH (n{label_clause})\n"
@@ -457,9 +458,9 @@ class CypherBuilder:
         workspace_id: str,
         limit: int,
     ) -> Tuple[str, Dict[str, Any]]:
-        a_label = f":`{anchor_label.replace('`', '')}`" if anchor_label else ""
-        t_label = f":`{target_label.replace('`', '')}`" if target_label else ""
-        rel_clause = f":`{self._rel_name(rel_type).replace('`', '')}`" if rel_type else ""
+        a_label = f":{quote_identifier(anchor_label)}" if anchor_label else ""
+        t_label = f":{quote_identifier(target_label)}" if target_label else ""
+        rel_clause = f":{quote_identifier(self._rel_name(rel_type))}" if rel_type else ""
 
         anchor_norm = normalize_entity(anchor)
         where_parts = [
@@ -498,7 +499,7 @@ class CypherBuilder:
         )
 
     def _neighbors(self, entity: str, label: str, workspace_id: str, limit: int) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":`{label.replace('`', '')}`" if label else ""
+        label_clause = f":{quote_identifier(label)}" if label else ""
         normalized = normalize_entity(entity)
         return (
             f"MATCH (n{label_clause})\n"
@@ -542,7 +543,7 @@ class CypherBuilder:
         )
 
     def _count(self, label: str, workspace_id: str) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":`{label.replace('`', '')}`" if label else ""
+        label_clause = f":{quote_identifier(label)}" if label else ""
         return (
             f"MATCH (n{label_clause})\n"
             "WHERE $workspace_id = '' OR coalesce(n._workspace_id, '') = $workspace_id\n"
@@ -551,7 +552,7 @@ class CypherBuilder:
         )
 
     def _list_all(self, label: str, workspace_id: str, limit: int) -> Tuple[str, Dict[str, Any]]:
-        label_clause = f":`{label.replace('`', '')}`" if label else ""
+        label_clause = f":{quote_identifier(label)}" if label else ""
         return (
             f"MATCH (n{label_clause})\n"
             "WHERE $workspace_id = '' OR coalesce(n._workspace_id, '') = $workspace_id\n"

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -27,6 +27,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
+from seocho.cypher_ident import IDENT_RE, is_valid_identifier, quote_identifier
 from seocho.ontology import Ontology
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,9 @@ logger = logging.getLogger(__name__)
 # Indirection so tests can monkeypatch the poll delay to run instantly.
 _sleep = time.sleep
 
-_LABEL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Canonical identifier validation/quoting lives in seocho.cypher_ident; the
+# ``_LABEL_RE`` alias keeps the existing call sites in this module unchanged.
+_LABEL_RE = IDENT_RE
 
 
 def _is_property_value(value: Any) -> bool:
@@ -376,6 +379,7 @@ class Neo4jGraphStore(GraphStore):
 
                 try:
                     session.run(
+                        # label validated against _LABEL_RE above; interpolated raw
                         f"MERGE (n:{label} {{id: $id}}) SET n += $props",
                         id=node_id,
                         props=props,
@@ -408,11 +412,11 @@ class Neo4jGraphStore(GraphStore):
                     for idx, (key, value) in enumerate(props.items()):
                         if not _is_property_value(value):
                             continue
-                        safe_key = key.replace("`", "")
                         param_name = f"prop_{idx}"
-                        set_clauses.append(f"r.`{safe_key}` = ${param_name}")
+                        set_clauses.append(f"r.{quote_identifier(key)} = ${param_name}")
                         params[param_name] = value
                     session.run(
+                        # rtype validated against _LABEL_RE above; interpolated raw
                         f"MATCH (a {{id: $src}}), (b {{id: $tgt}}) "
                         f"MERGE (a)-[r:{rtype}]->(b) "
                         f"SET {', '.join(set_clauses)}",
@@ -632,8 +636,6 @@ class Neo4jGraphStore(GraphStore):
         if key in self._index_stats_cache and (now - cached_ts) < self._schema_cache_ttl:
             return self._index_stats_cache[key]
 
-        from extraction.fulltext_index import is_valid_identifier
-
         try:
             with self._driver.session(database=database) as session:
                 indexes: List[Dict[str, Any]] = []
@@ -665,6 +667,7 @@ class Neo4jGraphStore(GraphStore):
                     try:
                         # F7: LIMIT-bounded probe caps the scan at sample_limit.
                         count_rec = session.run(
+                            # label passed is_valid_identifier above; interpolated raw
                             f"MATCH (n:{label}) "
                             "WHERE n._workspace_id = $workspace_id "
                             "WITH n LIMIT $sample_limit "
@@ -692,6 +695,7 @@ class Neo4jGraphStore(GraphStore):
                         continue
                     try:
                         count_rec = session.run(
+                            # rt passed is_valid_identifier above; interpolated raw
                             f"MATCH ()-[r:{rt}]->() "
                             "WHERE r._workspace_id = $workspace_id "
                             "WITH r LIMIT $sample_limit "

--- a/tests/test_cypher_ident.py
+++ b/tests/test_cypher_ident.py
@@ -1,0 +1,73 @@
+"""Tests for the canonical Cypher identifier helper (seocho-91s).
+
+Pins the two policies so the three former copies of the regex can't drift
+back apart, and proves backtick quoting can't be broken out of.
+"""
+
+import pytest
+
+from seocho.cypher_ident import (
+    IDENT_RE,
+    is_valid_identifier,
+    label_clause,
+    quote_identifier,
+)
+
+
+@pytest.mark.parametrize("name", ["Person", "_x", "Foo123", "rel_type", "A"])
+def test_valid_simple_identifiers(name):
+    assert is_valid_identifier(name)
+    assert IDENT_RE.match(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["1abc", "has space", "drop`table", "a-b", "", "n.prop", "foo;bar", "ünïcode"],
+)
+def test_rejected_by_strict_policy(name):
+    assert not is_valid_identifier(name)
+
+
+def test_quote_identifier_wraps_in_backticks():
+    assert quote_identifier("Person") == "`Person`"
+
+
+def test_quote_identifier_escapes_embedded_backtick_by_doubling():
+    # Cypher escapes a backtick inside a quoted identifier by doubling it,
+    # so the quoted form cannot terminate early. This is the injection guard.
+    assert quote_identifier("a`b") == "`a``b`"
+
+
+def test_quote_identifier_neutralizes_injection_attempt():
+    # A label crafted to break out stays trapped inside one quoted identifier:
+    # exactly one opening and one closing backtick at the ends, everything
+    # between them doubled.
+    hostile = "Foo`) DETACH DELETE (n) //"
+    quoted = quote_identifier(hostile)
+    assert quoted.startswith("`") and quoted.endswith("`")
+    assert quoted == "`" + hostile.replace("`", "``") + "`"
+    # No lone backtick survives to close the identifier prematurely.
+    assert "``) DETACH" in quoted
+
+
+def test_quote_identifier_is_lossless_unlike_strip():
+    # The old cypher_builder did ``.replace("`", "")`` which silently merged
+    # ``a`b`` into ``ab``; doubling preserves the original on un-escape.
+    quoted = quote_identifier("a`b")
+    inner = quoted[1:-1]
+    assert inner.replace("``", "`") == "a`b"
+
+
+@pytest.mark.parametrize("bad", ["", None, 0, []])
+def test_quote_identifier_rejects_empty_or_nonstr(bad):
+    with pytest.raises(ValueError):
+        quote_identifier(bad)
+
+
+def test_label_clause_quotes_and_prefixes():
+    assert label_clause("Person") == ":`Person`"
+
+
+@pytest.mark.parametrize("empty", ["", None])
+def test_label_clause_empty_is_blank(empty):
+    assert label_clause(empty) == ""


### PR DESCRIPTION
## What

Introduces `seocho.cypher_ident` as the single source of truth for turning dynamic strings (labels, relationship types, property keys) into Cypher.

## Why

The regex `^[A-Za-z_][A-Za-z0-9_]*$` was copied into **three** modules (`store.graph`, `ontology`, `extraction.fulltext_index`) and `cypher_builder` hand-rolled a lossy `.replace(\`, '')` quote that silently corrupted any label containing a backtick. `store.graph` also imported the validator **from `extraction.fulltext_index`** — the canonical SDK reaching backwards into the legacy compatibility surface, which CLAUDE.md forbids.

## How

Two explicit policies in one module:
- `is_valid_identifier` / `IDENT_RE` — strict whitelist; reject non-simple identifiers (schema probes, DDL, write-path guards).
- `quote_identifier` / `label_clause` — lossless backtick quoting (doubles embedded backticks per Cypher's escape rule); for ontology-driven/arbitrary identifiers.

- `store.graph`, `ontology`, `fulltext_index` import the shared regex; the backwards `extraction` import is gone.
- `cypher_builder`'s 7 lossy-strip sites + the rel property-key strip use `quote_identifier`.
- `schema_manager` validates label/property before DDL interpolation.
- Validated label/rel sites keep raw interpolation (the LadybugDB backend rejects backtick-quoted labels), now guarded by the shared regex.

## Tests

`tests/test_cypher_ident.py` (quote escaping, injection attempt, strict rejects). `scripts/ci/run_basic_ci.sh` green (394 passed).