### PR TITLE
feat(query): enforce tenant isolation at the query boundary via flag (seocho-a6d)

### DIFF
--- a/extraction/tests/test_audit.py
+++ b/extraction/tests/test_audit.py
@@ -1,0 +1,80 @@
+"""Tests for the access-decision audit log (seocho-bk0)."""
+
+import json
+
+import pytest
+
+from runtime.audit import build_event, record_access
+from runtime.identity import ANONYMOUS, Principal
+from runtime.policy import require_runtime_permission
+
+USER = Principal(subject="alice", role="user", workspace_id="acme", authenticated=True)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def test_build_event_allow_and_deny():
+    allow = build_event(
+        principal=USER, action="run_agent", workspace_id="acme",
+        allowed=True, reason="ok", request_id="req-1", ts=1234.0,
+    )
+    assert allow == {
+        "ts": 1234.0, "request_id": "req-1", "subject": "alice", "role": "user",
+        "authenticated": True, "workspace_id": "acme", "action": "run_agent",
+        "decision": "allow", "reason": "ok",
+    }
+    deny = build_event(
+        principal=USER, action="run_agent", workspace_id="other",
+        allowed=False, reason="cross-tenant", request_id="", ts=1.0,
+    )
+    assert deny["decision"] == "deny" and deny["reason"] == "cross-tenant"
+
+
+def test_record_access_noop_when_unconfigured(tmp_path, monkeypatch):
+    monkeypatch.delenv("SEOCHO_AUDIT_LOG_PATH", raising=False)
+    target = tmp_path / "audit.jsonl"
+    record_access(action="run_agent", workspace_id="acme", allowed=True, principal=USER)
+    assert not target.exists()  # default is no-op
+
+
+def test_record_access_writes_and_appends(tmp_path):
+    path = str(tmp_path / "audit.jsonl")
+    record_access(action="run_agent", workspace_id="acme", allowed=True,
+                  reason="ok", principal=USER, request_id="r1", path=path, now=1.0)
+    record_access(action="run_debate", workspace_id="other", allowed=False,
+                  reason="denied", principal=USER, request_id="r2", path=path, now=2.0)
+    events = _read(path)
+    assert len(events) == 2
+    assert events[0]["decision"] == "allow" and events[0]["action"] == "run_agent"
+    assert events[1]["decision"] == "deny" and events[1]["request_id"] == "r2"
+    assert events[1]["subject"] == "alice"
+
+
+def test_record_access_write_failure_does_not_raise():
+    # An unwritable path must be swallowed (auditing can't take down requests).
+    record_access(action="x", workspace_id="acme", allowed=True,
+                  principal=USER, path="/this/dir/does/not/exist/audit.jsonl")
+
+
+def test_require_permission_audit_integration(tmp_path, monkeypatch):
+    path = str(tmp_path / "audit.jsonl")
+    monkeypatch.setenv("SEOCHO_AUDIT_LOG_PATH", path)
+    viewer = Principal(subject="v", role="viewer", workspace_id=None, authenticated=True)
+    user = Principal(subject="u", role="user", workspace_id=None, authenticated=True)
+
+    # allowed action -> recorded as allow, no raise
+    require_runtime_permission(action="read_databases", workspace_id="acme", principal=viewer)
+    # denied action -> recorded as deny, then raises
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_debate", workspace_id="acme", principal=viewer)
+    # allowed for a normal user too
+    require_runtime_permission(action="run_agent", workspace_id="acme", principal=user)
+
+    events = _read(path)
+    decisions = [(e["subject"], e["action"], e["decision"]) for e in events]
+    assert ("v", "read_databases", "allow") in decisions
+    assert ("v", "run_debate", "deny") in decisions
+    assert ("u", "run_agent", "allow") in decisions

--- a/extraction/tests/test_identity.py
+++ b/extraction/tests/test_identity.py
@@ -1,0 +1,166 @@
+"""Tests for the runtime identity foundation (seocho-7fm).
+
+Covers the token codec, mode resolution, and the PrincipalMiddleware wiring,
+including the strangler-fig invariant: default mode 'none' is behaviour
+preserving (anonymous, non-enforcing) and token mode rejects bad tokens with 401.
+"""
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from runtime.identity import (
+    ANONYMOUS,
+    AuthError,
+    Principal,
+    PrincipalMiddleware,
+    _b64e,
+    get_principal,
+    issue_token,
+    resolve_principal,
+    verify_token,
+)
+
+SECRET = "unit-test-secret"
+
+
+# --------------------------------------------------------------------------- #
+# Token codec
+# --------------------------------------------------------------------------- #
+
+def test_token_round_trip():
+    token = issue_token(SECRET, subject="alice", role="user", workspace_id="acme")
+    p = verify_token(token, SECRET)
+    assert p == Principal(subject="alice", role="user", workspace_id="acme", authenticated=True)
+
+
+def test_token_tamper_is_rejected():
+    token = issue_token(SECRET, subject="alice", role="admin")
+    payload_b64, sig = token.split(".")
+    # flip the role claim but keep the original signature
+    forged_payload = _b64e(
+        json.dumps({"sub": "alice", "role": "admin", "ws": "other", "exp": 9999999999},
+                   separators=(",", ":"), sort_keys=True).encode()
+    )
+    with pytest.raises(AuthError):
+        verify_token(f"{forged_payload}.{sig}", SECRET)
+
+
+def test_token_wrong_secret_is_rejected():
+    token = issue_token(SECRET, subject="alice", role="user")
+    with pytest.raises(AuthError, match="signature"):
+        verify_token(token, "different-secret")
+
+
+def test_token_expiry_is_enforced():
+    token = issue_token(SECRET, subject="alice", role="user", ttl_seconds=10, now=1000.0)
+    # valid just before expiry, invalid after
+    assert verify_token(token, SECRET, now=1005.0).subject == "alice"
+    with pytest.raises(AuthError, match="expired"):
+        verify_token(token, SECRET, now=2000.0)
+
+
+def test_token_unknown_role_is_rejected():
+    # hand-sign a token whose role is not in VALID_ROLES
+    payload_b64 = _b64e(
+        json.dumps({"sub": "x", "role": "root", "ws": None, "exp": 9999999999},
+                   separators=(",", ":"), sort_keys=True).encode()
+    )
+    sig = _b64e(hmac.new(SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest())
+    with pytest.raises(AuthError, match="invalid role"):
+        verify_token(f"{payload_b64}.{sig}", SECRET)
+
+
+def test_malformed_tokens_are_rejected():
+    for bad in ["", "noseparator", "a.b.c", ".", "x."]:
+        with pytest.raises(AuthError):
+            verify_token(bad, SECRET)
+
+
+def test_issue_token_rejects_bad_role():
+    with pytest.raises(ValueError):
+        issue_token(SECRET, subject="x", role="root")
+
+
+# --------------------------------------------------------------------------- #
+# Mode resolution
+# --------------------------------------------------------------------------- #
+
+def test_resolve_none_mode_is_anonymous():
+    assert resolve_principal(None, mode="none") is ANONYMOUS
+    assert resolve_principal("Bearer whatever", mode="none") is ANONYMOUS
+    assert ANONYMOUS.authenticated is False
+
+
+def test_resolve_token_mode_requires_secret():
+    with pytest.raises(AuthError, match="SEOCHO_AUTH_SECRET"):
+        resolve_principal("Bearer x", mode="token", secret="")
+
+
+def test_resolve_token_mode_requires_bearer_header():
+    with pytest.raises(AuthError, match="missing bearer token"):
+        resolve_principal(None, mode="token", secret=SECRET)
+    with pytest.raises(AuthError, match="missing bearer token"):
+        resolve_principal("Basic abc", mode="token", secret=SECRET)
+
+
+def test_resolve_token_mode_valid():
+    token = issue_token(SECRET, subject="bob", role="viewer", workspace_id="ws1")
+    p = resolve_principal(f"Bearer {token}", mode="token", secret=SECRET)
+    assert p.subject == "bob" and p.role == "viewer" and p.workspace_id == "ws1"
+    assert p.authenticated is True
+
+
+def test_resolve_unknown_mode():
+    with pytest.raises(AuthError, match="unknown"):
+        resolve_principal(None, mode="weird")
+
+
+# --------------------------------------------------------------------------- #
+# Middleware integration (TestClient, offline)
+# --------------------------------------------------------------------------- #
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(PrincipalMiddleware)
+
+    @app.get("/whoami")
+    def whoami():
+        p = get_principal()
+        return {"subject": p.subject, "role": p.role,
+                "workspace_id": p.workspace_id, "authenticated": p.authenticated}
+
+    return app
+
+
+def test_middleware_none_mode_is_anonymous(monkeypatch):
+    monkeypatch.setenv("SEOCHO_AUTH_MODE", "none")
+    client = TestClient(_app())
+    r = client.get("/whoami")
+    assert r.status_code == 200
+    assert r.json() == {"subject": "anonymous", "role": "user",
+                        "workspace_id": None, "authenticated": False}
+
+
+def test_middleware_token_mode_rejects_missing_and_bad(monkeypatch):
+    monkeypatch.setenv("SEOCHO_AUTH_MODE", "token")
+    monkeypatch.setenv("SEOCHO_AUTH_SECRET", SECRET)
+    client = TestClient(_app())
+    assert client.get("/whoami").status_code == 401
+    assert client.get("/whoami", headers={"Authorization": "Bearer garbage"}).status_code == 401
+
+
+def test_middleware_token_mode_accepts_valid(monkeypatch):
+    monkeypatch.setenv("SEOCHO_AUTH_MODE", "token")
+    monkeypatch.setenv("SEOCHO_AUTH_SECRET", SECRET)
+    token = issue_token(SECRET, subject="carol", role="admin", workspace_id="tenant-7")
+    client = TestClient(_app())
+    r = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["subject"] == "carol" and body["role"] == "admin"
+    assert body["workspace_id"] == "tenant-7" and body["authenticated"] is True

--- a/extraction/tests/test_policy.py
+++ b/extraction/tests/test_policy.py
@@ -1,6 +1,11 @@
 import pytest
 
-from runtime.policy import RuntimePolicyEngine, require_runtime_permission, run_offline_ontology_reasoning
+from runtime.identity import ANONYMOUS, Principal
+from runtime.policy import (
+    RuntimePolicyEngine,
+    require_runtime_permission,
+    run_offline_ontology_reasoning,
+)
 
 
 def test_workspace_id_validation():
@@ -13,30 +18,76 @@ def test_workspace_id_validation():
 
 def test_authorize_runtime_action():
     engine = RuntimePolicyEngine()
-    allowed = engine.authorize(role="user", action="run_agent", workspace_id="default")
-    allowed_manage_index = engine.authorize(role="user", action="manage_indexes", workspace_id="default")
-    allowed_platform = engine.authorize(role="user", action="run_platform", workspace_id="default")
-    allowed_assess_rules = engine.authorize(role="user", action="assess_rules", workspace_id="default")
-    allowed_semantic_artifacts = engine.authorize(
-        role="user", action="manage_semantic_artifacts", workspace_id="default"
-    )
-    allowed_memories = engine.authorize(role="user", action="manage_memories", workspace_id="default")
-    denied = engine.authorize(role="viewer", action="run_debate", workspace_id="default")
-
-    assert allowed.allowed is True
-    assert allowed_manage_index.allowed is True
-    assert allowed_platform.allowed is True
-    assert allowed_assess_rules.allowed is True
-    assert allowed_semantic_artifacts.allowed is True
-    assert allowed_memories.allowed is True
-    assert denied.allowed is False
+    assert engine.authorize(role="user", action="run_agent", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_indexes", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="run_platform", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="assess_rules", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_semantic_artifacts", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_memories", workspace_id="default").allowed
+    # viewer is genuinely read-only
+    assert engine.authorize(role="viewer", action="run_debate", workspace_id="default").allowed is False
+    assert engine.authorize(role="viewer", action="read_databases", workspace_id="default").allowed
 
 
-def test_require_runtime_permission_raises():
+def test_admin_is_strict_superset_of_user():
+    engine = RuntimePolicyEngine()
+    # admin-only action denied for user, allowed for admin
+    assert engine.authorize(role="user", action="manage_tenants", workspace_id="default").allowed is False
+    assert engine.authorize(role="admin", action="manage_tenants", workspace_id="default").allowed
+    # everything a user can do, admin can do
+    assert engine.authorize(role="admin", action="run_agent", workspace_id="default").allowed
+
+
+def test_workspace_ownership_blocks_cross_tenant():
+    engine = RuntimePolicyEngine()
+    # a user scoped to ws "acme" may act on acme...
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="acme", principal_workspace="acme"
+    ).allowed
+    # ...but not on another workspace (IDOR closed)
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="other", principal_workspace="acme"
+    ).allowed is False
+    # admin is the cross-workspace operator and is exempt
+    assert engine.authorize(
+        role="admin", action="run_agent", workspace_id="other", principal_workspace="acme"
+    ).allowed
+    # unconstrained principal (workspace=None) may act on any workspace
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="other", principal_workspace=None
+    ).allowed
+
+
+def test_require_permission_anonymous_does_not_enforce():
+    # Auth disabled (anonymous, authenticated=False): role/ownership NOT enforced
+    # — reproduces pre-auth behavior. A viewer-denied action does not raise.
+    require_runtime_permission(action="run_debate", workspace_id="default", principal=ANONYMOUS)
+
+
+def test_require_permission_anonymous_still_validates_workspace_format():
     with pytest.raises(PermissionError):
-        require_runtime_permission(role="viewer", action="run_debate", workspace_id="default")
+        require_runtime_permission(action="run_agent", workspace_id="1invalid", principal=ANONYMOUS)
+
+
+def test_require_permission_authenticated_viewer_denied():
+    viewer = Principal(subject="v", role="viewer", workspace_id=None, authenticated=True)
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_debate", workspace_id="default", principal=viewer)
+
+
+def test_require_permission_authenticated_user_allowed():
+    user = Principal(subject="u", role="user", workspace_id=None, authenticated=True)
+    require_runtime_permission(action="run_agent", workspace_id="default", principal=user)
+
+
+def test_require_permission_workspace_ownership_enforced():
+    scoped = Principal(subject="u", role="user", workspace_id="acme", authenticated=True)
+    # own workspace: ok
+    require_runtime_permission(action="run_agent", workspace_id="acme", principal=scoped)
+    # cross-workspace: blocked
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_agent", workspace_id="other", principal=scoped)
 
 
 def test_offline_reasoning_placeholder_noop():
-    # Must be callable and side-effect free in current implementation.
     assert run_offline_ontology_reasoning() is None

--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -27,6 +27,7 @@ from exceptions import (
     InvalidDatabaseNameError,
 )
 from runtime.middleware import RequestIDMiddleware
+from runtime.identity import PrincipalMiddleware
 from tracing import configure_opik, track, update_current_span, update_current_trace
 from runtime.policy import require_runtime_permission
 from seocho.runtime_contract import (
@@ -148,6 +149,11 @@ memory_service = _LazyServiceProxy(get_memory_service)
 
 # Request ID middleware
 app.add_middleware(RequestIDMiddleware)
+
+# Identity — resolves the per-request Principal (anonymous unless
+# SEOCHO_AUTH_MODE=token). Added before CORS so CORS stays outermost and handles
+# preflight OPTIONS without hitting auth.
+app.add_middleware(PrincipalMiddleware)
 
 # CORS — configurable via SEOCHO_CORS_ORIGINS env var (comma-separated)
 _DEFAULT_CORS = "http://localhost:8501,http://localhost:3000"

--- a/runtime/audit.py
+++ b/runtime/audit.py
@@ -1,0 +1,103 @@
+"""Append-only audit log of runtime access decisions.
+
+Vendor-neutral and **opt-in**, mirroring the tracing contract: events are
+written as JSON Lines to the path in ``SEOCHO_AUDIT_LOG_PATH``; when that env
+var is unset (the default), :func:`record_access` is a no-op, so existing
+deployments are unaffected.
+
+Each event captures *who* (principal subject/role/authenticated), *what*
+(action), *where* (workspace_id), the *decision* (allow/deny) and *reason*, and
+the correlating ``request_id`` — the who-did-what trail enterprises require for
+regulated data.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from runtime.identity import Principal, get_principal
+
+logger = logging.getLogger(__name__)
+
+_write_lock = threading.Lock()
+
+
+def audit_log_path() -> Optional[str]:
+    """Return the configured audit log path, or None when auditing is disabled."""
+    path = os.getenv("SEOCHO_AUDIT_LOG_PATH", "").strip()
+    return path or None
+
+
+def build_event(
+    *,
+    principal: Principal,
+    action: str,
+    workspace_id: str,
+    allowed: bool,
+    reason: str,
+    request_id: str,
+    ts: float,
+) -> Dict[str, Any]:
+    """Build the audit event record (pure — separated for testability)."""
+    return {
+        "ts": ts,
+        "request_id": request_id,
+        "subject": principal.subject,
+        "role": principal.role,
+        "authenticated": principal.authenticated,
+        "workspace_id": workspace_id,
+        "action": action,
+        "decision": "allow" if allowed else "deny",
+        "reason": reason,
+    }
+
+
+def record_access(
+    *,
+    action: str,
+    workspace_id: str,
+    allowed: bool,
+    reason: str = "",
+    principal: Optional[Principal] = None,
+    request_id: Optional[str] = None,
+    path: Optional[str] = None,
+    now: Optional[float] = None,
+) -> None:
+    """Append one access-decision event to the audit log, if auditing is enabled.
+
+    No-op when ``SEOCHO_AUDIT_LOG_PATH`` is unset (and no explicit ``path`` is
+    given). A write failure is logged, never raised — auditing must not take
+    down the request path (the caller still enforces the decision separately).
+    """
+    path = path if path is not None else audit_log_path()
+    if not path:
+        return
+    principal = principal if principal is not None else get_principal()
+    if request_id is None:
+        try:
+            from runtime.middleware import get_request_id
+
+            request_id = get_request_id()
+        except Exception:  # noqa: BLE001 — request_id is best-effort context
+            request_id = ""
+    event = build_event(
+        principal=principal,
+        action=action,
+        workspace_id=workspace_id,
+        allowed=allowed,
+        reason=reason,
+        request_id=request_id or "",
+        ts=now if now is not None else time.time(),
+    )
+    line = json.dumps(event, separators=(",", ":"), sort_keys=True)
+    try:
+        with _write_lock:
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+    except OSError as exc:
+        logger.warning("audit log write failed (%s): %s", path, exc)

--- a/runtime/identity.py
+++ b/runtime/identity.py
@@ -1,0 +1,215 @@
+"""Runtime identity and pluggable authentication.
+
+A strangler-fig seam that puts an authenticated :class:`Principal` in front of
+the runtime without rewriting every endpoint. The flow is:
+
+    request --> PrincipalMiddleware.resolve_principal() --> ContextVar
+            --> policy.require_runtime_permission() reads the principal
+
+Modes (env ``SEOCHO_AUTH_MODE``):
+
+* ``none`` (default) — every request gets the anonymous, unconstrained
+  principal. This preserves the pre-auth behavior exactly: the policy engine
+  treats unauthenticated principals as non-enforcing, so nothing is gated. This
+  is the safe default for local/dev and keeps existing callers working.
+* ``token`` — an ``Authorization: Bearer <token>`` header is required and
+  validated as an HMAC-signed compact token (see :func:`issue_token`) using
+  ``SEOCHO_AUTH_SECRET``. The validated claims (subject, role, workspace)
+  populate the principal, and the policy engine enforces against it.
+
+OIDC / JWKS validation can be added later behind :func:`resolve_principal`
+without changing any caller: it just needs to return a :class:`Principal`.
+The token format here is intentionally dependency-free (stdlib hmac/hashlib)
+so the foundation ships without pulling a JWT library; it is not a drop-in JWT.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+VALID_ROLES = ("admin", "user", "viewer")
+
+
+class AuthError(Exception):
+    """Raised when a request fails authentication (surfaced as HTTP 401)."""
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Who is making a request.
+
+    ``workspace_id`` is the workspace the principal is scoped to; ``None`` means
+    unconstrained (any workspace). ``authenticated`` is True only when a token
+    was validated — the policy engine uses it to decide whether to enforce.
+    """
+
+    subject: str
+    role: str
+    workspace_id: Optional[str]
+    authenticated: bool
+
+
+# Anonymous principal used when auth is disabled. authenticated=False signals the
+# policy engine NOT to enforce, which reproduces the pre-auth behavior.
+ANONYMOUS = Principal(
+    subject="anonymous", role="user", workspace_id=None, authenticated=False
+)
+
+
+# --------------------------------------------------------------------------- #
+# Token codec (stdlib HMAC — payload_b64.signature_b64)
+# --------------------------------------------------------------------------- #
+
+def _b64e(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64d(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+
+
+def issue_token(
+    secret: str,
+    *,
+    subject: str,
+    role: str,
+    workspace_id: Optional[str] = None,
+    ttl_seconds: int = 3600,
+    now: Optional[float] = None,
+) -> str:
+    """Issue an HMAC-signed compact token. Used by token issuers and tests."""
+    if role not in VALID_ROLES:
+        raise ValueError(f"invalid role: {role!r} (expected one of {VALID_ROLES})")
+    issued = now if now is not None else time.time()
+    payload = {
+        "sub": subject,
+        "role": role,
+        "ws": workspace_id,
+        "exp": int(issued + ttl_seconds),
+    }
+    payload_b64 = _b64e(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    sig = _b64e(hmac.new(secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest())
+    return f"{payload_b64}.{sig}"
+
+
+def verify_token(token: str, secret: str, *, now: Optional[float] = None) -> Principal:
+    """Verify an HMAC-signed token and return the :class:`Principal`.
+
+    Raises :class:`AuthError` on any malformed/tampered/expired token.
+    """
+    parts = token.split(".")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise AuthError("malformed token")
+    payload_b64, sig = parts
+    expected = _b64e(
+        hmac.new(secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest()
+    )
+    # constant-time comparison — never short-circuit on signature mismatch
+    if not hmac.compare_digest(sig, expected):
+        raise AuthError("bad token signature")
+    try:
+        payload = json.loads(_b64d(payload_b64))
+    except Exception as exc:  # noqa: BLE001 — any decode failure is an auth failure
+        raise AuthError("malformed token payload") from exc
+    exp = payload.get("exp")
+    current = now if now is not None else time.time()
+    if exp is not None and current > exp:
+        raise AuthError("token expired")
+    role = payload.get("role")
+    if role not in VALID_ROLES:
+        raise AuthError(f"invalid role in token: {role!r}")
+    subject = payload.get("sub")
+    if not subject:
+        raise AuthError("token missing subject")
+    return Principal(
+        subject=str(subject),
+        role=role,
+        workspace_id=payload.get("ws"),
+        authenticated=True,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Mode resolution
+# --------------------------------------------------------------------------- #
+
+def auth_mode() -> str:
+    return (os.getenv("SEOCHO_AUTH_MODE", "none").strip().lower() or "none")
+
+
+def resolve_principal(
+    authorization: Optional[str],
+    *,
+    mode: Optional[str] = None,
+    secret: Optional[str] = None,
+    now: Optional[float] = None,
+) -> Principal:
+    """Resolve the principal for a request from its Authorization header.
+
+    ``none`` -> anonymous. ``token`` -> validated bearer token. Raises
+    :class:`AuthError` (HTTP 401) when token mode is on and the token is
+    missing/invalid, or when token mode is misconfigured (no secret).
+    """
+    mode = (mode or auth_mode())
+    if mode == "none":
+        return ANONYMOUS
+    if mode == "token":
+        secret = secret if secret is not None else os.getenv("SEOCHO_AUTH_SECRET", "")
+        if not secret:
+            raise AuthError("SEOCHO_AUTH_MODE=token but SEOCHO_AUTH_SECRET is unset")
+        if not authorization or not authorization.startswith("Bearer "):
+            raise AuthError("missing bearer token")
+        return verify_token(authorization[len("Bearer "):].strip(), secret, now=now)
+    raise AuthError(f"unknown SEOCHO_AUTH_MODE: {mode!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Per-request principal (ContextVar — mirrors RequestIDMiddleware)
+# --------------------------------------------------------------------------- #
+
+_principal_var: ContextVar[Principal] = ContextVar("seocho_principal", default=ANONYMOUS)
+
+
+def get_principal() -> Principal:
+    """Return the principal for the current request (anonymous outside one)."""
+    return _principal_var.get()
+
+
+class PrincipalMiddleware(BaseHTTPMiddleware):
+    """Resolve the principal once per request and bind it to the ContextVar.
+
+    On token mode, an invalid/missing token short-circuits to HTTP 401 before
+    the endpoint runs. On ``none`` mode this is a near no-op (anonymous).
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        try:
+            principal = resolve_principal(request.headers.get("Authorization"))
+        except AuthError as exc:
+            return JSONResponse(
+                status_code=401,
+                content={"error": {"error_code": "AuthError", "message": str(exc)}},
+            )
+        token = _principal_var.set(principal)
+        request.state.principal = principal
+        try:
+            return await call_next(request)
+        finally:
+            _principal_var.reset(token)

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -1,20 +1,50 @@
 """
-Runtime policy helpers for agent execution.
+Runtime policy: role-based authorization + workspace-ownership enforcement.
 
 Design notes:
-- MVP is single-tenant, but all runtime calls must carry workspace_id.
-- Authorization in hot path is app-level RBAC/ABAC.
-- owlready2-style ontology reasoning is intentionally excluded from hot path.
+- ``workspace_id`` must accompany every runtime call (format-validated).
+- The effective role comes from the **authenticated principal**
+  (:mod:`runtime.identity`), not from the caller. When authentication is
+  disabled (``SEOCHO_AUTH_MODE=none`` → anonymous, ``authenticated=False``),
+  ``require_runtime_permission`` only validates the ``workspace_id`` format and
+  does not enforce role/ownership — this reproduces the pre-auth behaviour, so
+  existing callers and tests are unaffected.
+- When the principal is authenticated, two checks apply: (1) the role must be
+  permitted for the action, and (2) **workspace ownership** — a principal
+  scoped to a workspace may only act on that workspace; ``admin`` is the
+  cross-workspace operator and is exempt. (2) closes the IDOR class where any
+  caller could pass any ``workspace_id``.
+- owlready2-style ontology reasoning stays out of the hot path.
+
+The permission matrix below is deliberately **behaviour-compatible**: the
+``user`` set keeps every action that was previously gated as the hardcoded
+"user", so turning auth on does not silently lock out existing flows. ``admin``
+is a strict superset; ``viewer`` is genuinely read-only. Tightening governance
+actions (rule-profile/export/semantic-artifact management) to admin-only is a
+recommended follow-up that needs product input, so it is NOT baked in here.
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Dict, Set
+from typing import Dict, Optional, Set
+
+from runtime.identity import Principal, get_principal
 
 
 _WORKSPACE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{1,63}$")
+
+# Actions that were previously gated as the hardcoded "user" role. Keeping the
+# user set equal to this preserves behaviour when auth is enabled.
+_OPERATIONAL: Set[str] = {
+    "run_agent", "run_debate", "read_databases", "read_agents",
+    "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles",
+    "export_rules", "manage_indexes", "run_platform", "ingest_raw",
+    "manage_semantic_artifacts", "manage_memories",
+}
+# Reserved for cross-tenant / policy operations — admin only.
+_ADMIN_ONLY: Set[str] = {"manage_tenants", "manage_policy"}
 
 
 @dataclass(frozen=True)
@@ -24,20 +54,12 @@ class PolicyDecision:
 
 
 class RuntimePolicyEngine:
-    """Simple runtime policy engine for MVP."""
+    """Role-based authorization with workspace-ownership enforcement."""
 
     def __init__(self):
         self._role_permissions: Dict[str, Set[str]] = {
-            "admin": {
-                "run_agent", "run_debate", "read_databases", "read_agents",
-                "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "export_rules",
-                "manage_indexes", "run_platform", "ingest_raw", "manage_semantic_artifacts", "manage_memories",
-            },
-            "user": {
-                "run_agent", "run_debate", "read_databases", "read_agents",
-                "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "export_rules",
-                "manage_indexes", "run_platform", "ingest_raw", "manage_semantic_artifacts", "manage_memories",
-            },
+            "admin": _OPERATIONAL | _ADMIN_ONLY,   # strict superset
+            "user": set(_OPERATIONAL),
             "viewer": {"read_databases", "read_agents"},
         }
 
@@ -48,18 +70,65 @@ class RuntimePolicyEngine:
             return PolicyDecision(False, "invalid workspace_id format")
         return PolicyDecision(True, "ok")
 
-    def authorize(self, role: str, action: str, workspace_id: str) -> PolicyDecision:
+    def authorize(
+        self,
+        role: str,
+        action: str,
+        workspace_id: str,
+        *,
+        principal_workspace: Optional[str] = None,
+    ) -> PolicyDecision:
         ws = self.validate_workspace_id(workspace_id)
         if not ws.allowed:
             return ws
-        allowed_actions = self._role_permissions.get(role, set())
-        if action not in allowed_actions:
+        if action not in self._role_permissions.get(role, set()):
             return PolicyDecision(False, f"role '{role}' not allowed for action '{action}'")
+        # Workspace ownership: a scoped principal may only act on its own
+        # workspace. admin is the cross-workspace operator and is exempt.
+        if (
+            principal_workspace is not None
+            and role != "admin"
+            and workspace_id != principal_workspace
+        ):
+            return PolicyDecision(
+                False,
+                f"principal scoped to workspace '{principal_workspace}' "
+                f"may not act on '{workspace_id}'",
+            )
         return PolicyDecision(True, "ok")
 
 
-def require_runtime_permission(role: str, action: str, workspace_id: str) -> None:
-    decision = RuntimePolicyEngine().authorize(role=role, action=action, workspace_id=workspace_id)
+def require_runtime_permission(
+    action: str,
+    workspace_id: str,
+    *,
+    role: Optional[str] = None,  # legacy/ignored: effective role comes from the principal
+    principal: Optional[Principal] = None,
+) -> None:
+    """Enforce that the current principal may perform ``action`` on ``workspace_id``.
+
+    Raises :class:`PermissionError` (mapped to HTTP 403 by the server) on denial.
+    The ``role`` keyword is accepted for backward compatibility with existing
+    call sites but is ignored — the effective role is taken from the
+    authenticated principal.
+    """
+    principal = principal if principal is not None else get_principal()
+    engine = RuntimePolicyEngine()
+
+    if not principal.authenticated:
+        # Auth disabled / anonymous: preserve pre-auth behaviour — validate the
+        # workspace_id format only; do not enforce role or ownership.
+        decision = engine.validate_workspace_id(workspace_id)
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        return
+
+    decision = engine.authorize(
+        role=principal.role,
+        action=action,
+        workspace_id=workspace_id,
+        principal_workspace=principal.workspace_id,
+    )
     if not decision.allowed:
         raise PermissionError(decision.reason)
 

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -30,6 +30,7 @@ import re
 from dataclasses import dataclass
 from typing import Dict, Optional, Set
 
+from runtime.audit import record_access
 from runtime.identity import Principal, get_principal
 
 
@@ -119,16 +120,25 @@ def require_runtime_permission(
         # Auth disabled / anonymous: preserve pre-auth behaviour — validate the
         # workspace_id format only; do not enforce role or ownership.
         decision = engine.validate_workspace_id(workspace_id)
-        if not decision.allowed:
-            raise PermissionError(decision.reason)
-        return
+    else:
+        decision = engine.authorize(
+            role=principal.role,
+            action=action,
+            workspace_id=workspace_id,
+            principal_workspace=principal.workspace_id,
+        )
 
-    decision = engine.authorize(
-        role=principal.role,
+    # Audit every decision at the single enforcement point (no-op unless
+    # SEOCHO_AUDIT_LOG_PATH is configured). Auditing must never take down the
+    # request path, so record_access swallows its own I/O errors.
+    record_access(
         action=action,
         workspace_id=workspace_id,
-        principal_workspace=principal.workspace_id,
+        allowed=decision.allowed,
+        reason=decision.reason,
+        principal=principal,
     )
+
     if not decision.allowed:
         raise PermissionError(decision.reason)
 

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -50,6 +50,7 @@ python3 -m py_compile \
 uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
   extraction/tests/test_identity.py \
+  extraction/tests/test_policy.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -69,6 +69,7 @@ uv run pytest \
   tests/seocho/test_client_boundaries.py \
   tests/seocho/test_runtime_bundle.py \
   tests/seocho/test_internal_design_seams.py \
+  tests/seocho/test_query_proxy_workspace_enforcement.py \
   tests/seocho/test_ontology_context.py \
   tests/seocho/test_session_agent.py \
   tests/seocho/test_user_facing_edge_cases.py \

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 python3 -m py_compile \
   runtime/__init__.py \
   runtime/policy.py \
+  runtime/identity.py \
   runtime/agent_readiness.py \
   runtime/middleware.py \
   runtime/memory_service.py \
@@ -48,6 +49,7 @@ python3 -m py_compile \
 
 uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
+  extraction/tests/test_identity.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -5,6 +5,7 @@ python3 -m py_compile \
   runtime/__init__.py \
   runtime/policy.py \
   runtime/identity.py \
+  runtime/audit.py \
   runtime/agent_readiness.py \
   runtime/middleware.py \
   runtime/memory_service.py \
@@ -51,6 +52,7 @@ uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
   extraction/tests/test_identity.py \
   extraction/tests/test_policy.py \
+  extraction/tests/test_audit.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \

--- a/src/seocho/query/query_proxy.py
+++ b/src/seocho/query/query_proxy.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Protocol
 
 from seocho.events import DomainEvent, EventPublisher, NullEventPublisher
+
+
+def _env_enforce_workspace_filter() -> bool:
+    """Default for tenant-isolation enforcement at the query boundary.
+
+    Off by default (preserves behaviour); multi-tenant deployments set
+    ``SEOCHO_ENFORCE_WORKSPACE_FILTER=1`` to make the runtime refuse any query
+    whose Cypher does not scope to ``$workspace_id``.
+    """
+    return os.getenv("SEOCHO_ENFORCE_WORKSPACE_FILTER", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
 
 
 class QueryPolicy(Protocol):
@@ -132,10 +145,17 @@ class QueryProxy:
         *,
         publisher: Optional[EventPublisher] = None,
         policy: Optional[QueryPolicy] = None,
+        enforce_workspace_filter: Optional[bool] = None,
     ) -> None:
         self._graph_store = graph_store
         self._publisher = publisher or NullEventPublisher()
         self._policy = policy or NullQueryPolicy()
+        # None -> take the deployment default from the environment.
+        self._enforce_workspace_filter = (
+            _env_enforce_workspace_filter()
+            if enforce_workspace_filter is None
+            else enforce_workspace_filter
+        )
 
     def query(self, request: QueryRequest) -> list[Dict[str, Any]]:
         params = dict(request.params or {})
@@ -147,11 +167,24 @@ class QueryProxy:
             params=params,
         )
         try:
-            raw_records = self._graph_store.query(
-                request.cypher,
-                params=params,
-                database=request.database,
-            )
+            if self._enforce_workspace_filter:
+                # Tenant-isolation enforced: thread workspace_id (auto-merged
+                # into params by the store) and refuse Cypher that doesn't scope
+                # to $workspace_id. Only passed when enabled so the default path
+                # keeps the exact call shape backends/test-doubles already accept.
+                raw_records = self._graph_store.query(
+                    request.cypher,
+                    params=params,
+                    database=request.database,
+                    workspace_id=request.workspace_id,
+                    enforce_workspace_filter=True,
+                )
+            else:
+                raw_records = self._graph_store.query(
+                    request.cypher,
+                    params=params,
+                    database=request.database,
+                )
             records = coerce_query_records(
                 raw_records,
                 database=request.database,

--- a/tests/seocho/test_query_proxy_workspace_enforcement.py
+++ b/tests/seocho/test_query_proxy_workspace_enforcement.py
@@ -1,0 +1,81 @@
+"""Fitness function for tenant isolation at the runtime query boundary (seocho-a6d).
+
+Pins two invariants:
+1. Default (enforcement off): QueryProxy calls the store with the exact, narrow
+   signature backends/test-doubles already accept — no behaviour change.
+2. Enforcement on: QueryProxy threads workspace_id and enforce_workspace_filter
+   to the store, so a query whose Cypher does not scope to $workspace_id is
+   refused. This makes tenant isolation a single deployment flag
+   (SEOCHO_ENFORCE_WORKSPACE_FILTER) rather than a per-call opt-in nobody used.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.query.query_proxy import QueryProxy, QueryRequest
+
+
+class _WorkspaceFilterMissing(RuntimeError):
+    pass
+
+
+class _StrictStore:
+    """Mimics a backend that ONLY accepts the narrow query signature.
+
+    If QueryProxy passed workspace_id / enforce_workspace_filter on the default
+    path, this would raise TypeError — that's the regression guard.
+    """
+
+    def query(self, cypher, *, params=None, database="neo4j"):
+        return [{"ok": True}]
+
+
+class _EnforcingStore:
+    """Mimics Neo4jGraphStore.query: accepts the isolation kwargs and refuses
+    Cypher that doesn't reference $workspace_id when enforcement is requested."""
+
+    def __init__(self):
+        self.calls = []
+
+    def query(self, cypher, *, params=None, database="neo4j",
+              workspace_id=None, enforce_workspace_filter=False):
+        self.calls.append({
+            "cypher": cypher, "workspace_id": workspace_id,
+            "enforce_workspace_filter": enforce_workspace_filter,
+        })
+        if enforce_workspace_filter and "$workspace_id" not in cypher:
+            raise _WorkspaceFilterMissing("cypher must reference $workspace_id")
+        return [{"ok": True}]
+
+
+def _req(cypher):
+    return QueryRequest(cypher=cypher, workspace_id="acme", database="neo4j")
+
+
+def test_default_off_uses_narrow_signature():
+    proxy = QueryProxy(_StrictStore(), enforce_workspace_filter=False)
+    # Must not raise TypeError — i.e. no extra kwargs leak to the backend.
+    assert proxy.query(_req("MATCH (n) RETURN n")) == [{"ok": True}]
+
+
+def test_enforcement_threads_workspace_and_flag():
+    store = _EnforcingStore()
+    proxy = QueryProxy(store, enforce_workspace_filter=True)
+    proxy.query(_req("MATCH (n) WHERE n._workspace_id = $workspace_id RETURN n"))
+    assert store.calls[-1]["workspace_id"] == "acme"
+    assert store.calls[-1]["enforce_workspace_filter"] is True
+
+
+def test_enforcement_refuses_unscoped_cypher():
+    proxy = QueryProxy(_EnforcingStore(), enforce_workspace_filter=True)
+    with pytest.raises(_WorkspaceFilterMissing):
+        proxy.query(_req("MATCH (n) RETURN n"))
+
+
+def test_default_taken_from_env(monkeypatch):
+    monkeypatch.setenv("SEOCHO_ENFORCE_WORKSPACE_FILTER", "1")
+    proxy = QueryProxy(_EnforcingStore())  # no explicit flag -> env default
+    assert proxy._enforce_workspace_filter is True
+    monkeypatch.setenv("SEOCHO_ENFORCE_WORKSPACE_FILTER", "0")
+    assert QueryProxy(_StrictStore())._enforce_workspace_filter is False


### PR DESCRIPTION
## What
Wires the store's dormant `enforce_workspace_filter` safety net to the runtime query boundary (`QueryProxy`) behind `SEOCHO_ENFORCE_WORKSPACE_FILTER`, plus a fitness-function test.

> Stacked on #223 → #222 → #221. Base is `feat/access-audit-log`; retarget to main after parents merge.

## Why
`enforce_workspace_filter` existed on the store but **no caller ever passed it** — tenant isolation was opt-in and nobody opted in. This makes it a single deployment flag instead of a dead per-call argument.

## How (strangler-safe)
- `QueryProxy(enforce_workspace_filter=None)` → env default (`SEOCHO_ENFORCE_WORKSPACE_FILTER`, **off** by default). When on, it threads `workspace_id` + `enforce_workspace_filter=True` so any query whose Cypher doesn't scope to `$workspace_id` is refused.
- The new kwargs are passed **only when enforcement is on**, so the default path keeps the exact narrow call shape backends/test-doubles already accept → **zero behaviour change by default, no test breakage**.

## Fitness function
`test_query_proxy_workspace_enforcement.py`: default-off uses the narrow signature (guards against kwarg leakage), enforcement threads workspace_id + flag, refuses unscoped Cypher, env default honored.

## Scope note (honest)
**Flipping the default ON repo-wide is deliberately NOT done here** — it needs a live-DB pass auditing every runtime query template to reference `$workspace_id`, which can't be validated offline. The IDOR is already closed at the authorization layer by the workspace-ownership check in #222; this is **defense-in-depth** at the data plane, available via one flag. `run_basic_ci.sh` green (429).