### PR TITLE
feat(agent): wire cost-aware model router into the ReAct loop (seocho-t8m)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -86,6 +86,7 @@ uv run pytest \
   tests/seocho/test_model_router.py \
   tests/seocho/test_reflection.py \
   tests/seocho/test_matchmaker.py \
+  tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
   tests/seocho/test_tracing_opik_regression.py \
   tests/seocho/test_cypher_builder.py \

--- a/src/seocho/agent/graph_loop.py
+++ b/src/seocho/agent/graph_loop.py
@@ -30,7 +30,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from ..routing import RoutingDecision, RoutingPolicy
+from ..routing import ModelRouter, RoutingDecision, RoutingPolicy
 from ..debate import should_stop as _debate_should_stop, extract_citations
 from ..gds import MetricSpec, gds_session
 
@@ -187,6 +187,7 @@ class GraphAgenticLoop:
         client: Any,
         *,
         policy: Optional[RoutingPolicy] = None,
+        model_router: Optional[ModelRouter] = None,
         max_iterations: int = 3,
         augment_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
         emit_trace_fn: Optional[Callable[[Dict[str, Any]], None]] = None,
@@ -197,6 +198,10 @@ class GraphAgenticLoop:
     ) -> None:
         self.client = client
         self.policy = policy or RoutingPolicy.default()
+        # Optional cost-aware model routing: when set, each ask() is sent to the
+        # tier the routed intent maps to, escalating on repair iterations. When
+        # None (default) no model is forced and behaviour is unchanged.
+        self.model_router = model_router
         self.max_iterations = int(max_iterations)
         self.augment_fn = augment_fn or _default_augment
         self.emit_trace_fn = emit_trace_fn
@@ -230,6 +235,8 @@ class GraphAgenticLoop:
             "repair_budget": 0,
             "answer_history": [],
         }
+        # How many repair iterations have happened — drives model escalation.
+        escalation = 0
 
         for i in range(1, self.max_iterations + 1):
             iter_t0 = time.perf_counter()
@@ -257,12 +264,15 @@ class GraphAgenticLoop:
                 break
 
             strategy = self._select_strategy(decision)
-            answer = self._execute(strategy, question, state=state)
+            answer = self._execute(
+                strategy, question, state=state, decision=decision, escalation=escalation
+            )
             evaluation = self._evaluate(answer, augmentation=augmentation)
 
             improvement = self._improvement_action(evaluation, prior=state["answer_history"])
             if improvement:
                 self._apply_improvement(state, action=improvement)
+                escalation += 1
 
             iteration = LoopIteration(
                 iteration=i,
@@ -306,7 +316,25 @@ class GraphAgenticLoop:
         top, _ = ranked[0]
         return {"cypher": "cypher", "vector": "vector", "fulltext": "fulltext"}.get(top, top)
 
-    def _execute(self, strategy: str, question: str, *, state: Dict[str, Any]) -> str:
+    def _model_for(self, decision: RoutingDecision, escalation: int) -> Optional[str]:
+        """Resolve the model for this attempt via the cost-aware router.
+
+        Returns None when no router is configured (caller adds no model kwarg,
+        preserving current behaviour). Escalation bumps the tier on repairs.
+        """
+        if self.model_router is None:
+            return None
+        return self.model_router.route(intent=decision.intent, escalate=escalation).model
+
+    def _execute(
+        self,
+        strategy: str,
+        question: str,
+        *,
+        state: Dict[str, Any],
+        decision: Optional[RoutingDecision] = None,
+        escalation: int = 0,
+    ) -> str:
         """Strategy-aware execution.
 
         ``analytics`` opens a :func:`seocho.gds.gds_session` against the
@@ -327,6 +355,10 @@ class GraphAgenticLoop:
         if state.get("reasoning_mode"):
             kwargs["reasoning_mode"] = True
             kwargs["repair_budget"] = int(state.get("repair_budget", 0))
+        if decision is not None:
+            routed_model = self._model_for(decision, escalation)
+            if routed_model:
+                kwargs["model"] = routed_model
         try:
             return ask(question, **kwargs)
         except TypeError:

--- a/tests/seocho/test_graph_loop_model_routing.py
+++ b/tests/seocho/test_graph_loop_model_routing.py
@@ -1,0 +1,65 @@
+"""Wiring the cost-aware model router into the ReAct loop (seocho-t8m).
+
+Demonstrates the benefit: across repair iterations the loop escalates the model
+tier (FAST -> BALANCED -> FRONTIER) instead of retrying the same model — and
+when no router is configured, no model is forced (behaviour preserved).
+"""
+
+from __future__ import annotations
+
+from seocho.agent.graph_loop import GraphAgenticLoop
+from seocho.routing import ModelRouter
+
+
+class _RecordingClient:
+    """Records the model each ask() receives; returns differing medium answers
+    so the loop keeps improving (and thus escalating) without early-stopping."""
+
+    def __init__(self):
+        self.models = []
+        self._n = 0
+
+    def ask(self, question, *, model=None, reasoning_mode=False, repair_budget=0):
+        self.models.append(model)
+        self._n += 1
+        # medium-length, distinct each call -> confidence "medium", no "no_change" stop
+        return (
+            f"This is a medium-length partial answer number {self._n} with enough "
+            "text to score as medium confidence in the loop evaluator."
+        )
+
+
+def _augment_lookup(_q):
+    return {"intent": {"intent": "lookup", "confidence": 0.9}}
+
+
+def test_loop_escalates_model_tier_on_repair():
+    client = _RecordingClient()
+    loop = GraphAgenticLoop(
+        client,
+        model_router=ModelRouter.mara_default(),
+        max_iterations=3,
+        augment_fn=_augment_lookup,
+        enable_analytics=False,
+    )
+    loop.run("what is acme's revenue")
+    # intent=lookup -> FAST base; each repair escalates one tier.
+    assert client.models[0] == "DeepSeek-V3.1"          # FAST  (escalate 0)
+    assert client.models[1] == "MiniMax-M2.5"           # BALANCED (escalate 1)
+    if len(client.models) >= 3:
+        assert client.models[2] == "MiniMax-M2.7"       # FRONTIER (escalate 2)
+    # monotonic, never de-escalates
+    assert client.models == sorted(
+        client.models, key=["DeepSeek-V3.1", "MiniMax-M2.5", "MiniMax-M2.7"].index
+    )
+
+
+def test_no_router_forces_no_model_preserving_behavior():
+    client = _RecordingClient()
+    loop = GraphAgenticLoop(
+        client, max_iterations=2, augment_fn=_augment_lookup, enable_analytics=False
+    )
+    loop.run("what is acme's revenue")
+    # No router -> no model kwarg added; ask sees the default None.
+    assert all(m is None for m in client.models)
+    assert len(client.models) >= 1


### PR DESCRIPTION
## What
Wires the model-tier router (#226) into `GraphAgenticLoop` so the agentic loop actually *uses* it: each `ask()` goes to the tier its routed intent maps to, **escalating one tier per repair iteration** instead of retrying the same model.

## Why
The router shipped as a proven standalone component but nothing consumed it. This is the first consumer, joining ReAct's repair loop with the router's `escalate=` hook (a cheap model that didn't resolve a step escalates, rather than retrying itself).

## How (default-preserving)
- `GraphAgenticLoop(model_router=None)` by default → **no model forced**, behaviour exactly as before (the existing `TypeError` fallback already tolerates clients that ignore a model kwarg).
- When set, `_model_for(decision, escalation)` resolves intent → tier → model; `run()` increments escalation whenever a repair/improvement fires.

## Demonstrated benefit (regression)
A recording client shows the loop escalate **FAST(DeepSeek-V3.1) → BALANCED(MiniMax-M2.5) → FRONTIER(MiniMax-M2.7)** across repairs for a 'lookup' intent, never de-escalating; with no router, every `ask()` receives no model (behaviour preserved).

## Scope
Wires into the agentic **loop**. Session/agent-factory model selection + an optional reflection pass in the answer flow remain (need live OpenAI-Agents-SDK runs to validate). `run_basic_ci.sh` green (456).