### PR TITLE
fix(runtime): stop blocking the event loop in bundle HTTP handlers (seocho-a23)

### DIFF
--- a/src/seocho/http_runtime.py
+++ b/src/seocho/http_runtime.py
@@ -169,7 +169,9 @@ def create_bundle_runtime_app(
         }
 
     @app.post(RuntimePath.API_MEMORIES)
-    async def create_memory(request: BundleMemoryCreateRequest) -> Dict[str, Any]:
+    # sync def: runtime_client.add() drives the Neo4j sync driver + LLM. Declared
+    # sync so FastAPI runs it in its threadpool instead of blocking the event loop.
+    def create_memory(request: BundleMemoryCreateRequest) -> Dict[str, Any]:
         _ensure_workspace(request.workspace_id)
         memory = runtime_client.add(
             request.content,
@@ -187,7 +189,8 @@ def create_bundle_runtime_app(
         }
 
     @app.post(RuntimePath.API_MEMORIES_SEARCH)
-    async def search_memories(request: BundleMemorySearchRequest) -> Dict[str, Any]:
+    # sync def: _search_graph() runs blocking Cypher; keep it off the event loop.
+    def search_memories(request: BundleMemorySearchRequest) -> Dict[str, Any]:
         _ensure_workspace(request.workspace_id)
         database = _resolve_database(request.databases)
         results = _search_graph(request.query, database=database, limit=request.limit)
@@ -202,7 +205,9 @@ def create_bundle_runtime_app(
         }
 
     @app.post(RuntimePath.API_CHAT)
-    async def chat(request: BundleChatRequest) -> Dict[str, Any]:
+    # sync def: _search_graph() + runtime_client.ask() are blocking (Cypher + LLM);
+    # keep them in the threadpool so one chat can't freeze the whole server.
+    def chat(request: BundleChatRequest) -> Dict[str, Any]:
         _ensure_workspace(request.workspace_id)
         database = _resolve_database(request.databases)
         search_results = _search_graph(request.message, database=database, limit=request.limit)
@@ -230,7 +235,8 @@ def create_bundle_runtime_app(
         }
 
     @app.post(RuntimePath.RUN_AGENT_SEMANTIC)
-    async def run_agent_semantic(request: BundleSemanticRequest) -> Dict[str, Any]:
+    # sync def: _search_graph() + runtime_client.ask() are blocking; threadpool them.
+    def run_agent_semantic(request: BundleSemanticRequest) -> Dict[str, Any]:
         _ensure_workspace(request.workspace_id)
         database = _resolve_database(request.databases)
         route = _route_for_database(database)

--- a/tests/seocho/test_runtime_bundle.py
+++ b/tests/seocho/test_runtime_bundle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 from fastapi.testclient import TestClient
 import pytest
 
@@ -488,3 +490,35 @@ def test_assert_bundle_hash_stable_skips_empty_payloads() -> None:
     bundle = RuntimeBundle(app_name="empty", workspace_id="default")
     # Empty ontology + empty registry should be a no-op, not a failure.
     assert_bundle_hash_stable(bundle)
+
+
+def test_blocking_handlers_are_sync_so_fastapi_threadpools_them() -> None:
+    """seocho-a23: the add/search/chat/semantic handlers do blocking Cypher +
+    LLM work. FastAPI runs ``async def`` endpoints directly on the event loop
+    but dispatches plain ``def`` endpoints to its threadpool, so declaring these
+    handlers sync is what keeps one slow request from freezing the whole server.
+    Pin that: the blocking paths must NOT be coroutine functions.
+    """
+    bundle = RuntimeBundle(
+        app_name="portable-app",
+        workspace_id="default",
+        graph_store=RuntimeGraphStoreConfig(default_database="finance"),
+    )
+    app = create_bundle_runtime_app(bundle, client=FakeBundleRuntimeClient())
+
+    endpoints = {
+        route.path: route.endpoint
+        for route in app.routes
+        if hasattr(route, "endpoint")
+    }
+    blocking_paths = [
+        "/api/memories",
+        "/api/memories/search",
+        "/api/chat",
+        "/run_agent_semantic",
+    ]
+    for path in blocking_paths:
+        assert path in endpoints, f"missing route {path}"
+        assert not asyncio.iscoroutinefunction(endpoints[path]), (
+            f"{path} is async; blocking work would run on the event loop"
+        )


### PR DESCRIPTION
## What

Declares the four blocking bundle-runtime HTTP handlers (`create_memory`, `search_memories`, `chat`, `run_agent_semantic`) as plain `def` instead of `async def`.

## Why

`http_runtime.py` declared every handler `async def`, but the file contains **zero `await`** — they are all fake-async. FastAPI runs `async def` endpoints directly on the event loop, so these handlers ran their blocking work (Neo4j sync driver + LLM completions) **on the loop itself**: one in-flight request froze the whole server, making it effectively concurrency-1.

## How

FastAPI dispatches sync (`def`) endpoints to its anyio threadpool, so blocking I/O no longer stalls the loop and requests run concurrently. `workspace_id` enforcement, policy checks, and typed responses are unchanged. Trivial non-blocking handlers (health, graphs, debate-stub) stay async — no threadpool hop needed.

## Tests

`test_blocking_handlers_are_sync_so_fastapi_threadpools_them` pins the invariant via route introspection. `scripts/ci/run_basic_ci.sh` green (395 passed).