### PR TITLE
fix(auth): correct runtime permissions on read-only semantic run endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1430,7 +1430,7 @@ async def semantic_runs_list(
     intent_id: Optional[str] = Query(default=None),
 ):
     try:
-        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 
@@ -1456,7 +1456,7 @@ async def semantic_runs_get(
     workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
 ):
     try:
-        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_agents", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 


### PR DESCRIPTION
## What
This PR corrects the authorization checks on the `semantic_runs_list` and `semantic_runs_get` endpoints in `runtime/agent_server.py`.

## Severity
Low - Moderate (Authorization / Privilege Separation)

## Vulnerability
The endpoints `GET /api/v1/semantic-runs` and `GET /api/v1/semantic-runs/{run_id}` were mistakenly requiring the `run_agent` execution permission instead of the read-only `read_agents` permission. While access was still gated to authenticated users within their own workspaces, this violated the Principle of Least Privilege.

## Impact
A user with only the `viewer` role (which grants `read_databases` and `read_agents`) would be incorrectly denied access to read the history of semantic runs, while execution permissions (`run_agent`) were over-provisioned to include read access.

## Fix
Changed `action="run_agent"` to `action="read_agents"` in the `require_runtime_permission` calls for both `semantic_runs_list` and `semantic_runs_get` in `runtime/agent_server.py`.

## Validation
- Ran the full `scripts/ci/run_basic_ci.sh` suite locally, validating that the change preserves system stability and does not break existing functional or authorization tests.

## Risks
No major risks. This relaxes access requirements to appropriately fit the read-only endpoints, improving the accuracy of the RBAC system without modifying the underlying retrieval or storage logic.

draft: true

---
*PR created automatically by Jules for task [9397727613046057773](https://jules.google.com/task/9397727613046057773) started by @tteon*