### PR TITLE
fix(security): enforce authorization on platform chat session endpoints (IDOR)

### DIFF
--- a/extraction/tests/test_api_endpoints.py
+++ b/extraction/tests/test_api_endpoints.py
@@ -158,6 +158,40 @@ class TestListEndpoints:
         assert kwargs["workspace_id"] == "tenant_a"
         assert kwargs["action"] == "read_databases"
 
+    # --- IDOR fix: platform chat session GET/DELETE were unguarded ---
+    # Any caller could read or clear any session_id. These pin the authz gate.
+
+    async def test_chat_session_get_denied_returns_403(self, client, app_module):
+        with patch.object(
+            app_module, "require_runtime_permission", side_effect=PermissionError("denied"),
+        ):
+            response = await client.get("/platform/chat/session/sess-1")
+        assert response.status_code == 403
+
+    async def test_chat_session_delete_denied_returns_403(self, client, app_module):
+        with patch.object(
+            app_module, "require_runtime_permission", side_effect=PermissionError("denied"),
+        ):
+            response = await client.delete("/platform/chat/session/sess-1")
+        assert response.status_code == 403
+
+    async def test_chat_session_get_allowed_by_default(self, client, app_module):
+        # auth disabled -> require_runtime_permission is a no-op -> 200 (preserved)
+        response = await client.get("/platform/chat/session/unknown-sess")
+        assert response.status_code == 200
+        assert response.json()["history"] == []
+
+    async def test_chat_session_authz_uses_session_workspace(self, client, app_module):
+        app_module.platform_session_store.append(
+            "sess-b", "user", "hi", metadata={"workspace_id": "tenant_b"}
+        )
+        with patch.object(app_module, "require_runtime_permission") as mock_perm:
+            response = await client.get("/platform/chat/session/sess-b")
+        assert response.status_code == 200
+        _, kwargs = mock_perm.call_args
+        assert kwargs["workspace_id"] == "tenant_b"
+        assert kwargs["action"] == "run_platform"
+
     async def test_execute_cypher_tool_uses_query_proxy(self, app_module):
         context = types.SimpleNamespace(
             context=app_module.ServerContext(

--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1083,16 +1083,40 @@ async def platform_chat_send(request: PlatformChatRequest):
     )
 
 
+def _session_workspace_id(raw_history: list) -> str:
+    """The workspace a session belongs to (from its first turn's metadata).
+
+    These read/delete endpoints had no authz at all — any caller could read or
+    clear any session_id (IDOR). Deriving the session's workspace lets the policy
+    engine enforce workspace ownership: an authenticated principal scoped to
+    workspace A is denied a session that belongs to workspace B. With auth
+    disabled this stays a no-op, preserving current behavior.
+    """
+    if raw_history:
+        return str((raw_history[0].get("metadata") or {}).get("workspace_id", "default"))
+    return "default"
+
+
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    raw_history = platform_session_store.get(session_id)
+    try:
+        require_runtime_permission(action="run_platform", workspace_id=_session_workspace_id(raw_history))
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    history = [PlatformTurn(**row) for row in raw_history]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    raw_history = platform_session_store.get(session_id)
+    try:
+        require_runtime_permission(action="run_platform", workspace_id=_session_workspace_id(raw_history))
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
## What
Adds authorization to `platform_chat_session_get` / `platform_chat_session_reset`, which took only a `session_id` and had **no authz** — any caller could read or clear any session (IDOR).

## Why
The real gap behind the open community PR cluster **#213 / #202 / #190 / #184 / #179**. My earlier RBAC PR (#228) added workspace-ownership *to the policy engine* but did not touch these endpoints — they didn't even call the policy. This wires them in, completing the fix on the merged principal/policy infrastructure, so it **supersedes** those 5 PRs.

## How
Both endpoints derive the session's workspace from its first turn's metadata and call `require_runtime_permission(action='run_platform', workspace_id=...)`. With the merged workspace-ownership policy, a principal scoped to workspace A is **denied** a session in workspace B. **Auth-off → no-op** (behavior preserved).

## Tests
`test_api_endpoints`: GET/DELETE → 403 when denied, default GET stays 200, authz scoped to the session's own workspace (seeded tenant_b → `workspace_id=tenant_b`). `run_basic_ci.sh` green (474).