### PR TITLE
fix(store): log rollback failures instead of swallowing them (seocho-ybj)

### DIFF
--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -527,8 +527,15 @@ class Neo4jGraphStore(GraphStore):
                 except Exception as exc:
                     try:
                         tx.rollback()
-                    except Exception:
-                        pass
+                    except Exception as rollback_exc:
+                        # A failed rollback can leave the transaction in an
+                        # unknown state; swallowing it silently makes that
+                        # impossible to diagnose. Log it, but still surface the
+                        # original error below.
+                        logger.warning(
+                            "rollback failed after ensure_constraints error: %s",
+                            rollback_exc,
+                        )
                     # Reset success counter — the rollback undid everything
                     # that successfully ran in this transaction.
                     summary["success"] = 0


### PR DESCRIPTION
## What

The transactional `ensure_constraints` path caught a rollback failure with a bare `except Exception: pass`. Logs the rollback exception at warning level instead; the original error is still surfaced in `summary['errors']`.

## Why

A failed rollback can leave the transaction in an unknown state, and swallowing it silently makes that impossible to diagnose in the field.

## Scope note (deliberately NOT changed after review)

The other items originally bundled under seocho-ybj were re-examined and left alone:
- **UNWIND batching** of the per-node/per-rel write path is a real perf win but needs group-by-label restructuring (labels can't be parameterized) and live-DB validation → split to seocho-b1a.
- **`id()` → `elementId()` reverted from scope**: both candidate sites are GDS Cypher projections, which require **integer** node ids; `elementId()` returns a string and would break projection. CLAUDE.md's elementId guidance does not apply to GDS projection queries.
- **`assert last_exc is not None`** in `store.llm` is benign: `_completion_retry_variants` always yields ≥1 variant, so `last_exc` is always set when reached (no raise-None risk under `python -O`).

## Tests

`run_basic_ci.sh` green; targeted ensure_constraints/schema tests pass (41).