### PR TITLE
feat(llm): live cost-aware model routing at the task-hint chokepoint (seocho-jdg)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ bench-finder-cache: ## Synergy #1: persistent-cache hit-rate + latency win (need
 	@echo "📊 FinDER cache synergy (persistent ResponseCache cross-session reuse)..."
 	@python3 scripts/benchmarks/finder_cache_synergy.py $(if $(PASSWORD),--neo4j-password $(PASSWORD),) $(if $(LIMIT),--limit $(LIMIT),)
 
+bench-finder-parity: ## Synergy #2 live: routed model tiers vs all-frontier on the wired path (needs DozerDB + MARA)
+	@echo "📊 FinDER routing parity (SEOCHO_MODEL_ROUTING wired path, routed vs all-frontier)..."
+	@python3 scripts/benchmarks/finder_routing_parity.py
+
 demo-raw: ## Run beginner raw-data demo pipeline
 	@bash scripts/demo/pipeline_raw_data.sh
 

--- a/scripts/benchmarks/finder_routing_parity.py
+++ b/scripts/benchmarks/finder_routing_parity.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Synergy #2 live: routed model tiers vs all-frontier on FinDER (seocho-jdg).
+
+Runs the REAL wired path: SEOCHO_MODEL_ROUTING=1 routes extraction/linking to
+the BALANCED tier and answer synthesis to FRONTIER at the
+complete_with_task_hints chokepoint; the all-frontier arm keeps routing OFF.
+Counts calls per model (relative cost) and compares answer quality.
+
+Measured 2026-06-11 (MARA + DozerDB, FinDER tutorial subset, n=4):
+  all_frontier: 14x MiniMax-M2.7            rel_cost=140  contains=0.50 numeric_recall=0.75
+  routed:        8x M2.5 + 6x M2.7          rel_cost= 84  contains=0.50 numeric_recall=0.88
+  -> cost 0.60x (40% saving) at equal-or-better answer quality.
+
+Needs DozerDB (NEO4J_PASSWORD) + MARA_API_KEY. Run:
+  python3 scripts/benchmarks/finder_routing_parity.py
+"""
+import os, re, sys, time
+from pathlib import Path
+from collections import Counter
+
+ROOT = Path(__file__).resolve().parents[2]
+for p in (ROOT, ROOT / "src", ROOT / "extraction"):
+    sys.path.insert(0, str(p))
+
+key = None
+for line in open(ROOT / ".env", encoding="utf-8"):
+    m = re.match(r'\s*MARA_API_KEY\s*=\s*"?([^"\n]+)"?', line)
+    if m: key = m.group(1).strip()
+os.environ.setdefault("MARA_API_KEY", key or "")
+
+from seocho import NodeDef, Ontology, P, RelDef, Seocho
+from seocho.benchmarking import load_finder_cases, compare_answers, score_answer_slots
+from seocho.routing import ModelTier, ModelRouter
+import seocho.store.llm as llm_mod
+
+REL_COST = {"DeepSeek-V3.1": 1.0, "MiniMax-M2.5": 3.0, "MiniMax-M2.7": 10.0}
+
+def onto():
+    return Ontology(
+        name="parity",
+        nodes={
+            "Company": NodeDef(properties={"name": P(str, unique=True), "sector": P(str)}),
+            "FinancialMetric": NodeDef(properties={"name": P(str, unique=True), "value": P(str), "year": P(str)}),
+            "Risk": NodeDef(properties={"name": P(str, unique=True), "category": P(str)}),
+        },
+        relationships={
+            "REPORTED": RelDef(source="Company", target="FinancialMetric"),
+            "FACES": RelDef(source="Company", target="Risk"),
+        },
+    )
+
+cases = load_finder_cases(ROOT / "examples/finder/datasets/finder_tutorial_subset.json")[:4]
+
+# instrument: count which model each completion actually used
+calls = Counter()
+_orig = llm_mod.complete_with_task_hints
+def counting(llm, **kw):
+    resp = _orig(llm, **kw)
+    routed = kw.get("model") or llm_mod._env_routed_model(llm, kw.get("task_hint"))
+    calls[routed or getattr(llm, "model", "?")] += 1
+    return resp
+llm_mod.complete_with_task_hints = counting
+# local_engine imported the symbol directly — patch there too
+import seocho.local_engine as le
+le.complete_with_task_hints = counting
+import seocho.query.answering as ans
+ans.complete_with_task_hints = counting
+import seocho.index.extraction_engine as xe
+xe.complete_with_task_hints = counting
+
+def run_arm(name, routing_on, db):
+    os.environ["SEOCHO_MODEL_ROUTING"] = "1" if routing_on else ""
+    calls.clear()
+    client = Seocho.local(onto(), llm="mara/MiniMax-M2.7", graph="bolt://localhost:7687",
+                          neo4j_user="neo4j", neo4j_password=os.getenv("NEO4J_PASSWORD", "seocho-dev"), api_key=key)
+    gs = client._engine.graph_store
+    try:
+        gs.ensure_database(db)
+    except Exception:
+        pass
+    rows = []
+    try:
+        for c in cases:
+            client.add(c.text, database=db, category=str(c.category or "memory"))
+        for c in cases:
+            t0 = time.perf_counter()
+            try:
+                a = client.ask(c.question, database=db)
+            except Exception as e:
+                a = f"(error {type(e).__name__})"
+            dt = (time.perf_counter() - t0) * 1000
+            _, contains = compare_answers(c.expected_answer, a)
+            slots = score_answer_slots(c.expected_answer, a)
+            rows.append({"contains": bool(contains),
+                         "numeric_recall": float(slots.get("numeric_recall", 0.0)),
+                         "ms": dt})
+    finally:
+        try:
+            gs.query("MATCH (n) WHERE n._source_id IS NOT NULL DETACH DELETE n", database=db)
+        except Exception:
+            pass
+        client.close()
+    cost = sum(REL_COST.get(m, 10.0) * n for m, n in calls.items())
+    return {
+        "arm": name,
+        "model_calls": dict(calls),
+        "relative_cost": cost,
+        "contains_rate": sum(r["contains"] for r in rows) / len(rows),
+        "numeric_recall": sum(r["numeric_recall"] for r in rows) / len(rows),
+        "p50_ms": sorted(r["ms"] for r in rows)[len(rows)//2],
+    }
+
+a = run_arm("all_frontier", routing_on=False, db="paritybencha")
+b = run_arm("routed", routing_on=True, db="paritybenchb")
+
+print("=" * 64)
+print("SYNERGY #2 LIVE — routed tiers vs all-frontier (MARA + DozerDB)")
+print("=" * 64)
+for r in (a, b):
+    print(f"  [{r['arm']:12s}] calls={r['model_calls']}  rel_cost={r['relative_cost']:.0f}")
+    print(f"                 contains={r['contains_rate']:.2f}  numeric_recall={r['numeric_recall']:.2f}  p50={r['p50_ms']:.0f}ms")
+ratio = b["relative_cost"] / a["relative_cost"] if a["relative_cost"] else 1.0
+print(f"\n  routed/all-frontier cost ratio = {ratio:.2f}x "
+      f"({'<0.6x MET' if ratio < 0.6 else 'above 0.6x'})")
+print(f"  support parity: contains {a['contains_rate']:.2f} -> {b['contains_rate']:.2f}, "
+      f"numeric_recall {a['numeric_recall']:.2f} -> {b['numeric_recall']:.2f}")

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -253,6 +253,57 @@ class LLMBackend(ABC):
         )
 
 
+# seocho-jdg: task_hint -> ModelRouter task. Only mapped hints are routed;
+# unmapped hints conservatively keep the backend's bound model.
+_TASK_HINT_TO_ROUTER_TASK: Dict[str, str] = {
+    "json_extraction": "extract",
+    "entity_linking": "link",
+    "answer_synthesis": "synthesize",
+}
+
+
+def _env_routed_model(llm: Any, task_hint: Optional[str]) -> Optional[str]:
+    """Cost-aware model for this call, or None (the default: routing OFF).
+
+    'Route on a known signal': every live LLM call funnels through
+    complete_with_task_hints carrying a task_hint, so this single chokepoint
+    covers extraction, linking, and answer synthesis without per-caller wiring.
+
+    Guards (all must hold, else None — bound model unchanged):
+    - SEOCHO_MODEL_ROUTING is truthy (explicit opt-in),
+    - the task_hint maps to a router task,
+    - the backend provider is 'mara' (the default tier map names MARA-hosted
+      models; routing across provider families would 404). Other providers can
+      opt in by overriding tiers via SEOCHO_MODEL_ROUTING_TIERS, e.g.
+      "FAST=gpt-4o-mini,BALANCED=gpt-4o,FRONTIER=gpt-4o" — the provider guard
+      is skipped when explicit tiers are supplied.
+    """
+    if os.getenv("SEOCHO_MODEL_ROUTING", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return None
+    task = _TASK_HINT_TO_ROUTER_TASK.get((task_hint or "").strip().lower())
+    if not task:
+        return None
+    from ..routing import ModelRouter, ModelTier  # lazy: avoid import cycles
+
+    tiers_env = os.getenv("SEOCHO_MODEL_ROUTING_TIERS", "").strip()
+    if tiers_env:
+        tier_models = {}
+        for part in tiers_env.split(","):
+            name, _, model_id = part.partition("=")
+            try:
+                tier_models[ModelTier[name.strip().upper()]] = model_id.strip()
+            except KeyError:
+                continue
+        if not tier_models:
+            return None
+        router = ModelRouter(tier_models=tier_models)
+    else:
+        if getattr(llm, "provider", "") != "mara":
+            return None
+        router = ModelRouter.mara_default()
+    return router.route(task=task).model
+
+
 def complete_with_task_hints(
     llm: Any,
     *,
@@ -289,6 +340,10 @@ def complete_with_task_hints(
         kwargs["task_hint"] = task_hint
     if mode is not None:
         kwargs["mode"] = mode
+    if model is None:
+        # opt-in cost-aware routing on the task_hint signal (seocho-jdg);
+        # an explicit model= from the caller always wins over the router.
+        model = _env_routed_model(llm, task_hint)
     if model is not None:
         kwargs["model"] = model
     try:

--- a/tests/seocho/test_llm_model_override.py
+++ b/tests/seocho/test_llm_model_override.py
@@ -65,3 +65,63 @@ def test_complete_with_task_hints_is_dropin_for_legacy_backends():
     # legacy backend rejects model= -> helper strips it and retries (no crash)
     out = complete_with_task_hints(llm, system="s", user="q", model="DeepSeek-V3.1")
     assert out == "ok" and llm.calls[-1] == {"user": "q"}
+
+
+# --- env-gated live routing at the chokepoint (seocho-jdg) ------------------
+
+def test_env_routing_off_by_default(monkeypatch):
+    monkeypatch.delenv("SEOCHO_MODEL_ROUTING", raising=False)
+    llm = _RecordingLLM()
+    llm.provider = "mara"
+    complete_with_task_hints(llm, system="s", user="q", task_hint="json_extraction")
+    assert llm.calls[-1]["model"] is None  # OFF -> bound model untouched
+
+
+def test_env_routing_routes_mapped_hints_for_mara(monkeypatch):
+    monkeypatch.setenv("SEOCHO_MODEL_ROUTING", "1")
+    monkeypatch.delenv("SEOCHO_MODEL_ROUTING_TIERS", raising=False)
+    llm = _RecordingLLM()
+    llm.provider = "mara"
+    # extract/link -> BALANCED tier; answer_synthesis -> FRONTIER tier
+    complete_with_task_hints(llm, system="s", user="q", task_hint="json_extraction")
+    assert llm.calls[-1]["model"] == "MiniMax-M2.5"
+    complete_with_task_hints(llm, system="s", user="q", task_hint="entity_linking")
+    assert llm.calls[-1]["model"] == "MiniMax-M2.5"
+    complete_with_task_hints(llm, system="s", user="q", task_hint="answer_synthesis")
+    assert llm.calls[-1]["model"] == "MiniMax-M2.7"
+
+
+def test_env_routing_skips_non_mara_provider(monkeypatch):
+    monkeypatch.setenv("SEOCHO_MODEL_ROUTING", "1")
+    monkeypatch.delenv("SEOCHO_MODEL_ROUTING_TIERS", raising=False)
+    llm = _RecordingLLM()
+    llm.provider = "openai"  # default tiers name MARA models -> guard refuses
+    complete_with_task_hints(llm, system="s", user="q", task_hint="json_extraction")
+    assert llm.calls[-1]["model"] is None
+
+
+def test_env_routing_unmapped_hint_keeps_bound_model(monkeypatch):
+    monkeypatch.setenv("SEOCHO_MODEL_ROUTING", "1")
+    llm = _RecordingLLM()
+    llm.provider = "mara"
+    complete_with_task_hints(llm, system="s", user="q", task_hint="weird_hint")
+    assert llm.calls[-1]["model"] is None
+
+
+def test_env_routing_explicit_model_wins(monkeypatch):
+    monkeypatch.setenv("SEOCHO_MODEL_ROUTING", "1")
+    llm = _RecordingLLM()
+    llm.provider = "mara"
+    complete_with_task_hints(llm, system="s", user="q",
+                             task_hint="json_extraction", model="forced-model")
+    assert llm.calls[-1]["model"] == "forced-model"
+
+
+def test_env_routing_tiers_override_skips_provider_guard(monkeypatch):
+    monkeypatch.setenv("SEOCHO_MODEL_ROUTING", "1")
+    monkeypatch.setenv("SEOCHO_MODEL_ROUTING_TIERS",
+                       "FAST=gpt-4o-mini,BALANCED=gpt-4o,FRONTIER=gpt-4o")
+    llm = _RecordingLLM()
+    llm.provider = "openai"  # explicit tiers -> family is caller's choice
+    complete_with_task_hints(llm, system="s", user="q", task_hint="json_extraction")
+    assert llm.calls[-1]["model"] == "gpt-4o"


### PR DESCRIPTION
## What
Completes seocho-jdg's consumer wiring: opt-in cost-aware model routing on the **live path**, at the single chokepoint every live LLM call already passes through — `complete_with_task_hints` with its `task_hint` signal (extraction / linking / **ask-path answer synthesis**). Zero per-caller wiring.

## How (default-OFF)
- `SEOCHO_MODEL_ROUTING=1` opts in; unset = bound model untouched (exact prior behavior).
- Mapped hints: `json_extraction`/`entity_linking` → **BALANCED**, `answer_synthesis` → **FRONTIER**. Unmapped hints conservatively keep the bound model; explicit `model=` always wins.
- **Provider guard**: default MARA tiers apply only when `llm.provider == 'mara'` (cross-family routing would 404). Other providers opt in via `SEOCHO_MODEL_ROUTING_TIERS=FAST=...,BALANCED=...,FRONTIER=...`.

## 🔢 Live result (synergy #2 — the council's headline, real wired path, MARA + DozerDB)
| arm | calls | rel cost | contains | numeric recall |
|---|---|---|---|---|
| all-frontier | 14× MiniMax-M2.7 | 140 | 0.50 | 0.75 |
| **routed** | 8× M2.5 + 6× M2.7 | **84** | 0.50 | **0.88** |

**Cost 0.60x (40% saving) at equal-or-better answer quality.** The tiny answer-heavy mix sits at the 0.6x boundary; broader mixes with FAST-tier lookups go lower (deterministic cost arm measured **0.51x** on the realistic mix, #264).

## Repro + tests
`make bench-finder-parity` reproduces the live number. 6 new unit tests (off-by-default, mara mapped hints, non-mara guard, unmapped hint, explicit-model-wins, tiers override). `run_basic_ci.sh` green (518).