### PR TITLE
feat: benchmark/infra runbook skills + harness port (vector-vs-graph)

### DIFF
--- a/.claude/skills/dozerdb-up/SKILL.md
+++ b/.claude/skills/dozerdb-up/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: dozerdb-up
+description: Bring up the local DozerDB (Neo4j-compatible) graph backend for SEOCHO benchmarks and verify it is reachable on bolt. Invoke before any run that needs a graph store (finder-graphrag-bench, graph/hybrid retrieval, phase extraction to Neo4j) or when a script fails with "Connection refused" on 7687 / "Graph not found" / auth errors.
+---
+
+# dozerdb-up
+
+Purpose: get the graph backend running and reachable with one predictable recipe, so benchmark runs don't fail mid-flight on a down container, a missing database, or an auth mismatch. DozerDB is the fixed graph backend (CLAUDE.md §1).
+
+## When to invoke
+
+- Before `finder-graphrag-bench`, phase extraction with `--graph bolt://...`, or any graph/hybrid retrieval.
+- When a run errors with: `Couldn't connect to localhost:7687`, `Connection refused`, `ServiceUnavailable`, `Neo.ClientError.Security.Unauthorized`, or `Neo.ClientError.Database.DatabaseNotFound: Graph not found: <db>`.
+- After a host reboot or a long idle (the container is flaky across sessions and exits silently).
+
+## Bring-up recipe
+
+1. **Set credentials in `.env`** (repo root). `docker-compose.yml` requires `NEO4J_PASSWORD` or compose aborts:
+   ```
+   NEO4J_URI="bolt://localhost:7687"
+   NEO4J_USER="neo4j"          # lowercase — the DozerDB default account is 'neo4j', NOT 'NEO4J'
+   NEO4J_PASSWORD="<your-password>"
+   NEO4J_BOLT_PORT=7687
+   NEO4J_HTTP_PORT=7474
+   ```
+2. **Start the container** (service name is `neo4j`, image `graphstack/dozerdb`):
+   ```bash
+   docker compose --env-file .env up -d neo4j
+   ```
+3. **Wait for bolt before connecting** — the container reports "Started" before bolt is ready; poll the log:
+   ```bash
+   until docker logs graphrag-neo4j 2>&1 | grep -q "Bolt enabled" || [ $SECONDS -gt 90 ]; do sleep 3; done
+   ```
+4. **Verify** connectivity + auth:
+   ```bash
+   python3 - <<'PY'
+   import os
+   from neo4j import GraphDatabase
+   d = GraphDatabase.driver(os.environ["NEO4J_URI"], auth=(os.environ["NEO4J_USER"], os.environ["NEO4J_PASSWORD"]))
+   d.verify_connectivity(); print("DozerDB OK")
+   PY
+   ```
+
+## Gotchas (each cost real debugging time)
+
+- **Username case sensitivity.** `NEO4J_USER="NEO4J"` (uppercase) fails auth; the default account is lowercase `neo4j`. Normalize before connecting.
+- **Wrong / forgotten password → reset by wiping the volume.** If you don't know the password, stop+remove the container and delete `./data/neo4j/` (DESTRUCTIVE — confirm with the user first), then recreate with a fresh `NEO4J_PASSWORD`.
+- **DozerDB does NOT auto-create a database on first write.** Multi-DB layouts (one DB per ontology, e.g. `fibobeindlpg`) must be created explicitly — see `finder-graphrag-bench` for the `ensure_database` step. A write to a non-existent DB silently lands 0 nodes; reads then raise `Graph not found`.
+- **Container exits silently across sessions.** Always re-run the bring-up + bolt-wait at the start of a graph session; don't assume yesterday's container is still up.
+- **Multi-database needs an enterprise-capable image.** DozerDB supports `CREATE DATABASE`; stock Neo4j Community does not. Confirm the image is `graphstack/dozerdb` if multi-DB `ensure_database` is failing with a syntax/privilege error.
+
+## Verify done
+
+`verify_connectivity()` returns without error and `SHOW DATABASES` (run on the `system` db) lists at least `neo4j` + `system`. For multi-DB benchmark runs, also confirm each ontology-derived DB exists.

--- a/.claude/skills/finder-graphrag-bench/SKILL.md
+++ b/.claude/skills/finder-graphrag-bench/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: finder-graphrag-bench
+description: Run SEOCHO's vector-vs-graph(-vs-hybrid) RAG comparison on FinDER-style financial QA, end to end — extract per-ontology graphs into DozerDB, embed evidence into LanceDB, then compare retrieval modes across one or more LLMs with token_f1 + LLM-judge and Opik traces. Invoke when asked to run/extend the FinDER or GraphRAG vector-vs-graph benchmark, reproduce the content-vs-context study, or measure where graph retrieval beats vector.
+---
+
+# finder-graphrag-bench
+
+Purpose: a single runbook for the multi-LLM vector/graph/hybrid comparison so a fresh clone can reproduce it without rediscovering the env contract, the per-ontology database setup, the rate-limit discipline, and the gotchas that silently corrupt results. This is the operational companion to CLAUDE.md §19–§20 (the vector-vs-graph study and its experimenter ethics).
+
+Pairs with: `dozerdb-up` (graph backend), `mara-gateway` (LLM provider), `opik-trace-meta` (trace tagging). Invoke those for their specifics.
+
+## Pipeline (4 stages)
+
+```
+extract → load(graph already in DozerDB) + embed(LanceDB) → compare → score
+```
+
+1. **Extract** per-ontology graphs into DozerDB — `scripts/benchmarks/finder_phase_experiment.py` (phase cases) or `finder_4arm_sample.py` (ontology-arm sweep). Writes typed nodes to an ontology-derived DB.
+2. **Embed** evidence into LanceDB — `scripts/benchmarks/finder_load_to_lancedb.py` (`--all` for all 910 cases, keyed by slice). Needed for the `vector` and `hybrid` lanes.
+3. **Compare** retrieval modes × LLMs — `scripts/benchmarks/finder_compare_vector_graph.py`.
+4. **Score** — token_f1 + LLM-judge (json), emitted to `outputs/evaluation/finder_compare/<run>/` + Opik.
+
+## Preconditions (check ALL before launching a long run)
+
+- **`.env`** (repo root) has: `MARA_API_KEY`, `OPENAI_API_KEY` (embeddings), `NEO4J_URI/USER/PASSWORD`, and Opik vars. `bench_common.bootstrap()` loads `.env` then `/home/hadry/openup/.env`; the repo-root `.env` wins per key.
+- **DozerDB up + reachable** → see `dozerdb-up`.
+- **Per-ontology databases exist.** Each ontology composition maps to its own DB (`sanitize(ontology.name + "lpg")`, e.g. `be+ind`→`fibobeindlpg`, `be+fbc`→`fibobefbclpg`). DozerDB does NOT auto-create on write. `finder_phase_experiment.run_one` now calls `graph_store.ensure_database(default_database)`, but if you bypass it, pre-create every DB the run needs — a missing DB silently stores 0 nodes and the compare's graph lane then 429s on `Graph not found`.
+- **LanceDB embedded for the cases you'll compare.** If a case isn't embedded, its vector/hybrid lane retrieves the wrong evidence. Run `finder_load_to_lancedb.py --all` once (cheap) to cover everything.
+- **LLM choice + rate limits** → see `mara-gateway`. Use `--judge mara/gpt-oss-120b` to keep the judge off the heaviest answer model; set `FINDER_LLM_TIMEOUT=300`.
+- **Opik tagging** → see `opik-trace-meta`.
+
+## Run recipes
+
+Smoke (1 case × all LLMs × 3 modes — validate the loop + Opik tags first):
+```bash
+python3 -u scripts/benchmarks/finder_compare_vector_graph.py \
+  --smoke --case 4af93b03 \
+  --llms "mara/DeepSeek-V3.1,mara/MiniMax-M2.5,mara/MiniMax-M2.7,mara/gpt-oss-120b" \
+  --judge mara/gpt-oss-120b --modes vector,graph,hybrid \
+  --graph-workspace-prefix <extraction-workspace-prefix>
+```
+
+Stratified slice-% (scale up after smoke passes):
+```bash
+# 1) extract (writes graphs; FINDER_LLM_TIMEOUT guards big cases)
+FINDER_LLM_TIMEOUT=300 python3 -u scripts/benchmarks/finder_phase_experiment.py \
+  --stratified 0.10 --llm mara/DeepSeek-V3.1 --variants treatment \
+  --workspace-prefix mara-strat10-<ts>
+# 2) embed all cases once
+python3 -u scripts/benchmarks/finder_load_to_lancedb.py --all --overwrite
+# 3) compare
+python3 -u scripts/benchmarks/finder_compare_vector_graph.py \
+  --stratified 0.10 --llms "mara/DeepSeek-V3.1,..." --judge mara/gpt-oss-120b \
+  --modes vector,graph,hybrid --graph-workspace-prefix mara-strat10-<ts>
+```
+
+`--graph-workspace-prefix` MUST match the extraction `--workspace-prefix` — the compare's graph lane reads nodes from the ontology DB filtered by `_workspace_id` built from this prefix. Mismatch → empty graph context.
+
+## Background + monitoring (long runs)
+
+- Launch detached (`python3 -u ... > log 2>&1 &`) — sweeps run hours; never as a fragile foreground child.
+- Resume-safe: per-(case,mode,llm) partials land in `<run>/partial/`; the final `aggregate.json` is rebuilt from in-memory records. Re-running the same command skips matching partials.
+- Watch milestones, not every line; aggregate partials mid-run by `mode` and by `slice`.
+
+## Gotchas that silently corrupt results (each cost a wasted run this is built from)
+
+- **Entity fallback.** A weak extractor labels everything generic `Entity` instead of the ontology's domain classes, gutting the graph. MARA DeepSeek-V3.1 ≈ 0% fallback; some models ~67%. Check the per-label distribution in the target DB after extraction (`MATCH (n) WHERE NOT n:_infra RETURN labels(n)[0], count(*)`); near-100% `Entity` = re-extract with a better model.
+- **Graph serializer dropping raw text (`keep_raw`).** The typed-only graph view drops the raw Chunk/Section text the graph already stores, handicapping the graph lane vs vector/Graphiti. `_graph_context(..., keep_raw=True)` re-adds it — the False/True delta is the *serialization* effect, not recall. Don't attribute a graph-lane loss to "ontology/recall" until you've A/B'd `keep_raw`.
+- **judge 0 → -1 bug.** `int(d.get("score", -1) or -1)` turns a real `0` into `-1`; reserve `-1` for parse failures only.
+- **Per-case vector scoping.** With many cases embedded, vector retrieval must filter to the case's own evidence (`where case_id = ...`), else top-k returns other cases' chunks.
+- **MARA daily quota / 429** → `mara-gateway`. Separate the judge model; never re-run completed partials.
+
+## Experimenter ethics (binding — CLAUDE.md §20)
+
+Report all slices every run; pair point estimates with n / spread; small-sample wins are noise until reproduced at scale (a 9-case "graph beats vector on S1" reversed at 28 cases). Keep ontology the only moving part across graph arms. State measured result before mechanism. Disconfirming evidence is the finding, not noise to filter.
+
+## Verify done
+
+Smoke: all runs OK, judge parse-errors 0, the 4 Opik axis-tags present (`opik-trace-meta`). Full run: `aggregate.json` written, per-slice vector/graph/hybrid table produced with n per cell, error rate reported (not hidden).

--- a/.claude/skills/mara-gateway/SKILL.md
+++ b/.claude/skills/mara-gateway/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: mara-gateway
+description: Use the MARA cloud gateway (OpenAI-compatible, multi-model) as the default generator + LLM-judge for SEOCHO benchmarks. Invoke when selecting an LLM for extraction/answer/judge, when a model id 404s, when hitting 429 rate limits, or when wiring a new provider/model into a benchmark run.
+---
+
+# mara-gateway
+
+Purpose: one place that captures how to call MARA correctly so runs don't 404 on a mistyped model id, stall on rate limits, or skew results with a self-judging model. MARA is the repo's preferred live-experiment provider for generator + judge (CLAUDE.md §19 live-experiment default; `feedback_provider_cost_policy`).
+
+## When to invoke
+
+- Choosing the extraction / answer / judge LLM for any benchmark (`finder-graphrag-bench`, `finder_4arm_sample.py`, `graphrag_bench.py`).
+- A call fails with `model_not_found` (404) or `RateLimitError` (429).
+- Adding MARA to a new script via `seocho.store.llm.create_llm_backend` or `examples/finder/lib/llm_io.parse_llm_spec`.
+
+## The gateway
+
+- OpenAI-compatible. `base_url = https://api.cloud.mara.com/v1`, key env `MARA_API_KEY`.
+- Provider id is **`mara`** — registered in BOTH `src/seocho/store/llm.py` (`_PROVIDER_SPECS`) and `examples/finder/lib/llm_io.py` (`_PROVIDER_PRESETS`). Use it as `mara/<Model>`.
+- Drives any benchmark via `--llm mara/<Model>` (extraction) or `--llms mara/<Model>,...` / `--judge mara/<Model>` (compare).
+
+## The 4 models — EXACT case-sensitive ids (gateway 404s on wrong casing)
+
+| id (use verbatim) | notes |
+|---|---|
+| `DeepSeek-V3.1` | strong default generator; **~1500 RPD** rate limit (tightest) |
+| `MiniMax-M2.5` | capital `M`s; may echo a reasoning trace in `content` |
+| `MiniMax-M2.7` | capital `M`s |
+| `gpt-oss-120b` | may return `content=None`; rely on JSON-parse fallback |
+
+`minimax-m2.5` (lowercase) → 404. Always pass the exact casing. `client.models.list()` returns the authoritative ids.
+
+## Rate-limit discipline (429)
+
+- DeepSeek-V3.1 ≈ 1500 requests/day. A multi-LLM × multi-mode sweep blows through this fast, **especially if DeepSeek is both an answer model AND the judge** (doubles its load).
+- **Separate the judge from the heaviest answer model.** Prefer `--judge mara/gpt-oss-120b` (or another model) when DeepSeek-V3.1 is in the answer set.
+- Use the patient 429 retry schedule in `examples/finder/lib/llm_io.py:with_retry` — generic transient errors retry 3× (1/4/16s) but **429 retries 6× with 10/30/60/90/120s backoff**. Don't shorten it; the gateway throttles for tens of seconds.
+- Mind the **daily** quota: if a long sweep starts 429-ing across all slices, you are likely at the daily cap — pause and resume after reset rather than burning retries.
+- Cost-sensitivity (`feedback_cost_sensitivity_llm_calls`): the user pays every call. Never re-run a sweep that already produced partials; resume from checkpoints.
+
+## Timeouts
+
+Large-context answers (reasoning_mode + big evidence) can exceed the default 120s. Set `FINDER_LLM_TIMEOUT=300` for extraction/answer runs that include long cases (e.g. footnotes/debt with 5KB+ evidence).
+
+## Verify done
+
+A 1-token ping to each requested model returns `finish_reason` without 404; the judge model is not the same as the dominant answer model (unless self-judging is explicitly intended and tagged).

--- a/.claude/skills/opik-trace-meta/SKILL.md
+++ b/.claude/skills/opik-trace-meta/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: opik-trace-meta
+description: Tag SEOCHO benchmark traces with the 4 mandatory comparison axes (dataset, model, GraphRAG flow, ontology) so Opik runs are filterable and comparable, and verify they landed. Invoke when emitting Opik traces from a benchmark, adding a new run dimension, or when traces show up in Opik with missing/blank tags.
+---
+
+# opik-trace-meta
+
+Purpose: make every benchmark trace answer the four questions a comparison needs — **(1) what data, (2) what model, (3) what GraphRAG flow, (4) what ontology** — as filterable Opik tag chips, not just buried metadata. Without this, a multi-LLM × multi-mode × multi-ontology sweep is unanalyzable in the UI. (CLAUDE.md §9 observability; §19 minimal-tag contract.)
+
+## When to invoke
+
+- Emitting Opik traces from any benchmark runner (`finder_compare_vector_graph.py`, `finder_4arm_sample.py`, `graphrag_bench.py`).
+- Adding a new comparison dimension (a new model, retrieval mode, ontology arm, graph-quality variant).
+- Traces appear in Opik with blank `name`/`tags`/`metadata`, or the UI can't filter by data/model/flow/ontology.
+
+## The 4 mandatory axes (build via `bench_common.build_core_meta`)
+
+Use `examples/finder/lib/bench_common.build_core_meta(...)` — it returns `(tags, metadata)` with all four axes promoted to **tags** (filter chips), the rest in metadata:
+
+| Axis | Tags emitted |
+|---|---|
+| 1. dataset | `dataset:<csv>`, `case:<id>`, `slice:<S#>`, `category:<...>` |
+| 2. model | `model:<provider/model>`, `provider:<...>`, `judge:<provider/model>` (judge traces) |
+| 3. GraphRAG flow | `flow:graphrag`, `mode:<vector|graph|hybrid>`, `retrieval_k`, `reasoning_mode`, `repair_budget` |
+| 4. ontology | `ontology_hash:<10hex>`, `modules:<be+ind+...>`, `prompt_hash:<10hex>` |
+| A/B dims | `graph_quality:<raw|qualified|...>`, `cypher_agent:<v1|v2>` |
+
+Wrap the actual work in `bench_common.run_under_opik_track(name, tags, metadata, work_fn)` so the LLM sub-call traces nest under a tagged parent. `name` convention: `<phase|stage>/<provider>/<mode>/<case>`.
+
+## Self-hosted vs cloud
+
+- **Self-hosted (default here):** `.env` sets `OPIK_URL_OVERRIDE=http://localhost:5173/api` + `SEOCHO_TRACE_OPIK_MODE=self_host` + `OPIK_WORKSPACE` + `OPIK_PROJECT_NAME`. Setting `OPIK_URL_OVERRIDE` auto-flips `seocho.tracing` to self-host. Bring the server up (`./opik.sh` from the cloned comet-ml/opik repo) and confirm `http://localhost:5173/api/...` returns 200 before relying on traces.
+- Keep a cloud key (if any) in a separate var like `OPIK_CLOUD_API_KEY` so it doesn't override the self-host config.
+- **SDK must match server major version** (self-host `:latest` ≈ opik 2.x). A stale SDK silently writes traces with NULL name/tags/metadata.
+
+## Verify the tags actually landed (don't trust "it ran")
+
+Query the REST API directly (no MCP needed):
+```bash
+python3 - <<'PY'
+import os, json, urllib.request, urllib.parse
+base=os.environ["OPIK_URL_OVERRIDE"].rstrip("/"); ws=os.environ["OPIK_WORKSPACE"]; proj=os.environ["OPIK_PROJECT_NAME"]
+def get(p,q): 
+    u=base+p+"?"+urllib.parse.urlencode(q)
+    return json.loads(urllib.request.urlopen(urllib.request.Request(u,headers={"Comet-Workspace":ws}),timeout=10).read())
+pid=next(p["id"] for p in get("/v1/private/projects",{"workspace_name":ws,"size":100})["content"] if p["name"]==proj)
+t=get("/v1/private/traces",{"workspace_name":ws,"project_id":pid,"size":1})["content"][0]
+tags=" ".join(t.get("tags") or [])
+print({k:(n in tags) for k,n in [("dataset","dataset:"),("model","model:"),("flow","flow:"),("ontology","ontology_hash:")]})
+PY
+```
+All four must be `True`.
+
+## Gotchas
+
+- **Empty tags despite a "successful" run** = trace was created outside the `@track`/`run_under_opik_track` context (so `update_current_trace` was a no-op), or an SDK/server version skew. Wrap work in the track helper and match SDK to server.
+- **A real `0` score must not become `-1`.** When recording judge scores, `int(d.get("score", -1) or -1)` turns a legitimate `0` (refusal/wrong) into `-1`; use an `isinstance` check and reserve `-1` for genuine parse failures only.

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,10 @@ runs/
 # Public middleware code should not track editor/agent state directories.
 .agents/
 .beads/
-.claude/
+# .claude is personal/agent state EXCEPT shared model-invoked skills, which
+# ship with the repo so a fresh clone gets the benchmark/infra runbooks.
+.claude/*
+!.claude/skills/
 .githooks/
 .jules/
 .serena/

--- a/examples/finder/lib/bench_common.py
+++ b/examples/finder/lib/bench_common.py
@@ -434,21 +434,33 @@ def build_core_meta(
     # Minimal, human-readable, FILTERABLE tag set (CLAUDE.md §19 Opik contract):
     # keep the Opik project legible at ~7 tags/trace. Everything else lives in
     # metadata (reproduce/inspect) or feedback_scores (numeric, comparable).
+    # The 4 user-mandated filter axes are ALL promoted to tags so they're
+    # filterable chips in the Opik UI: (1) dataset, (2) model, (3) flow,
+    # (4) ontology. Plus mode/case/slice for slicing. Everything else stays
+    # in metadata (still searchable, just not a chip).
     tags = [
+        # 1. dataset
+        f"dataset:{dataset_name}",
+        f"case:{case_id}",
         f"slice:{slice_tag}",
+        # 2. model
         f"model:{llm_spec}",
+        f"provider:{provider}",
+        # 3. flow
         f"flow:{flow}",
+        f"mode:{mode}",
+        # 4. ontology
+        f"ontology_hash:{ontology_hash}",
+        f"modules:{ontology_modules}",
+        # graph-quality / cypher-agent A/B axes
         f"graph_quality:{graph_quality}",
+        f"cypher_agent:{cypher_agent_version}",
     ]
     if run_prefix:
         tags.append(f"run:{run_prefix}")
-    # Promote ONLY the two primary comparison axes from extra_tags to tags
-    # (retrieval, ontology); the rest (prompt, seed, …) go to metadata.
-    _TAG_WHITELIST = {"retrieval", "ontology"}
     if extra_tags:
         for k, v in extra_tags.items():
-            if k in _TAG_WHITELIST:
-                tags.append(f"{k}:{v}")
+            tags.append(f"{k}:{v}")
 
     metadata: dict = {
         # 1. dataset

--- a/examples/finder/lib/llm_io.py
+++ b/examples/finder/lib/llm_io.py
@@ -36,6 +36,11 @@ def _status_of(exc: Exception) -> int | None:
     return None
 
 
+# Rate-limit (429) gets its own, more patient retry schedule because shared
+# gateways like MARA (DeepSeek-V3.1 ≈ 1500 RPD) throttle for tens of seconds.
+_RATE_LIMIT_BACKOFF = (10.0, 30.0, 60.0, 90.0, 120.0)
+
+
 def with_retry(
     fn: Callable[[], Any],
     *,
@@ -45,34 +50,50 @@ def with_retry(
     retry_on_exc_names: Iterable[str] = ("Timeout", "APIConnectionError", "ReadTimeout", "ConnectError"),
     label: str = "llm",
     verbose: bool = False,
+    rate_limit_attempts: int = 6,
+    rate_limit_backoff: Iterable[float] = _RATE_LIMIT_BACKOFF,
 ) -> Any:
     """Run ``fn()`` with retries on transient HTTP / network errors.
 
-    Idempotent ``fn`` only — the caller is responsible for ensuring the
-    operation is safe to retry. Adds small jitter to each backoff delay.
+    Idempotent ``fn`` only. Two schedules:
+      - generic transient (5xx/timeout/conn): ``max_attempts`` w/ ``backoff_seconds``
+      - rate limit (429): ``rate_limit_attempts`` w/ the longer ``rate_limit_backoff``
+        (MARA & other shared gateways throttle for tens of seconds).
+    Adds ±25% jitter to each delay.
     """
     backoffs = list(backoff_seconds)
+    rl_backoffs = list(rate_limit_backoff)
     statuses = set(retry_on_status)
     exc_names = tuple(retry_on_exc_names)
     last_exc: Exception | None = None
-    for attempt in range(1, max_attempts + 1):
+    generic_used = 0
+    rl_used = 0
+    while True:
         try:
             return fn()
-        except Exception as exc:  # noqa: BLE001 — broad on purpose; rethrow non-retriable below
+        except Exception as exc:  # noqa: BLE001
             last_exc = exc
             name = type(exc).__name__
             status = _status_of(exc)
-            retriable = (status in statuses) or any(n in name for n in exc_names)
-            if not retriable or attempt >= max_attempts:
+            is_rate_limit = status == 429 or "RateLimit" in name
+            is_generic = (status in statuses and status != 429) or any(n in name for n in exc_names)
+            if is_rate_limit:
+                rl_used += 1
+                if rl_used >= rate_limit_attempts:
+                    raise
+                wait = rl_backoffs[min(rl_used - 1, len(rl_backoffs) - 1)]
+            elif is_generic:
+                generic_used += 1
+                if generic_used >= max_attempts:
+                    raise
+                wait = backoffs[min(generic_used - 1, len(backoffs) - 1)]
+            else:
                 raise
-            wait = backoffs[min(attempt - 1, len(backoffs) - 1)]
-            wait = wait * (0.75 + random.random() * 0.5)  # jitter ±25%
+            wait = wait * (0.75 + random.random() * 0.5)
             if verbose:
-                print(f"  [retry:{label}] attempt {attempt}/{max_attempts} failed ({name} status={status}); sleep {wait:.1f}s", flush=True)
+                kind = "429" if is_rate_limit else "transient"
+                print(f"  [retry:{label}] {kind} ({name} status={status}); sleep {wait:.1f}s", flush=True)
             time.sleep(wait)
-    if last_exc is not None:
-        raise last_exc
-    raise RuntimeError(f"with_retry({label}) exhausted without exception")
 
 
 # ---------------------------------------------------------------------------
@@ -123,8 +144,11 @@ _PROVIDER_PRESETS: dict[str, dict] = {
         "forced_temperature": None,
         "supports_response_format_json": True,  # deepseek docs document JSON Output mode
     },
-    # MARA cloud — OpenAI-compatible endpoint serving MiniMax-class models.
-    # Mirrors src/seocho/store/llm.py's "mara" ProviderSpec (the SDK default).
+    # MARA cloud gateway (OpenAI-compatible). Models: DeepSeek-V3.1,
+    # MiniMax-M2.5, MiniMax-M2.7, gpt-oss-120b. Mirrors src/seocho/store/llm.py's
+    # "mara" ProviderSpec. supports_response_format_json kept False (gateway OSS
+    # models vary in JSON discipline); chat_complete falls back to a JSON-only
+    # system tail + lenient parse, so the judge still works.
     "mara": {
         "default_model": "MiniMax-M2.5",
         "base_url": "https://api.cloud.mara.com/v1",
@@ -133,6 +157,9 @@ _PROVIDER_PRESETS: dict[str, dict] = {
         "supports_response_format_json": False,
     },
 }
+
+# Known MARA model ids (exact casing — gateway is case-sensitive).
+MARA_MODELS = ("DeepSeek-V3.1", "MiniMax-M2.5", "MiniMax-M2.7", "gpt-oss-120b")
 
 
 def parse_llm_spec(spec: str) -> LLMSpec:

--- a/scripts/benchmarks/finder_4arm_sample.py
+++ b/scripts/benchmarks/finder_4arm_sample.py
@@ -185,22 +185,34 @@ _ANSWER_SYSTEM = (
 )
 
 
-def _graph_context(graph_store, ws: str, db: str) -> str:
+def _graph_context(graph_store, ws: str, db: str, *, keep_raw: bool = False) -> str:
     """Serialize the case's extracted subgraph to text (graph-as-context).
 
     Robust alternative to structured Cypher Q&A: dumps typed nodes (+ value/
-    period/basis), relationships, and stored chunk text for the workspace so the
-    LLM can read what this ontology arm actually extracted. (CLAUDE.md §19.)
+    period/basis) and relationships for the workspace. (CLAUDE.md §19.)
+
+    ``keep_raw`` (fairness fix, 2026-06-04): by default the typed-only view DROPS
+    the raw ``Chunk``/``Section`` text the graph already stores (``_INFRA_LABELS``),
+    handicapping the graph lane vs vector and vs Graphiti's episodes. Set
+    ``keep_raw=True`` to ALSO emit a "Source passages" section — the SEOCHO
+    full-context equivalent of Graphiti's episodes. A/B-able: the difference
+    between keep_raw False/True is the serialization (not extraction) effect.
     """
     lines: list[str] = ["=== Knowledge graph: entities & metrics ==="]
+    raw_passages: list[str] = []
     nodes = graph_store.query(
         "MATCH (n {_workspace_id:$w}) RETURN labels(n) AS l, properties(n) AS p",
         params={"w": ws}, database=db)
     for r in nodes or []:
-        labs = [x for x in (r["l"] or []) if x not in _INFRA_LABELS]
-        if not labs:
-            continue
+        all_labs = r["l"] or []
+        labs = [x for x in all_labs if x not in _INFRA_LABELS]
         p = r["p"] or {}
+        if not labs:
+            if keep_raw:
+                txt = (p.get("text") or p.get("content") or p.get("body") or "").strip()
+                if txt:
+                    raw_passages.append(txt)
+            continue
         nm = p.get("name") or p.get("uri") or ""
         bits = [f"{k}={p[k]}" for k in
                 ("value", "period", "basis", "segment", "amount", "amount_per_share",
@@ -214,6 +226,10 @@ def _graph_context(graph_store, ws: str, db: str) -> str:
         lines.append("=== Relationships ===")
         for r in rels:
             lines.append(f"- {r['s']} -{r['t']}-> {r['o']}")
+    if keep_raw and raw_passages:
+        lines.append("=== Source passages ===")
+        for t in raw_passages:
+            lines.append(f"- {t}")
     return "\n".join(lines)
 
 
@@ -322,6 +338,7 @@ def run_one(*, case: dict, arm: str, modules: list[str], llm_spec: str,
             pass
 
         graph_ctx = _graph_context(graph_store, workspace_id, database)
+        graph_ctx_keepraw = _graph_context(graph_store, workspace_id, database, keep_raw=True)
         vec_ctx = _vector_context(case["references"], case["query"], oai_client)
     except Exception as exc:
         error = f"{type(exc).__name__}: {exc}"
@@ -345,6 +362,10 @@ def run_one(*, case: dict, arm: str, modules: list[str], llm_spec: str,
 
     mode_specs = [
         ("graph", "graphrag", "graph", "=== GRAPH CONTEXT ===\n" + graph_ctx),
+        # keep_raw A/B: identical graph/arm/query/judge as `graph`; the ONLY
+        # difference is the graph serializer re-adding raw Chunk/Section text.
+        # graph_keepraw − graph = pure serialization effect (confound test, §20).
+        ("graph_keepraw", "graphrag", "graph", "=== GRAPH CONTEXT ===\n" + graph_ctx_keepraw),
         ("vector_graph", "hybrid", "vector_graph",
          "=== VECTOR CONTEXT (retrieved chunks) ===\n" + vec_ctx +
          "\n\n=== GRAPH CONTEXT ===\n" + graph_ctx),

--- a/scripts/benchmarks/finder_compare_vector_graph.py
+++ b/scripts/benchmarks/finder_compare_vector_graph.py
@@ -49,6 +49,27 @@ from examples.finder.lib import llm_io  # noqa: E402
 DATASET_NAME = "all_slices.csv"
 DEFAULT_SMOKE_CASE = "4af93b03"   # P0 ROST
 
+# Slice → FIBO modules (matches finder_phase_experiment.SLICE_MODULES) so a
+# stratified compare resolves the same ontology/DB that extraction wrote to.
+SLICE_MODULES: dict[str, tuple[str, ...]] = {
+    "S1_FIN_COMP": ("be", "ind"),
+    "S2_FIN_NONQUANT_MULTI": ("be", "ind"),
+    "S3_CO_COMP": ("be", "fbc"),
+    "S4_CO_MULTI_NONQUANT": ("be", "fbc"),
+    "S5_FN_MULTI": ("be", "ind", "fnd", "acc"),
+    "S6_BASELINE_SINGLE": ("be", "ind"),
+}
+
+
+def _modules_for_code(code: str) -> tuple[str, ...] | None:
+    """Resolve treatment modules for a phase code (P0…) or slice tag (S1…)."""
+    if code in SLICE_MODULES:
+        return SLICE_MODULES[code]
+    try:
+        return tuple(bc.get_phase(code).treatment_modules)
+    except Exception:
+        return None
+
 
 # ---------------------------------------------------------------------------
 # data loading
@@ -74,8 +95,11 @@ def load_case_data(case_id: str) -> dict:
 # retrieval
 # ---------------------------------------------------------------------------
 
-def vector_retrieve(query: str, *, case_id: str, top_k: int = 5) -> str:
-    """LanceDB semantic top-k over the phase evidence index."""
+def vector_retrieve(query: str, *, case_id: str, top_k: int = 5, scope_case: bool = True) -> str:
+    """LanceDB semantic top-k. By default scope to the case's own evidence
+    (correct per-case RAG); with many cases embedded a global search would
+    return other cases' chunks. Falls back to global if the case has no rows.
+    """
     import lancedb
     from openai import OpenAI
 
@@ -84,7 +108,14 @@ def vector_retrieve(query: str, *, case_id: str, top_k: int = 5) -> str:
 
     db = lancedb.connect(str(ROOT / ".seocho/lancedb"))
     table = db.open_table("finder_phase_evidence")
-    hits = table.search(qvec).limit(top_k).to_list()
+    hits = []
+    if scope_case:
+        try:
+            hits = table.search(qvec).where(f"case_id = '{case_id}'").limit(top_k).to_list()
+        except Exception:
+            hits = []
+    if not hits:
+        hits = table.search(qvec).limit(top_k).to_list()
 
     pieces = []
     for i, h in enumerate(hits, 1):
@@ -100,8 +131,16 @@ _KEEP_PROPS = frozenset({
 })
 
 
-def graph_retrieve(case_id: str, query: str) -> str:
-    """Neo4j retrieve: case-scoped entities + 1-hop relations rendered as text."""
+def graph_retrieve(case_id: str, query: str, *, database: str | None = None,
+                   workspace_id: str | None = None) -> str:
+    """Neo4j retrieve: scoped entities + 1-hop relations rendered as text.
+
+    Scoping precedence:
+      - if ``workspace_id`` given → filter by ``n._workspace_id`` (phase-extract
+        nodes carry _workspace_id, not _case_id), in the ontology-derived
+        ``database`` (e.g. fibobeindlpg).
+      - else → legacy ``_case_id`` filter in the default DB (load_to_neo4j merge).
+    """
     from neo4j import GraphDatabase
 
     drv = GraphDatabase.driver(
@@ -109,34 +148,40 @@ def graph_retrieve(case_id: str, query: str) -> str:
         auth=(os.environ.get("NEO4J_USER", "neo4j"), os.environ["NEO4J_PASSWORD"]),
     )
 
+    if workspace_id:
+        scope_prop, scope_val = "_workspace_id", workspace_id
+    else:
+        scope_prop, scope_val = "_case_id", case_id
+    sess_kwargs = {"database": database} if database else {}
+
     try:
-        with drv.session() as s:
+        with drv.session(**sess_kwargs) as s:
             nodes_rows = s.run(
-                """
-                MATCH (n {_case_id: $cid})
+                f"""
+                MATCH (n {{{scope_prop}: $sv}})
                 WHERE NOT n:Chunk AND NOT n:Document AND NOT n:DocumentVersion AND NOT n:Section
                 RETURN labels(n)[0] AS lbl, properties(n) AS props
                 """,
-                cid=case_id,
+                sv=scope_val,
             ).data()
             edge_rows = s.run(
-                """
-                MATCH (a {_case_id: $cid})-[r]->(b {_case_id: $cid})
+                f"""
+                MATCH (a {{{scope_prop}: $sv}})-[r]->(b {{{scope_prop}: $sv}})
                 WHERE NOT a:Chunk AND NOT a:Document AND NOT a:DocumentVersion AND NOT a:Section
                   AND NOT b:Chunk AND NOT b:Document AND NOT b:DocumentVersion AND NOT b:Section
                 RETURN labels(a)[0] AS a_lbl, a.name AS a_name,
                        type(r) AS rt,
                        labels(b)[0] AS b_lbl, b.name AS b_name
                 """,
-                cid=case_id,
+                sv=scope_val,
             ).data()
             chunk_rows = s.run(
-                """
-                MATCH (c:Chunk {_case_id: $cid})
+                f"""
+                MATCH (c:Chunk {{{scope_prop}: $sv}})
                 RETURN c.content_preview AS preview, c.content AS content
                 LIMIT 3
                 """,
-                cid=case_id,
+                sv=scope_val,
             ).data()
     finally:
         drv.close()
@@ -160,10 +205,30 @@ def graph_retrieve(case_id: str, query: str) -> str:
     return "\n".join(lines)
 
 
-def hybrid_retrieve(query: str, *, case_id: str, top_k: int = 5) -> str:
+def hybrid_retrieve(query: str, *, case_id: str, top_k: int = 5,
+                    database: str | None = None, workspace_id: str | None = None) -> str:
     v = vector_retrieve(query, case_id=case_id, top_k=top_k)
-    g = graph_retrieve(case_id, query)
+    g = graph_retrieve(case_id, query, database=database, workspace_id=workspace_id)
     return f"===== VECTOR CONTEXT =====\n{v}\n\n===== GRAPH CONTEXT =====\n{g}"
+
+
+def _phase_database(phase_code: str) -> str | None:
+    """Map a phase code to its ontology-derived DozerDB database name.
+
+    Mirrors seocho.client._resolve_default_database: sanitize(f"{ontology.name}lpg").
+    """
+    try:
+        sys.path.insert(0, str(ROOT))
+        from examples.finder.datasets.fibo_modules.compose import compose_modules
+        from seocho.store.graph import sanitize_database_name
+        modules = _modules_for_code(phase_code)
+        if not modules:
+            return None
+        o = compose_modules(list(modules))
+        domain = o.name.lower().replace(" ", "").replace("-", "").replace("_", "")
+        return sanitize_database_name(f"{domain}lpg")
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +329,8 @@ def run_one(
     graph_quality: str = "raw",
     cypher_agent_version: str = "v1",
     retrieval_k: int = 5,
+    graph_database: str | None = None,
+    graph_workspace_id: str | None = None,
 ) -> RunRecord:
     name = f"compare/{llm_spec.provider}/{mode}/{phase}/{case_id}"
     onto_hash = bc.short_hash(modules_label)
@@ -302,9 +369,11 @@ def run_one(
         if mode == "vector":
             context = vector_retrieve(case["query"], case_id=case_id, top_k=retrieval_k)
         elif mode == "graph":
-            context = graph_retrieve(case_id, case["query"])
+            context = graph_retrieve(case_id, case["query"],
+                                     database=graph_database, workspace_id=graph_workspace_id)
         elif mode == "hybrid":
-            context = hybrid_retrieve(case["query"], case_id=case_id, top_k=retrieval_k)
+            context = hybrid_retrieve(case["query"], case_id=case_id, top_k=retrieval_k,
+                                      database=graph_database, workspace_id=graph_workspace_id)
         else:
             raise ValueError(f"unknown mode {mode}")
         answer = generate_answer(case["query"], context,
@@ -338,6 +407,11 @@ def run_one(
         except Exception as exc:
             judge = {"score": -1, "rationale": f"judge call err: {type(exc).__name__}: {exc}"}
 
+    # Score coalescing: a legitimate 0 (refusal/wrong) must NOT become -1.
+    # -1 is reserved for "judge failed to produce a parseable score".
+    _raw_score = judge.get("score", None)
+    _judge_score = int(_raw_score) if isinstance(_raw_score, (int, float)) else -1
+
     rec = RunRecord(
         phase=phase, case_id=case_id, slice_tag=case["slice"],
         category=case["category"], mode=mode,
@@ -345,7 +419,7 @@ def run_one(
         query=case["query"],
         gold=case["expected_answer"], context_chars=len(context),
         answer=answer, answer_chars=len(answer),
-        token_f1=f1, judge_score=int(judge.get("score", -1) or -1),
+        token_f1=f1, judge_score=_judge_score,
         judge_rationale=str(judge.get("rationale", "")),
         latency_s=latency,
         graph_quality=graph_quality, cypher_agent_version=cypher_agent_version,
@@ -353,7 +427,9 @@ def run_one(
     )
 
     # Partial checkpoint — atomic (includes provider in filename for multi-LLM)
-    partial_path = out_partial_dir / f"{llm_spec.provider}__{phase}_{case_id}_{mode}.json"
+    # Include the full model (not just provider) so 4 MARA models don't collide.
+    _model_slug = llm_spec.llm_string.replace("/", "_").replace(".", "_")
+    partial_path = out_partial_dir / f"{_model_slug}__{phase}_{case_id}_{mode}.json"
     try:
         bc.atomic_write_json(partial_path, asdict(rec))
     except Exception as exc:
@@ -426,10 +502,8 @@ def _row_to_case(r) -> dict:
 
 
 def _modules_label_for_phase(phase_code: str) -> str:
-    try:
-        return "+".join(bc.get_phase(phase_code).treatment_modules)
-    except KeyError:
-        return "baseline"
+    modules = _modules_for_code(phase_code)
+    return "+".join(modules) if modules else "baseline"
 
 
 def main() -> int:
@@ -454,17 +528,26 @@ def main() -> int:
     parser.add_argument("--cypher-agent", default="v1",
                         help="Meta dim for text2cypher agent version.")
     parser.add_argument("--run-prefix", default="")
+    parser.add_argument("--graph-workspace-prefix", default="",
+                        help="If set, graph/hybrid retrieve reads from the ontology-derived "
+                             "phase DB filtered by workspace_id built from this prefix "
+                             "(e.g. mara-ds-20260606234147). Omit to use legacy _case_id in default DB.")
     args = parser.parse_args()
 
     bc.bootstrap(verbose=True)
 
-    requested_providers = [p.strip().lower() for p in args.llms.split(",") if p.strip()]
+    # --llms accepts bare providers ("kimi") OR full specs ("mara/MiniMax-M2.5").
+    # Keyed by full llm_string so e.g. 4 distinct MARA models stay separate.
+    requested_llms = [x.strip() for x in args.llms.split(",") if x.strip()]
     requested_modes = [m.strip().lower() for m in args.modes.split(",") if m.strip()]
-    if not requested_providers or not requested_modes:
+    if not requested_llms or not requested_modes:
         raise SystemExit("--llms and --modes must each have at least one entry")
-    unknown = [p for p in requested_providers if p not in llm_io.known_providers()]
-    if unknown:
-        raise SystemExit(f"unknown providers: {unknown}. Known: {llm_io.known_providers()}")
+
+    answer_specs: dict[str, llm_io.LLMSpec] = {}
+    for raw in requested_llms:
+        spec = llm_io.parse_llm_spec(raw if "/" in raw else f"{raw}/")
+        answer_specs[spec.llm_string] = spec
+    requested_providers = sorted({s.provider for s in answer_specs.values()})
 
     report = bc.preflight(
         strict=True,
@@ -488,13 +571,10 @@ def main() -> int:
         print(f"tracing init skipped: {e}")
         def flush_tracing(): pass  # type: ignore
 
-    # Build LLM client pool
-    answer_specs: dict[str, llm_io.LLMSpec] = {}
-    answer_clients: dict[str, object] = {}
-    for prov in requested_providers:
-        spec = llm_io.parse_llm_spec(f"{prov}/")
-        answer_specs[prov] = spec
-        answer_clients[prov] = llm_io.make_chat_client(spec)
+    # Build one client per distinct llm_string
+    answer_clients: dict[str, object] = {
+        key: llm_io.make_chat_client(spec) for key, spec in answer_specs.items()
+    }
 
     judge_spec = llm_io.parse_llm_spec(args.judge)
     judge_client = llm_io.make_chat_client(judge_spec)
@@ -515,8 +595,8 @@ def main() -> int:
     out_partial_dir.mkdir(parents=True, exist_ok=True)
 
     records: list[RunRecord] = []
-    total = len(cases) * len(requested_providers) * len(requested_modes)
-    print(f"\n== plan: {len(cases)} cases × {len(requested_providers)} llms × {len(requested_modes)} modes = {total} runs ==", flush=True)
+    total = len(cases) * len(answer_specs) * len(requested_modes)
+    print(f"\n== plan: {len(cases)} cases × {len(answer_specs)} llms × {len(requested_modes)} modes = {total} runs ==", flush=True)
     print(f"  providers: {requested_providers}")
     print(f"  modes:     {requested_modes}")
     print(f"  judge:     {judge_spec.llm_string}")
@@ -526,12 +606,16 @@ def main() -> int:
 
     for phase_code, case in cases:
         modules_label = _modules_label_for_phase(phase_code)
-        for prov in requested_providers:
-            spec = answer_specs[prov]
-            client = answer_clients[prov]
+        graph_db = _phase_database(phase_code) if args.graph_workspace_prefix else None
+        graph_ws = None
+        if args.graph_workspace_prefix:
+            graph_ws = bc.workspace_id_for(phase_code, case["case_id"], "treatment",
+                                           prefix=args.graph_workspace_prefix)
+        for llm_key, spec in answer_specs.items():
+            client = answer_clients[llm_key]
             for mode in requested_modes:
                 counter += 1
-                label = f"[{counter:3d}/{total}] {prov:9s} {mode:6s} {phase_code}/{case['case_id']}"
+                label = f"[{counter:3d}/{total}] {llm_key:24s} {mode:6s} {phase_code}/{case['case_id']}"
                 print(f">>> {label}", flush=True)
                 rec = run_one(
                     phase=phase_code, case_id=case["case_id"], modules_label=modules_label,
@@ -542,6 +626,8 @@ def main() -> int:
                     graph_quality=args.graph_quality,
                     cypher_agent_version=args.cypher_agent,
                     retrieval_k=args.retrieval_k,
+                    graph_database=graph_db,
+                    graph_workspace_id=graph_ws,
                 )
                 mark = "OK" if not rec.error else "ERR"
                 print(

--- a/scripts/benchmarks/finder_load_to_lancedb.py
+++ b/scripts/benchmarks/finder_load_to_lancedb.py
@@ -37,43 +37,55 @@ EMBED_MODEL = "text-embedding-3-small"
 EMBED_DIM = 1536  # OpenAI text-embedding-3-small default
 
 
-def build_records(workspace_prefix: str) -> list[dict]:
-    """Materialize the evidence chunks with phase/case/workspace metadata.
+# Slice → modules (matches finder_phase_experiment.SLICE_MODULES)
+SLICE_MODULES = {
+    "S1_FIN_COMP": ("be", "ind"), "S2_FIN_NONQUANT_MULTI": ("be", "ind"),
+    "S3_CO_COMP": ("be", "fbc"), "S4_CO_MULTI_NONQUANT": ("be", "fbc"),
+    "S5_FN_MULTI": ("be", "ind", "fnd", "acc"), "S6_BASELINE_SINGLE": ("be", "ind"),
+}
 
-    Uses ``bench_common.PHASES`` as the single source of truth (T1.1 / §6.1).
-    Each row gets a ``workspace_id`` so it can be joined against Neo4j nodes
-    that share the same id.
+
+def build_records(workspace_prefix: str, *, all_cases: bool = False) -> list[dict]:
+    """Materialize evidence chunks with phase/case/workspace metadata.
+
+    Default: the 9 PHASES cases (T1.1 source of truth).
+    ``all_cases=True``: every row in all_slices.csv (910 cases), keyed by slice
+    tag instead of phase code — needed so a stratified compare can vector-search
+    each case's own evidence.
     """
     df = pd.read_csv(SLICES_CSV)
-    by_id = {row["_id"]: row for _, row in df.iterrows()}
-
     records: list[dict] = []
-    for phase in bc.PHASES:
-        modules = "+".join(phase.treatment_modules)
-        for case_spec in phase.cases:
-            row = by_id.get(case_spec.case_id)
-            if row is None:
-                print(f"  ! case {case_spec.case_id} not in slices CSV — skipping")
-                continue
-            workspace_id = bc.workspace_id_for(phase.code, case_spec.case_id, "loaded", prefix=workspace_prefix)
-            refs = [r.strip() for r in str(row["references_joined"]).split(REF_SEPARATOR) if r.strip()]
-            for idx, text in enumerate(refs):
-                records.append({
-                    "id": f"{phase.code}::{case_spec.case_id}::{idx}",
-                    "phase": phase.code,
-                    "case_id": case_spec.case_id,
-                    "slice": row["slice"],
-                    "category": row["category"],
-                    "type": row["type"] if isinstance(row.get("type"), str) else "",
-                    "ontology_modules": modules,
-                    "workspace_id": workspace_id,  # §6.1 — cross-script join key
-                    "ref_idx": idx,
-                    "ref_count": len(refs),
-                    "n_chars": len(text),
-                    "query": row["query"],
-                    "expected_answer": row["answer"],
-                    "text": text,
-                })
+
+    def _emit(code: str, modules: tuple[str, ...], row) -> None:
+        cid = row["_id"]
+        refs = [r.strip() for r in str(row["references_joined"]).split(REF_SEPARATOR) if r.strip()]
+        wid = bc.workspace_id_for(code, cid, "loaded", prefix=workspace_prefix)
+        for idx, text in enumerate(refs):
+            def _s(v):  # coerce NaN/float/None → str for arrow schema stability
+                return "" if v is None or (isinstance(v, float)) else str(v)
+            records.append({
+                "id": f"{code}::{cid}::{idx}",
+                "phase": code, "case_id": str(cid), "slice": _s(row["slice"]),
+                "category": _s(row["category"]),
+                "type": row["type"] if isinstance(row.get("type"), str) else "",
+                "ontology_modules": "+".join(modules), "workspace_id": wid,
+                "ref_idx": idx, "ref_count": len(refs), "n_chars": len(text),
+                "query": _s(row["query"]), "expected_answer": _s(row["answer"]), "text": _s(text),
+            })
+
+    if all_cases:
+        for _, row in df.iterrows():
+            sl = row["slice"]
+            _emit(sl, SLICE_MODULES.get(sl, ("be", "ind")), row)
+    else:
+        by_id = {row["_id"]: row for _, row in df.iterrows()}
+        for phase in bc.PHASES:
+            for case_spec in phase.cases:
+                row = by_id.get(case_spec.case_id)
+                if row is None:
+                    print(f"  ! case {case_spec.case_id} not in slices CSV — skipping")
+                    continue
+                _emit(phase.code, phase.treatment_modules, row)
     return records
 
 
@@ -100,6 +112,8 @@ def main() -> int:
                         help="Drop the LanceDB table if it exists before writing.")
     parser.add_argument("--workspace-prefix",
                         default=f"finder-load-{time.strftime('%Y%m%d%H%M%S', time.gmtime())}")
+    parser.add_argument("--all", action="store_true",
+                        help="Embed ALL 910 cases (keyed by slice) instead of just the 9 PHASES cases.")
     args = parser.parse_args()
 
     bc.bootstrap(verbose=True)
@@ -116,7 +130,7 @@ def main() -> int:
     if not args.dry_run and not report.ok:
         raise SystemExit("preflight failed — fix env/connectivity before running")
 
-    records = build_records(args.workspace_prefix)
+    records = build_records(args.workspace_prefix, all_cases=args.all)
     print(f"= {len(records)} evidence chunks across {len({r['case_id'] for r in records})} cases =")
     per_phase: dict[str, int] = {}
     for r in records:

--- a/scripts/benchmarks/finder_phase_experiment.py
+++ b/scripts/benchmarks/finder_phase_experiment.py
@@ -37,6 +37,20 @@ from examples.finder.lib import bench_common as bc  # noqa: E402
 REF_SEPARATOR = "===EVIDENCE_BOUNDARY==="
 _NUM_RE = re.compile(r"-?\$?\d[\d,]*\.?\d*(?:%| million| billion| thousand)?", re.IGNORECASE)
 
+# Fixed slice → FIBO ontology modules (mirrors the P0–P1D phase design):
+#   S1·S2 (Financials)        → be+ind
+#   S3·S4 (Company overview)  → be+fbc
+#   S5    (Footnotes)         → be+ind+fnd+acc
+#   S6    (baseline single)   → be+ind
+SLICE_MODULES: dict[str, tuple[str, ...]] = {
+    "S1_FIN_COMP": ("be", "ind"),
+    "S2_FIN_NONQUANT_MULTI": ("be", "ind"),
+    "S3_CO_COMP": ("be", "fbc"),
+    "S4_CO_MULTI_NONQUANT": ("be", "fbc"),
+    "S5_FN_MULTI": ("be", "ind", "fnd", "acc"),
+    "S6_BASELINE_SINGLE": ("be", "ind"),
+}
+
 
 # ---------------------------------------------------------------------------
 # Data loading
@@ -210,7 +224,8 @@ def run_one(
     client = None
     try:
         provider, model = (llm_spec.split("/", 1) if "/" in llm_spec else ("openai", llm_spec))
-        raw_backend = create_llm_backend(provider=provider.strip(), model=model.strip())
+        _llm_timeout = float(os.environ.get("FINDER_LLM_TIMEOUT", "120"))
+        raw_backend = create_llm_backend(provider=provider.strip(), model=model.strip(), timeout=_llm_timeout)
         wrapped_llm = bc.MetaPromptLLMWrapper(raw_backend, meta_prompt) if meta_prompt else raw_backend
 
         if use_neo4j:
@@ -232,6 +247,21 @@ def run_one(
             llm=wrapped_llm,
             workspace_id=workspace_id,
         )
+
+        # Neo4j/DozerDB does NOT auto-create the ontology-derived database on
+        # first write — explicitly ensure it exists, else add() silently writes
+        # 0 nodes (root cause of the strat10 S3/S4 graph being empty).
+        if use_neo4j:
+            try:
+                target_db = getattr(client, "default_database", None) or "neo4j"
+                if hasattr(graph_store, "ensure_database"):
+                    graph_store.ensure_database(target_db)
+                    try:
+                        graph_store.ensure_constraints(ontology, database=target_db)
+                    except TypeError:
+                        graph_store.ensure_constraints(ontology)
+            except Exception as exc:
+                print(f"    [warn] ensure_database failed for {target_db!r}: {exc}", flush=True)
 
         timing = {"add_ms": 0.0, "ask_ms": 0.0}
 
@@ -397,6 +427,9 @@ def _print_table(phase_summary: dict) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--phases", default="all", help="Comma list of phase codes (P0,P1A,P1B,P1C,P1D) or 'all'.")
+    parser.add_argument("--stratified", default="",
+                        help="If set (e.g. 0.10), extract a stratified slice-% sample from "
+                             "all_slices.csv using SLICE_MODULES ontology mapping (ignores --phases).")
     parser.add_argument("--llm", default=os.environ.get("SEOCHO_LLM", "kimi/kimi-k2.5"))
     parser.add_argument("--dry-run", action="store_true", help="Skip LLM calls; report plan only.")
     parser.add_argument("--workspace-prefix",
@@ -434,24 +467,45 @@ def main() -> int:
     if not args.dry_run and not report.ok:
         raise SystemExit("preflight failed — fix env/connectivity before running")
 
-    # Resolve phase selection
-    if args.phases == "all":
-        selected_phases = bc.PHASES
-    else:
-        wanted = {p.strip().upper() for p in args.phases.split(",")}
-        selected_phases = tuple(p for p in bc.PHASES if p.code in wanted)
-        if not selected_phases:
-            raise SystemExit(f"No matching phases for filter {args.phases!r}")
-
     cases_index = load_cases()
     plan: list[tuple[bc.PhaseSpec, dict]] = []
-    for phase in selected_phases:
-        for case_spec in phase.cases:
-            case = cases_index.get(case_spec.case_id)
+
+    if args.stratified:
+        # Stratified sample across all_slices.csv; map each row's slice → a
+        # synthetic PhaseSpec carrying the slice's fixed ontology modules.
+        import pandas as pd
+        df = pd.read_csv(ROOT / ".seocho/datasets/finder/slices/all_slices.csv")
+        samp = bc.stratified_sample(df, fraction=float(args.stratified), seed=42)
+        for _, row in samp.iterrows():
+            cid = row["_id"]
+            case = cases_index.get(cid)
             if case is None:
-                print(f"  ! case {case_spec.case_id} not found in slices CSV — skipping")
                 continue
-            plan.append((phase, case))
+            modules = SLICE_MODULES.get(row["slice"], ("be", "ind"))
+            pseudo = bc.PhaseSpec(
+                code=row["slice"],   # use slice tag as the "phase code"
+                name=f"stratified_{row['slice']}",
+                treatment_modules=tuple(modules),
+                rationale=f"stratified {args.stratified} sample, slice {row['slice']}",
+                cases=(),
+            )
+            plan.append((pseudo, case))
+    else:
+        # Resolve phase selection
+        if args.phases == "all":
+            selected_phases = bc.PHASES
+        else:
+            wanted = {p.strip().upper() for p in args.phases.split(",")}
+            selected_phases = tuple(p for p in bc.PHASES if p.code in wanted)
+            if not selected_phases:
+                raise SystemExit(f"No matching phases for filter {args.phases!r}")
+        for phase in selected_phases:
+            for case_spec in phase.cases:
+                case = cases_index.get(case_spec.case_id)
+                if case is None:
+                    print(f"  ! case {case_spec.case_id} not found in slices CSV — skipping")
+                    continue
+                plan.append((phase, case))
 
     variant_plan: list[tuple[str, tuple[str, ...] | None]] = []
     if args.variants in ("baseline", "both"):


### PR DESCRIPTION
## Feature
Four model-invoked **skills** that capture this benchmark line's recurring setup + gotchas, plus the **harness improvements** they document — ported to main so the skill recipes are runnable from a fresh clone.

Skills (`.claude/skills/`):
- **finder-graphrag-bench** — end-to-end vector-vs-graph(-vs-hybrid) runbook (extract→embed→compare→score), preconditions, smoke/stratified recipes, and the traps that silently corrupt results (Entity fallback, keep_raw serializer confound, judge 0→-1, per-case vector scoping) + §20 experimenter ethics.
- **mara-gateway** — MARA OpenAI-compatible gateway: exact case-sensitive model ids, ~1500 RPD limit, 429 backoff discipline, judge/answer-model separation.
- **dozerdb-up** — bring up + bolt-wait + ensure_database / username-case / password-reset traps.
- **opik-trace-meta** — the 4 mandatory filter axes (dataset/model/flow/ontology) via `build_core_meta` + REST verification.

Harness port (so recipes work on main): `--graph-workspace-prefix`, per-case vector scoping, full `--llms` specs, judge 0→-1 fix (compare); `--stratified` + `ensure_database` (phase extract); `--all` embed (lancedb); `keep_raw` + `graph_keepraw` A/B (4arm); 4-axis Opik tags + patient 429 backoff (lib).

## Why
A fresh clone hit the same friction every session: which model ids, which flags, DozerDB not auto-creating databases, MARA rate limits, Opik self-host tagging, and confounds that quietly invalidate runs. Encoding these as skills + landing the matching harness lets others reproduce the study with minimal rediscovery.

## Design
- Skills follow the repo's existing `.claude/skills/<name>/SKILL.md` convention (frontmatter trigger + procedure).
- `.gitignore` now tracks `.claude/skills/` (was blanket-ignored) so skills ship via `git pull`; personal `.claude/*` state stays ignored.
- Harness changes are benchmark-script only (`scripts/benchmarks/*`, `examples/finder/lib/*`); no `src/seocho/` core change. All referenced symbols (`ensure_database`, `build_core_meta`, MARA provider) already exist on main.

## Expected Effect
`finder-graphrag-bench` (and friends) auto-surface when a user works on the vector-vs-graph benchmark; recipes run as written against main.

## Impact Results
Validated on the source worktrees: 0% Entity fallback (MARA DeepSeek-V3.1), keep_raw A/B isolates +3180 chars of re-added raw text, Opik 4-axis tags confirmed via REST, 429 backoff recovers under fake-429. Full stratified re-measure pending MARA quota reset.

## Validation
- `python3 -c "import ast; ast.parse(...)"` on all 6 harness files — syntax OK.
- All skill-referenced paths/symbols exist on main (verified).
- keep_raw A/B produces distinct context (typed-only 4296c vs keep_raw 7476c) against an existing DozerDB graph, zero LLM calls.

## Risks
- Harness scripts assume the env contract (MARA/OpenAI/DozerDB/Opik) — skills document it; missing env fails fast at preflight, not mid-run.
- `.gitignore` change re-includes `.claude/skills/` only; confirm no unintended `.claude` content gets tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)