### PR TITLE
feat(runtime): enforce RBAC by principal + workspace ownership (seocho-8uy)

### DIFF
--- a/extraction/tests/test_policy.py
+++ b/extraction/tests/test_policy.py
@@ -1,6 +1,11 @@
 import pytest
 
-from runtime.policy import RuntimePolicyEngine, require_runtime_permission, run_offline_ontology_reasoning
+from runtime.identity import ANONYMOUS, Principal
+from runtime.policy import (
+    RuntimePolicyEngine,
+    require_runtime_permission,
+    run_offline_ontology_reasoning,
+)
 
 
 def test_workspace_id_validation():
@@ -13,30 +18,76 @@ def test_workspace_id_validation():
 
 def test_authorize_runtime_action():
     engine = RuntimePolicyEngine()
-    allowed = engine.authorize(role="user", action="run_agent", workspace_id="default")
-    allowed_manage_index = engine.authorize(role="user", action="manage_indexes", workspace_id="default")
-    allowed_platform = engine.authorize(role="user", action="run_platform", workspace_id="default")
-    allowed_assess_rules = engine.authorize(role="user", action="assess_rules", workspace_id="default")
-    allowed_semantic_artifacts = engine.authorize(
-        role="user", action="manage_semantic_artifacts", workspace_id="default"
-    )
-    allowed_memories = engine.authorize(role="user", action="manage_memories", workspace_id="default")
-    denied = engine.authorize(role="viewer", action="run_debate", workspace_id="default")
-
-    assert allowed.allowed is True
-    assert allowed_manage_index.allowed is True
-    assert allowed_platform.allowed is True
-    assert allowed_assess_rules.allowed is True
-    assert allowed_semantic_artifacts.allowed is True
-    assert allowed_memories.allowed is True
-    assert denied.allowed is False
+    assert engine.authorize(role="user", action="run_agent", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_indexes", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="run_platform", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="assess_rules", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_semantic_artifacts", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_memories", workspace_id="default").allowed
+    # viewer is genuinely read-only
+    assert engine.authorize(role="viewer", action="run_debate", workspace_id="default").allowed is False
+    assert engine.authorize(role="viewer", action="read_databases", workspace_id="default").allowed
 
 
-def test_require_runtime_permission_raises():
+def test_admin_is_strict_superset_of_user():
+    engine = RuntimePolicyEngine()
+    # admin-only action denied for user, allowed for admin
+    assert engine.authorize(role="user", action="manage_tenants", workspace_id="default").allowed is False
+    assert engine.authorize(role="admin", action="manage_tenants", workspace_id="default").allowed
+    # everything a user can do, admin can do
+    assert engine.authorize(role="admin", action="run_agent", workspace_id="default").allowed
+
+
+def test_workspace_ownership_blocks_cross_tenant():
+    engine = RuntimePolicyEngine()
+    # a user scoped to ws "acme" may act on acme...
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="acme", principal_workspace="acme"
+    ).allowed
+    # ...but not on another workspace (IDOR closed)
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="other", principal_workspace="acme"
+    ).allowed is False
+    # admin is the cross-workspace operator and is exempt
+    assert engine.authorize(
+        role="admin", action="run_agent", workspace_id="other", principal_workspace="acme"
+    ).allowed
+    # unconstrained principal (workspace=None) may act on any workspace
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="other", principal_workspace=None
+    ).allowed
+
+
+def test_require_permission_anonymous_does_not_enforce():
+    # Auth disabled (anonymous, authenticated=False): role/ownership NOT enforced
+    # — reproduces pre-auth behavior. A viewer-denied action does not raise.
+    require_runtime_permission(action="run_debate", workspace_id="default", principal=ANONYMOUS)
+
+
+def test_require_permission_anonymous_still_validates_workspace_format():
     with pytest.raises(PermissionError):
-        require_runtime_permission(role="viewer", action="run_debate", workspace_id="default")
+        require_runtime_permission(action="run_agent", workspace_id="1invalid", principal=ANONYMOUS)
+
+
+def test_require_permission_authenticated_viewer_denied():
+    viewer = Principal(subject="v", role="viewer", workspace_id=None, authenticated=True)
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_debate", workspace_id="default", principal=viewer)
+
+
+def test_require_permission_authenticated_user_allowed():
+    user = Principal(subject="u", role="user", workspace_id=None, authenticated=True)
+    require_runtime_permission(action="run_agent", workspace_id="default", principal=user)
+
+
+def test_require_permission_workspace_ownership_enforced():
+    scoped = Principal(subject="u", role="user", workspace_id="acme", authenticated=True)
+    # own workspace: ok
+    require_runtime_permission(action="run_agent", workspace_id="acme", principal=scoped)
+    # cross-workspace: blocked
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_agent", workspace_id="other", principal=scoped)
 
 
 def test_offline_reasoning_placeholder_noop():
-    # Must be callable and side-effect free in current implementation.
     assert run_offline_ontology_reasoning() is None

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -1,20 +1,50 @@
 """
-Runtime policy helpers for agent execution.
+Runtime policy: role-based authorization + workspace-ownership enforcement.
 
 Design notes:
-- MVP is single-tenant, but all runtime calls must carry workspace_id.
-- Authorization in hot path is app-level RBAC/ABAC.
-- owlready2-style ontology reasoning is intentionally excluded from hot path.
+- ``workspace_id`` must accompany every runtime call (format-validated).
+- The effective role comes from the **authenticated principal**
+  (:mod:`runtime.identity`), not from the caller. When authentication is
+  disabled (``SEOCHO_AUTH_MODE=none`` → anonymous, ``authenticated=False``),
+  ``require_runtime_permission`` only validates the ``workspace_id`` format and
+  does not enforce role/ownership — this reproduces the pre-auth behaviour, so
+  existing callers and tests are unaffected.
+- When the principal is authenticated, two checks apply: (1) the role must be
+  permitted for the action, and (2) **workspace ownership** — a principal
+  scoped to a workspace may only act on that workspace; ``admin`` is the
+  cross-workspace operator and is exempt. (2) closes the IDOR class where any
+  caller could pass any ``workspace_id``.
+- owlready2-style ontology reasoning stays out of the hot path.
+
+The permission matrix below is deliberately **behaviour-compatible**: the
+``user`` set keeps every action that was previously gated as the hardcoded
+"user", so turning auth on does not silently lock out existing flows. ``admin``
+is a strict superset; ``viewer`` is genuinely read-only. Tightening governance
+actions (rule-profile/export/semantic-artifact management) to admin-only is a
+recommended follow-up that needs product input, so it is NOT baked in here.
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Dict, Set
+from typing import Dict, Optional, Set
+
+from runtime.identity import Principal, get_principal
 
 
 _WORKSPACE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{1,63}$")
+
+# Actions that were previously gated as the hardcoded "user" role. Keeping the
+# user set equal to this preserves behaviour when auth is enabled.
+_OPERATIONAL: Set[str] = {
+    "run_agent", "run_debate", "read_databases", "read_agents",
+    "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles",
+    "export_rules", "manage_indexes", "run_platform", "ingest_raw",
+    "manage_semantic_artifacts", "manage_memories",
+}
+# Reserved for cross-tenant / policy operations — admin only.
+_ADMIN_ONLY: Set[str] = {"manage_tenants", "manage_policy"}
 
 
 @dataclass(frozen=True)
@@ -24,20 +54,12 @@ class PolicyDecision:
 
 
 class RuntimePolicyEngine:
-    """Simple runtime policy engine for MVP."""
+    """Role-based authorization with workspace-ownership enforcement."""
 
     def __init__(self):
         self._role_permissions: Dict[str, Set[str]] = {
-            "admin": {
-                "run_agent", "run_debate", "read_databases", "read_agents",
-                "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "export_rules",
-                "manage_indexes", "run_platform", "ingest_raw", "manage_semantic_artifacts", "manage_memories",
-            },
-            "user": {
-                "run_agent", "run_debate", "read_databases", "read_agents",
-                "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "export_rules",
-                "manage_indexes", "run_platform", "ingest_raw", "manage_semantic_artifacts", "manage_memories",
-            },
+            "admin": _OPERATIONAL | _ADMIN_ONLY,   # strict superset
+            "user": set(_OPERATIONAL),
             "viewer": {"read_databases", "read_agents"},
         }
 
@@ -48,18 +70,65 @@ class RuntimePolicyEngine:
             return PolicyDecision(False, "invalid workspace_id format")
         return PolicyDecision(True, "ok")
 
-    def authorize(self, role: str, action: str, workspace_id: str) -> PolicyDecision:
+    def authorize(
+        self,
+        role: str,
+        action: str,
+        workspace_id: str,
+        *,
+        principal_workspace: Optional[str] = None,
+    ) -> PolicyDecision:
         ws = self.validate_workspace_id(workspace_id)
         if not ws.allowed:
             return ws
-        allowed_actions = self._role_permissions.get(role, set())
-        if action not in allowed_actions:
+        if action not in self._role_permissions.get(role, set()):
             return PolicyDecision(False, f"role '{role}' not allowed for action '{action}'")
+        # Workspace ownership: a scoped principal may only act on its own
+        # workspace. admin is the cross-workspace operator and is exempt.
+        if (
+            principal_workspace is not None
+            and role != "admin"
+            and workspace_id != principal_workspace
+        ):
+            return PolicyDecision(
+                False,
+                f"principal scoped to workspace '{principal_workspace}' "
+                f"may not act on '{workspace_id}'",
+            )
         return PolicyDecision(True, "ok")
 
 
-def require_runtime_permission(role: str, action: str, workspace_id: str) -> None:
-    decision = RuntimePolicyEngine().authorize(role=role, action=action, workspace_id=workspace_id)
+def require_runtime_permission(
+    action: str,
+    workspace_id: str,
+    *,
+    role: Optional[str] = None,  # legacy/ignored: effective role comes from the principal
+    principal: Optional[Principal] = None,
+) -> None:
+    """Enforce that the current principal may perform ``action`` on ``workspace_id``.
+
+    Raises :class:`PermissionError` (mapped to HTTP 403 by the server) on denial.
+    The ``role`` keyword is accepted for backward compatibility with existing
+    call sites but is ignored — the effective role is taken from the
+    authenticated principal.
+    """
+    principal = principal if principal is not None else get_principal()
+    engine = RuntimePolicyEngine()
+
+    if not principal.authenticated:
+        # Auth disabled / anonymous: preserve pre-auth behaviour — validate the
+        # workspace_id format only; do not enforce role or ownership.
+        decision = engine.validate_workspace_id(workspace_id)
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        return
+
+    decision = engine.authorize(
+        role=principal.role,
+        action=action,
+        workspace_id=workspace_id,
+        principal_workspace=principal.workspace_id,
+    )
     if not decision.allowed:
         raise PermissionError(decision.reason)
 

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -50,6 +50,7 @@ python3 -m py_compile \
 uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
   extraction/tests/test_identity.py \
+  extraction/tests/test_policy.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \


### PR DESCRIPTION
## What
Makes the policy engine actually enforce: effective role comes from the authenticated **Principal** (not a hardcoded literal), and a workspace-scoped principal **cannot act on another workspace**.

> Stacked on #221 (identity foundation) — base is `feat/runtime-identity-foundation`; retarget to main after #221 merges.

## Why
`require_runtime_permission(role="user", ...)` hardcoded the role at every call site, and `admin`/`user` had **identical** permission sets, so authorization was effectively a no-op. There was also no workspace-ownership check, so any caller could pass any `workspace_id` (the IDOR class behind the open chat-session auth findings #202/#190/#184/#179).

## The two fixes
1. **Role from principal** — `require_runtime_permission` reads `get_principal()`. The legacy `role` kwarg is accepted but ignored (zero call-site churn). **Auth-off preserves behavior**: anonymous principal → only workspace-format validation, no role/ownership enforcement.
2. **Workspace ownership** — a scoped principal may only act on its own workspace; `admin` is the cross-workspace operator and exempt. Closes the IDOR class.

## Permission matrix (behaviour-compatible)
`user` keeps every action previously gated as the hardcoded user (so enabling auth doesn't lock out existing flows); `admin` is a strict superset (`manage_tenants`/`manage_policy`); `viewer` is read-only. **Not baked in:** tightening governance actions (rule-profile/export/semantic-artifact mgmt) to admin-only — flagged as a product follow-up.

## Tests
`test_policy.py` rewritten for the principal-driven contract (role matrix, admin superset, workspace-ownership allow/deny + admin exemption, anonymous non-enforcement, anonymous-still-validates-format, viewer-denied/user-allowed/scoped-user-IDOR-blocked). `test_api_endpoints` unaffected. `run_basic_ci.sh` green (420).