### PR TITLE
feat(debate): fact-triple quorum gate on convergence (seocho-6gt, Lamport)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -91,6 +91,7 @@ uv run pytest \
   tests/seocho/test_matchmaker.py \
   tests/seocho/test_ontology_context_map.py \
   tests/seocho/test_promotion_boundary_gate.py \
+  tests/seocho/test_debate_quorum.py \
   tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
   tests/seocho/test_tracing_opik_regression.py \

--- a/src/seocho/debate/__init__.py
+++ b/src/seocho/debate/__init__.py
@@ -68,6 +68,119 @@ def convergence_curve(per_round_panels: Sequence[Mapping[str, str]]) -> List[flo
     return curve
 
 
+# ---------------------------------------------------------------------------
+# Fact-triple agreement (seocho-6gt, Lamport)
+#
+# Citation-Jaccard is a liveness/echo-chamber signal, not fact consensus: two
+# agents can cite the same source while asserting CONTRADICTORY facts and still
+# read as "converged". These helpers extract lightweight (subject, predicate,
+# object) fact triples from answers and score per-round quorum agreement, so
+# convergence can additionally require that a supermajority of panelists assert
+# the same top facts. Extraction is deterministic lexical-normalized matching
+# (no LLM/embeddings) — proportional to the opt-in debate path and offline-
+# testable; a semantic-similarity matcher can replace _canon_obj later without
+# changing the quorum contract.
+# ---------------------------------------------------------------------------
+
+_ENTITY_RE = re.compile(r"\b[A-Z][A-Za-z0-9.&'-]+(?:\s+[A-Z][A-Za-z0-9.&'-]+)*\b")
+_NUMBER_RE = re.compile(
+    r"-?\$?\d[\d,]*(?:\.\d+)?%?(?:\s*(?:billion|million|thousand|bn|mm|k))?",
+    re.IGNORECASE,
+)
+_MAX_TRIPLES_PER_ANSWER = 12
+
+
+def _canon_obj(text: str) -> str:
+    """Normalize an object slot: numbers lose commas/$ and trailing zeros."""
+    raw = text.strip().casefold()
+    m = re.match(r"-?\$?([\d,]+(?:\.\d+)?)(%?)(.*)", raw)
+    if m:
+        try:
+            num = float(m.group(1).replace(",", ""))
+            scale = m.group(3).strip()
+            return f"{num:g}{m.group(2)}{(' ' + scale) if scale else ''}".strip()
+        except ValueError:
+            pass
+    return raw
+
+
+def extract_fact_triples(answer: str) -> Set[Tuple[str, str, str]]:
+    """Extract lightweight (subject, predicate, object) fact triples.
+
+    Per sentence: subject = first capitalized entity span; object = the first
+    number (canonicalized) or the next entity after the subject; predicate =
+    the lowercase tokens between them (up to 4). Citations are stripped first
+    so ``[src:...]`` markers never pollute slots.
+    """
+    triples: Set[Tuple[str, str, str]] = set()
+    text = _CITE_RE.sub(" ", answer or "")
+    # split on sentence boundaries without breaking decimals ("2.1 billion")
+    for sentence in re.split(r"[;\n]+|\.(?!\d)", text):
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        ent = _ENTITY_RE.search(sentence)
+        if not ent:
+            continue
+        rest = sentence[ent.end():]
+        num = _NUMBER_RE.search(rest)
+        ent2 = _ENTITY_RE.search(rest)
+        # prefer the nearer of (number, second entity) as the object
+        obj_match = None
+        obj_is_num = False
+        if num and (not ent2 or num.start() <= ent2.start()):
+            obj_match, obj_is_num = num, True
+        elif ent2:
+            obj_match = ent2
+        if obj_match is None:
+            continue
+        between = rest[: obj_match.start()]
+        pred_tokens = [t for t in re.findall(r"[a-z][a-z'-]*", between)][:4]
+        if not pred_tokens:
+            continue
+        obj = _canon_obj(obj_match.group(0)) if obj_is_num else obj_match.group(0).casefold()
+        triples.add((ent.group(0).casefold(), " ".join(pred_tokens), obj))
+        if len(triples) >= _MAX_TRIPLES_PER_ANSWER:
+            break
+    return triples
+
+
+def quorum_report(
+    panel: Mapping[str, str],
+    *,
+    top_k: int = 5,
+    quorum: float = 2 / 3,
+) -> Dict[str, Any]:
+    """Per-round fact-quorum report for one panel (participant -> answer).
+
+    ``score`` = fraction of the top-K most-supported triples asserted by more
+    than ``quorum`` of the panel. ``contested`` lists top-K triples below
+    quorum — the tie-break input for the policy's ``moderator_chain``.
+    """
+    per_participant = [extract_fact_triples(a) for a in panel.values()]
+    n = max(1, len(per_participant))
+    support: Dict[Tuple[str, str, str], int] = {}
+    for triple_set in per_participant:
+        for t in triple_set:
+            support[t] = support.get(t, 0) + 1
+    ranked = sorted(support.items(), key=lambda kv: (-kv[1], kv[0]))[:top_k]
+    agreed = [t for t, c in ranked if c / n > quorum]
+    contested = [t for t, c in ranked if c / n <= quorum]
+    score = len(agreed) / len(ranked) if ranked else 0.0
+    return {"score": score, "agreed": agreed, "contested": contested, "panel_size": n}
+
+
+def triple_agreement_curve(
+    per_round_panels: Sequence[Mapping[str, str]],
+    *,
+    top_k: int = 5,
+    quorum: float = 2 / 3,
+) -> List[float]:
+    """Per-round quorum score (companion to :func:`convergence_curve`)."""
+    return [quorum_report(panel, top_k=top_k, quorum=quorum)["score"]
+            for panel in per_round_panels]
+
+
 def should_stop(
     curve: Sequence[float],
     *,
@@ -78,13 +191,33 @@ def should_stop(
     no_improvement_eps: float = 0.05,
     time_budget_ms: int = 60_000,
     token_budget: int = 30_000,
+    quorum_curve: Optional[Sequence[float]] = None,
+    quorum_threshold: float = 2 / 3,
 ) -> Tuple[bool, str]:
-    """Return ``(stop, reason)``. ``reason`` is empty when not stopping."""
+    """Return ``(stop, reason)``. ``reason`` is empty when not stopping.
+
+    ``quorum_curve`` (seocho-6gt, optional — default None preserves prior
+    behavior): when supplied, declaring ``convergence`` additionally requires
+    the latest fact-quorum score to clear ``quorum_threshold``, so a panel
+    citing the same source while asserting contradictory facts (echo chamber)
+    keeps debating instead of "converging". All other stop criteria
+    (stagnation, round cap, budgets) are unaffected.
+    """
     if not curve:
         return False, ""
     last = curve[-1]
     if last >= convergence_threshold:
-        return True, f"convergence reached ({last:.2f})"
+        quorum_ok = (
+            quorum_curve is None
+            or (len(quorum_curve) > 0 and quorum_curve[-1] >= quorum_threshold)
+        )
+        if quorum_ok:
+            if quorum_curve is None:
+                return True, f"convergence reached ({last:.2f})"
+            return True, (
+                f"convergence reached ({last:.2f}, fact-quorum {quorum_curve[-1]:.2f})"
+            )
+        # citation echo without fact agreement -> not convergence; fall through
     if len(curve) >= 3:
         d1 = abs(curve[-1] - curve[-2])
         d2 = abs(curve[-2] - curve[-3])
@@ -218,6 +351,9 @@ __all__ = [
     "DebatePolicy",
     "DebateResult",
     "convergence_curve",
+    "extract_fact_triples",
+    "quorum_report",
+    "triple_agreement_curve",
     "detect_anti_patterns",
     "extract_citations",
     "select_participants",

--- a/tests/seocho/test_debate_quorum.py
+++ b/tests/seocho/test_debate_quorum.py
@@ -1,0 +1,91 @@
+"""Fact-triple quorum for debate convergence (seocho-6gt, Lamport).
+
+Citation-Jaccard is an echo-chamber signal: two agents citing the same source
+while asserting CONTRADICTORY facts read as 'converged'. The quorum layer makes
+convergence additionally require >2/3 of the panel to assert the same top facts.
+Default (no quorum_curve) preserves prior behavior exactly.
+"""
+
+from __future__ import annotations
+
+from seocho.debate import (
+    convergence_curve,
+    extract_fact_triples,
+    quorum_report,
+    should_stop,
+    triple_agreement_curve,
+)
+
+# Same citation, contradictory revenue numbers — the echo chamber.
+_ECHO_PANEL = {
+    "openai": "ACME reported revenue of $2.1 billion in 2023. [src:10k]",
+    "kimi": "ACME reported revenue of $9.9 billion in 2023. [src:10k]",
+}
+# Same citation, same fact.
+_AGREE_PANEL = {
+    "openai": "ACME reported revenue of $2.1 billion in 2023. [src:10k]",
+    "kimi": "ACME reported revenue of $2.1 billion in 2023. [src:10k]",
+}
+
+
+def test_extract_fact_triples_numeric_fact():
+    triples = extract_fact_triples("ACME reported revenue of $2.1 billion in 2023. [src:10k]")
+    assert ("acme", "reported revenue of", "2.1 billion") in triples
+
+
+def test_canonicalization_matches_format_variants():
+    a = extract_fact_triples("ACME reported revenue of $2,100,000,000.")
+    b = extract_fact_triples("ACME reported revenue of 2100000000.")
+    assert a and a == b  # commas/$ stripped -> same canonical triple
+
+
+def test_echo_chamber_jaccard_converges_but_quorum_does_not():
+    jacc = convergence_curve([_ECHO_PANEL])
+    quorum = triple_agreement_curve([_ECHO_PANEL])
+    assert jacc[-1] == 1.0          # identical citations -> "converged" by Jaccard
+    assert quorum[-1] < 2 / 3       # contradictory facts -> no quorum
+
+
+def test_should_stop_blocks_echo_chamber_convergence():
+    jacc = convergence_curve([_ECHO_PANEL])
+    quorum = triple_agreement_curve([_ECHO_PANEL])
+    stop, reason = should_stop(
+        jacc, elapsed_ms=0, tokens=0, max_rounds=5,
+        quorum_curve=quorum,
+    )
+    assert stop is False and reason == ""  # keeps debating instead of converging
+
+
+def test_should_stop_converges_when_facts_agree():
+    jacc = convergence_curve([_AGREE_PANEL])
+    quorum = triple_agreement_curve([_AGREE_PANEL])
+    stop, reason = should_stop(
+        jacc, elapsed_ms=0, tokens=0, max_rounds=5,
+        quorum_curve=quorum,
+    )
+    assert stop is True
+    assert "convergence" in reason and "fact-quorum" in reason
+
+
+def test_default_behavior_unchanged_without_quorum_curve():
+    jacc = convergence_curve([_ECHO_PANEL])
+    stop, reason = should_stop(jacc, elapsed_ms=0, tokens=0, max_rounds=5)
+    assert stop is True and "convergence" in reason  # prior contract preserved
+
+
+def test_other_stop_criteria_unaffected_by_quorum_block():
+    # echo chamber blocked from converging, but the hard round cap still stops it
+    jacc = [1.0, 1.0, 1.0]
+    quorum = [0.0, 0.0, 0.0]
+    stop, reason = should_stop(jacc, elapsed_ms=0, tokens=0, max_rounds=3,
+                               quorum_curve=quorum)
+    # stops via a NON-convergence rule (stagnation fires before the round cap)
+    assert stop is True and "convergence" not in reason
+
+
+def test_quorum_report_exposes_contested_for_moderator():
+    report = quorum_report(_ECHO_PANEL)
+    # both contradictory revenue triples are contested -> moderator_chain input
+    assert report["score"] < 2 / 3
+    assert len(report["contested"]) == 2 and report["agreed"] == []
+    assert report["panel_size"] == 2


### PR DESCRIPTION
## What
The last council item: debate convergence now (optionally) requires **fact consensus**, not just citation overlap.

## Why (Lamport, council-verified)
Citation-Jaccard at 0.80 is an **echo-chamber** signal: two agents citing the same source while asserting **contradictory facts** read as 'converged'.

## How (additive, default-preserving)
- `extract_fact_triples()` — deterministic (s,p,o) triples (entity / predicate tokens / canonicalized number-or-entity; decimal-safe splitting; citations stripped). Lexical matching, no LLM — proportional to the opt-in debate path.
- `quorum_report()` / `triple_agreement_curve()` — per-round score = fraction of top-K most-supported triples asserted by **>2/3** of the panel; `contested` triples are the tie-break input for `DebatePolicy.moderator_chain`.
- `should_stop(quorum_curve=..., quorum_threshold=2/3)` — convergence additionally requires fact-quorum; **`None` (default) = prior behavior exactly**; stagnation/round-cap/budget stops unaffected.

## Demonstrated benefit (tests, 8)
The echo-chamber panel (same `[src:10k]`, $2.1B vs $9.9B revenue) scores **Jaccard 1.0 but quorum <2/3** → `should_stop` keeps debating; with agreeing facts it converges (reason carries the fact-quorum); `$2,100,000,000` ≡ `2100000000` canonicalization; default path byte-identical. `run_basic_ci.sh` green (526).