### PR TITLE
feat(ontology): DDD bounded-context map with proactive boundary validation

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -44,6 +44,7 @@ python3 -m py_compile \
   src/seocho/routing/model_router.py \
   src/seocho/agent/reflection.py \
   src/seocho/agent/matchmaker.py \
+  src/seocho/ontology_context_map.py \
   src/seocho/query/query_proxy.py \
   src/seocho/query/agent_factory.py \
   src/seocho/tracing.py \
@@ -86,6 +87,7 @@ uv run pytest \
   tests/seocho/test_model_router.py \
   tests/seocho/test_reflection.py \
   tests/seocho/test_matchmaker.py \
+  tests/seocho/test_ontology_context_map.py \
   tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
   tests/seocho/test_tracing_opik_regression.py \

--- a/src/seocho/ontology_context_map.py
+++ b/src/seocho/ontology_context_map.py
@@ -1,0 +1,144 @@
+"""DDD bounded contexts + context map over SEOCHO ontologies (Eric Evans).
+
+SEOCHO's ontology is a strong domain model (aliases = ubiquitous language,
+``same_as`` = context mapping, cardinality/SHACL = invariants), but its
+*bounded-context boundaries* are implicit: multiple ontologies can be registered
+per workspace, and misalignment is only caught **after** the fact via
+``OntologyDriftError``. DDD wants the opposite — an explicit **context map** that
+says which context owns which concept and how concepts translate across
+contexts, validated **proactively**.
+
+This module models that:
+
+* :class:`BoundedContext` — a named context that *owns* a set of concepts and
+  declares *translations* of its concepts to other contexts (the
+  anti-corruption mapping, derived from the ontology's ``same_as``).
+* :class:`ContextMap` — registers contexts and validates boundaries up front:
+  a concept owned by two contexts (blurred boundary), or a translation that
+  points at an unknown context / a concept that context doesn't own (a broken
+  anti-corruption layer).
+
+Pure and deterministic — no graph, no LLM — so boundary checks run in CI as a
+fitness function instead of surfacing at runtime as drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping
+
+__all__ = ["BoundedContext", "BoundaryViolation", "ContextMap"]
+
+
+def _norm(value: str) -> str:
+    return str(value).strip()
+
+
+@dataclass(frozen=True)
+class BoundedContext:
+    """A bounded context: the concepts it owns + cross-context translations.
+
+    ``translations`` maps a locally-owned concept to ``"<other_context>:<concept>"``
+    — the explicit statement "our X is their Y" that DDD's context map and
+    anti-corruption layer require.
+    """
+
+    name: str
+    concepts: frozenset
+    translations: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_ontology(cls, name: str, ontology, *, context_of_same_as=None) -> "BoundedContext":
+        """Build a context from an Ontology-like object (duck-typed).
+
+        Concepts = node labels it owns. Translations = each node's ``same_as``
+        (e.g. ``"schema:Organization"``), interpreted as
+        ``<prefix>:<concept>`` where the prefix names the foreign context.
+        ``context_of_same_as`` may remap a ``same_as`` prefix to a context name.
+        """
+        nodes = getattr(ontology, "nodes", {}) or {}
+        concepts = {_norm(label) for label in nodes.keys()}
+        translations: Dict[str, str] = {}
+        for label, nodedef in nodes.items():
+            same_as = getattr(nodedef, "same_as", None)
+            if not same_as:
+                continue
+            target = same_as
+            if context_of_same_as and ":" in same_as:
+                prefix, _, local = same_as.partition(":")
+                mapped = context_of_same_as.get(prefix)
+                if mapped:
+                    target = f"{mapped}:{local}"
+            translations[_norm(label)] = _norm(target)
+        return cls(name=_norm(name), concepts=frozenset(concepts), translations=translations)
+
+
+@dataclass(frozen=True)
+class BoundaryViolation:
+    kind: str     # "shared_ownership" | "dangling_translation"
+    detail: str
+
+
+class ContextMap:
+    """Registry of bounded contexts with proactive boundary validation."""
+
+    def __init__(self) -> None:
+        self._contexts: Dict[str, BoundedContext] = {}
+
+    def register(self, context: BoundedContext) -> None:
+        self._contexts[context.name] = context
+
+    def owners_of(self, concept: str) -> List[str]:
+        concept = _norm(concept)
+        return sorted(c.name for c in self._contexts.values() if concept in c.concepts)
+
+    def translate(self, concept: str, *, from_context: str) -> str | None:
+        ctx = self._contexts.get(_norm(from_context))
+        if ctx is None:
+            return None
+        return ctx.translations.get(_norm(concept))
+
+    def validate(self) -> List[BoundaryViolation]:
+        """Return boundary violations, proactively (empty == clean).
+
+        - shared_ownership: a concept owned by more than one context — the
+          boundary is blurred; one context should own it and others translate to it.
+        - dangling_translation: a translation whose target context is unknown, or
+          whose target concept that context doesn't own — a broken anti-corruption
+          mapping. Translations to an *external* vocabulary (a prefix that is not a
+          registered context, e.g. ``schema:``) are left alone — only translations
+          that name a known context are checked.
+        """
+        violations: List[BoundaryViolation] = []
+
+        # shared ownership across contexts
+        owners: Dict[str, List[str]] = {}
+        for ctx in self._contexts.values():
+            for concept in ctx.concepts:
+                owners.setdefault(concept, []).append(ctx.name)
+        for concept, names in owners.items():
+            if len(names) > 1:
+                violations.append(BoundaryViolation(
+                    "shared_ownership",
+                    f"concept '{concept}' is owned by multiple contexts: {sorted(names)}",
+                ))
+
+        # translations that name a known context must resolve to a concept it owns
+        for ctx in self._contexts.values():
+            for local, target in ctx.translations.items():
+                if ":" not in target:
+                    continue
+                prefix, _, foreign_concept = target.partition(":")
+                other = self._contexts.get(prefix)
+                if other is None:
+                    continue  # external vocabulary (schema:, fibo:, ...) — not our boundary
+                if _norm(foreign_concept) not in other.concepts:
+                    violations.append(BoundaryViolation(
+                        "dangling_translation",
+                        f"{ctx.name}.{local} -> {target}, but context '{prefix}' "
+                        f"does not own concept '{foreign_concept}'",
+                    ))
+        return sorted(violations, key=lambda v: (v.kind, v.detail))
+
+    def is_consistent(self) -> bool:
+        return not self.validate()

--- a/tests/seocho/test_ontology_context_map.py
+++ b/tests/seocho/test_ontology_context_map.py
@@ -1,0 +1,78 @@
+"""Tests for the DDD bounded-context / context map (Eric Evans).
+
+Demonstrates the benefit over post-hoc OntologyDriftError: boundary problems
+(blurred ownership, broken anti-corruption translations) are caught proactively
+by validate(), before any data flows.
+"""
+
+from __future__ import annotations
+
+from seocho.ontology_context_map import BoundedContext, ContextMap
+
+
+def _bc(name, concepts, translations=None):
+    return BoundedContext(name=name, concepts=frozenset(concepts), translations=translations or {})
+
+
+def test_disjoint_contexts_are_consistent():
+    mm = ContextMap()
+    mm.register(_bc("sales", ["Lead", "Opportunity", "Account"]))
+    mm.register(_bc("finance", ["Invoice", "Payment", "Account".replace("Account", "Ledger")]))
+    assert mm.validate() == []
+    assert mm.is_consistent()
+
+
+def test_shared_ownership_is_flagged():
+    mm = ContextMap()
+    mm.register(_bc("sales", ["Account", "Lead"]))
+    mm.register(_bc("finance", ["Account", "Invoice"]))  # both own "Account"
+    violations = mm.validate()
+    kinds = {v.kind for v in violations}
+    assert "shared_ownership" in kinds
+    assert any("Account" in v.detail for v in violations)
+
+
+def test_valid_cross_context_translation_passes():
+    mm = ContextMap()
+    mm.register(_bc("finance", ["Ledger"]))
+    # sales' Account translates to finance's Ledger (which finance owns) -> clean
+    mm.register(_bc("sales", ["Account"], {"Account": "finance:Ledger"}))
+    assert mm.validate() == []
+    assert mm.translate("Account", from_context="sales") == "finance:Ledger"
+
+
+def test_dangling_translation_to_unowned_concept_is_flagged():
+    mm = ContextMap()
+    mm.register(_bc("finance", ["Ledger"]))
+    mm.register(_bc("sales", ["Account"], {"Account": "finance:Invoice"}))  # finance doesn't own Invoice
+    violations = mm.validate()
+    assert any(v.kind == "dangling_translation" for v in violations)
+
+
+def test_translation_to_external_vocab_is_not_a_boundary_violation():
+    mm = ContextMap()
+    # schema: is an external vocabulary, not a registered context -> left alone
+    mm.register(_bc("sales", ["Account"], {"Account": "schema:Organization"}))
+    assert mm.validate() == []
+
+
+def test_owners_of_lists_all_owning_contexts():
+    mm = ContextMap()
+    mm.register(_bc("sales", ["Account"]))
+    mm.register(_bc("finance", ["Account"]))
+    assert mm.owners_of("Account") == ["finance", "sales"]
+
+
+def test_from_ontology_extracts_concepts_and_translations():
+    # duck-typed ontology: .nodes maps label -> object with .same_as
+    class _Node:
+        def __init__(self, same_as=None):
+            self.same_as = same_as
+
+    class _Onto:
+        name = "sales"
+        nodes = {"Account": _Node(same_as="finance:Ledger"), "Lead": _Node()}
+
+    ctx = BoundedContext.from_ontology("sales", _Onto())
+    assert ctx.concepts == frozenset({"Account", "Lead"})
+    assert ctx.translations == {"Account": "finance:Ledger"}


### PR DESCRIPTION
## What
Adds `src/seocho/ontology_context_map.py` — an explicit **context map** over SEOCHO's ontologies, validated **proactively**.

## Why (Eric Evans lens)
SEOCHO's ontology is a strong *domain* model (aliases = ubiquitous language, `same_as` = context mapping, cardinality/SHACL = invariants). But bounded-context **boundaries are implicit**: multiple ontologies per workspace, and misalignment is only caught **after the fact** via `OntologyDriftError`. DDD wants the opposite — say which context owns which concept and how concepts translate, and check it up front.

## How
- `BoundedContext`: concepts a context **owns** + **translations** to other contexts ('our X is their Y' — the anti-corruption mapping, derivable from the ontology's `same_as` via `from_ontology`).
- `ContextMap.validate()`: proactive checks — **shared_ownership** (a concept owned by >1 context = blurred boundary) and **dangling_translation** (names a known context but a concept it doesn't own = broken anti-corruption layer). External-vocabulary translations (`schema:`, `fibo:`) are left alone. Pure/deterministic → runs in CI as a fitness function instead of surfacing as runtime drift.

## Demonstrated benefit (tests)
Disjoint contexts clean; shared ownership flagged; valid cross-context translation passes; dangling translation flagged; external-vocab translation not a violation; `owners_of` lists owners; `from_ontology` extracts concepts+translations. `run_basic_ci.sh` green (470).

## Scope
Decision/validation component + proof. Wiring it into the workspace ontology registry as a registration-time gate is a follow-up.