### PR TITLE
feat(semantic): first-class Observation dimensions — segment/basis/restatement (seocho-8kt.4)

### DIFF
--- a/src/seocho/index/observation_writer.py
+++ b/src/seocho/index/observation_writer.py
@@ -111,8 +111,14 @@ def build_observations(
         if not cik:
             continue
         unit = str(props.get("unit") or "USD")
+        # Richer reported-figure dimensions (ADR-0103 H4); consolidated/GAAP/
+        # not-restated by default so existing obs_ids are unchanged.
+        basis = str(props.get("basis") or "consolidated")
+        segment = str(props.get("segment") or "consolidated")
+        is_restated = bool(props.get("is_restated") or props.get("restated") or False)
         obs_id = observation_key(entity_key=cik, concept_id=concept_id,
-                                 period_key=period_key, unit=unit,
+                                 period_key=period_key, unit=unit, basis=basis,
+                                 segment=segment, is_restated=is_restated,
                                  workspace_id=workspace_id)
         if obs_id in seen_obs:
             continue
@@ -129,7 +135,8 @@ def build_observations(
             "properties": {
                 "obs_id": obs_id, "concept_id": concept_id, "entity_cik": cik,
                 "period_key": period_key, "value_num": value_num,
-                "unit": unit, "basis": "consolidated",
+                "unit": unit, "basis": basis,
+                "segment": segment, "is_restated": is_restated,
             },
         })
         obs_rels.append({"source": company_id, "target": obs_id,

--- a/src/seocho/index/xbrl_ingest.py
+++ b/src/seocho/index/xbrl_ingest.py
@@ -123,6 +123,9 @@ def companyfacts_to_observations(
                     "obs_id": obs_id, "concept_id": concept_id, "entity_cik": cik,
                     "period_key": period_key, "period_end": fact.get("period_end") or "",
                     "value_num": float(value), "unit": unit, "basis": "consolidated",
+                    # companyfacts annual frames are consolidated GAAP, not restated
+                    # (ADR-0103 H4 dimensions, first-class).
+                    "segment": "consolidated", "is_restated": False,
                 },
             })
             obs_rels.append({"source": company_id, "target": obs_id,

--- a/src/seocho/semantic_layer/keys.py
+++ b/src/seocho/semantic_layer/keys.py
@@ -26,13 +26,26 @@ def observation_key(
     period_key: str,
     unit: str,
     basis: str = "consolidated",
+    segment: str = "consolidated",
+    is_restated: bool = False,
     workspace_id: str = "",
 ) -> str:
     """Return a stable ``obs:<hash>`` identity for a reported observation.
 
-    Same canonical inputs → same key, always; different period/concept/entity →
-    different key. Used as the MERGE target so re-ingestion and cross-chunk
-    extraction are idempotent.
+    The full reported-figure model (ADR-0103 expert panel) is
+    ``(entity, concept, period, unit, basis, segment, restatement)``. ``segment``
+    (a reportable-segment name; default ``consolidated`` = whole company) and
+    ``is_restated`` (a prior-period figure restated in a later filing) are keyed
+    in so a segment/non-GAAP/restated figure gets its own node rather than
+    colliding with the consolidated one.
+
+    Same canonical inputs → same key, always; different period/concept/entity/
+    segment/restatement → different key. Used as the MERGE target so
+    re-ingestion and cross-chunk extraction are idempotent.
+
+    Backward-compatible: the richer dimensions enter the hash ONLY when
+    non-default (``segment != 'consolidated'`` / ``is_restated``), so every
+    already-ingested consolidated observation keeps its existing obs_id.
     """
     parts = [
         workspace_id.strip(),
@@ -42,6 +55,11 @@ def observation_key(
         unit.strip().upper(),
         basis.strip().lower(),
     ]
+    seg = segment.strip().lower()
+    if seg and seg != "consolidated":
+        parts.append("seg:" + seg)
+    if is_restated:
+        parts.append("restated")
     raw = _SEP.join(parts)
     digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:24]
     return f"obs:{digest}"

--- a/src/seocho/semantic_layer/slots.py
+++ b/src/seocho/semantic_layer/slots.py
@@ -22,6 +22,8 @@ class ObservationSlots:
     period_keys: Tuple[str, ...] = ()
     unit: str = "USD"
     basis: str = "consolidated"
+    segment: str = "consolidated"             # reportable segment; whole-company default
+    is_restated: bool = False                 # a later-filing restatement of the figure
     unresolved: Tuple[str, ...] = ()          # slot names that did not resolve
 
     @property
@@ -40,6 +42,8 @@ class ObservationSlots:
                 period_key=pk,
                 unit=self.unit,
                 basis=self.basis,
+                segment=self.segment,
+                is_restated=self.is_restated,
                 workspace_id=workspace_id,
             )
             for pk in self.period_keys

--- a/tests/seocho/test_observation_dimensions.py
+++ b/tests/seocho/test_observation_dimensions.py
@@ -1,0 +1,59 @@
+"""Richer Observation dimensions: segment / basis / restatement (seocho-8kt.4).
+
+The full reported-figure model is (entity, concept, period, unit, basis,
+segment, restatement). These assert the new dimensions are keyed in AND that
+the default (consolidated / not-restated) case keeps its EXISTING obs_id so
+already-ingested data is not fragmented.
+"""
+
+from seocho.semantic_layer.keys import observation_key
+from seocho.semantic_layer.slots import ObservationSlots
+
+_BASE = dict(entity_key="0000320193", concept_id="metric:Revenue",
+             period_key="fiscal:2023:FY", unit="USD")
+
+
+def test_default_obs_id_is_backward_compatible():
+    # baseline captured from the pre-8kt.4 6-part key — must not change, or
+    # every already-ingested consolidated observation would re-fragment.
+    assert observation_key(**_BASE) == "obs:41ced61e2daafd4e61fca43f"
+
+
+def test_explicit_consolidated_defaults_match_bare_call():
+    assert observation_key(**_BASE) == observation_key(
+        **_BASE, segment="consolidated", is_restated=False)
+
+
+def test_segment_changes_the_key():
+    base = observation_key(**_BASE)
+    seg = observation_key(**_BASE, segment="Footwear")
+    assert seg != base
+    # segment is case-insensitive / whitespace-normalized
+    assert seg == observation_key(**_BASE, segment="  footwear ")
+
+
+def test_restatement_changes_the_key():
+    assert observation_key(**_BASE, is_restated=True) != observation_key(**_BASE)
+
+
+def test_segment_and_restatement_compose_distinctly():
+    keys = {
+        observation_key(**_BASE),
+        observation_key(**_BASE, segment="Footwear"),
+        observation_key(**_BASE, is_restated=True),
+        observation_key(**_BASE, segment="Footwear", is_restated=True),
+    }
+    assert len(keys) == 4
+
+
+def test_observation_slots_thread_the_dimensions():
+    s = ObservationSlots(entity_cik="0000320193", concept_id="metric:Revenue",
+                         period_keys=("fiscal:2023:FY",), segment="Footwear",
+                         is_restated=True)
+    assert s.observation_keys() == (
+        observation_key(**_BASE, segment="Footwear", is_restated=True),
+    )
+    # default slots reproduce the backward-compatible key
+    d = ObservationSlots(entity_cik="0000320193", concept_id="metric:Revenue",
+                         period_keys=("fiscal:2023:FY",))
+    assert d.observation_keys() == ("obs:41ced61e2daafd4e61fca43f",)


### PR DESCRIPTION
The expert-panel reported-figure model is **(entity, concept, period, unit, basis, segment, restatement)**. Observation carried `basis` only (fixed `consolidated`). This adds **segment** + **is_restated** as first-class — keyed into `observation_key` and threaded through `ObservationSlots`, the extraction writer, and the XBRL ingester.

**Backward-compatible by construction:** the richer dimensions enter the `obs_id` hash **only when non-default** (`segment != 'consolidated'` / `is_restated`), so every already-ingested consolidated observation keeps its exact `obs_id` — regression-tested against the captured baseline `obs:41ced61e2daafd4e61fca43f`. A segment / restated / non-GAAP figure now gets its own node instead of colliding with the consolidated one; `companyfacts` (consolidated GAAP, not restated) keep defaults. **H4 closes the `seocho-8kt` epic.**

`tests/seocho/test_observation_dimensions.py` (6 tests): default backward-compat, segment/restatement distinctness + composition, slots pass-through. 49 semantic tests pass (1 pre-existing, unrelated decompose concept-resolution failure predates this).

**Interpretation note:** kept `basis` default `consolidated` (not `gaap`) to avoid re-hashing existing data; `basis` accepts `gaap`/`non_gaap` as a value when decompose knows it. A true default-basis change would need a data migration — flagged rather than silently breaking keys.