### PR TITLE
fix(test): repair session->extraction boundary check (wrong path) + add to CI

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -97,6 +97,7 @@ uv run pytest \
   tests/seocho/test_extraction_engine.py \
   tests/seocho/test_graph_ensure_database.py \
   tests/seocho/test_graph_writer_lww.py \
+  tests/seocho/test_agents_runtime_packaging.py \
   tests/seocho/test_finder_eval_helpers.py \
   tests/seocho/test_finder_judge.py \
   tests/seocho/test_finder_synergy.py \

--- a/tests/seocho/test_agents_runtime_packaging.py
+++ b/tests/seocho/test_agents_runtime_packaging.py
@@ -46,7 +46,13 @@ def test_session_does_not_import_from_extraction() -> None:
     """
     from pathlib import Path
 
-    src = Path(__file__).resolve().parent.parent / "session.py"
+    import seocho.session
+
+    # Locate the real module via the package, not a path relative to the test:
+    # the test lives under tests/seocho/, the module under src/seocho/, so the
+    # old ``__file__.parent.parent / 'session.py'`` resolved to a nonexistent
+    # tests/session.py and the check silently errored instead of guarding.
+    src = Path(seocho.session.__file__)
     text = src.read_text()
     assert "from extraction.agents_runtime" not in text, (
         "seocho.session must import the adapter via seocho.agents_runtime "


### PR DESCRIPTION
## What
Fixes `test_session_does_not_import_from_extraction`, which was **failing on main** — but as a **test path bug, not a real violation**.

## Root cause
The test resolved the module as `Path(__file__).parent.parent / 'session.py'` = `tests/session.py` (nonexistent) — it was written when the test lived beside the module (`src/seocho/tests/`) and broke when it moved to `tests/seocho/` under a src/ layout. It raised `FileNotFoundError` and silently failed instead of guarding anything.

## Verified
The real `src/seocho/session.py` is **compliant**: `from .agents_runtime import get_agents_runtime`, no `from extraction.agents_runtime`. So there was no boundary violation — just a broken guard.

## Fix
Locate the module via `seocho.session.__file__` (layout-independent) and **add the test to `run_basic_ci.sh`** so the wheel-install import boundary is actually enforced from now on. `run_basic_ci.sh` green.