### PR TITLE
feat(runtime,ontology): auth ON-mode e2e + promotion-gate boundary fitness function (seocho-6gt)

### DIFF
--- a/extraction/tests/test_api_endpoints.py
+++ b/extraction/tests/test_api_endpoints.py
@@ -1347,3 +1347,63 @@ class TestQueryValidation:
         request = fake_proxy.query.call_args.args[0]
         assert request.workspace_id == "default"
         assert request.database == "kgnormal"
+
+
+@pytest.mark.anyio
+class TestAuthOnMode:
+    """seocho-6gt: end-to-end enforcement when SEOCHO_AUTH_MODE=token.
+
+    Auth is wired (PrincipalMiddleware + require_runtime_permission) but had no
+    ON-mode e2e coverage. The middleware reads the mode per request, so flipping
+    the env mid-test exercises the real token path.
+    """
+
+    @staticmethod
+    def _token(role, workspace_id="default", subject="u"):
+        from runtime.identity import issue_token
+        return issue_token("e2e-secret", subject=subject, role=role, workspace_id=workspace_id)
+
+    @staticmethod
+    def _enable(monkeypatch):
+        monkeypatch.setenv("SEOCHO_AUTH_MODE", "token")
+        monkeypatch.setenv("SEOCHO_AUTH_SECRET", "e2e-secret")
+
+    async def test_missing_token_is_401(self, client, monkeypatch):
+        self._enable(monkeypatch)
+        resp = await client.get("/databases")
+        assert resp.status_code == 401
+
+    async def test_bad_token_is_401(self, client, monkeypatch):
+        self._enable(monkeypatch)
+        resp = await client.get("/databases", headers={"Authorization": "Bearer garbage"})
+        assert resp.status_code == 401
+
+    async def test_viewer_denied_write_action_is_403(self, client, monkeypatch):
+        self._enable(monkeypatch)
+        # viewer lacks run_agent -> 403 fires before the agent runs
+        resp = await client.post(
+            "/run_agent_semantic",
+            json={"query": "hi", "workspace_id": "default"},
+            headers={"Authorization": f"Bearer {self._token('viewer')}"},
+        )
+        assert resp.status_code == 403
+
+    async def test_cross_workspace_principal_is_403(self, client, monkeypatch):
+        self._enable(monkeypatch)
+        # user scoped to 'acme' may not act on 'other' (workspace ownership)
+        resp = await client.get(
+            "/databases",
+            params={"workspace_id": "other"},
+            headers={"Authorization": f"Bearer {self._token('user', workspace_id='acme')}"},
+        )
+        assert resp.status_code == 403
+
+    async def test_in_scope_user_is_allowed(self, client, monkeypatch):
+        self._enable(monkeypatch)
+        # user@default, read_databases on its own workspace -> allowed
+        resp = await client.get(
+            "/databases",
+            params={"workspace_id": "default"},
+            headers={"Authorization": f"Bearer {self._token('user', workspace_id='default')}"},
+        )
+        assert resp.status_code == 200

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -89,6 +89,7 @@ uv run pytest \
   tests/seocho/test_reflection.py \
   tests/seocho/test_matchmaker.py \
   tests/seocho/test_ontology_context_map.py \
+  tests/seocho/test_promotion_boundary_gate.py \
   tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
   tests/seocho/test_tracing_opik_regression.py \

--- a/src/seocho/ontology_control_plane.py
+++ b/src/seocho/ontology_control_plane.py
@@ -5,6 +5,19 @@ from hashlib import sha256
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from .models import JsonSerializable
+from .ontology_context_map import BoundaryViolation, BoundedContext, ContextMap
+
+
+class PromotionBoundaryError(ValueError):
+    """Raised by promote(strict_boundaries=True) when a profile blurs a DDD
+    bounded-context boundary against another approved profile in the workspace."""
+
+    def __init__(self, violations: "List[BoundaryViolation]") -> None:
+        self.violations = list(violations)
+        super().__init__(
+            "promotion blocked by bounded-context boundary violations: "
+            + "; ".join(v.detail for v in violations)
+        )
 
 
 def _clean_text(value: Any, default: str = "") -> str:
@@ -223,10 +236,33 @@ class OntologyProfileRegistry:
         ]
         return sorted(out, key=lambda item: (item.status != "approved", item.profile_id))
 
-    def promote(self, profile_id: str, *, workspace_id: str = "default") -> OntologyProfile:
+    def promote(
+        self,
+        profile_id: str,
+        *,
+        workspace_id: str = "default",
+        strict_boundaries: bool = False,
+    ) -> OntologyProfile:
         profile = self.get(profile_id, workspace_id=workspace_id)
         if profile is None:
             raise KeyError(profile_id)
+
+        # seocho-6gt: DDD bounded-context fitness function, run at promotion time
+        # (Fowler "shift left") rather than surfacing as OntologyDriftError at
+        # query time. Reuses the otherwise-dormant ContextMap as a validator.
+        # Default: report into promotion_note (legitimate shared concepts are
+        # common across domain ontologies). strict_boundaries=True hard-blocks.
+        others = [p for p in self.list(workspace_id=workspace_id, status="approved")
+                  if p.profile_id != profile_id]
+        violations = check_promotion_boundaries(profile, others)
+        if violations:
+            if strict_boundaries:
+                raise PromotionBoundaryError(violations)
+            profile.promotion_note = (
+                (profile.promotion_note + " | " if profile.promotion_note else "")
+                + "boundary: " + "; ".join(v.detail for v in violations)
+            )
+
         profile.status = "approved"
         return profile
 
@@ -507,3 +543,39 @@ __all__ = [
     "OntologyProfileSelection",
     "OntologySignal",
 ]
+
+
+def _profile_concepts(profile: OntologyProfile) -> frozenset:
+    """Concept (class) names an ontology profile claims to own."""
+    names = set()
+    for cls in (profile.ontology_candidate.get("classes", []) or []):
+        if isinstance(cls, dict):
+            name = _clean_text(cls.get("name"))
+            if name:
+                names.add(name)
+    return frozenset(names)
+
+
+def check_promotion_boundaries(
+    candidate: OntologyProfile, existing_approved: Sequence[OntologyProfile]
+) -> List[BoundaryViolation]:
+    """Bounded-context fitness function (seocho-6gt).
+
+    Builds a ContextMap from the candidate + already-approved profiles in the
+    workspace and reports each concept the candidate would co-own with another
+    approved profile (a blurred boundary). Pure; reused at promotion time so the
+    blur is caught before deploy instead of as a query-time OntologyDriftError.
+    """
+    cmap = ContextMap()
+    cmap.register(BoundedContext(name=candidate.profile_id, concepts=_profile_concepts(candidate)))
+    for prof in existing_approved:
+        cmap.register(BoundedContext(name=prof.profile_id, concepts=_profile_concepts(prof)))
+    violations: List[BoundaryViolation] = []
+    for concept in sorted(_profile_concepts(candidate)):
+        owners = [o for o in cmap.owners_of(concept) if o != candidate.profile_id]
+        if owners:
+            violations.append(BoundaryViolation(
+                "shared_ownership",
+                f"concept {concept!r} (promoting {candidate.profile_id!r}) is already owned by {owners}",
+            ))
+    return violations

--- a/tests/seocho/test_promotion_boundary_gate.py
+++ b/tests/seocho/test_promotion_boundary_gate.py
@@ -1,0 +1,67 @@
+"""Bounded-context promotion gate (seocho-6gt) — the dormant ContextMap reused
+as an ontology-promotion fitness function (Fowler shift-left).
+
+Catches concept-ownership blur at promotion time instead of as a query-time
+OntologyDriftError. Default reports into promotion_note; strict_boundaries=True
+hard-blocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology_control_plane import (
+    OntologyProfile,
+    OntologyProfileRegistry,
+    PromotionBoundaryError,
+    check_promotion_boundaries,
+)
+
+
+def _profile(pid, classes, *, workspace="w", status="draft"):
+    return OntologyProfile(
+        profile_id=pid, workspace_id=workspace, status=status,
+        ontology_candidate={"classes": [{"name": c} for c in classes]},
+    )
+
+
+def test_profile_concepts_check_disjoint_is_clean():
+    cand = _profile("legal", ["Lawsuit", "Court"])
+    existing = [_profile("finance", ["Company", "Filing"], status="approved")]
+    assert check_promotion_boundaries(cand, existing) == []
+
+
+def test_shared_concept_is_flagged():
+    cand = _profile("legal", ["Company", "Lawsuit"])  # Company also in finance
+    existing = [_profile("finance", ["Company", "Filing"], status="approved")]
+    violations = check_promotion_boundaries(cand, existing)
+    assert len(violations) == 1
+    assert violations[0].kind == "shared_ownership"
+    assert "Company" in violations[0].detail and "finance" in violations[0].detail
+
+
+def test_promote_strict_blocks_boundary_blur():
+    reg = OntologyProfileRegistry()
+    reg.register(_profile("finance", ["Company", "Filing"], status="approved"))
+    reg.register(_profile("legal", ["Company", "Lawsuit"]))
+    with pytest.raises(PromotionBoundaryError):
+        reg.promote("legal", workspace_id="w", strict_boundaries=True)
+    # candidate was NOT approved
+    assert reg.get("legal", workspace_id="w").status == "draft"
+
+
+def test_promote_default_reports_but_does_not_block():
+    reg = OntologyProfileRegistry()
+    reg.register(_profile("finance", ["Company", "Filing"], status="approved"))
+    reg.register(_profile("legal", ["Company", "Lawsuit"]))
+    p = reg.promote("legal", workspace_id="w")  # non-strict
+    assert p.status == "approved"
+    assert "Company" in p.promotion_note and "boundary" in p.promotion_note
+
+
+def test_promote_clean_profile_passes_strict():
+    reg = OntologyProfileRegistry()
+    reg.register(_profile("finance", ["Company", "Filing"], status="approved"))
+    reg.register(_profile("hr", ["Employee", "Department"]))
+    p = reg.promote("hr", workspace_id="w", strict_boundaries=True)
+    assert p.status == "approved" and p.promotion_note == ""


### PR DESCRIPTION
## What (two council items from seocho-6gt)

### (a) Auth ON-mode e2e coverage
Enterprise auth is wired (PrincipalMiddleware + `require_runtime_permission` on ~30 endpoints) but had **no token-path test**. `TestAuthOnMode` drives the real ASGI app with `SEOCHO_AUTH_MODE=token` (the middleware reads mode per request): missing/bad token → **401**; viewer → **403** on a write action; workspace-scoped principal → **403** cross-workspace; in-scope user → **200**.

### (b) Promotion-gate fitness function (Fowler 'shift left')
The **dormant ContextMap** is reused as a validator at ontology **promotion time** instead of surfacing boundary blur as a query-time `OntologyDriftError`. `OntologyProfileRegistry.promote` runs `check_promotion_boundaries()` vs the workspace's approved profiles: default **reports** concept-ownership overlap into `promotion_note`; `strict_boundaries=True` **hard-blocks** (`PromotionBoundaryError`). matchmaker/ContextMap stay **out of the request path** — used only as a gate, as the council prescribed.

## Deliberately NOT done (verified)
- **`self_reflection_used` flag removal**: it is **NOT dead** — produced at `semantic_agents.py:1284` and consumed at `strategy_chooser.py:264-279`. The council's 'frozen-False, no producer' claim was wrong; left intact.
- **Debate triple-agreement quorum**: deferred (P2, opt-in debate path, largest change) — stays in seocho-6gt.

## Tests
`TestAuthOnMode` (5) + `test_promotion_boundary_gate.py` (5). `run_basic_ci.sh` green (505).