### PR TITLE
feat(ci): doc structure / drift linter + fix real broken links (seocho-b01.4)

### DIFF
--- a/.github/codex/prompts/daily-maintenance-pr.md
+++ b/.github/codex/prompts/daily-maintenance-pr.md
@@ -21,6 +21,10 @@ Execution rules:
 - Keep edits minimal and intentional.
 - Run `bash scripts/ci/run_basic_ci.sh` if your change touches the current
   basic CI surface; otherwise run the narrowest relevant subset and report it.
+- Doc-vs-code drift checklist: run `python3 scripts/ci/check_doc_structure.py`
+  (relative links resolve, read-order files exist, required sections present);
+  also scan for docs whose stated endpoints/paths/ADR claims no longer match the
+  code, and prefer fixing one such drift.
 - Do not commit, push, open a browser, or merge anything.
 
 Final response format:

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -16,3 +16,11 @@ jobs:
 
       - name: Run docs contract checks
         run: bash scripts/ci/check-doc-contracts.sh
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run doc structure / drift checks
+        run: python3 scripts/ci/check_doc_structure.py

--- a/docs/BEGINNER_GUIDE.md
+++ b/docs/BEGINNER_GUIDE.md
@@ -3,7 +3,7 @@
 This guide is for a first-time user who wants to understand SEOCHO by running a
 small end-to-end workflow.
 
-If you only need the shortest command path, use [QUICKSTART.md](QUICKSTART.md).
+If you only need the shortest command path, use [QUICKSTART.md](../QUICKSTART.md).
 If you want the full system architecture, use [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## 1. The One-Minute Mental Model
@@ -318,7 +318,7 @@ open http://localhost:8001/docs
 
 Recommended learning path:
 
-1. [QUICKSTART.md](QUICKSTART.md)
+1. [QUICKSTART.md](../QUICKSTART.md)
 2. [BEGINNER_PIPELINES_DEMO.md](BEGINNER_PIPELINES_DEMO.md)
 3. [PYTHON_INTERFACE_QUICKSTART.md](PYTHON_INTERFACE_QUICKSTART.md)
 4. [INDEXING_DESIGN_SPECS.md](INDEXING_DESIGN_SPECS.md)

--- a/docs/BEGINNER_PIPELINES_DEMO.md
+++ b/docs/BEGINNER_PIPELINES_DEMO.md
@@ -1,6 +1,6 @@
 # Beginner Pipeline Demos
 
-Use this document after [QUICKSTART.md](QUICKSTART.md) succeeds.
+Use this document after [QUICKSTART.md](../QUICKSTART.md) succeeds.
 
 This is the scripted demo path.
 Unlike `QUICKSTART`, it is not the shortest way to first success.
@@ -23,7 +23,7 @@ Use it when you need:
 
 ## 2. Before You Start
 
-Complete [QUICKSTART.md](QUICKSTART.md) first:
+Complete [QUICKSTART.md](../QUICKSTART.md) first:
 
 ```bash
 make setup-env
@@ -142,6 +142,6 @@ That order explains the product from source material to governed graph memory to
 
 ## 7. When To Use Which Doc
 
-- [QUICKSTART.md](QUICKSTART.md): fastest first run
+- [QUICKSTART.md](../QUICKSTART.md): fastest first run
 - [TUTORIAL_FIRST_RUN.md](TUTORIAL_FIRST_RUN.md): manual API walkthrough
 - this document: scripted staged demos

--- a/docs/PROMPT_ASSEMBLY_DISCUSSION_MEMO.md
+++ b/docs/PROMPT_ASSEMBLY_DISCUSSION_MEMO.md
@@ -45,7 +45,7 @@ The four review perspectives converged on the same position:
 2. SEOCHO should not expose a prompt DSL with unconstrained override freedom.
 3. Prompt assembly should be stage-aware and typed.
 4. Provider-specific behavior should stay in adapter code such as
-   [seocho/store/llm.py](/home/hadry/lab/seocho/seocho/store/llm.py:269).
+   [src/seocho/store/llm.py](../src/seocho/store/llm.py).
 5. The public seam should remain ontology- and artifact-centric.
 
 ## Proposed Boundary

--- a/docs/ontology/ONTOLOGY_GUIDE.md
+++ b/docs/ontology/ONTOLOGY_GUIDE.md
@@ -103,7 +103,7 @@ Every published **FIBO ontology**, regardless of its maturity level, must includ
 1. An **ontology IRI**, following the [FIBO standard IRI format](#fibo-standard-iri-format)
 1. A **label** (in English, which is a spelled out name for the ontology)
 1. An **abstract** - short description of the ontology
-1. A **license** - we use the [MIT open source license](LICENSE) for all FIBO ontologies
+1. A **license** - we use the [MIT open source license](../../LICENSE) for all FIBO ontologies
 1. An indication of the **content language, which is OWL**, linking to the W3C site
 1. A **copyright statement** - which always includes the EDM Council copyright and, for released ontologies that are being incorporated into the joint EDM Council / OMG standard, the OMG copyright
 1. An indication of the **dependencies that the ontology has on other ontologies** - a link to the other domains/modules referenced, and within the relevant domain, links to the domain-level ontologies referenced

--- a/scripts/ci/check_doc_structure.py
+++ b/scripts/ci/check_doc_structure.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Doc structure / drift linter (seocho-b01.4).
+
+check-doc-contracts.sh asserts required docs are PRESENT; this asserts they are
+STRUCTURALLY sound and not drifting:
+
+  1. relative markdown links resolve (no link to a moved/renamed/deleted file)
+  2. CLAUDE.md / AGENTS.md read-order files exist
+  3. a few key docs carry their required sections
+
+Pure stdlib, deterministic, no network. Exit non-zero (naming each offender) on
+any failure so CI blocks doc drift. Run:
+    python3 scripts/ci/check_doc_structure.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# Markdown surfaces to lint: root agent/entry docs + everything under docs/.
+ROOT_DOCS = ["README.md", "AGENTS.md", ".AGENTS.md", "CLAUDE.md", "docs/README.md"]
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+# read-order seeds (CLAUDE.md "Read Order"): these must always resolve.
+READ_ORDER = [
+    "README.md", "AGENTS.md", "docs/REPOSITORY_LAYOUT.md", "docs/WORKFLOW.md",
+    "docs/decisions/DECISION_LOG.md",
+]
+# required sections per key doc (substring match on a heading line).
+REQUIRED_SECTIONS = {
+    "docs/ARCHITECTURE_HEALTH.md": ["Architecture Health Scorecard", "How to use this"],
+    "docs/MODULE_OWNERSHIP_MAP.md": ["Ownership Table"],
+}
+
+
+def _md_files() -> list[Path]:
+    files = [ROOT / p for p in ROOT_DOCS if (ROOT / p).exists()]
+    files += sorted((ROOT / "docs").rglob("*.md"))
+    return files
+
+
+def _is_external(target: str) -> bool:
+    t = target.strip()
+    return (t.startswith(("http://", "https://", "mailto:", "#"))
+            or t.startswith("<") or not t)
+
+
+def check_links(errors: list[str]) -> None:
+    for f in _md_files():
+        try:
+            text = f.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        for m in LINK_RE.finditer(text):
+            target = m.group(1).split()[0]          # drop optional "title"
+            if _is_external(target):
+                continue
+            path_part = target.split("#", 1)[0]
+            if not path_part:                        # pure in-page anchor
+                continue
+            resolved = (f.parent / path_part).resolve()
+            if not resolved.exists():
+                rel = f.relative_to(ROOT)
+                errors.append(f"broken link in {rel}: ({target})")
+
+
+def check_read_order(errors: list[str]) -> None:
+    for rel in READ_ORDER:
+        if not (ROOT / rel).exists():
+            errors.append(f"read-order file missing: {rel}")
+
+
+def check_sections(errors: list[str]) -> None:
+    for rel, needed in REQUIRED_SECTIONS.items():
+        p = ROOT / rel
+        if not p.exists():
+            errors.append(f"required doc missing: {rel}")
+            continue
+        text = p.read_text(encoding="utf-8")
+        for section in needed:
+            if section not in text:
+                errors.append(f"{rel}: missing required section '{section}'")
+
+
+def main() -> int:
+    errors: list[str] = []
+    check_links(errors)
+    check_read_order(errors)
+    check_sections(errors)
+    if errors:
+        print("Doc structure/drift check FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    n = len(_md_files())
+    print(f"Doc structure check passed: {n} markdown files, links + read-order + "
+          f"sections OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`check-doc-contracts.sh` asserts docs are PRESENT; this asserts they're **structurally sound and not drifting**. `scripts/ci/check_doc_structure.py` (stdlib, deterministic): relative markdown links resolve, read-order files exist, key docs carry required sections — fails naming each offender. Wired into `docs-consistency.yml` (every PR) + added a doc-vs-code drift checklist to the daily-codex maintenance prompt.

On first run it caught **real broken links** (drift), now fixed: BEGINNER_GUIDE/BEGINNER_PIPELINES_DEMO `(QUICKSTART.md)`→`(../QUICKSTART.md)`, and a leaked absolute path in PROMPT_ASSEMBLY_DISCUSSION_MEMO → `../src/seocho/store/llm.py`. (`docs/ontology/` is gitignored, so absent in CI checkouts — the linter doesn't scan it there.)

Linter passes clean across the tracked markdown set. Closes seocho-b01.4.