### PR TITLE
feat(agent): optional config-gated reflection pass in the graph loop (seocho-t8m)

### DIFF
--- a/src/seocho/agent/graph_loop.py
+++ b/src/seocho/agent/graph_loop.py
@@ -76,6 +76,8 @@ class LoopResult:
     stop_reason: str = ""
     total_ms: int = 0
     refused: bool = False
+    reflected: bool = False          # an optional reflection pass ran
+    reflection_revised: bool = False  # and it changed the final answer
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -85,6 +87,8 @@ class LoopResult:
             "refused": self.refused,
             "iterations": [it.to_dict() for it in self.iterations],
             "total_ms": self.total_ms,
+            "reflected": self.reflected,
+            "reflection_revised": self.reflection_revised,
         }
 
     def summary(self) -> str:
@@ -189,6 +193,11 @@ class GraphAgenticLoop:
         policy: Optional[RoutingPolicy] = None,
         model_router: Optional[ModelRouter] = None,
         max_iterations: int = 3,
+        enable_reflection: bool = False,
+        reflection_critic: Optional[Callable[[str, str], Any]] = None,
+        reflection_reviser: Optional[Callable[[str, str, Any], str]] = None,
+        reflection_model: Optional[str] = None,
+        reflection_max_iters: int = 2,
         augment_fn: Optional[Callable[[str], Dict[str, Any]]] = None,
         emit_trace_fn: Optional[Callable[[Dict[str, Any]], None]] = None,
         enable_analytics: bool = True,
@@ -203,6 +212,15 @@ class GraphAgenticLoop:
         # None (default) no model is forced and behaviour is unchanged.
         self.model_router = model_router
         self.max_iterations = int(max_iterations)
+        # Optional post-answer reflection (self-critique -> revise) pass. OFF by
+        # default -> behaviour unchanged. critic/reviser are injectable (unit
+        # tests pass fakes); when absent and enabled, they are built lazily from
+        # self.client via reflection.make_llm_critic/reviser.
+        self.enable_reflection = bool(enable_reflection)
+        self._reflection_critic = reflection_critic
+        self._reflection_reviser = reflection_reviser
+        self.reflection_model = reflection_model
+        self.reflection_max_iters = int(reflection_max_iters)
         self.augment_fn = augment_fn or _default_augment
         self.emit_trace_fn = emit_trace_fn
         self.enable_analytics = enable_analytics
@@ -297,9 +315,34 @@ class GraphAgenticLoop:
             result.final_answer = state["answer_history"][-1] if state["answer_history"] else ""
             if not result.stop_reason:
                 result.stop_reason = "max_iterations"
+            self._maybe_reflect(result)
 
         result.total_ms = int((time.perf_counter() - t0) * 1000)
         return result
+
+    def _maybe_reflect(self, result: "LoopResult") -> None:
+        """Optional self-critique -> revise pass over the final answer (OFF by
+        default). Injected critic/reviser win; otherwise built from self.client.
+        Any reflection error is swallowed — it must never break the answer."""
+        if not self.enable_reflection or not result.final_answer:
+            return
+        try:
+            from .reflection import make_llm_critic, make_llm_reviser, reflect
+            critic = self._reflection_critic
+            reviser = self._reflection_reviser
+            if critic is None or reviser is None:
+                model = self.reflection_model or "default"
+                critic = critic or make_llm_critic(self.client, model)
+                reviser = reviser or make_llm_reviser(self.client, model)
+            r = reflect(result.question, result.final_answer,
+                        critic=critic, reviser=reviser,
+                        max_iterations=self.reflection_max_iters)
+            result.reflected = True
+            result.reflection_revised = r.revised
+            if r.revised:
+                result.final_answer = r.final
+        except Exception:
+            return  # reflection is best-effort; never degrade the base answer
 
     # -- Internals ---------------------------------------------------------
 

--- a/tests/seocho/test_graph_loop_model_routing.py
+++ b/tests/seocho/test_graph_loop_model_routing.py
@@ -63,3 +63,46 @@ def test_no_router_forces_no_model_preserving_behavior():
     # No router -> no model kwarg added; ask sees the default None.
     assert all(m is None for m in client.models)
     assert len(client.models) >= 1
+
+
+# --- optional reflection pass (seocho-t8m) ---------------------------------
+from seocho.agent.reflection import Critique  # noqa: E402
+
+
+def test_reflection_off_by_default_preserves_answer():
+    client = _RecordingClient()
+    loop = GraphAgenticLoop(client, max_iterations=1, augment_fn=_augment_lookup,
+                            enable_analytics=False)
+    r = loop.run("what is acme's revenue")
+    assert r.reflected is False and r.reflection_revised is False
+    assert r.final_answer  # an answer was produced, unchanged by reflection
+
+
+def test_reflection_revises_final_answer_when_enabled():
+    seen = {"n": 0}
+
+    def critic(_task, _draft):
+        seen["n"] += 1
+        return Critique(ok=seen["n"] > 1, issues=["incomplete"] if seen["n"] == 1 else [])
+
+    def reviser(_task, _draft, _crit):
+        return "REVISED final answer with the missing piece added."
+
+    loop = GraphAgenticLoop(_RecordingClient(), max_iterations=1, augment_fn=_augment_lookup,
+                            enable_analytics=False, enable_reflection=True,
+                            reflection_critic=critic, reflection_reviser=reviser)
+    r = loop.run("what is acme's revenue")
+    assert r.reflected is True and r.reflection_revised is True
+    assert r.final_answer == "REVISED final answer with the missing piece added."
+
+
+def test_reflection_error_never_degrades_answer():
+    def boom(_task, _draft):
+        raise RuntimeError("critic exploded")
+
+    loop = GraphAgenticLoop(_RecordingClient(), max_iterations=1, augment_fn=_augment_lookup,
+                            enable_analytics=False, enable_reflection=True,
+                            reflection_critic=boom, reflection_reviser=lambda *a: "x")
+    r = loop.run("what is acme's revenue")
+    assert r.final_answer  # base answer preserved; exception swallowed
+    assert r.reflection_revised is False


### PR DESCRIPTION
t8m wires "model-tier router + reflection into the live agent path". The loop **model-tier router** shipped in #230; this adds the **reflection** half: an optional self-critique → revise pass over `GraphAgenticLoop`'s final answer, **OFF by default** (behaviour-preserving).

- `enable_reflection=True` turns it on; `reflection_critic`/`reflection_reviser` are **injectable** (unit tests pass fakes), otherwise built lazily from `self.client` via `reflection.make_llm_critic/reviser` (#227).
- **Best-effort:** any reflection error is swallowed so it can never degrade the base answer.
- Outcome surfaced on `LoopResult.reflected` / `reflection_revised` (+ `to_dict`).

**Tests** (+3 in `test_graph_loop_model_routing.py`): off-by-default preserves the answer; enabled + critic-flags-incomplete revises the final answer; a throwing critic never degrades the answer. **5 pass.**

**Scope note (honest):** the remaining t8m sub-item — router consulted for **session/factory** model selection — is left for a coordinated pass: it threads through 4+ call sites in `session.py`, which **seocho-jdg (P1) is actively editing** (ResponseCache wiring), so forcing it now risks clobbering in-flight work. Loop-router (#230) + reflection (this PR) cover "model-tier router + reflection into the live agent path".