### PR TITLE
Fix missing authorization check on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1086,13 +1086,25 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    workspace_id = (raw_history[0].get("metadata") or {}).get("workspace_id", "default") if raw_history else "default"
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
### What
Added missing `require_runtime_permission` checks to the `platform_chat_session_get` and `platform_chat_session_reset` API endpoints.

### Why
These endpoints were missing authorization checks, meaning anyone who knew a valid `session_id` could potentially view or clear another user's chat history.

### Severity
Medium

### Vulnerability
Insecure Direct Object Reference (IDOR) due to missing access control.

### Impact
An attacker with a valid token could enumerate or guess session IDs to view or wipe out private chat histories of other users/workspaces.

### Fix
Added the `require_runtime_permission(role="user", action="run_platform", ...)` policy check to both endpoints. The `workspace_id` is extracted defensively from the stored chat history metadata, safely handling empty histories or empty metadata by falling back to the `"default"` workspace. Failed checks raise a standard `HTTPException` with a `403` status code.

### Validation
Ran the standard test suite with `bash scripts/ci/run_basic_ci.sh`, which passed successfully, verifying that the new permissions integrate cleanly into the existing runtime framework.

### Risks
Extremely low risk. The new checks adhere to the identical structure as other platform endpoints (like `platform_chat_send`). Safe fallback logic prevents index/attribute errors on empty histories.

---
*PR created automatically by Jules for task [1749255338459966540](https://jules.google.com/task/1749255338459966540) started by @tteon*