### PR TITLE
fix: Enforce least privilege for semantic_runs endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1430,7 +1430,7 @@ async def semantic_runs_list(
     intent_id: Optional[str] = Query(default=None),
 ):
     try:
-        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_semantic_runs", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 
@@ -1456,7 +1456,7 @@ async def semantic_runs_get(
     workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
 ):
     try:
-        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_semantic_runs", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -42,7 +42,7 @@ _OPERATIONAL: Set[str] = {
     "run_agent", "run_debate", "read_databases", "read_agents",
     "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles",
     "export_rules", "manage_indexes", "run_platform", "ingest_raw",
-    "manage_semantic_artifacts", "manage_memories",
+    "manage_semantic_artifacts", "manage_memories", "read_semantic_runs",
 }
 # Reserved for cross-tenant / policy operations — admin only.
 _ADMIN_ONLY: Set[str] = {"manage_tenants", "manage_policy"}
@@ -61,7 +61,7 @@ class RuntimePolicyEngine:
         self._role_permissions: Dict[str, Set[str]] = {
             "admin": _OPERATIONAL | _ADMIN_ONLY,   # strict superset
             "user": set(_OPERATIONAL),
-            "viewer": {"read_databases", "read_agents"},
+            "viewer": {"read_databases", "read_agents", "read_semantic_runs"},
         }
 
     def validate_workspace_id(self, workspace_id: str) -> PolicyDecision:


### PR DESCRIPTION
**Severity**: Low-Medium

**Vulnerability**: The `semantic_runs_list` and `semantic_runs_get` read-only endpoints incorrectly required the `"run_agent"` (execution-level) permission, violating the principle of least privilege. This forced administrators to grant users full agent execution permissions just so they could view their historical query traces.

**Impact**: Read-only users (assigned the `viewer` role) could not read semantic runs without being inappropriately elevated to a `user` or `admin` role, expanding their access footprint unnecessarily.

**Fix**: 
1. Defined a new `"read_semantic_runs"` permission in `runtime/policy.py`, adding it to `_OPERATIONAL` (retaining access for `user` and `admin` roles).
2. Mapped `"read_semantic_runs"` explicitly to the `viewer` role alongside other read-only permissions (`read_databases`, `read_agents`).
3. Updated the `require_runtime_permission` checks in `runtime/agent_server.py` for `/semantic/runs` and `/semantic/runs/{run_id}` to enforce `"read_semantic_runs"` instead of `"run_agent"`.

**Validation**: 
- Validated via `bash scripts/ci/run_basic_ci.sh`, confirming all canonical test suites pass without regression.
- Confirmed that other list endpoints already correctly use read-only permissions (`read_databases`, `read_agents`).

**Risks**: 
Very low. By adding the action to `_OPERATIONAL`, existing clients configured with the standard `user` role will continue to function seamlessly without experiencing HTTP 403 errors.

*(Draft PR as per security workflow contract)*

---
*PR created automatically by Jules for task [14007720914701045690](https://jules.google.com/task/14007720914701045690) started by @tteon*