### PR TITLE
fix(store): last-writer-wins-by-timestamp graph writes (seocho-4rg, Lamport)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -96,6 +96,7 @@ uv run pytest \
   tests/seocho/test_cypher_builder_ontology_aware.py \
   tests/seocho/test_extraction_engine.py \
   tests/seocho/test_graph_ensure_database.py \
+  tests/seocho/test_graph_writer_lww.py \
   tests/seocho/test_finder_eval_helpers.py \
   tests/seocho/test_finder_judge.py \
   tests/seocho/test_finder_synergy.py \

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -364,6 +364,13 @@ class Neo4jGraphStore(GraphStore):
 
         summary = {"nodes_created": 0, "relationships_created": 0, "errors": []}
 
+        # seocho-4rg (Lamport): stamp a writer timestamp so concurrent/replayed
+        # writes are last-writer-wins by time rather than by arrival order. The
+        # MERGE guards below refuse to overwrite a node/rel that already carries
+        # a NEWER _writer_ts, so a stale retry (e.g. a crashed ingest replayed)
+        # cannot clobber a fresher fact. One ts per write() call.
+        now = time.time()
+
         # Group by label/type and write each group in one UNWIND round-trip
         # (labels/rel-types can't be parameterized in MERGE, so we batch per
         # distinct label). A batch that throws falls back to per-row so one bad
@@ -378,6 +385,8 @@ class Neo4jGraphStore(GraphStore):
             props = dict(node.get("properties", {}))
             props["_source_id"] = source_id
             props["_workspace_id"] = workspace_id
+            props["_writer_ts"] = now
+            props["_writer_agent"] = source_id or "unknown"
             node_id = node.get("id", props.get("name", ""))
             props["id"] = node_id
             nodes_by_label.setdefault(label, []).append({"id": node_id, "props": props})
@@ -392,14 +401,22 @@ class Neo4jGraphStore(GraphStore):
                      if _is_property_value(v)}
             props["_source_id"] = source_id
             props["_workspace_id"] = workspace_id
+            props["_writer_ts"] = now
+            props["_writer_agent"] = source_id or "unknown"
             rels_by_type.setdefault(rtype, []).append(
                 {"src": rel.get("source", ""), "tgt": rel.get("target", ""), "props": props})
 
         with self._driver.session(database=database) as session:
             # --- Nodes (one UNWIND per label) ---
             for label, rows in nodes_by_label.items():
-                # label validated against _LABEL_RE above; interpolated raw
-                batch_q = f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id}}) SET n += row.props"
+                # label validated against _LABEL_RE above; interpolated raw.
+                # LWW guard: apply incoming props only if this write is newer
+                # (or the node has no writer ts yet); stale replays no-op.
+                batch_q = (
+                    f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id}}) "
+                    "SET n += CASE WHEN n._writer_ts IS NULL "
+                    "OR n._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
+                )
                 try:
                     session.run(batch_q, rows=rows)
                     summary["nodes_created"] += len(rows)
@@ -407,7 +424,9 @@ class Neo4jGraphStore(GraphStore):
                     for row in rows:
                         try:
                             session.run(
-                                f"MERGE (n:{label} {{id: $id}}) SET n += $props",
+                                f"MERGE (n:{label} {{id: $id}}) SET n += CASE WHEN "
+                                "n._writer_ts IS NULL OR n._writer_ts <= $props._writer_ts "
+                                "THEN $props ELSE {} END",
                                 id=row["id"], props=row["props"])
                             summary["nodes_created"] += 1
                         except Exception as exc:
@@ -417,7 +436,9 @@ class Neo4jGraphStore(GraphStore):
             for rtype, rows in rels_by_type.items():
                 # rtype validated against _LABEL_RE above; interpolated raw
                 batch_q = (f"UNWIND $rows AS row MATCH (a {{id: row.src}}), (b {{id: row.tgt}}) "
-                           f"MERGE (a)-[r:{rtype}]->(b) SET r += row.props")
+                           f"MERGE (a)-[r:{rtype}]->(b) "
+                           "SET r += CASE WHEN r._writer_ts IS NULL "
+                           "OR r._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END")
                 try:
                     session.run(batch_q, rows=rows)
                     summary["relationships_created"] += len(rows)
@@ -426,7 +447,9 @@ class Neo4jGraphStore(GraphStore):
                         try:
                             session.run(
                                 f"MATCH (a {{id: $src}}), (b {{id: $tgt}}) "
-                                f"MERGE (a)-[r:{rtype}]->(b) SET r += $props",
+                                f"MERGE (a)-[r:{rtype}]->(b) SET r += CASE WHEN "
+                                "r._writer_ts IS NULL OR r._writer_ts <= $props._writer_ts "
+                                "THEN $props ELSE {} END",
                                 src=row["src"], tgt=row["tgt"], props=row["props"])
                             summary["relationships_created"] += 1
                         except Exception as exc:

--- a/tests/seocho/test_graph_writer_lww.py
+++ b/tests/seocho/test_graph_writer_lww.py
@@ -1,0 +1,143 @@
+"""Last-writer-wins-with-timestamps on graph writes (seocho-4rg, Lamport).
+
+Offline: writes stamp _writer_ts/_writer_agent and the MERGE carries the LWW
+guard. Live (DozerDB, skipped without it): a stale write cannot clobber a node
+that already carries a newer _writer_ts — the ordering primitive the
+reflection/escalation retry loop assumes.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from seocho.store.graph import Neo4jGraphStore
+
+
+# --------------------------------------------------------------------------- #
+# Offline — stamping + guard wiring (mock driver, no DB)
+# --------------------------------------------------------------------------- #
+
+class _Rec:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+
+        class _R:
+            def single(self_inner):
+                return None
+
+            def __iter__(self_inner):
+                return iter([])
+
+        return _R()
+
+
+class _SessCtx:
+    def __init__(self, rec):
+        self._rec = rec
+
+    def __enter__(self):
+        return self._rec
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.rec = _Rec()
+
+    def session(self, database=None, **kw):
+        return _SessCtx(self.rec)
+
+    def close(self):
+        pass
+
+
+def _store_with_fake():
+    store = Neo4jGraphStore("bolt://unit-test:7687", "neo4j", "p")
+    store._driver = _FakeDriver()
+    return store
+
+
+def test_node_write_stamps_writer_ts_and_lww_guard():
+    store = _store_with_fake()
+    store.write(
+        [{"id": "c1", "label": "Company", "properties": {"name": "ACME"}}],
+        [],
+        database="testdb",
+        source_id="src1",
+    )
+    node_calls = [c for c in store._driver.rec.calls if "MERGE (n:" in c[0]]
+    assert node_calls, "no node MERGE issued"
+    query, params = node_calls[0]
+    # LWW guard present in the Cypher
+    assert "_writer_ts" in query and "CASE WHEN" in query and "ELSE {}" in query
+    # incoming row carries a writer timestamp + agent
+    row = params["rows"][0]
+    assert isinstance(row["props"]["_writer_ts"], float)
+    assert row["props"]["_writer_agent"] == "src1"
+
+
+def test_relationship_write_is_lww_guarded():
+    store = _store_with_fake()
+    store.write(
+        [{"id": "a", "label": "Company", "properties": {}},
+         {"id": "b", "label": "Company", "properties": {}}],
+        [{"source": "a", "target": "b", "type": "REPORTED", "properties": {}}],
+        database="testdb",
+        source_id="src1",
+    )
+    rel_calls = [c for c in store._driver.rec.calls if "MERGE (a)-[r:" in c[0]]
+    assert rel_calls, "no rel MERGE issued"
+    query, params = rel_calls[0]
+    assert "r._writer_ts" in query and "CASE WHEN" in query
+    assert params["rows"][0]["props"]["_writer_ts"] is not None
+
+
+# --------------------------------------------------------------------------- #
+# Live (DozerDB) — stale write is ignored
+# --------------------------------------------------------------------------- #
+
+def _live_store():
+    pw = os.getenv("NEO4J_PASSWORD", "seocho-dev")
+    uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    try:
+        store = Neo4jGraphStore(uri, os.getenv("NEO4J_USER", "neo4j"), pw)
+        with store._driver.session(database="neo4j") as s:
+            s.run("RETURN 1").single()
+        return store
+    except Exception:
+        return None
+
+
+@pytest.mark.integration
+def test_stale_write_does_not_clobber_newer_live():
+    store = _live_store()
+    if store is None:
+        pytest.skip("DozerDB not reachable")
+    db = "neo4j"
+    nid = "lww_itest_node"
+    try:
+        # seed a node with a FAR-FUTURE writer ts + sentinel value
+        with store._driver.session(database=db) as s:
+            s.run(
+                "MERGE (n:_LWWTest {id:$id}) SET n._writer_ts=9e18, n.v='keep', n._source_id='lww'",
+                id=nid,
+            )
+        # a normal write (now << 9e18) must NOT overwrite v
+        store.write(
+            [{"id": nid, "label": "_LWWTest", "properties": {"v": "clobbered"}}],
+            [], database=db, source_id="lww",
+        )
+        with store._driver.session(database=db) as s:
+            v = s.run("MATCH (n:_LWWTest {id:$id}) RETURN n.v AS v", id=nid).single()["v"]
+        assert v == "keep", f"stale write clobbered a newer node: v={v!r}"
+    finally:
+        with store._driver.session(database=db) as s:
+            s.run("MATCH (n:_LWWTest {id:$id}) DETACH DELETE n", id=nid)
+        store.close()


### PR DESCRIPTION
## What
Adds a wall-clock **last-writer-wins-with-timestamps** ordering primitive to `Neo4jGraphStore.write` so stale/replayed writes can't clobber a newer fact.

## Why (Lamport, council-verified)
`MERGE ... SET n += props` had **no ordering** — concurrent extractions and replayed writes were last-write-by-arrival. A crashed-then-replayed ingest (or a late-landing slow writer) could overwrite a fresher fact, undermining the retry-safety the reflection/escalation loop assumes.

## How (proportional — not a CRDT)
- Every node/rel write is stamped `_writer_ts` (one ts per `write()`) + `_writer_agent` (source_id).
- node/rel MERGE apply incoming props only when the target has no ts yet or its ts ≤ incoming:  `SET n += CASE WHEN n._writer_ts IS NULL OR n._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END`. A stale replay no-ops.
- Neo4j-only (LadybugGraphStore untouched). CASE-in-SET verified valid on DozerDB 5.26.

## Tests
Offline (mock driver): stamping + LWW guard in node & rel Cypher. Live DozerDB integration (self-skips without a reachable instance): seeds a far-future `_writer_ts`, asserts a normal write does **not** clobber it. `run_basic_ci.sh` green (492). Pre-existing failures (real_ladybug bug; an import test) verified unrelated (fail on clean main).