### PR TITLE
feat(runtime): pluggable authentication + Principal foundation (seocho-7fm)

### DIFF
--- a/extraction/tests/test_identity.py
+++ b/extraction/tests/test_identity.py
@@ -1,0 +1,166 @@
+"""Tests for the runtime identity foundation (seocho-7fm).
+
+Covers the token codec, mode resolution, and the PrincipalMiddleware wiring,
+including the strangler-fig invariant: default mode 'none' is behaviour
+preserving (anonymous, non-enforcing) and token mode rejects bad tokens with 401.
+"""
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from runtime.identity import (
+    ANONYMOUS,
+    AuthError,
+    Principal,
+    PrincipalMiddleware,
+    _b64e,
+    get_principal,
+    issue_token,
+    resolve_principal,
+    verify_token,
+)
+
+SECRET = "unit-test-secret"
+
+
+# --------------------------------------------------------------------------- #
+# Token codec
+# --------------------------------------------------------------------------- #
+
+def test_token_round_trip():
+    token = issue_token(SECRET, subject="alice", role="user", workspace_id="acme")
+    p = verify_token(token, SECRET)
+    assert p == Principal(subject="alice", role="user", workspace_id="acme", authenticated=True)
+
+
+def test_token_tamper_is_rejected():
+    token = issue_token(SECRET, subject="alice", role="admin")
+    payload_b64, sig = token.split(".")
+    # flip the role claim but keep the original signature
+    forged_payload = _b64e(
+        json.dumps({"sub": "alice", "role": "admin", "ws": "other", "exp": 9999999999},
+                   separators=(",", ":"), sort_keys=True).encode()
+    )
+    with pytest.raises(AuthError):
+        verify_token(f"{forged_payload}.{sig}", SECRET)
+
+
+def test_token_wrong_secret_is_rejected():
+    token = issue_token(SECRET, subject="alice", role="user")
+    with pytest.raises(AuthError, match="signature"):
+        verify_token(token, "different-secret")
+
+
+def test_token_expiry_is_enforced():
+    token = issue_token(SECRET, subject="alice", role="user", ttl_seconds=10, now=1000.0)
+    # valid just before expiry, invalid after
+    assert verify_token(token, SECRET, now=1005.0).subject == "alice"
+    with pytest.raises(AuthError, match="expired"):
+        verify_token(token, SECRET, now=2000.0)
+
+
+def test_token_unknown_role_is_rejected():
+    # hand-sign a token whose role is not in VALID_ROLES
+    payload_b64 = _b64e(
+        json.dumps({"sub": "x", "role": "root", "ws": None, "exp": 9999999999},
+                   separators=(",", ":"), sort_keys=True).encode()
+    )
+    sig = _b64e(hmac.new(SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest())
+    with pytest.raises(AuthError, match="invalid role"):
+        verify_token(f"{payload_b64}.{sig}", SECRET)
+
+
+def test_malformed_tokens_are_rejected():
+    for bad in ["", "noseparator", "a.b.c", ".", "x."]:
+        with pytest.raises(AuthError):
+            verify_token(bad, SECRET)
+
+
+def test_issue_token_rejects_bad_role():
+    with pytest.raises(ValueError):
+        issue_token(SECRET, subject="x", role="root")
+
+
+# --------------------------------------------------------------------------- #
+# Mode resolution
+# --------------------------------------------------------------------------- #
+
+def test_resolve_none_mode_is_anonymous():
+    assert resolve_principal(None, mode="none") is ANONYMOUS
+    assert resolve_principal("Bearer whatever", mode="none") is ANONYMOUS
+    assert ANONYMOUS.authenticated is False
+
+
+def test_resolve_token_mode_requires_secret():
+    with pytest.raises(AuthError, match="SEOCHO_AUTH_SECRET"):
+        resolve_principal("Bearer x", mode="token", secret="")
+
+
+def test_resolve_token_mode_requires_bearer_header():
+    with pytest.raises(AuthError, match="missing bearer token"):
+        resolve_principal(None, mode="token", secret=SECRET)
+    with pytest.raises(AuthError, match="missing bearer token"):
+        resolve_principal("Basic abc", mode="token", secret=SECRET)
+
+
+def test_resolve_token_mode_valid():
+    token = issue_token(SECRET, subject="bob", role="viewer", workspace_id="ws1")
+    p = resolve_principal(f"Bearer {token}", mode="token", secret=SECRET)
+    assert p.subject == "bob" and p.role == "viewer" and p.workspace_id == "ws1"
+    assert p.authenticated is True
+
+
+def test_resolve_unknown_mode():
+    with pytest.raises(AuthError, match="unknown"):
+        resolve_principal(None, mode="weird")
+
+
+# --------------------------------------------------------------------------- #
+# Middleware integration (TestClient, offline)
+# --------------------------------------------------------------------------- #
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(PrincipalMiddleware)
+
+    @app.get("/whoami")
+    def whoami():
+        p = get_principal()
+        return {"subject": p.subject, "role": p.role,
+                "workspace_id": p.workspace_id, "authenticated": p.authenticated}
+
+    return app
+
+
+def test_middleware_none_mode_is_anonymous(monkeypatch):
+    monkeypatch.setenv("SEOCHO_AUTH_MODE", "none")
+    client = TestClient(_app())
+    r = client.get("/whoami")
+    assert r.status_code == 200
+    assert r.json() == {"subject": "anonymous", "role": "user",
+                        "workspace_id": None, "authenticated": False}
+
+
+def test_middleware_token_mode_rejects_missing_and_bad(monkeypatch):
+    monkeypatch.setenv("SEOCHO_AUTH_MODE", "token")
+    monkeypatch.setenv("SEOCHO_AUTH_SECRET", SECRET)
+    client = TestClient(_app())
+    assert client.get("/whoami").status_code == 401
+    assert client.get("/whoami", headers={"Authorization": "Bearer garbage"}).status_code == 401
+
+
+def test_middleware_token_mode_accepts_valid(monkeypatch):
+    monkeypatch.setenv("SEOCHO_AUTH_MODE", "token")
+    monkeypatch.setenv("SEOCHO_AUTH_SECRET", SECRET)
+    token = issue_token(SECRET, subject="carol", role="admin", workspace_id="tenant-7")
+    client = TestClient(_app())
+    r = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["subject"] == "carol" and body["role"] == "admin"
+    assert body["workspace_id"] == "tenant-7" and body["authenticated"] is True

--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -27,6 +27,7 @@ from exceptions import (
     InvalidDatabaseNameError,
 )
 from runtime.middleware import RequestIDMiddleware
+from runtime.identity import PrincipalMiddleware
 from tracing import configure_opik, track, update_current_span, update_current_trace
 from runtime.policy import require_runtime_permission
 from seocho.runtime_contract import (
@@ -148,6 +149,11 @@ memory_service = _LazyServiceProxy(get_memory_service)
 
 # Request ID middleware
 app.add_middleware(RequestIDMiddleware)
+
+# Identity — resolves the per-request Principal (anonymous unless
+# SEOCHO_AUTH_MODE=token). Added before CORS so CORS stays outermost and handles
+# preflight OPTIONS without hitting auth.
+app.add_middleware(PrincipalMiddleware)
 
 # CORS — configurable via SEOCHO_CORS_ORIGINS env var (comma-separated)
 _DEFAULT_CORS = "http://localhost:8501,http://localhost:3000"

--- a/runtime/identity.py
+++ b/runtime/identity.py
@@ -1,0 +1,215 @@
+"""Runtime identity and pluggable authentication.
+
+A strangler-fig seam that puts an authenticated :class:`Principal` in front of
+the runtime without rewriting every endpoint. The flow is:
+
+    request --> PrincipalMiddleware.resolve_principal() --> ContextVar
+            --> policy.require_runtime_permission() reads the principal
+
+Modes (env ``SEOCHO_AUTH_MODE``):
+
+* ``none`` (default) — every request gets the anonymous, unconstrained
+  principal. This preserves the pre-auth behavior exactly: the policy engine
+  treats unauthenticated principals as non-enforcing, so nothing is gated. This
+  is the safe default for local/dev and keeps existing callers working.
+* ``token`` — an ``Authorization: Bearer <token>`` header is required and
+  validated as an HMAC-signed compact token (see :func:`issue_token`) using
+  ``SEOCHO_AUTH_SECRET``. The validated claims (subject, role, workspace)
+  populate the principal, and the policy engine enforces against it.
+
+OIDC / JWKS validation can be added later behind :func:`resolve_principal`
+without changing any caller: it just needs to return a :class:`Principal`.
+The token format here is intentionally dependency-free (stdlib hmac/hashlib)
+so the foundation ships without pulling a JWT library; it is not a drop-in JWT.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+VALID_ROLES = ("admin", "user", "viewer")
+
+
+class AuthError(Exception):
+    """Raised when a request fails authentication (surfaced as HTTP 401)."""
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Who is making a request.
+
+    ``workspace_id`` is the workspace the principal is scoped to; ``None`` means
+    unconstrained (any workspace). ``authenticated`` is True only when a token
+    was validated — the policy engine uses it to decide whether to enforce.
+    """
+
+    subject: str
+    role: str
+    workspace_id: Optional[str]
+    authenticated: bool
+
+
+# Anonymous principal used when auth is disabled. authenticated=False signals the
+# policy engine NOT to enforce, which reproduces the pre-auth behavior.
+ANONYMOUS = Principal(
+    subject="anonymous", role="user", workspace_id=None, authenticated=False
+)
+
+
+# --------------------------------------------------------------------------- #
+# Token codec (stdlib HMAC — payload_b64.signature_b64)
+# --------------------------------------------------------------------------- #
+
+def _b64e(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64d(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+
+
+def issue_token(
+    secret: str,
+    *,
+    subject: str,
+    role: str,
+    workspace_id: Optional[str] = None,
+    ttl_seconds: int = 3600,
+    now: Optional[float] = None,
+) -> str:
+    """Issue an HMAC-signed compact token. Used by token issuers and tests."""
+    if role not in VALID_ROLES:
+        raise ValueError(f"invalid role: {role!r} (expected one of {VALID_ROLES})")
+    issued = now if now is not None else time.time()
+    payload = {
+        "sub": subject,
+        "role": role,
+        "ws": workspace_id,
+        "exp": int(issued + ttl_seconds),
+    }
+    payload_b64 = _b64e(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    sig = _b64e(hmac.new(secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest())
+    return f"{payload_b64}.{sig}"
+
+
+def verify_token(token: str, secret: str, *, now: Optional[float] = None) -> Principal:
+    """Verify an HMAC-signed token and return the :class:`Principal`.
+
+    Raises :class:`AuthError` on any malformed/tampered/expired token.
+    """
+    parts = token.split(".")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise AuthError("malformed token")
+    payload_b64, sig = parts
+    expected = _b64e(
+        hmac.new(secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest()
+    )
+    # constant-time comparison — never short-circuit on signature mismatch
+    if not hmac.compare_digest(sig, expected):
+        raise AuthError("bad token signature")
+    try:
+        payload = json.loads(_b64d(payload_b64))
+    except Exception as exc:  # noqa: BLE001 — any decode failure is an auth failure
+        raise AuthError("malformed token payload") from exc
+    exp = payload.get("exp")
+    current = now if now is not None else time.time()
+    if exp is not None and current > exp:
+        raise AuthError("token expired")
+    role = payload.get("role")
+    if role not in VALID_ROLES:
+        raise AuthError(f"invalid role in token: {role!r}")
+    subject = payload.get("sub")
+    if not subject:
+        raise AuthError("token missing subject")
+    return Principal(
+        subject=str(subject),
+        role=role,
+        workspace_id=payload.get("ws"),
+        authenticated=True,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Mode resolution
+# --------------------------------------------------------------------------- #
+
+def auth_mode() -> str:
+    return (os.getenv("SEOCHO_AUTH_MODE", "none").strip().lower() or "none")
+
+
+def resolve_principal(
+    authorization: Optional[str],
+    *,
+    mode: Optional[str] = None,
+    secret: Optional[str] = None,
+    now: Optional[float] = None,
+) -> Principal:
+    """Resolve the principal for a request from its Authorization header.
+
+    ``none`` -> anonymous. ``token`` -> validated bearer token. Raises
+    :class:`AuthError` (HTTP 401) when token mode is on and the token is
+    missing/invalid, or when token mode is misconfigured (no secret).
+    """
+    mode = (mode or auth_mode())
+    if mode == "none":
+        return ANONYMOUS
+    if mode == "token":
+        secret = secret if secret is not None else os.getenv("SEOCHO_AUTH_SECRET", "")
+        if not secret:
+            raise AuthError("SEOCHO_AUTH_MODE=token but SEOCHO_AUTH_SECRET is unset")
+        if not authorization or not authorization.startswith("Bearer "):
+            raise AuthError("missing bearer token")
+        return verify_token(authorization[len("Bearer "):].strip(), secret, now=now)
+    raise AuthError(f"unknown SEOCHO_AUTH_MODE: {mode!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Per-request principal (ContextVar — mirrors RequestIDMiddleware)
+# --------------------------------------------------------------------------- #
+
+_principal_var: ContextVar[Principal] = ContextVar("seocho_principal", default=ANONYMOUS)
+
+
+def get_principal() -> Principal:
+    """Return the principal for the current request (anonymous outside one)."""
+    return _principal_var.get()
+
+
+class PrincipalMiddleware(BaseHTTPMiddleware):
+    """Resolve the principal once per request and bind it to the ContextVar.
+
+    On token mode, an invalid/missing token short-circuits to HTTP 401 before
+    the endpoint runs. On ``none`` mode this is a near no-op (anonymous).
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        try:
+            principal = resolve_principal(request.headers.get("Authorization"))
+        except AuthError as exc:
+            return JSONResponse(
+                status_code=401,
+                content={"error": {"error_code": "AuthError", "message": str(exc)}},
+            )
+        token = _principal_var.set(principal)
+        request.state.principal = principal
+        try:
+            return await call_next(request)
+        finally:
+            _principal_var.reset(token)

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 python3 -m py_compile \
   runtime/__init__.py \
   runtime/policy.py \
+  runtime/identity.py \
   runtime/agent_readiness.py \
   runtime/middleware.py \
   runtime/memory_service.py \
@@ -48,6 +49,7 @@ python3 -m py_compile \
 
 uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
+  extraction/tests/test_identity.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \


### PR DESCRIPTION
## What
Adds `runtime/identity.py` — a `Principal` abstraction + pluggable authentication (`PrincipalMiddleware`), wired into the agent-server runtime. **First of 4** enterprise-readiness slices (identity → RBAC → audit → default isolation).

## Why
HTTP surfaces had **no authentication**, and `policy.require_runtime_permission(role="user", ...)` hardcoded the role at every call site — so authorization couldn't actually be enforced. This establishes *who* is calling, which everything else depends on.

## Strangler-fig: default is behaviour-preserving
- `SEOCHO_AUTH_MODE=none` (default) → anonymous principal, `authenticated=False`. The policy engine treats unauthenticated principals as non-enforcing, so **nothing is gated and existing callers/tests are unchanged**.
- `SEOCHO_AUTH_MODE=token` → `Authorization: Bearer <token>` required, validated as a stdlib **HMAC-signed** compact token (`SEOCHO_AUTH_SECRET`); claims (sub/role/workspace) populate the principal.
- `resolve_principal()` is the single seam — **OIDC/JWKS plugs in here later** without touching callers. The token codec is intentionally dependency-free (not a JWT lib); it's the bridge, not the destination.
- `PrincipalMiddleware` binds the principal to a ContextVar (mirrors the existing `RequestIDMiddleware`) and returns **401** on bad/missing tokens in token mode. Added before CORS so preflight OPTIONS bypass auth.

## Scope boundary
**No enforcement in this PR** — `require_runtime_permission` still behaves as before. RBAC + workspace-ownership enforcement lands in **seocho-8uy**, audit in **seocho-bk0**, default isolation in **seocho-a6d**.

## Tests
`extraction/tests/test_identity.py`: token round-trip, tamper/wrong-secret/expiry/unknown-role/malformed rejects, mode resolution, and TestClient middleware (none→anonymous, token→401 missing/bad, 200+principal on valid). `run_basic_ci.sh` green (410 passed); runtime-shell + module-ownership + root-hierarchy contracts pass.