### PR TITLE
Draft: Refactor resetSessionBtn inline styles to CSS class

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-session-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -586,3 +586,20 @@ textarea:focus {
   box-shadow: 0 0 0 1px var(--accent-blue);
   outline: none;
 }
+
+/* Reset Session Button */
+.reset-session-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.reset-session-btn:hover {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.5);
+}


### PR DESCRIPTION
**What**
Refactored the `resetSessionBtn` inline styles and javascript `onmouseover`/`onmouseout` attributes in `evaluation/static/index.html` to a standard CSS class `.reset-session-btn` in `evaluation/static/styles.css`.

**Why**
Using inline JavaScript and styles for simple hover states violates separation of concerns, makes the code harder to maintain, and does not allow for smooth CSS transitions. Migrating this to CSS simplifies the HTML and aligns the button with standard CSS practices.

**Accessibility / UX Impact**
Improved the visual feedback UX for mouse users by adding a smooth transition (`transition: color 0.2s, border-color 0.2s`) and a complementary border color shift (`rgba(255, 255, 255, 0.5)`) on hover, creating a more responsive feel when interacting with the button.

**Validation**
- Validated via Playwright script capturing the active `.reset-session-btn:hover` CSS state.
- Checked frontend health with `run_basic_ci.sh`, all tests passed.

**Risks**
No semantic logic or behavior changes, risks are strictly contained to visual alignment within the evaluation UI.

---
*PR created automatically by Jules for task [16475433768337959568](https://jules.google.com/task/16475433768337959568) started by @tteon*