### PR TITLE
feat(bench): FinDER synergy headline — signal-routed cost vs all-frontier (seocho-9xo)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ e2e-smoke: ## Run dockerized runtime smoke checks (ingest + semantic + debate)
 	@echo "🧪 Running e2e smoke checks..."
 	@bash scripts/integration/e2e_runtime_smoke.sh
 
+bench-finder-synergy: ## FinDER synergy headline: signal-routed cost vs all-frontier (add LIVE=N for MARA support parity)
+	@echo "📊 FinDER synergy benchmark (ontology-governed answering + signal-routed model)..."
+	@python3 scripts/benchmarks/finder_synergy.py $(if $(LIVE),--live $(LIVE),) $(if $(DATASET),--dataset $(DATASET),)
+
 demo-raw: ## Run beginner raw-data demo pipeline
 	@bash scripts/demo/pipeline_raw_data.sh
 

--- a/scripts/benchmarks/finder_synergy.py
+++ b/scripts/benchmarks/finder_synergy.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""FinDER synergy benchmark — the composed headline metric (council seocho-9xo).
+
+The luminary council's chosen headline (synergy #2): on FinDER, signal-routed
+model selection costs **< 0.6x all-frontier** while answer-support is held within
+noise of the all-frontier baseline. This composes two SEOCHO differentiators —
+**ontology-governed answering** (support/faithfulness) and the **agent router**
+("route on a known signal" → model tier) — into one number.
+
+The router is not yet wired into the live query path (verified: model_router has
+zero live importers; that wiring is ticket seocho-jdg). So this harness composes
+the arms EXTERNALLY and is honest about it:
+
+  * cost arm (deterministic, runs today): route each REAL FinDER case by its
+    known signal (category/reasoning_type) → tier → relative cost; report
+    routed_cost / all_frontier_cost on the real category distribution.
+  * support arm (--live, MARA): answer a sample under all-frontier vs routed
+    model and compare answer-support/match parity. Proves the cost saving does
+    not cost answer quality. (Heavier; the full run lands once seocho-jdg wires
+    the router into graph_cot_flow.)
+
+Run:
+  scripts/benchmarks/finder_synergy.py --dataset examples/finder/datasets/finder_tutorial_subset.json
+  scripts/benchmarks/finder_synergy.py --live 3   # + MARA support-parity sample
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parents[2]
+for p in (ROOT, ROOT / "src", ROOT / "extraction"):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from seocho.routing import ModelRouter, ModelTier  # noqa: E402
+from seocho.benchmarking import (  # noqa: E402
+    FinDERBenchmarkCase,
+    compare_answers,
+    load_finder_cases,
+    score_answer_slots,
+)
+
+# --------------------------------------------------------------------------- #
+# Signal → tier: "route on a known signal you already have" (the FinDER category
+# + reasoning_type IS the signal). Hard multi-step financial math needs the
+# frontier; single-passage lookups do not.
+# --------------------------------------------------------------------------- #
+
+_HARD_REASONING = {"compositional", "subtraction", "numeric"}
+_BALANCED_CATEGORIES = {"footnotes", "accounting", "legal", "risk", "governance"}
+_FAST_CATEGORIES = {"companyoverview", "company_overview", "shareholderreturn"}
+
+
+def route_tier_for_case(case: FinDERBenchmarkCase) -> ModelTier:
+    category = str(getattr(case, "category", "") or "").strip().lower()
+    reasoning = str(getattr(case, "reasoning_type", "") or "").strip().lower()
+    if reasoning in _HARD_REASONING:
+        return ModelTier.FRONTIER
+    if category in _FAST_CATEGORIES:
+        return ModelTier.FAST
+    if category == "financials":
+        return ModelTier.FRONTIER  # numbers with units/periods — don't risk a cheap model
+    if category in _BALANCED_CATEGORIES:
+        return ModelTier.BALANCED
+    return ModelTier.BALANCED
+
+
+def synergy_cost_report(cases: List[FinDERBenchmarkCase], router: ModelRouter) -> Dict[str, Any]:
+    """Deterministic: routed vs all-frontier relative cost on the real FinDER mix."""
+    routed = 0.0
+    frontier = 0.0
+    tier_counts: Dict[str, int] = {}
+    for case in cases:
+        tier = route_tier_for_case(case)
+        tier_counts[tier.name] = tier_counts.get(tier.name, 0) + 1
+        routed += router.relative_cost(tier)
+        frontier += router.relative_cost(ModelTier.FRONTIER)
+    ratio = (routed / frontier) if frontier else 1.0
+    return {
+        "n": len(cases),
+        "tier_counts": tier_counts,
+        "routed_cost": routed,
+        "all_frontier_cost": frontier,
+        "cost_ratio": ratio,
+        "cost_saving_pct": round((1.0 - ratio) * 100, 1),
+        "meets_0_6x_target": ratio < 0.6,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Live support-parity arm (optional, MARA)
+# --------------------------------------------------------------------------- #
+
+def _mara_key() -> Optional[str]:
+    key = os.getenv("MARA_API_KEY")
+    if key:
+        return key
+    try:
+        for line in open(ROOT / ".env", encoding="utf-8"):
+            m = re.match(r'\s*MARA_API_KEY\s*=\s*"?([^"\n]+)"?', line)
+            if m:
+                return m.group(1).strip()
+    except OSError:
+        pass
+    return None
+
+
+def _ontology():
+    from seocho import NodeDef, Ontology, P, RelDef
+    return Ontology(
+        name="finder_synergy",
+        nodes={
+            "Company": NodeDef(properties={"name": P(str, unique=True), "sector": P(str)}),
+            "FinancialMetric": NodeDef(properties={"name": P(str, unique=True), "value": P(str), "year": P(str)}),
+            "Risk": NodeDef(properties={"name": P(str, unique=True), "category": P(str)}),
+        },
+        relationships={
+            "REPORTED": RelDef(source="Company", target="FinancialMetric"),
+            "FACES": RelDef(source="Company", target="Risk"),
+        },
+    )
+
+
+def run_live_support_arm(cases: List[FinDERBenchmarkCase], router: ModelRouter, key: str) -> Dict[str, Any]:
+    """Answer a sample under all-frontier vs routed model; compare support/match parity.
+
+    Ontology-governed answering is held fixed; only the answer model varies, so
+    the delta isolates 'does cheap-when-signal-allows cost answer quality?'.
+    """
+    from seocho import Seocho
+
+    frontier_model = router.tier_models[ModelTier.FRONTIER]
+
+    def _score(model: str, case: FinDERBenchmarkCase) -> Dict[str, Any]:
+        client = Seocho.local(_ontology(), llm=f"mara/{model}", api_key=key,
+                              workspace_id=f"synergy-{model}")
+        try:
+            client.add(case.text, category=str(case.category or "memory"))
+            ans = client.ask(case.question)
+        finally:
+            client.close()
+        exact, contains = compare_answers(case.expected_answer, ans)
+        slots = score_answer_slots(case.expected_answer, ans)
+        return {"contains": contains, "numeric_recall": slots.get("numeric_recall", 0.0)}
+
+    arms: Dict[str, Dict[str, float]] = {"all_frontier": {}, "routed": {}}
+    rows = []
+    for case in cases:
+        tier = route_tier_for_case(case)
+        routed_model = router.tier_models[tier]
+        f = _score(frontier_model, case)
+        r = _score(routed_model, case)
+        rows.append({"case": case.case_id, "tier": tier.name, "routed_model": routed_model,
+                     "frontier": f, "routed": r})
+    def _agg(keyarm):
+        vals = [row[keyarm] for row in rows]
+        return {
+            "contains_rate": round(sum(v["contains"] for v in vals) / len(vals), 3) if vals else 0.0,
+            "numeric_recall": round(sum(v["numeric_recall"] for v in vals) / len(vals), 3) if vals else 0.0,
+        }
+    return {"n": len(rows), "all_frontier": _agg("frontier"), "routed": _agg("routed"), "rows": rows}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", default="examples/finder/datasets/finder_tutorial_subset.json")
+    ap.add_argument("--live", type=int, default=0, help="answer N sampled cases live via MARA for support parity")
+    ap.add_argument("--out", default="outputs/evaluation/finder_synergy")
+    args = ap.parse_args()
+
+    cases = load_finder_cases(args.dataset)
+    router = ModelRouter.mara_default()
+
+    report: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "dataset": args.dataset,
+        "tier_models": {t.name: m for t, m in router.tier_models.items()},
+        "cost_arm": synergy_cost_report(cases, router),
+    }
+
+    if args.live > 0:
+        key = _mara_key()
+        if key:
+            report["support_arm"] = run_live_support_arm(cases[: args.live], router, key)
+        else:
+            report["support_arm"] = {"skipped": "MARA_API_KEY unavailable"}
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = out_dir / f"synergy_{stamp}.json"
+    out_path.write_text(json.dumps(report, indent=2))
+
+    c = report["cost_arm"]
+    print("=" * 64)
+    print("FinDER SYNERGY — ontology-governed answering + signal-routed model")
+    print("=" * 64)
+    print(f"  cases={c['n']}  tier mix={c['tier_counts']}")
+    print(f"  routed cost {c['routed_cost']:.0f} vs all-frontier {c['all_frontier_cost']:.0f}")
+    print(f"  -> cost {c['cost_ratio']:.2f}x  (saving {c['cost_saving_pct']}%)  "
+          f"{'MEETS' if c['meets_0_6x_target'] else 'below'} the <0.6x target")
+    if report.get("support_arm", {}).get("rows"):
+        s = report["support_arm"]
+        print(f"  support parity (n={s['n']}): all-frontier contains={s['all_frontier']['contains_rate']} "
+              f"vs routed contains={s['routed']['contains_rate']}")
+    print(f"  written: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -97,6 +97,7 @@ uv run pytest \
   tests/seocho/test_graph_ensure_database.py \
   tests/seocho/test_finder_eval_helpers.py \
   tests/seocho/test_finder_judge.py \
+  tests/seocho/test_finder_synergy.py \
   tests/seocho/test_ontology_extraction_firewall.py \
   tests/seocho/test_ontology_lint.py \
   tests/seocho/test_ontology_subclass_ttl.py \

--- a/tests/seocho/test_finder_synergy.py
+++ b/tests/seocho/test_finder_synergy.py
@@ -1,0 +1,80 @@
+"""Tests for the FinDER synergy benchmark cost arm (council seocho-9xo).
+
+The deterministic half — signal→tier routing + routed-vs-all-frontier cost on the
+real FinDER signal distribution — is unit-tested offline (no LLM). The live
+support-parity arm is exercised separately via MARA.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from seocho.benchmarking import FinDERBenchmarkCase
+from seocho.routing import ModelRouter, ModelTier
+
+ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "finder_synergy", ROOT / "scripts" / "benchmarks" / "finder_synergy.py"
+)
+finder_synergy = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(finder_synergy)
+route_tier_for_case = finder_synergy.route_tier_for_case
+synergy_cost_report = finder_synergy.synergy_cost_report
+
+
+def _case(cid, category, reasoning=""):
+    return FinDERBenchmarkCase(
+        case_id=cid, text="x", question="q", expected_answer="a",
+        category=category, reasoning_type=reasoning,
+    )
+
+
+def test_hard_reasoning_routes_to_frontier():
+    assert route_tier_for_case(_case("1", "Financials", "Compositional")) == ModelTier.FRONTIER
+    assert route_tier_for_case(_case("2", "Footnotes", "Subtraction")) == ModelTier.FRONTIER
+
+
+def test_financials_routes_to_frontier_even_without_reasoning_type():
+    assert route_tier_for_case(_case("3", "Financials")) == ModelTier.FRONTIER
+
+
+def test_single_passage_lookup_routes_to_fast():
+    assert route_tier_for_case(_case("4", "CompanyOverview")) == ModelTier.FAST
+
+
+def test_qualitative_categories_route_to_balanced():
+    for cat in ("Footnotes", "Accounting", "Legal", "Risk", "Governance"):
+        assert route_tier_for_case(_case("5", cat)) == ModelTier.BALANCED
+
+
+def test_unknown_category_defaults_balanced():
+    assert route_tier_for_case(_case("6", "Whatever")) == ModelTier.BALANCED
+
+
+def test_cost_report_computes_ratio_and_saving():
+    router = ModelRouter.mara_default()
+    cases = (
+        [_case(f"f{i}", "CompanyOverview") for i in range(8)]      # FAST x8
+        + [_case(f"b{i}", "Risk") for i in range(1)]               # BALANCED x1
+        + [_case(f"x{i}", "Financials") for i in range(1)]         # FRONTIER x1
+    )
+    rep = synergy_cost_report(cases, router)
+    assert rep["n"] == 10
+    assert rep["tier_counts"] == {"FAST": 8, "BALANCED": 1, "FRONTIER": 1}
+    # cost = 8*1 + 1*3 + 1*10 = 21 ; all-frontier = 10*10 = 100 -> 0.21x
+    assert rep["routed_cost"] == 21.0
+    assert rep["all_frontier_cost"] == 100.0
+    assert rep["cost_ratio"] == pytest.approx(0.21)
+    assert rep["meets_0_6x_target"] is True
+
+
+def test_all_frontier_workload_has_no_saving():
+    router = ModelRouter.mara_default()
+    cases = [_case(f"x{i}", "Financials", "Numeric") for i in range(5)]  # all FRONTIER
+    rep = synergy_cost_report(cases, router)
+    assert rep["cost_ratio"] == pytest.approx(1.0)
+    assert rep["cost_saving_pct"] == 0.0
+    assert rep["meets_0_6x_target"] is False


### PR DESCRIPTION
## What
`scripts/benchmarks/finder_synergy.py` + `make bench-finder-synergy` — the headline number from the luminary council: on FinDER, **signal-routed model selection costs a fraction of all-frontier while ontology-governed answer-support holds**. Composes two SEOCHO differentiators (ontology governance + the agent router's 'route on a known signal') into one metric.

## Council reflection (why it's shaped this way)
A 6-luminary panel (Lamport/Fowler/Dean/Sycara/Wooldridge/Bellard) debated and **verified** that `model_router` has **zero live importers** — it only reaches the demo `GraphAgenticLoop`; the live `GraphCoTQueryOrchestrator` never instantiates it. So a naive 'router on/off' ablation would measure nothing real on the live path. This harness is honest: it composes the arms **externally**.

## Two arms
- **cost arm** (deterministic, offline): route real FinDER cases by signal (category/reasoning_type) → tier → relative cost. **10-case subset: 0.51x (49% saving), meets the <0.6x target.** Full FinDER skews cheaper (more single-passage lookups).
- **support arm** (`--live N`, MARA): answer under all-frontier vs routed model, compare contains/numeric-recall parity — proves the saving doesn't cost quality. Runnable, but trustworthy numbers need a sound graph backend (embedded LadybugDB hits a `real_ladybug` query bug) + larger sample → full run with seocho-jdg.

## Tests
`test_finder_synergy.py` pins the signal→tier map + cost math offline (7 tests). `run_basic_ci.sh` green (481).

## Follow-ups (council plan, ticketed)
seocho-jdg (P0: wire ResponseCache+ModelRouter into live graph_cot, default-OFF), seocho-4rg (P1: Lamport idempotent/ordered writes), seocho-6gt (P1: auth ON e2e + promotion-gate fitness functions for matchmaker/ContextMap).