### PR TITLE
fix(ui): Remove inline hover styles and add proper button hover states

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn" class="reset-btn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -254,6 +254,10 @@ body {
   cursor: not-allowed;
 }
 
+#ingestBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
 #oneClickDemoBtn {
   background: var(--accent-blue);
   color: #fff;
@@ -268,6 +272,25 @@ body {
 #oneClickDemoBtn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+#oneClickDemoBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.reset-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.reset-btn:hover {
+  color: #fff;
 }
 
 /* Dual Pane Workspace */


### PR DESCRIPTION
### What
Extracted inline Javascript hover events (`onmouseover`, `onmouseout`) from the "Reset Trace" button in `index.html` into a new `.reset-btn` CSS class in `styles.css`. Added proper `:hover` states to `ingestBtn`, `oneClickDemoBtn`, and `resetSessionBtn`, ensuring that disabled buttons do not show a hover effect.

### Why
Inline JavaScript for hover states hides visual feedback from keyboard users because the events rely entirely on mouse interactions. Moving these into CSS with `:hover` allows the global `button:focus-visible` rule to naturally apply to these elements, restoring accessibility parity for keyboard users.

### Accessibility / UX Impact
- Keyboard users will now see visual feedback when focusing on these buttons (through the global `:focus-visible` ring), matching the visual feedback mouse users receive via `:hover`.
- Disabled buttons correctly avoid showing interactive hover states.

### Validation
- **Local Playwright UI test**: Booted the FastAPI uvicorn runtime and verified that focusing the "Reset Trace" button triggers the focus outline, and hovering over the "Ingest Raw" button triggers the `opacity: 0.9` state.
- **Repository CI**: Ran `bash scripts/ci/run_basic_ci.sh`, all tests passed.
- **Verification via `cat`**: Confirmed `.reset-btn` replaces the inline logic correctly.

### Risks
- Very low. CSS rules are strictly scoped to these specific button IDs/classes and do not affect structural layout. No backend logic or provider contracts are modified.

---
*PR created automatically by Jules for task [5014224832244595779](https://jules.google.com/task/5014224832244595779) started by @tteon*