### PR TITLE
feat(runtime): enterprise auth stack — RBAC + audit + tenant isolation (seocho-8uy/bk0/a6d)

### DIFF
--- a/extraction/tests/test_audit.py
+++ b/extraction/tests/test_audit.py
@@ -1,0 +1,80 @@
+"""Tests for the access-decision audit log (seocho-bk0)."""
+
+import json
+
+import pytest
+
+from runtime.audit import build_event, record_access
+from runtime.identity import ANONYMOUS, Principal
+from runtime.policy import require_runtime_permission
+
+USER = Principal(subject="alice", role="user", workspace_id="acme", authenticated=True)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def test_build_event_allow_and_deny():
+    allow = build_event(
+        principal=USER, action="run_agent", workspace_id="acme",
+        allowed=True, reason="ok", request_id="req-1", ts=1234.0,
+    )
+    assert allow == {
+        "ts": 1234.0, "request_id": "req-1", "subject": "alice", "role": "user",
+        "authenticated": True, "workspace_id": "acme", "action": "run_agent",
+        "decision": "allow", "reason": "ok",
+    }
+    deny = build_event(
+        principal=USER, action="run_agent", workspace_id="other",
+        allowed=False, reason="cross-tenant", request_id="", ts=1.0,
+    )
+    assert deny["decision"] == "deny" and deny["reason"] == "cross-tenant"
+
+
+def test_record_access_noop_when_unconfigured(tmp_path, monkeypatch):
+    monkeypatch.delenv("SEOCHO_AUDIT_LOG_PATH", raising=False)
+    target = tmp_path / "audit.jsonl"
+    record_access(action="run_agent", workspace_id="acme", allowed=True, principal=USER)
+    assert not target.exists()  # default is no-op
+
+
+def test_record_access_writes_and_appends(tmp_path):
+    path = str(tmp_path / "audit.jsonl")
+    record_access(action="run_agent", workspace_id="acme", allowed=True,
+                  reason="ok", principal=USER, request_id="r1", path=path, now=1.0)
+    record_access(action="run_debate", workspace_id="other", allowed=False,
+                  reason="denied", principal=USER, request_id="r2", path=path, now=2.0)
+    events = _read(path)
+    assert len(events) == 2
+    assert events[0]["decision"] == "allow" and events[0]["action"] == "run_agent"
+    assert events[1]["decision"] == "deny" and events[1]["request_id"] == "r2"
+    assert events[1]["subject"] == "alice"
+
+
+def test_record_access_write_failure_does_not_raise():
+    # An unwritable path must be swallowed (auditing can't take down requests).
+    record_access(action="x", workspace_id="acme", allowed=True,
+                  principal=USER, path="/this/dir/does/not/exist/audit.jsonl")
+
+
+def test_require_permission_audit_integration(tmp_path, monkeypatch):
+    path = str(tmp_path / "audit.jsonl")
+    monkeypatch.setenv("SEOCHO_AUDIT_LOG_PATH", path)
+    viewer = Principal(subject="v", role="viewer", workspace_id=None, authenticated=True)
+    user = Principal(subject="u", role="user", workspace_id=None, authenticated=True)
+
+    # allowed action -> recorded as allow, no raise
+    require_runtime_permission(action="read_databases", workspace_id="acme", principal=viewer)
+    # denied action -> recorded as deny, then raises
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_debate", workspace_id="acme", principal=viewer)
+    # allowed for a normal user too
+    require_runtime_permission(action="run_agent", workspace_id="acme", principal=user)
+
+    events = _read(path)
+    decisions = [(e["subject"], e["action"], e["decision"]) for e in events]
+    assert ("v", "read_databases", "allow") in decisions
+    assert ("v", "run_debate", "deny") in decisions
+    assert ("u", "run_agent", "allow") in decisions

--- a/extraction/tests/test_policy.py
+++ b/extraction/tests/test_policy.py
@@ -1,6 +1,11 @@
 import pytest
 
-from runtime.policy import RuntimePolicyEngine, require_runtime_permission, run_offline_ontology_reasoning
+from runtime.identity import ANONYMOUS, Principal
+from runtime.policy import (
+    RuntimePolicyEngine,
+    require_runtime_permission,
+    run_offline_ontology_reasoning,
+)
 
 
 def test_workspace_id_validation():
@@ -13,30 +18,76 @@ def test_workspace_id_validation():
 
 def test_authorize_runtime_action():
     engine = RuntimePolicyEngine()
-    allowed = engine.authorize(role="user", action="run_agent", workspace_id="default")
-    allowed_manage_index = engine.authorize(role="user", action="manage_indexes", workspace_id="default")
-    allowed_platform = engine.authorize(role="user", action="run_platform", workspace_id="default")
-    allowed_assess_rules = engine.authorize(role="user", action="assess_rules", workspace_id="default")
-    allowed_semantic_artifacts = engine.authorize(
-        role="user", action="manage_semantic_artifacts", workspace_id="default"
-    )
-    allowed_memories = engine.authorize(role="user", action="manage_memories", workspace_id="default")
-    denied = engine.authorize(role="viewer", action="run_debate", workspace_id="default")
-
-    assert allowed.allowed is True
-    assert allowed_manage_index.allowed is True
-    assert allowed_platform.allowed is True
-    assert allowed_assess_rules.allowed is True
-    assert allowed_semantic_artifacts.allowed is True
-    assert allowed_memories.allowed is True
-    assert denied.allowed is False
+    assert engine.authorize(role="user", action="run_agent", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_indexes", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="run_platform", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="assess_rules", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_semantic_artifacts", workspace_id="default").allowed
+    assert engine.authorize(role="user", action="manage_memories", workspace_id="default").allowed
+    # viewer is genuinely read-only
+    assert engine.authorize(role="viewer", action="run_debate", workspace_id="default").allowed is False
+    assert engine.authorize(role="viewer", action="read_databases", workspace_id="default").allowed
 
 
-def test_require_runtime_permission_raises():
+def test_admin_is_strict_superset_of_user():
+    engine = RuntimePolicyEngine()
+    # admin-only action denied for user, allowed for admin
+    assert engine.authorize(role="user", action="manage_tenants", workspace_id="default").allowed is False
+    assert engine.authorize(role="admin", action="manage_tenants", workspace_id="default").allowed
+    # everything a user can do, admin can do
+    assert engine.authorize(role="admin", action="run_agent", workspace_id="default").allowed
+
+
+def test_workspace_ownership_blocks_cross_tenant():
+    engine = RuntimePolicyEngine()
+    # a user scoped to ws "acme" may act on acme...
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="acme", principal_workspace="acme"
+    ).allowed
+    # ...but not on another workspace (IDOR closed)
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="other", principal_workspace="acme"
+    ).allowed is False
+    # admin is the cross-workspace operator and is exempt
+    assert engine.authorize(
+        role="admin", action="run_agent", workspace_id="other", principal_workspace="acme"
+    ).allowed
+    # unconstrained principal (workspace=None) may act on any workspace
+    assert engine.authorize(
+        role="user", action="run_agent", workspace_id="other", principal_workspace=None
+    ).allowed
+
+
+def test_require_permission_anonymous_does_not_enforce():
+    # Auth disabled (anonymous, authenticated=False): role/ownership NOT enforced
+    # — reproduces pre-auth behavior. A viewer-denied action does not raise.
+    require_runtime_permission(action="run_debate", workspace_id="default", principal=ANONYMOUS)
+
+
+def test_require_permission_anonymous_still_validates_workspace_format():
     with pytest.raises(PermissionError):
-        require_runtime_permission(role="viewer", action="run_debate", workspace_id="default")
+        require_runtime_permission(action="run_agent", workspace_id="1invalid", principal=ANONYMOUS)
+
+
+def test_require_permission_authenticated_viewer_denied():
+    viewer = Principal(subject="v", role="viewer", workspace_id=None, authenticated=True)
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_debate", workspace_id="default", principal=viewer)
+
+
+def test_require_permission_authenticated_user_allowed():
+    user = Principal(subject="u", role="user", workspace_id=None, authenticated=True)
+    require_runtime_permission(action="run_agent", workspace_id="default", principal=user)
+
+
+def test_require_permission_workspace_ownership_enforced():
+    scoped = Principal(subject="u", role="user", workspace_id="acme", authenticated=True)
+    # own workspace: ok
+    require_runtime_permission(action="run_agent", workspace_id="acme", principal=scoped)
+    # cross-workspace: blocked
+    with pytest.raises(PermissionError):
+        require_runtime_permission(action="run_agent", workspace_id="other", principal=scoped)
 
 
 def test_offline_reasoning_placeholder_noop():
-    # Must be callable and side-effect free in current implementation.
     assert run_offline_ontology_reasoning() is None

--- a/runtime/audit.py
+++ b/runtime/audit.py
@@ -1,0 +1,103 @@
+"""Append-only audit log of runtime access decisions.
+
+Vendor-neutral and **opt-in**, mirroring the tracing contract: events are
+written as JSON Lines to the path in ``SEOCHO_AUDIT_LOG_PATH``; when that env
+var is unset (the default), :func:`record_access` is a no-op, so existing
+deployments are unaffected.
+
+Each event captures *who* (principal subject/role/authenticated), *what*
+(action), *where* (workspace_id), the *decision* (allow/deny) and *reason*, and
+the correlating ``request_id`` — the who-did-what trail enterprises require for
+regulated data.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from runtime.identity import Principal, get_principal
+
+logger = logging.getLogger(__name__)
+
+_write_lock = threading.Lock()
+
+
+def audit_log_path() -> Optional[str]:
+    """Return the configured audit log path, or None when auditing is disabled."""
+    path = os.getenv("SEOCHO_AUDIT_LOG_PATH", "").strip()
+    return path or None
+
+
+def build_event(
+    *,
+    principal: Principal,
+    action: str,
+    workspace_id: str,
+    allowed: bool,
+    reason: str,
+    request_id: str,
+    ts: float,
+) -> Dict[str, Any]:
+    """Build the audit event record (pure — separated for testability)."""
+    return {
+        "ts": ts,
+        "request_id": request_id,
+        "subject": principal.subject,
+        "role": principal.role,
+        "authenticated": principal.authenticated,
+        "workspace_id": workspace_id,
+        "action": action,
+        "decision": "allow" if allowed else "deny",
+        "reason": reason,
+    }
+
+
+def record_access(
+    *,
+    action: str,
+    workspace_id: str,
+    allowed: bool,
+    reason: str = "",
+    principal: Optional[Principal] = None,
+    request_id: Optional[str] = None,
+    path: Optional[str] = None,
+    now: Optional[float] = None,
+) -> None:
+    """Append one access-decision event to the audit log, if auditing is enabled.
+
+    No-op when ``SEOCHO_AUDIT_LOG_PATH`` is unset (and no explicit ``path`` is
+    given). A write failure is logged, never raised — auditing must not take
+    down the request path (the caller still enforces the decision separately).
+    """
+    path = path if path is not None else audit_log_path()
+    if not path:
+        return
+    principal = principal if principal is not None else get_principal()
+    if request_id is None:
+        try:
+            from runtime.middleware import get_request_id
+
+            request_id = get_request_id()
+        except Exception:  # noqa: BLE001 — request_id is best-effort context
+            request_id = ""
+    event = build_event(
+        principal=principal,
+        action=action,
+        workspace_id=workspace_id,
+        allowed=allowed,
+        reason=reason,
+        request_id=request_id or "",
+        ts=now if now is not None else time.time(),
+    )
+    line = json.dumps(event, separators=(",", ":"), sort_keys=True)
+    try:
+        with _write_lock:
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+    except OSError as exc:
+        logger.warning("audit log write failed (%s): %s", path, exc)

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -1,20 +1,50 @@
 """
-Runtime policy helpers for agent execution.
+Runtime policy: role-based authorization + workspace-ownership enforcement.
 
 Design notes:
-- MVP is single-tenant, but all runtime calls must carry workspace_id.
-- Authorization in hot path is app-level RBAC/ABAC.
-- owlready2-style ontology reasoning is intentionally excluded from hot path.
+- ``workspace_id`` must accompany every runtime call (format-validated).
+- The effective role comes from the **authenticated principal**
+  (:mod:`runtime.identity`), not from the caller. When authentication is
+  disabled (``SEOCHO_AUTH_MODE=none`` → anonymous, ``authenticated=False``),
+  ``require_runtime_permission`` only validates the ``workspace_id`` format and
+  does not enforce role/ownership — this reproduces the pre-auth behaviour, so
+  existing callers and tests are unaffected.
+- When the principal is authenticated, two checks apply: (1) the role must be
+  permitted for the action, and (2) **workspace ownership** — a principal
+  scoped to a workspace may only act on that workspace; ``admin`` is the
+  cross-workspace operator and is exempt. (2) closes the IDOR class where any
+  caller could pass any ``workspace_id``.
+- owlready2-style ontology reasoning stays out of the hot path.
+
+The permission matrix below is deliberately **behaviour-compatible**: the
+``user`` set keeps every action that was previously gated as the hardcoded
+"user", so turning auth on does not silently lock out existing flows. ``admin``
+is a strict superset; ``viewer`` is genuinely read-only. Tightening governance
+actions (rule-profile/export/semantic-artifact management) to admin-only is a
+recommended follow-up that needs product input, so it is NOT baked in here.
 """
 
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Dict, Set
+from typing import Dict, Optional, Set
+
+from runtime.identity import Principal, get_principal
 
 
 _WORKSPACE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{1,63}$")
+
+# Actions that were previously gated as the hardcoded "user" role. Keeping the
+# user set equal to this preserves behaviour when auth is enabled.
+_OPERATIONAL: Set[str] = {
+    "run_agent", "run_debate", "read_databases", "read_agents",
+    "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles",
+    "export_rules", "manage_indexes", "run_platform", "ingest_raw",
+    "manage_semantic_artifacts", "manage_memories",
+}
+# Reserved for cross-tenant / policy operations — admin only.
+_ADMIN_ONLY: Set[str] = {"manage_tenants", "manage_policy"}
 
 
 @dataclass(frozen=True)
@@ -24,20 +54,12 @@ class PolicyDecision:
 
 
 class RuntimePolicyEngine:
-    """Simple runtime policy engine for MVP."""
+    """Role-based authorization with workspace-ownership enforcement."""
 
     def __init__(self):
         self._role_permissions: Dict[str, Set[str]] = {
-            "admin": {
-                "run_agent", "run_debate", "read_databases", "read_agents",
-                "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "export_rules",
-                "manage_indexes", "run_platform", "ingest_raw", "manage_semantic_artifacts", "manage_memories",
-            },
-            "user": {
-                "run_agent", "run_debate", "read_databases", "read_agents",
-                "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "export_rules",
-                "manage_indexes", "run_platform", "ingest_raw", "manage_semantic_artifacts", "manage_memories",
-            },
+            "admin": _OPERATIONAL | _ADMIN_ONLY,   # strict superset
+            "user": set(_OPERATIONAL),
             "viewer": {"read_databases", "read_agents"},
         }
 
@@ -48,18 +70,65 @@ class RuntimePolicyEngine:
             return PolicyDecision(False, "invalid workspace_id format")
         return PolicyDecision(True, "ok")
 
-    def authorize(self, role: str, action: str, workspace_id: str) -> PolicyDecision:
+    def authorize(
+        self,
+        role: str,
+        action: str,
+        workspace_id: str,
+        *,
+        principal_workspace: Optional[str] = None,
+    ) -> PolicyDecision:
         ws = self.validate_workspace_id(workspace_id)
         if not ws.allowed:
             return ws
-        allowed_actions = self._role_permissions.get(role, set())
-        if action not in allowed_actions:
+        if action not in self._role_permissions.get(role, set()):
             return PolicyDecision(False, f"role '{role}' not allowed for action '{action}'")
+        # Workspace ownership: a scoped principal may only act on its own
+        # workspace. admin is the cross-workspace operator and is exempt.
+        if (
+            principal_workspace is not None
+            and role != "admin"
+            and workspace_id != principal_workspace
+        ):
+            return PolicyDecision(
+                False,
+                f"principal scoped to workspace '{principal_workspace}' "
+                f"may not act on '{workspace_id}'",
+            )
         return PolicyDecision(True, "ok")
 
 
-def require_runtime_permission(role: str, action: str, workspace_id: str) -> None:
-    decision = RuntimePolicyEngine().authorize(role=role, action=action, workspace_id=workspace_id)
+def require_runtime_permission(
+    action: str,
+    workspace_id: str,
+    *,
+    role: Optional[str] = None,  # legacy/ignored: effective role comes from the principal
+    principal: Optional[Principal] = None,
+) -> None:
+    """Enforce that the current principal may perform ``action`` on ``workspace_id``.
+
+    Raises :class:`PermissionError` (mapped to HTTP 403 by the server) on denial.
+    The ``role`` keyword is accepted for backward compatibility with existing
+    call sites but is ignored — the effective role is taken from the
+    authenticated principal.
+    """
+    principal = principal if principal is not None else get_principal()
+    engine = RuntimePolicyEngine()
+
+    if not principal.authenticated:
+        # Auth disabled / anonymous: preserve pre-auth behaviour — validate the
+        # workspace_id format only; do not enforce role or ownership.
+        decision = engine.validate_workspace_id(workspace_id)
+        if not decision.allowed:
+            raise PermissionError(decision.reason)
+        return
+
+    decision = engine.authorize(
+        role=principal.role,
+        action=action,
+        workspace_id=workspace_id,
+        principal_workspace=principal.workspace_id,
+    )
     if not decision.allowed:
         raise PermissionError(decision.reason)
 

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -30,6 +30,7 @@ import re
 from dataclasses import dataclass
 from typing import Dict, Optional, Set
 
+from runtime.audit import record_access
 from runtime.identity import Principal, get_principal
 
 
@@ -119,16 +120,25 @@ def require_runtime_permission(
         # Auth disabled / anonymous: preserve pre-auth behaviour — validate the
         # workspace_id format only; do not enforce role or ownership.
         decision = engine.validate_workspace_id(workspace_id)
-        if not decision.allowed:
-            raise PermissionError(decision.reason)
-        return
+    else:
+        decision = engine.authorize(
+            role=principal.role,
+            action=action,
+            workspace_id=workspace_id,
+            principal_workspace=principal.workspace_id,
+        )
 
-    decision = engine.authorize(
-        role=principal.role,
+    # Audit every decision at the single enforcement point (no-op unless
+    # SEOCHO_AUDIT_LOG_PATH is configured). Auditing must never take down the
+    # request path, so record_access swallows its own I/O errors.
+    record_access(
         action=action,
         workspace_id=workspace_id,
-        principal_workspace=principal.workspace_id,
+        allowed=decision.allowed,
+        reason=decision.reason,
+        principal=principal,
     )
+
     if not decision.allowed:
         raise PermissionError(decision.reason)
 

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -50,6 +50,7 @@ python3 -m py_compile \
 uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
   extraction/tests/test_identity.py \
+  extraction/tests/test_policy.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -69,6 +69,7 @@ uv run pytest \
   tests/seocho/test_client_boundaries.py \
   tests/seocho/test_runtime_bundle.py \
   tests/seocho/test_internal_design_seams.py \
+  tests/seocho/test_query_proxy_workspace_enforcement.py \
   tests/seocho/test_ontology_context.py \
   tests/seocho/test_session_agent.py \
   tests/seocho/test_user_facing_edge_cases.py \

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -5,6 +5,7 @@ python3 -m py_compile \
   runtime/__init__.py \
   runtime/policy.py \
   runtime/identity.py \
+  runtime/audit.py \
   runtime/agent_readiness.py \
   runtime/middleware.py \
   runtime/memory_service.py \
@@ -51,6 +52,7 @@ uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
   extraction/tests/test_identity.py \
   extraction/tests/test_policy.py \
+  extraction/tests/test_audit.py \
   extraction/tests/test_agent_readiness.py \
   extraction/tests/test_middleware.py \
   extraction/tests/test_memory_service.py \

--- a/src/seocho/query/query_proxy.py
+++ b/src/seocho/query/query_proxy.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Protocol
 
 from seocho.events import DomainEvent, EventPublisher, NullEventPublisher
+
+
+def _env_enforce_workspace_filter() -> bool:
+    """Default for tenant-isolation enforcement at the query boundary.
+
+    Off by default (preserves behaviour); multi-tenant deployments set
+    ``SEOCHO_ENFORCE_WORKSPACE_FILTER=1`` to make the runtime refuse any query
+    whose Cypher does not scope to ``$workspace_id``.
+    """
+    return os.getenv("SEOCHO_ENFORCE_WORKSPACE_FILTER", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
 
 
 class QueryPolicy(Protocol):
@@ -132,10 +145,17 @@ class QueryProxy:
         *,
         publisher: Optional[EventPublisher] = None,
         policy: Optional[QueryPolicy] = None,
+        enforce_workspace_filter: Optional[bool] = None,
     ) -> None:
         self._graph_store = graph_store
         self._publisher = publisher or NullEventPublisher()
         self._policy = policy or NullQueryPolicy()
+        # None -> take the deployment default from the environment.
+        self._enforce_workspace_filter = (
+            _env_enforce_workspace_filter()
+            if enforce_workspace_filter is None
+            else enforce_workspace_filter
+        )
 
     def query(self, request: QueryRequest) -> list[Dict[str, Any]]:
         params = dict(request.params or {})
@@ -147,11 +167,24 @@ class QueryProxy:
             params=params,
         )
         try:
-            raw_records = self._graph_store.query(
-                request.cypher,
-                params=params,
-                database=request.database,
-            )
+            if self._enforce_workspace_filter:
+                # Tenant-isolation enforced: thread workspace_id (auto-merged
+                # into params by the store) and refuse Cypher that doesn't scope
+                # to $workspace_id. Only passed when enabled so the default path
+                # keeps the exact call shape backends/test-doubles already accept.
+                raw_records = self._graph_store.query(
+                    request.cypher,
+                    params=params,
+                    database=request.database,
+                    workspace_id=request.workspace_id,
+                    enforce_workspace_filter=True,
+                )
+            else:
+                raw_records = self._graph_store.query(
+                    request.cypher,
+                    params=params,
+                    database=request.database,
+                )
             records = coerce_query_records(
                 raw_records,
                 database=request.database,

--- a/tests/seocho/test_query_proxy_workspace_enforcement.py
+++ b/tests/seocho/test_query_proxy_workspace_enforcement.py
@@ -1,0 +1,81 @@
+"""Fitness function for tenant isolation at the runtime query boundary (seocho-a6d).
+
+Pins two invariants:
+1. Default (enforcement off): QueryProxy calls the store with the exact, narrow
+   signature backends/test-doubles already accept — no behaviour change.
+2. Enforcement on: QueryProxy threads workspace_id and enforce_workspace_filter
+   to the store, so a query whose Cypher does not scope to $workspace_id is
+   refused. This makes tenant isolation a single deployment flag
+   (SEOCHO_ENFORCE_WORKSPACE_FILTER) rather than a per-call opt-in nobody used.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.query.query_proxy import QueryProxy, QueryRequest
+
+
+class _WorkspaceFilterMissing(RuntimeError):
+    pass
+
+
+class _StrictStore:
+    """Mimics a backend that ONLY accepts the narrow query signature.
+
+    If QueryProxy passed workspace_id / enforce_workspace_filter on the default
+    path, this would raise TypeError — that's the regression guard.
+    """
+
+    def query(self, cypher, *, params=None, database="neo4j"):
+        return [{"ok": True}]
+
+
+class _EnforcingStore:
+    """Mimics Neo4jGraphStore.query: accepts the isolation kwargs and refuses
+    Cypher that doesn't reference $workspace_id when enforcement is requested."""
+
+    def __init__(self):
+        self.calls = []
+
+    def query(self, cypher, *, params=None, database="neo4j",
+              workspace_id=None, enforce_workspace_filter=False):
+        self.calls.append({
+            "cypher": cypher, "workspace_id": workspace_id,
+            "enforce_workspace_filter": enforce_workspace_filter,
+        })
+        if enforce_workspace_filter and "$workspace_id" not in cypher:
+            raise _WorkspaceFilterMissing("cypher must reference $workspace_id")
+        return [{"ok": True}]
+
+
+def _req(cypher):
+    return QueryRequest(cypher=cypher, workspace_id="acme", database="neo4j")
+
+
+def test_default_off_uses_narrow_signature():
+    proxy = QueryProxy(_StrictStore(), enforce_workspace_filter=False)
+    # Must not raise TypeError — i.e. no extra kwargs leak to the backend.
+    assert proxy.query(_req("MATCH (n) RETURN n")) == [{"ok": True}]
+
+
+def test_enforcement_threads_workspace_and_flag():
+    store = _EnforcingStore()
+    proxy = QueryProxy(store, enforce_workspace_filter=True)
+    proxy.query(_req("MATCH (n) WHERE n._workspace_id = $workspace_id RETURN n"))
+    assert store.calls[-1]["workspace_id"] == "acme"
+    assert store.calls[-1]["enforce_workspace_filter"] is True
+
+
+def test_enforcement_refuses_unscoped_cypher():
+    proxy = QueryProxy(_EnforcingStore(), enforce_workspace_filter=True)
+    with pytest.raises(_WorkspaceFilterMissing):
+        proxy.query(_req("MATCH (n) RETURN n"))
+
+
+def test_default_taken_from_env(monkeypatch):
+    monkeypatch.setenv("SEOCHO_ENFORCE_WORKSPACE_FILTER", "1")
+    proxy = QueryProxy(_EnforcingStore())  # no explicit flag -> env default
+    assert proxy._enforce_workspace_filter is True
+    monkeypatch.setenv("SEOCHO_ENFORCE_WORKSPACE_FILTER", "0")
+    assert QueryProxy(_StrictStore())._enforce_workspace_filter is False


### PR DESCRIPTION
## What
Consolidates the remaining enterprise access-control stack on top of the now-merged identity foundation (#221): **RBAC by principal + workspace ownership**, **append-only audit log**, and **query-boundary tenant isolation**. Three distinct commits preserved.

> Recovery note: the original stacked PRs #222/#223/#224 broke when #221's branch was deleted on merge (GitHub closed #222 and the squashed-parent ancestry made the rest conflict). These 3 commits were cherry-picked cleanly onto current main and re-verified — superseding #222/#223/#224.

## Commits
- **seocho-8uy** RBAC: effective role from the authenticated Principal (not hardcoded), workspace-ownership enforcement (closes IDOR), viewer read-only, admin strict superset. Auth-off preserves behavior.
- **seocho-bk0** Audit: opt-in append-only JSONL of every access decision (allow+deny) at the single enforcement point; no-op unless `SEOCHO_AUDIT_LOG_PATH` set.
- **seocho-a6d** Isolation: `enforce_workspace_filter` wired to the QueryProxy behind `SEOCHO_ENFORCE_WORKSPACE_FILTER` + fitness function; strangler-safe default-off.

## Tests
`run_basic_ci.sh` green (429); test_policy / test_audit / test_query_proxy_workspace_enforcement + all contracts pass. All default behavior preserved (auth off = pre-auth behavior).