### PR TITLE
feat(agent): ontology-aware capability matchmaking (Sycara/RETSINA)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -43,6 +43,7 @@ python3 -m py_compile \
   src/seocho/index/ingestion_facade.py \
   src/seocho/routing/model_router.py \
   src/seocho/agent/reflection.py \
+  src/seocho/agent/matchmaker.py \
   src/seocho/query/query_proxy.py \
   src/seocho/query/agent_factory.py \
   src/seocho/tracing.py \
@@ -84,6 +85,7 @@ uv run pytest \
   tests/seocho/test_llm_backends.py \
   tests/seocho/test_model_router.py \
   tests/seocho/test_reflection.py \
+  tests/seocho/test_matchmaker.py \
   tests/seocho/test_tracing.py \
   tests/seocho/test_tracing_opik_regression.py \
   tests/seocho/test_cypher_builder.py \

--- a/src/seocho/agent/matchmaker.py
+++ b/src/seocho/agent/matchmaker.py
@@ -1,0 +1,130 @@
+"""Ontology-aware agent capability matchmaking (Sycara / RETSINA / OWL-S).
+
+SEOCHO routes work to agents with a hardcoded keyword router
+(``QueryRouterAgent``: scan the question for RDF/LPG hint words). That can't
+express *what an agent is good at* — only what words trigger it — and it can't
+respect an agent's **ontology scope** (a finance specialist vs a generic graph
+agent).
+
+This module is the RETSINA pattern: agents **advertise capabilities**
+(:class:`AgentCapability` — which task kinds they handle, which ontology concepts
+they cover, what inputs they need), and a middle-agent :class:`Matchmaker`
+**matches** an incoming :class:`TaskDescriptor` to the best-scoring capability.
+It is a pure, deterministic decision (no LLM), so selection is debuggable and
+unit-testable — the same role the model-tier router plays for *models*, this
+plays for *agents*.
+
+A capability is only eligible if it can actually run the task (it handles the
+kind and its required inputs are available). Among eligible capabilities, the
+score rewards **ontology-scope overlap** — a scoped specialist beats a generic
+agent on its own concepts, while a generic agent (empty scope = "any") still
+covers everything else.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import FrozenSet, List, Optional, Set
+
+__all__ = ["AgentCapability", "TaskDescriptor", "Match", "Matchmaker"]
+
+
+def _fs(values) -> FrozenSet[str]:
+    return frozenset(str(v).lower() for v in (values or ()))
+
+
+@dataclass(frozen=True)
+class AgentCapability:
+    """An agent's advertised profile.
+
+    ``ontology_scope`` empty means "any concept" (a generalist). ``inputs`` are
+    the input kinds the agent needs to run; if the task can't supply them the
+    agent is not eligible. ``priority`` breaks ties between equally-scored peers.
+    """
+
+    name: str
+    handles: FrozenSet[str]                       # task kinds / intents served
+    ontology_scope: FrozenSet[str] = frozenset()  # concepts covered; empty = any
+    inputs: FrozenSet[str] = frozenset()          # required input kinds
+    outputs: FrozenSet[str] = frozenset()
+    priority: float = 0.0
+
+    @classmethod
+    def make(cls, name, handles, *, ontology_scope=(), inputs=(), outputs=(), priority=0.0):
+        return cls(
+            name=name,
+            handles=_fs(handles),
+            ontology_scope=_fs(ontology_scope),
+            inputs=_fs(inputs),
+            outputs=_fs(outputs),
+            priority=priority,
+        )
+
+
+@dataclass(frozen=True)
+class TaskDescriptor:
+    kind: str
+    concepts: FrozenSet[str] = frozenset()
+    available_inputs: FrozenSet[str] = frozenset()
+
+    @classmethod
+    def make(cls, kind, *, concepts=(), available_inputs=()):
+        return cls(kind=str(kind).lower(), concepts=_fs(concepts), available_inputs=_fs(available_inputs))
+
+
+@dataclass(frozen=True)
+class Match:
+    capability: AgentCapability
+    score: float
+    reasons: List[str] = field(default_factory=list)
+
+
+class Matchmaker:
+    """Registry of advertised capabilities + best-match selection."""
+
+    # scoring weights — scope overlap is what lets a specialist beat a generalist
+    _KIND_BASE = 1.0
+    _SCOPE_OVERLAP = 2.0      # per overlapping concept
+    _GENERALIST_BONUS = 0.1   # tiny edge so a generalist still ranks above nothing
+
+    def __init__(self) -> None:
+        self._caps: List[AgentCapability] = []
+
+    def advertise(self, capability: AgentCapability) -> None:
+        self._caps.append(capability)
+
+    def _eligible(self, cap: AgentCapability, task: TaskDescriptor) -> bool:
+        # must handle the task kind AND have its required inputs available
+        if task.kind not in cap.handles:
+            return False
+        return cap.inputs <= task.available_inputs
+
+    def _score(self, cap: AgentCapability, task: TaskDescriptor) -> Match:
+        reasons = [f"handles '{task.kind}'"]
+        score = self._KIND_BASE
+        if not cap.ontology_scope:
+            score += self._GENERALIST_BONUS
+            reasons.append("generalist (any concept)")
+        else:
+            overlap = cap.ontology_scope & task.concepts
+            if overlap:
+                score += self._SCOPE_OVERLAP * len(overlap)
+                reasons.append(f"ontology-scope overlap {sorted(overlap)}")
+            else:
+                # scoped specialist but none of its concepts apply: still eligible
+                # (it handles the kind) but unrewarded — a generalist will outrank it.
+                reasons.append("scoped, no concept overlap")
+        score += cap.priority
+        if cap.priority:
+            reasons.append(f"priority {cap.priority:+}")
+        return Match(capability=cap, score=score, reasons=reasons)
+
+    def rank(self, task: TaskDescriptor) -> List[Match]:
+        """All eligible capabilities, highest score first (name as stable tiebreak)."""
+        matches = [self._score(c, task) for c in self._caps if self._eligible(c, task)]
+        return sorted(matches, key=lambda m: (-m.score, m.capability.name))
+
+    def match(self, task: TaskDescriptor) -> Optional[Match]:
+        """The single best capability for the task, or None if nothing can run it."""
+        ranked = self.rank(task)
+        return ranked[0] if ranked else None

--- a/tests/seocho/test_matchmaker.py
+++ b/tests/seocho/test_matchmaker.py
@@ -1,0 +1,79 @@
+"""Tests for ontology-aware agent capability matchmaking (Sycara/RETSINA).
+
+Demonstrates the benefit over the hardcoded keyword router: the SAME matchmaker
+routes diverse tasks to the right specialist, and an ontology-scoped specialist
+beats a generalist on its own concepts — something keyword matching can't do.
+"""
+
+from __future__ import annotations
+
+from seocho.agent.matchmaker import AgentCapability, Matchmaker, TaskDescriptor
+
+
+def _registry() -> Matchmaker:
+    mm = Matchmaker()
+    # Generic graph agents (any concept).
+    mm.advertise(AgentCapability.make("lpg", handles=["lookup", "aggregation"], inputs=["question"]))
+    mm.advertise(AgentCapability.make("rdf", handles=["explanation", "comparison"], inputs=["question"]))
+    # A finance specialist scoped to finance concepts.
+    mm.advertise(AgentCapability.make(
+        "finance", handles=["lookup", "aggregation"],
+        ontology_scope=["Company", "Filing", "Metric"], inputs=["question"], priority=0.0,
+    ))
+    # Synthesis agent needs records (not a raw question).
+    mm.advertise(AgentCapability.make("answer", handles=["synthesize"], inputs=["records"]))
+    return mm
+
+
+def test_specialist_beats_generalist_on_its_concepts():
+    mm = _registry()
+    task = TaskDescriptor.make("lookup", concepts=["Company"], available_inputs=["question"])
+    best = mm.match(task)
+    assert best is not None and best.capability.name == "finance"
+    assert any("overlap" in r for r in best.reasons)
+
+
+def test_generalist_wins_outside_specialist_scope():
+    mm = _registry()
+    task = TaskDescriptor.make("lookup", concepts=["Person"], available_inputs=["question"])
+    best = mm.match(task)
+    # finance scope doesn't cover Person -> generic lpg wins.
+    assert best is not None and best.capability.name == "lpg"
+
+
+def test_kind_routes_to_correct_specialist():
+    mm = _registry()
+    assert mm.match(TaskDescriptor.make("explanation", available_inputs=["question"])).capability.name == "rdf"
+    assert mm.match(TaskDescriptor.make("comparison", available_inputs=["question"])).capability.name == "rdf"
+
+
+def test_inputs_gate_eligibility():
+    mm = _registry()
+    # synthesize needs records; a question-only task can't run it -> no match.
+    assert mm.match(TaskDescriptor.make("synthesize", available_inputs=["question"])) is None
+    # with records available, answer agent is selected.
+    best = mm.match(TaskDescriptor.make("synthesize", available_inputs=["records"]))
+    assert best is not None and best.capability.name == "answer"
+
+
+def test_unknown_kind_has_no_match():
+    mm = _registry()
+    assert mm.match(TaskDescriptor.make("teleport", available_inputs=["question"])) is None
+
+
+def test_rank_orders_by_score_then_name():
+    mm = _registry()
+    task = TaskDescriptor.make("lookup", concepts=["Metric"], available_inputs=["question"])
+    ranked = mm.rank(task)
+    names = [m.capability.name for m in ranked]
+    # finance (scope overlap) ranks above generic lpg; both eligible.
+    assert names[0] == "finance" and "lpg" in names
+    assert ranked[0].score > ranked[1].score
+
+
+def test_priority_breaks_ties_between_generalists():
+    mm = Matchmaker()
+    mm.advertise(AgentCapability.make("a", handles=["lookup"], inputs=["question"], priority=0.0))
+    mm.advertise(AgentCapability.make("b", handles=["lookup"], inputs=["question"], priority=1.0))
+    best = mm.match(TaskDescriptor.make("lookup", available_inputs=["question"]))
+    assert best.capability.name == "b"  # higher priority wins the tie


### PR DESCRIPTION
## What
Adds `src/seocho/agent/matchmaker.py` — agents **advertise capabilities**, a middle-agent **Matchmaker** routes work to the best fit. The RETSINA pattern, realized over SEOCHO's ontology.

## Why (Katia Sycara lens)
SEOCHO's ontology is a strong *domain* model but a weak *collaboration* substrate: work is routed to agents by a **hardcoded keyword router** (`QueryRouterAgent` scans for RDF/LPG hint words). That can't express *what an agent is good at*, and can't respect an agent's **ontology scope** (finance specialist vs generic graph agent).

## How
- `AgentCapability`: task kinds handled, ontology concepts covered, required inputs/outputs, priority.
- `Matchmaker.match(task)`: eligible = handles the kind AND required inputs available; score rewards **ontology-scope overlap** so a scoped specialist beats a generalist on its own concepts, while a generalist (empty scope = any) covers the rest. Pure, deterministic, no LLM — the agent-level sibling of the model-tier router (#226).

## Demonstrated benefit (tests)
A registry mirroring SEOCHO's agents routes diverse tasks correctly: finance specialist wins on Company/Metric, generic lpg wins outside that scope, rdf handles explanation/comparison, synthesize gated on records availability, unknown kinds match nothing, priority breaks ties. **Keyword matching can't make the specialist-vs-generalist call; capability matching can.**

## Scope
Decision component + proof. Wiring it into `QueryRouterAgent`'s call site in the live flow is a follow-up. `run_basic_ci.sh` green (461).