### PR TITLE
feat(llm): per-call model override — the primitive for live model routing (seocho-jdg Part B)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -85,6 +85,7 @@ uv run pytest \
   tests/seocho/test_finder_benchmark_script.py \
   tests/seocho/test_indexing_design.py \
   tests/seocho/test_llm_backends.py \
+  tests/seocho/test_llm_model_override.py \
   tests/seocho/test_model_router.py \
   tests/seocho/test_reflection.py \
   tests/seocho/test_matchmaker.py \

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -199,6 +199,7 @@ class LLMBackend(ABC):
         reasoning_mode: Optional[bool] = None,
         task_hint: Optional[str] = None,
         mode: Optional[str] = None,
+        model: Optional[str] = None,
     ) -> LLMResponse:
         """Synchronous completion.
 
@@ -263,8 +264,15 @@ def complete_with_task_hints(
     reasoning_mode: Optional[bool] = None,
     task_hint: Optional[str] = None,
     mode: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> Any:
-    """Call ``llm.complete`` while remaining compatible with older test doubles."""
+    """Call ``llm.complete`` while remaining compatible with older test doubles.
+
+    ``model`` (seocho-jdg) is an optional per-call override of the backend's
+    bound model — the primitive that lets a cost-aware router send this single
+    request to a cheaper/stronger tier without rebuilding the client. ``None``
+    (default) leaves the backend's configured model untouched.
+    """
 
     kwargs: Dict[str, Any] = {
         "system": system,
@@ -281,16 +289,19 @@ def complete_with_task_hints(
         kwargs["task_hint"] = task_hint
     if mode is not None:
         kwargs["mode"] = mode
+    if model is not None:
+        kwargs["model"] = model
     try:
         return llm.complete(**kwargs)
     except TypeError as exc:
         if "unexpected keyword argument" not in str(exc):
             raise
-        # Older backends predate mode/reasoning_mode/task_hint — strip
+        # Older backends predate mode/reasoning_mode/task_hint/model — strip
         # them and retry so this helper stays drop-in for legacy doubles.
         kwargs.pop("reasoning_mode", None)
         kwargs.pop("task_hint", None)
         kwargs.pop("mode", None)
+        kwargs.pop("model", None)
         return llm.complete(**kwargs)
 
 
@@ -461,9 +472,10 @@ class OpenAICompatibleBackend(LLMBackend):
         reasoning_mode: Optional[bool],
         task_hint: Optional[str],
         mode: Optional[str] = None,
+        model: Optional[str] = None,
     ) -> Dict[str, Any]:
         kwargs: Dict[str, Any] = {
-            "model": self.model,
+            "model": model or self.model,
             "messages": messages,
         }
         reasoning_overrides = self._reasoning_request_overrides(
@@ -569,6 +581,7 @@ class OpenAICompatibleBackend(LLMBackend):
         reasoning_mode: Optional[bool] = None,
         task_hint: Optional[str] = None,
         mode: Optional[str] = None,
+        model: Optional[str] = None,
     ) -> LLMResponse:
         messages = [
             {"role": "system", "content": system},
@@ -582,6 +595,7 @@ class OpenAICompatibleBackend(LLMBackend):
             reasoning_mode=reasoning_mode,
             task_hint=task_hint,
             mode=mode,
+            model=model,
         )
         last_exc: Optional[Exception] = None
         for attempt_kwargs in self._completion_retry_variants(kwargs):
@@ -604,6 +618,7 @@ class OpenAICompatibleBackend(LLMBackend):
         reasoning_mode: Optional[bool] = None,
         task_hint: Optional[str] = None,
         mode: Optional[str] = None,
+        model: Optional[str] = None,
     ) -> LLMResponse:
         messages = [
             {"role": "system", "content": system},
@@ -617,6 +632,7 @@ class OpenAICompatibleBackend(LLMBackend):
             reasoning_mode=reasoning_mode,
             task_hint=task_hint,
             mode=mode,
+            model=model,
         )
         last_exc: Optional[Exception] = None
         for attempt_kwargs in self._completion_retry_variants(kwargs):

--- a/tests/seocho/test_llm_model_override.py
+++ b/tests/seocho/test_llm_model_override.py
@@ -1,0 +1,67 @@
+"""Per-call model override in the LLM layer (seocho-jdg Part B primitive).
+
+This is the missing capability cost-aware model routing needs on the live path:
+a single request can be sent to a different tier's model without rebuilding the
+client. Verified at both seams — the backend request builder and the
+complete_with_task_hints helper — and kept drop-in for legacy backends.
+"""
+
+from __future__ import annotations
+
+from seocho.store.llm import complete_with_task_hints, create_llm_backend
+
+
+def test_backend_request_kwargs_honor_model_override():
+    backend = create_llm_backend(provider="mara", model="MiniMax-M2.5", api_key="x")
+    base = backend._completion_request_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0, max_tokens=None, response_format=None,
+        reasoning_mode=None, task_hint=None,
+    )
+    assert base["model"] == "MiniMax-M2.5"  # default = bound model
+
+    overridden = backend._completion_request_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0, max_tokens=None, response_format=None,
+        reasoning_mode=None, task_hint=None, model="DeepSeek-V3.1",
+    )
+    assert overridden["model"] == "DeepSeek-V3.1"  # per-call override wins
+
+
+class _RecordingLLM:
+    def __init__(self):
+        self.calls = []
+
+    def complete(self, *, system, user, temperature=0.0, model=None, **kw):
+        self.calls.append({"model": model, "user": user})
+        return "ok"
+
+
+class _LegacyLLM:
+    """Predates the model kwarg — complete_with_task_hints must stay drop-in."""
+
+    def __init__(self):
+        self.calls = []
+
+    def complete(self, *, system, user, temperature=0.0):
+        self.calls.append({"user": user})
+        return "ok"
+
+
+def test_complete_with_task_hints_threads_model():
+    llm = _RecordingLLM()
+    complete_with_task_hints(llm, system="s", user="q", model="DeepSeek-V3.1")
+    assert llm.calls[-1]["model"] == "DeepSeek-V3.1"
+
+
+def test_complete_with_task_hints_default_passes_no_model():
+    llm = _RecordingLLM()
+    complete_with_task_hints(llm, system="s", user="q")
+    assert llm.calls[-1]["model"] is None  # no override -> backend default used
+
+
+def test_complete_with_task_hints_is_dropin_for_legacy_backends():
+    llm = _LegacyLLM()
+    # legacy backend rejects model= -> helper strips it and retries (no crash)
+    out = complete_with_task_hints(llm, system="s", user="q", model="DeepSeek-V3.1")
+    assert out == "ok" and llm.calls[-1] == {"user": "q"}


### PR DESCRIPTION
## What
Adds a per-call `model` override through the LLM layer (`complete_with_task_hints` → `backend.complete` → `_completion_request_kwargs`), default `None` = the bound model. This is the **missing primitive** cost-aware model routing needs on the live path.

## Verification corrected the council's Part B premise
Part B was framed as 'escalate the model tier inside graph_cot recovery'. But verified:
- `graph_cot_flow.revise()` is **deterministic text shaping** — no LLM.
- `semantic_agents.py` has **zero LLM calls**.
- The only LLM-with-model call in the query path is `complete_with_task_hints(self.llm, ...)` in `local_engine`, using the client's **single bound model with no per-request override**.

So there was no model to route on the live path — the real blocker was the missing override, not a wiring into recovery.

## How (default-preserving)
`model or self.model` in the request builder; `complete_with_task_hints(..., model=None)` threads it and its TypeError fallback strips `model` so it stays drop-in for legacy backends/test-doubles.

## Tests
backend honors override + defaults to bound model; helper threads it; default passes none; legacy backend still works. `run_basic_ci.sh` green (509); LLM + session regression clean.

## Remaining (seocho-jdg)
Consumer wiring: `local_engine.ask` consults a `ModelRouter` by query intent and passes the routed model to its two `complete_with_task_hints` calls (default-OFF) + a live FinDER support-parity run for synergy #2. Provider-coupling caveat (tiers must share the client's provider, e.g. MARA) + needs the live env.