### PR TITLE
feat(session): wire persistent ResponseCache into the live ask() path (seocho-jdg P0)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -76,6 +76,7 @@ uv run pytest \
   tests/seocho/test_query_proxy_workspace_enforcement.py \
   tests/seocho/test_ontology_context.py \
   tests/seocho/test_session_agent.py \
+  tests/seocho/test_response_cache_wiring.py \
   tests/seocho/test_user_facing_edge_cases.py \
   tests/seocho/test_semantic_query_phase_a.py \
   extraction/tests/test_sdk_evaluation.py \

--- a/src/seocho/response_cache.py
+++ b/src/seocho/response_cache.py
@@ -184,3 +184,17 @@ class JSONLResponseCache(ResponseCache):
                 os.unlink(self._path)
             except FileNotFoundError:
                 pass
+
+
+def response_cache_from_env() -> Optional[ResponseCache]:
+    """Build the opt-in persistent response cache from the environment.
+
+    Returns a :class:`JSONLResponseCache` when ``SEOCHO_RESPONSE_CACHE_PATH`` is
+    set, else ``None`` (the default — the cache is OFF and Session.ask behaves
+    exactly as before). This is the single switch that turns the dormant
+    cross-process cache on; see seocho-jdg.
+    """
+    path = os.getenv("SEOCHO_RESPONSE_CACHE_PATH", "").strip()
+    if not path:
+        return None
+    return JSONLResponseCache(path)

--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -164,6 +164,14 @@ class Session:
         self.user_id = user_id
 
         self.context = SessionContext()
+        # seocho-jdg: opt-in persistent cross-process answer cache. None (default)
+        # = OFF, behaves exactly as before. Set SEOCHO_RESPONSE_CACHE_PATH to
+        # enable; survives restarts/parallel workers, keyed by the same
+        # (workspace, database, ontology_hash, question) tuple as the in-memory cache.
+        from .response_cache import make_response_cache_key, response_cache_from_env
+
+        self._response_cache = response_cache_from_env()
+        self._make_response_cache_key = make_response_cache_key
         from .ontology_context import OntologyContextCache
 
         self._ontology_context_cache = OntologyContextCache(max_size=8)
@@ -512,6 +520,26 @@ class Session:
             self.context.add_query(question, cached, mode="cache")
             return cached
 
+        # seocho-jdg: persistent cross-process cache (opt-in, OFF by default).
+        # On hit, warm the in-memory cache so the rest of the session is fast too.
+        persistent_key = None
+        if self._response_cache is not None:
+            persistent_key = self._make_response_cache_key(
+                question,
+                workspace_id=self.workspace_id,
+                database=db,
+                ontology_identity_hash=identity_hash,
+            )
+            hit = self._response_cache.get(persistent_key)
+            if hit is not None:
+                self.context.cache_query(
+                    question, hit.answer,
+                    workspace_id=self.workspace_id, database=db,
+                    ontology_identity_hash=identity_hash,
+                )
+                self.context.add_query(question, hit.answer, mode="cache_persistent")
+                return hit.answer
+
         start = time.time()
 
         # Pass structured context (entities, not history)
@@ -573,6 +601,14 @@ class Session:
             database=db,
             ontology_identity_hash=identity_hash,
         )
+        # seocho-jdg: persist for cross-process reuse (opt-in). Only cache real
+        # answers — never an empty/degraded result.
+        if self._response_cache is not None and persistent_key is not None and answer.strip():
+            if not bool(query_result.get("degraded", False)):
+                self._response_cache.put(
+                    persistent_key, answer,
+                    metadata={"database": db, "mode": str(query_result.get("mode", "") or "")},
+                )
 
         # Trace
         if self._trace:

--- a/tests/seocho/test_response_cache_wiring.py
+++ b/tests/seocho/test_response_cache_wiring.py
@@ -1,0 +1,48 @@
+"""Tests for the persistent response cache + its env switch (seocho-jdg).
+
+The cross-process reuse mechanism (the council's synergy #1) is proven here:
+an answer written by one cache instance is served by a fresh instance over the
+same file — i.e. a fresh Session/process/worker gets the hit.
+"""
+
+from __future__ import annotations
+
+from seocho.response_cache import (
+    JSONLResponseCache,
+    make_response_cache_key,
+    response_cache_from_env,
+)
+
+
+def test_env_switch_is_off_by_default(monkeypatch):
+    monkeypatch.delenv("SEOCHO_RESPONSE_CACHE_PATH", raising=False)
+    assert response_cache_from_env() is None
+
+
+def test_env_switch_builds_jsonl_cache(tmp_path, monkeypatch):
+    path = str(tmp_path / "rc.jsonl")
+    monkeypatch.setenv("SEOCHO_RESPONSE_CACHE_PATH", path)
+    cache = response_cache_from_env()
+    assert isinstance(cache, JSONLResponseCache)
+
+
+def test_key_shape_matches_session_tuple():
+    key = make_response_cache_key("  What is X? ", workspace_id="acme", database="finance",
+                                  ontology_identity_hash="h1")
+    # (workspace, database, ontology_hash, normalized_question)
+    assert key == ("acme", "finance", "h1", "what is x?")
+
+
+def test_cross_process_reuse(tmp_path):
+    path = str(tmp_path / "rc.jsonl")
+    key = make_response_cache_key("q", workspace_id="acme", database="finance",
+                                  ontology_identity_hash="h1")
+    # writer process
+    JSONLResponseCache(path).put(key, "the answer", metadata={"database": "finance"})
+    # a FRESH instance (simulating another process/worker) gets the hit
+    hit = JSONLResponseCache(path).get(key)
+    assert hit is not None and hit.answer == "the answer"
+    # a different ontology version (different hash) does NOT collide
+    other = make_response_cache_key("q", workspace_id="acme", database="finance",
+                                    ontology_identity_hash="h2")
+    assert JSONLResponseCache(path).get(other) is None

--- a/tests/seocho/test_session_agent.py
+++ b/tests/seocho/test_session_agent.py
@@ -287,6 +287,44 @@ class TestSession:
         assert sess.context.queries[0]["mode"] == "pipeline"
         assert sess.context.queries[0]["degraded"] is False
 
+    def test_persistent_cache_serves_a_fresh_session(self):
+        # seocho-jdg: an answer computed in one Session is served from the
+        # persistent cache by a FRESH Session (cross-process reuse) — the
+        # in-memory cache would have died with the first session.
+        from seocho.session import Session
+        from seocho.response_cache import InMemoryResponseCache
+
+        shared = InMemoryResponseCache()
+        onto = _make_test_ontology()
+        store = FakeGraphStore()
+        responses = [
+            json.dumps({"intent": "entity_lookup", "anchor_entity": "TestCorp", "anchor_label": "Company"}),
+            "TestCorp is in the Tech industry.",
+        ]
+
+        sess1 = Session(name="s1", ontology=onto, graph_store=store,
+                        llm=FakeLLM(responses=list(responses)), database="testdb")
+        sess1._response_cache = shared
+        a1 = sess1.ask("What industry is TestCorp in?")
+        assert a1
+
+        # Fresh session, SAME shared cache, but an LLM that returns a DIFFERENT
+        # answer if it were called — proving the result came from the cache.
+        sess2 = Session(name="s2", ontology=onto, graph_store=store,
+                        llm=FakeLLM(responses=["WRONG-should-not-be-used", "WRONG"]), database="testdb")
+        sess2._response_cache = shared
+        a2 = sess2.ask("What industry is TestCorp in?")
+        assert a2 == a1
+        assert "WRONG" not in a2
+        assert sess2.context.queries[-1]["mode"] == "cache_persistent"
+
+    def test_persistent_cache_off_by_default(self):
+        # Default (no SEOCHO_RESPONSE_CACHE_PATH) -> no persistent cache wired.
+        from seocho.session import Session
+        sess = Session(name="s", ontology=_make_test_ontology(), graph_store=FakeGraphStore(),
+                       llm=FakeLLM(responses=["{}", "ans"]), database="testdb")
+        assert sess._response_cache is None
+
     def test_session_agent_add_fallback_records_degraded_metadata(self, monkeypatch):
         onto = _make_test_ontology()
         llm = FakeLLM()


### PR DESCRIPTION
## What
Wires the dormant persistent `ResponseCache` into the **live** `Session.ask` path, **OFF by default** — the council's undisputed highest-leverage P0.

## Why
The council verified `response_cache.py` had **zero live importers**: `Session.ask` only used the in-memory cache that dies with the session, leaving the ~60% cross-process reuse win (Dean) on the floor.

## How (default-OFF)
- `response_cache_from_env()` → `JSONLResponseCache` when `SEOCHO_RESPONSE_CACHE_PATH` is set, else `None` (OFF = exact prior behavior).
- `ask()` checks the persistent cache after the in-memory miss (warming in-memory on a hit) and writes real answers, keyed by the **same** `(workspace, database, ontology_identity_hash, normalized_question)` tuple as the in-memory cache. A fresh Session/worker on the same ontology version gets the hit; recompute only on ontology bump.

## Tests
Cross-process reuse (fresh instance serves what another wrote; different ontology hash doesn't collide), env-off-by-default, key shape; and an **e2e Session test**: a second fresh Session sharing the cache returns the first's answer (`mode='cache_persistent'`) while its LLM (which would answer WRONG) is never called. `run_basic_ci.sh` green (487).

## Scope
Highest-leverage half of seocho-jdg. The other half — escalate model tier via `ModelRouter` in graph_cot recovery — is **not a clean seam** (the graph_cot supervisor is deterministic and doesn't hold the llm; model selection is a layer down), so it needs a cross-layer model channel + a live FinDER cost-at-support run to validate. Tracked in seocho-jdg.