### PR TITLE
feat(sdk,cli): YAML e2e runner — seocho run <config.yaml> (seocho-0u7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ the ontology, sample documents, and script.
 
 Prefer the smallest possible hello world? Use [QUICKSTART.md](QUICKSTART.md).
 
+### One YAML, one command
+
+Skip Python entirely with a run spec — declare your ontology, documents, and
+questions in YAML, then run the whole index → query → report flow:
+
+```bash
+export MARA_API_KEY=...
+seocho run examples/run/quickstart.yaml
+```
+
+`seocho run --init` writes a commented template. See
+[docs/RUN_SPECS.md](docs/RUN_SPECS.md) for per-phase models, agent patterns,
+and ontology enforcement modes.
+
 ## How SEOCHO Works
 
 SEOCHO has three practical layers:

--- a/docs/RUN_SPECS.md
+++ b/docs/RUN_SPECS.md
@@ -1,0 +1,155 @@
+# Run Specs
+
+`seocho run` executes one end-to-end flow — index documents, ask questions,
+write a report — from a single YAML file. A run spec is the run-scoped layer
+on top of the existing design dialects:
+
+- run-scoped vocabulary (models, graph connection, inputs, output) lives here
+- agent behavior is delegated to [agent design specs](AGENT_DESIGN_SPECS.md)
+- ingestion behavior is delegated to [indexing design specs](INDEXING_DESIGN_SPECS.md)
+
+A run spec never redefines a key those dialects already own; it references or
+embeds their documents.
+
+## Quickstart
+
+```bash
+seocho run --init           # writes a commented seocho.run.yaml template
+# edit ontology/documents/questions, then:
+seocho run                  # or: seocho run path/to/config.yaml
+```
+
+A working example ships in the repo:
+
+```bash
+export MARA_API_KEY=...
+seocho run examples/run/quickstart.yaml
+```
+
+## Minimal spec
+
+With no graph server and no model keys beyond one provider env var:
+
+```yaml
+ontology: ./schema.yaml
+documents: ./docs/
+questions:
+  - Which companies reported revenue growth?
+  - Who is the CEO of Acme?
+```
+
+Defaults: `mara/MiniMax-M2.5` for both phases, embedded LadybugDB
+(`.seocho/local.lbug`), `guided` enforcement, `pipeline` execution mode.
+
+## Full spec
+
+```yaml
+name: filings-demo                  # default: config filename stem
+description: Optional free text.
+
+ontology:
+  path: ./schema.yaml               # YAML / JSON-LD / TTL (Ontology.load)
+  enforcement: guided               # strict | guided | open (default: guided)
+
+documents:
+  path: ./docs/                     # .txt .md .csv .json .jsonl .pdf
+  recursive: true
+
+models:
+  default: mara/MiniMax-M2.5        # provider/model for both phases
+  indexing: mara/MiniMax-M2         # per-phase override → separate client
+  query: mara/MiniMax-M2.5
+
+graph: bolt://localhost:7687        # omit for embedded LadybugDB
+graph_user: neo4j
+graph_password: ${NEO4J_PASSWORD:-password}
+database: neo4j                     # omit to derive from the ontology name
+workspace_id: filings_demo          # default: derived from name
+
+indexing:
+  design: ./indexing_design.yaml    # optional IndexingDesignSpec (path or inline)
+  category: filing
+  force: false
+
+agent:
+  design: ./agent_design.yaml       # optional AgentDesignSpec (path or inline)
+  execution_mode: pipeline          # pipeline | agent | supervisor
+  routing_policy: balanced          # fast | balanced | thorough
+
+query:
+  reasoning_mode: true
+  repair_budget: 1
+  answer_style: concise             # concise | evidence | table
+  limit: 5
+
+questions:                          # strings, or mappings with expectations
+  - Which companies reported revenue growth?
+  - question: Who is the CEO of Acme?
+    expect: Jane Park               # recorded in the report, not auto-graded
+    id: ceo-check
+
+output:
+  dir: runs                         # report lands in runs/<name>-<timestamp>/
+```
+
+Omitting `questions` entirely makes the run index-only.
+
+## Ontology enforcement
+
+`ontology.enforcement` declares the admission policy for extracted graph
+data against the ontology vocabulary:
+
+| Mode | Behavior today (v1) |
+| --- | --- |
+| `strict` | Chunks failing SHACL validation are rejected, not written (`strict_validation=True`; default `validation_on_fail` becomes `reject`). |
+| `guided` | Default. The ontology guides extraction prompts; validation errors are reported but content is written. |
+| `open` | Same write behavior as `guided`; reserved for open-vocabulary admission with out-of-ontology annotation. |
+
+Full closed-vocabulary semantics for `strict` (no `Entity` fallback, no
+relaxed retry, endpoint conformance) and `_out_of_ontology` annotation for
+`open` are tracked in `seocho-snt` and will tighten these modes without
+changing the YAML surface.
+
+## Per-phase models
+
+When `models.indexing` and `models.query` differ, the runner builds two
+clients sharing one graph store, ontology, and workspace — per-phase model
+separation without per-call plumbing. Env-driven routing
+(`SEOCHO_MODEL_ROUTING`) still applies within each phase if configured.
+
+## Environment variables in values
+
+Any string value may interpolate `${VAR}` or `${VAR:-default}`. An unset
+variable without a default is a config error. Put env var *names* in YAML,
+never literal API keys; provider keys are read from the provider's standard
+env var (`MARA_API_KEY`, `OPENAI_API_KEY`, ...).
+
+## CLI
+
+```
+seocho run [CONFIG] [options]
+
+  CONFIG            Run spec YAML (default: ./seocho.run.yaml)
+  --init            Write a commented template and exit (refuses to overwrite)
+  --dry-run         Validate config + offline preflight; no LLM calls
+  --only index|query  Run a single phase (query reuses the existing graph)
+  -o, --output DIR  Report directory (default: runs/<name>-<timestamp>/)
+  --force           Re-index files even if unchanged
+  --output-json     Machine-readable output
+
+Exit codes: 0 ok · 1 runtime/preflight failure · 2 invalid config
+```
+
+Every run starts with a preflight that reports **all** failing checks
+(ontology loads, documents found, API key present, graph reachable) before
+anything spends tokens. `--dry-run` is the same preflight without the graph
+connection attempt.
+
+## Report
+
+Each run writes `report.json` (machine-readable: run metadata, per-file
+indexing stats, per-question records with latency and errors) and
+`report.md` (human summary) under `output.dir/<name>-<timestamp>/`. Empty
+answers and per-question errors are surfaced in the summary table; a
+question error marks the run as failed (exit 1) without aborting remaining
+questions.

--- a/examples/e2e_evaluation.py
+++ b/examples/e2e_evaluation.py
@@ -16,6 +16,9 @@ Requires:
     - Neo4j/DozerDB running on bolt://localhost:7687
     - OPENAI_API_KEY in .env
     - OPIK_API_KEY in .env (optional, for Opik cloud)
+
+For a config-driven version of this flow (one YAML, no Python), see
+``seocho run`` and docs/RUN_SPECS.md.
 """
 
 from __future__ import annotations

--- a/examples/run/docs/acme.md
+++ b/examples/run/docs/acme.md
@@ -1,0 +1,5 @@
+# Acme Corp — 2025 annual summary
+
+Acme Corp reported revenue growth of 18% year over year in 2025, driven by
+strong demand for its flagship product AcmeCloud. Jane Park, the CEO of
+Acme Corp, attributed the growth to enterprise adoption in the APAC region.

--- a/examples/run/docs/beta.md
+++ b/examples/run/docs/beta.md
@@ -1,0 +1,6 @@
+# Beta Industries — Q4 update
+
+Beta Industries also reported revenue growth in 2025, up 7% year over year.
+During the fourth quarter, Beta Industries acquired Gamma Logistics to
+expand its supply-chain offering. CEO Marcus Lee said the acquisition closes
+a long-standing gap in last-mile delivery.

--- a/examples/run/docs/sector_notes.md
+++ b/examples/run/docs/sector_notes.md
@@ -1,0 +1,5 @@
+# Sector notes
+
+Analysts highlight two names in the enterprise software sector: Acme Corp
+(AcmeCloud) and Beta Industries (BetaTrack). Both companies grew revenue in
+2025, while smaller competitors stayed flat.

--- a/examples/run/quickstart.yaml
+++ b/examples/run/quickstart.yaml
@@ -1,0 +1,17 @@
+# Quickstart run spec — try it from the repo root:
+#
+#   export MARA_API_KEY=...        # or switch models.default below
+#   seocho run examples/run/quickstart.yaml
+#
+# No graph server needed: with no `graph:` key the run uses the embedded
+# LadybugDB engine. See docs/RUN_SPECS.md for every available key.
+name: quickstart
+
+ontology: ./schema.yaml
+documents: ./docs/
+
+questions:
+  - What product does Acme Corp offer?
+  - question: Who is the CEO of Acme Corp?
+    expect: Jane Park
+  - What did Beta Industries acquire?

--- a/examples/run/schema.yaml
+++ b/examples/run/schema.yaml
@@ -1,0 +1,34 @@
+name: quickstart
+description: Minimal company/person/product schema for the seocho run quickstart.
+nodes:
+  Company:
+    description: A business organization
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+  Person:
+    description: A person such as an executive or founder
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+  Product:
+    description: A product or service offered by a company
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+relationships:
+  CEO_OF:
+    source: Person
+    target: Company
+    description: Person leads the company as chief executive
+  ACQUIRED:
+    source: Company
+    target: Company
+    description: Company acquired another company
+  OFFERS:
+    source: Company
+    target: Product
+    description: Company offers a product or service

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -50,7 +50,12 @@ python3 -m py_compile \
   src/seocho/tracing.py \
   src/seocho/store/graph.py \
   src/seocho/query/cypher_builder.py \
-  src/seocho/index/extraction_engine.py
+  src/seocho/index/extraction_engine.py \
+  src/seocho/index/file_reader.py \
+  src/seocho/run_spec.py \
+  src/seocho/run_preflight.py \
+  src/seocho/e2e.py \
+  src/seocho/cli.py
 
 uv run pytest \
   extraction/tests/test_runtime_package_aliases.py \
@@ -110,6 +115,8 @@ uv run pytest \
   tests/seocho/test_ontology_subclass_ttl.py \
   tests/seocho/test_ontology_reasoner.py \
   tests/seocho/test_ontology_iso704_cq.py \
+  tests/seocho/test_run_spec.py \
+  tests/seocho/test_e2e_runner.py \
   -q
 
 git diff --check

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -112,6 +112,9 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
         "RelationshipCurationPolicy",
         "load_curation_design_spec",
     ],
+    ".e2e": [
+        "run_from_config",
+    ],
     ".http_runtime": [
         "create_bundle_runtime_app",
     ],
@@ -179,6 +182,11 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
         "enforce_drift_policy",
         "ontology_context_graph_properties",
         "query_ontology_context_mismatch",
+    ],
+    ".run_spec": [
+        "RunSpec",
+        "RunSpecError",
+        "load_run_spec",
     ],
     ".ontology_versioning": [
         "OntologyUpgradePlan",

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -328,6 +328,38 @@ def build_parser() -> argparse.ArgumentParser:
     serve_http_parser.add_argument("--port", type=int, default=8010, help="Bind port")
     serve_http_parser.add_argument("--reload", action="store_true", help="Enable uvicorn reload mode")
 
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run a YAML-declared e2e flow: index documents, ask questions, write a report",
+    )
+    run_parser.add_argument(
+        "config",
+        nargs="?",
+        default="seocho.run.yaml",
+        help="Run spec YAML (default: ./seocho.run.yaml)",
+    )
+    run_parser.add_argument(
+        "--init", action="store_true",
+        help="Write a commented run spec template to the config path and exit",
+    )
+    run_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Validate the config and run offline preflight checks; no LLM calls",
+    )
+    run_parser.add_argument(
+        "--only", choices=["index", "query"],
+        help="Run a single phase (query reuses the existing graph)",
+    )
+    run_parser.add_argument(
+        "-o", "--output", default=None,
+        help="Report directory (default: runs/<name>-<timestamp>/)",
+    )
+    run_parser.add_argument(
+        "--force", action="store_true",
+        help="Re-index files even if unchanged",
+    )
+    run_parser.add_argument("--output-json", action="store_true", help="Emit JSON")
+
     traces_parser = subparsers.add_parser(
         "traces",
         help="Query trace spans from a JSONL file (read-safe, no server)",
@@ -361,7 +393,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-LOCAL_COMMANDS = {"init", "index", "local-ask", "status", "compare", "experiment", "bundle", "ontology", "serve-http", "traces"}
+LOCAL_COMMANDS = {"init", "index", "local-ask", "status", "compare", "experiment", "bundle", "ontology", "serve-http", "traces", "run"}
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -800,6 +832,8 @@ def _dispatch_local(args: argparse.Namespace) -> int:
         return _cmd_serve_http(args)
     if args.command == "traces":
         return _cmd_traces(args)
+    if args.command == "run":
+        return _cmd_run(args)
     raise SeochoError(f"Unknown local command: {args.command}")
 
 
@@ -1010,6 +1044,32 @@ def _cmd_index(args: argparse.Namespace) -> int:
         client.close()
 
     return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    """Run a YAML-declared e2e flow (or write a template with --init)."""
+    if args.init:
+        from .run_spec import RUN_SPEC_TEMPLATE
+
+        target = Path(args.config)
+        if target.exists():
+            print(f"{target} already exists — refusing to overwrite.", file=sys.stderr)
+            return 1
+        target.write_text(RUN_SPEC_TEMPLATE, encoding="utf-8")
+        print(f"Run spec template written to {target}")
+        print("Edit the ontology/documents/questions, then: seocho run")
+        return 0
+
+    from .e2e import run_from_config
+
+    return run_from_config(
+        args.config,
+        dry_run=args.dry_run,
+        only=args.only,
+        output_dir=args.output,
+        force=args.force,
+        json_output=getattr(args, "output_json", False),
+    )
 
 
 def _cmd_local_ask(args: argparse.Namespace) -> int:

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1287,6 +1287,7 @@ class Seocho:
         database: str = "neo4j",
         category: str = "file",
         force: bool = False,
+        strict_validation: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Index a single file (.txt, .md, .csv, .json, .jsonl).
 
@@ -1301,6 +1302,9 @@ class Seocho:
             Path to the file.
         force:
             Re-index even if the file hasn't changed.
+        strict_validation:
+            When True, chunks failing SHACL validation are rejected
+            (not written). Defaults to the pipeline's configured flag.
 
         Returns
         -------
@@ -1311,7 +1315,10 @@ class Seocho:
             raise RuntimeError("index_file() requires local engine mode")
         from .file_indexer import FileIndexer
         indexer = FileIndexer(self._engine._indexing, database=database, category=category)
-        result = indexer.index_file(path, database=database, category=category, force=force)
+        result = indexer.index_file(
+            path, database=database, category=category, force=force,
+            strict_validation=strict_validation,
+        )
         return result.to_dict()
 
     def index_directory(
@@ -1323,6 +1330,7 @@ class Seocho:
         recursive: bool = True,
         force: bool = False,
         on_file: Optional[Any] = None,
+        strict_validation: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Index all supported files in a directory.
 
@@ -1340,6 +1348,9 @@ class Seocho:
             Re-index all files regardless of change status.
         on_file:
             Progress callback ``(file_path, current, total)``.
+        strict_validation:
+            When True, chunks failing SHACL validation are rejected
+            (not written). Defaults to the pipeline's configured flag.
 
         Returns
         -------
@@ -1354,6 +1365,7 @@ class Seocho:
         result = indexer.index_directory(
             directory, database=database, category=category,
             recursive=recursive, force=force, on_file=on_file,
+            strict_validation=strict_validation,
         )
         return result.to_dict()
 

--- a/src/seocho/e2e.py
+++ b/src/seocho/e2e.py
@@ -1,0 +1,513 @@
+"""End-to-end runner behind ``seocho run``: build → index → query → report.
+
+The builder turns a validated :class:`~seocho.run_spec.RunSpec` into live
+SDK objects (ontology, graph store, one or two clients), and the runner
+drives the three phases. Design vocabulary is delegated to
+:class:`~seocho.agent_design.AgentDesignSpec` and
+:class:`~seocho.indexing_design.IndexingDesignSpec`; this module only adds
+run-scoped wiring.
+
+When the indexing and query models differ, two clients are built sharing
+one graph store, ontology, and workspace — per-phase model separation
+without any per-call plumbing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .run_spec import RunSpec, RunSpecError, load_run_spec, parse_model_ref
+from .run_preflight import run_preflight
+
+_BOLT_SCHEMES = ("bolt://", "neo4j://", "neo4j+s://", "bolt+s://")
+
+
+@dataclass(slots=True)
+class RunContext:
+    """Live objects assembled from a run spec, ready to execute."""
+
+    spec: RunSpec
+    ontology: Any
+    graph_store: Any
+    index_client: Any
+    query_client: Any
+    database: str
+    documents_path: Path
+    output_dir: Path
+
+    def close(self) -> None:
+        for client in {id(self.index_client): self.index_client, id(self.query_client): self.query_client}.values():
+            try:
+                client.close()
+            except Exception:
+                pass
+
+
+def _resolve(spec: RunSpec, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+    base = Path(spec.source_path).parent if spec.source_path else Path(".")
+    return base / path
+
+
+def _load_design(spec: RunSpec, *, section: str) -> Optional[Any]:
+    design = getattr(spec, section).get("design")
+    if not design:
+        return None
+    if section == "agent":
+        from .agent_design import AgentDesignSpec as design_cls
+    else:
+        from .indexing_design import IndexingDesignSpec as design_cls
+    if isinstance(design, dict):
+        return design_cls.from_dict(design)
+    return design_cls.from_yaml(_resolve(spec, str(design)))
+
+
+def build_agent_config(spec: RunSpec) -> Any:
+    """Compile the run spec's agent/query sections into an AgentConfig.
+
+    Precedence: agent-design pattern defaults < inline run-spec keys —
+    the same layering AgentDesignSpec.to_agent_config() applies to its
+    own sections.
+    """
+    from .agent_config import AgentConfig, RoutingPolicy
+
+    agent_design = _load_design(spec, section="agent")
+    config = agent_design.to_agent_config() if agent_design is not None else AgentConfig()
+
+    overrides: Dict[str, Any] = {}
+    execution_mode = str(spec.agent.get("execution_mode") or "").strip().lower()
+    if execution_mode:
+        overrides["execution_mode"] = execution_mode
+        if execution_mode == "supervisor":
+            overrides["handoff"] = True
+    routing_policy = str(spec.agent.get("routing_policy") or "").strip().lower()
+    if routing_policy:
+        overrides["routing_policy"] = {
+            "fast": RoutingPolicy.fast,
+            "balanced": RoutingPolicy.balanced,
+            "thorough": RoutingPolicy.thorough,
+        }[routing_policy]()
+    if "reasoning_mode" in spec.query:
+        overrides["reasoning_mode"] = bool(spec.query["reasoning_mode"])
+    if "repair_budget" in spec.query:
+        overrides["repair_budget"] = int(spec.query["repair_budget"])
+    if "answer_style" in spec.query:
+        overrides["answer_style"] = str(spec.query["answer_style"]).strip().lower()
+    if spec.strict_validation() and config.validation_on_fail == "warn":
+        overrides["validation_on_fail"] = "reject"
+
+    return dataclasses.replace(config, **overrides) if overrides else config
+
+
+def _build_llm(model_ref: str) -> Any:
+    from .store.llm import create_llm_backend
+
+    errors: List[str] = []
+    provider, model = parse_model_ref(model_ref, where="models", errors=errors)
+    if errors:
+        raise RunSpecError(errors)
+    return create_llm_backend(provider=provider, model=model)
+
+
+def _build_graph_store(spec: RunSpec, ontology: Any) -> Any:
+    if spec.graph and spec.graph.startswith(_BOLT_SCHEMES):
+        from .store.graph import Neo4jGraphStore
+
+        return Neo4jGraphStore(spec.graph, spec.graph_user, spec.graph_password)
+    from .store.graph import LadybugGraphStore
+
+    store = LadybugGraphStore(spec.graph or ".seocho/local.lbug")
+    try:
+        store.ensure_constraints(ontology)
+    except Exception:
+        pass
+    return store
+
+
+def build(spec: RunSpec) -> RunContext:
+    """Assemble live SDK objects from a validated run spec."""
+    from .client import Seocho
+    from .ontology import Ontology
+
+    ontology = Ontology.load(_resolve(spec, spec.ontology_path))
+
+    client_kwargs: Dict[str, Any] = {
+        "ontology": ontology,
+        "workspace_id": spec.resolved_workspace_id(),
+        "agent_config": build_agent_config(spec),
+    }
+    indexing_design = _load_design(spec, section="indexing")
+    if indexing_design is not None:
+        design_kwargs = indexing_design.client_kwargs(ontology=ontology)
+        client_kwargs.update({k: v for k, v in design_kwargs.items() if v is not None})
+        ontology = client_kwargs["ontology"]
+
+    graph_store = _build_graph_store(spec, ontology)
+    client_kwargs["graph_store"] = graph_store
+
+    index_client = Seocho(llm=_build_llm(spec.indexing_model()), **client_kwargs)
+    if spec.uses_split_models():
+        query_client = Seocho(llm=_build_llm(spec.query_model()), **client_kwargs)
+    else:
+        query_client = index_client
+
+    database = spec.database or index_client.default_database
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_dir = _resolve(spec, spec.output_dir) / f"{spec.name}-{timestamp}"
+
+    return RunContext(
+        spec=spec,
+        ontology=ontology,
+        graph_store=graph_store,
+        index_client=index_client,
+        query_client=query_client,
+        database=database,
+        documents_path=_resolve(spec, spec.documents_path),
+        output_dir=output_dir,
+    )
+
+
+@dataclass(slots=True)
+class RunReport:
+    """Aggregated outcome of one e2e run."""
+
+    payload: Dict[str, Any] = field(default_factory=dict)
+    report_json: Optional[Path] = None
+    report_md: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        indexing = self.payload.get("indexing") or {}
+        queries = self.payload.get("queries") or []
+        files_found = int(indexing.get("files_found", 0))
+        files_failed = int(indexing.get("files_failed", 0))
+        all_files_failed = files_found > 0 and files_failed >= files_found
+        any_query_error = any(item.get("error") for item in queries)
+        return not all_files_failed and not any_query_error
+
+
+def _emit(quiet: bool, message: str = "") -> None:
+    if not quiet:
+        print(message)
+
+
+def _run_index_phase(ctx: RunContext, *, force: bool, quiet: bool) -> Dict[str, Any]:
+    spec = ctx.spec
+    path = ctx.documents_path
+    strict = spec.strict_validation()
+
+    if path.is_file():
+        result = ctx.index_client.index_file(
+            str(path),
+            database=ctx.database,
+            category=str(spec.indexing.get("category") or "file"),
+            force=force or bool(spec.indexing.get("force", False)),
+            strict_validation=strict,
+        )
+        indexing = result.get("indexing") or {}
+        summary = {
+            "directory": str(path),
+            "files_found": 1,
+            "files_indexed": 1 if result.get("status") == "indexed" else 0,
+            "files_skipped": 1 if result.get("status") == "skipped" else 0,
+            "files_failed": 1 if result.get("status") == "failed" else 0,
+            "files_unchanged": 1 if result.get("status") == "unchanged" else 0,
+            "results": [result],
+        }
+    else:
+        def _on_file(file_path: str, index: int, total: int) -> None:
+            _emit(quiet, f"  [{index + 1}/{total}] {Path(file_path).name}")
+
+        summary = ctx.index_client.index_directory(
+            str(path),
+            database=ctx.database,
+            category=str(spec.indexing.get("category") or "file"),
+            recursive=spec.documents_recursive,
+            force=force or bool(spec.indexing.get("force", False)),
+            on_file=None if quiet else _on_file,
+            strict_validation=strict,
+        )
+
+    total_nodes = 0
+    total_relationships = 0
+    validation_errors: List[str] = []
+    for file_result in summary.get("results", []):
+        indexing = file_result.get("indexing") or {}
+        total_nodes += int(indexing.get("total_nodes", 0))
+        total_relationships += int(indexing.get("total_relationships", 0))
+        validation_errors.extend(indexing.get("validation_errors", []) or [])
+    summary["total_nodes"] = total_nodes
+    summary["total_relationships"] = total_relationships
+    summary["validation_errors_count"] = len(validation_errors)
+
+    _emit(
+        quiet,
+        f"  indexed {summary.get('files_indexed', 0)}, "
+        f"unchanged {summary.get('files_unchanged', 0)}, "
+        f"failed {summary.get('files_failed', 0)} — "
+        f"{total_nodes} nodes, {total_relationships} rels"
+        + (f", {len(validation_errors)} validation errors" if validation_errors else ""),
+    )
+    return summary
+
+
+def _run_query_phase(ctx: RunContext, *, quiet: bool) -> List[Dict[str, Any]]:
+    spec = ctx.spec
+    records: List[Dict[str, Any]] = []
+    total = len(spec.questions)
+    for index, question in enumerate(spec.questions):
+        _emit(quiet, f"  [{index + 1}/{total}] {question.question}")
+        record: Dict[str, Any] = {
+            "id": question.question_id or str(index + 1),
+            "question": question.question,
+        }
+        if question.expect:
+            record["expect"] = question.expect
+        started = time.monotonic()
+        try:
+            answer = ctx.query_client.ask(
+                question.question,
+                database=ctx.database,
+                reasoning_mode=bool(spec.query.get("reasoning_mode", True)),
+                repair_budget=int(spec.query.get("repair_budget", 1)),
+                limit=int(spec.query.get("limit", 5)),
+            )
+        except Exception as exc:
+            record["answer"] = ""
+            record["error"] = str(exc)
+            record["latency_s"] = round(time.monotonic() - started, 2)
+            records.append(record)
+            _emit(quiet, f"        -> ERROR: {exc}")
+            continue
+        record["answer"] = answer
+        record["empty"] = not str(answer or "").strip()
+        record["latency_s"] = round(time.monotonic() - started, 2)
+        records.append(record)
+        preview = str(answer or "").replace("\n", " ")
+        if len(preview) > 100:
+            preview = preview[:100] + "..."
+        _emit(quiet, f"        -> {preview or '(empty)'}   ({record['latency_s']}s)")
+    return records
+
+
+def _render_report_md(payload: Dict[str, Any]) -> str:
+    run = payload.get("run", {})
+    indexing = payload.get("indexing", {})
+    queries = payload.get("queries", [])
+    lines = [
+        f"# SEOCHO run: {run.get('name', '')}",
+        "",
+        f"- started: {run.get('started_at', '')}",
+        f"- models: indexing={run.get('models', {}).get('indexing', '')}, "
+        f"query={run.get('models', {}).get('query', '')}",
+        f"- enforcement: {run.get('enforcement', '')}",
+        f"- graph: {run.get('graph', 'embedded ladybug')} (database={run.get('database', '')})",
+        "",
+        "## Indexing",
+        "",
+        f"- files: {indexing.get('files_indexed', 0)} indexed, "
+        f"{indexing.get('files_unchanged', 0)} unchanged, "
+        f"{indexing.get('files_failed', 0)} failed",
+        f"- graph: {indexing.get('total_nodes', 0)} nodes, "
+        f"{indexing.get('total_relationships', 0)} relationships",
+        f"- validation errors: {indexing.get('validation_errors_count', 0)}",
+        "",
+    ]
+    if queries:
+        lines += ["## Queries", "", "| # | question | answered | latency |", "|---|---|---|---|"]
+        for item in queries:
+            if item.get("error"):
+                answered = "error"
+            elif item.get("empty"):
+                answered = "empty"
+            else:
+                answered = "yes"
+            question_text = str(item.get("question", ""))
+            if len(question_text) > 60:
+                question_text = question_text[:60] + "..."
+            lines.append(
+                f"| {item.get('id', '')} | {question_text} | {answered} | {item.get('latency_s', '')}s |"
+            )
+        lines.append("")
+        for item in queries:
+            lines += [f"### Q{item.get('id', '')}: {item.get('question', '')}", ""]
+            if item.get("expect"):
+                lines += [f"**Expected:** {item['expect']}", ""]
+            if item.get("error"):
+                lines += [f"**Error:** {item['error']}", ""]
+            else:
+                lines += [str(item.get("answer", "")) or "_(empty answer)_", ""]
+    else:
+        lines += ["## Queries", "", "Index-only run (no questions declared).", ""]
+    return "\n".join(lines)
+
+
+def run(
+    ctx: RunContext,
+    *,
+    only: Optional[str] = None,
+    force: bool = False,
+    quiet: bool = False,
+) -> RunReport:
+    """Execute the run: index → query → report. ``only`` limits to one phase."""
+    spec = ctx.spec
+    started_at = datetime.now().isoformat(timespec="seconds")
+    payload: Dict[str, Any] = {
+        "run": {
+            "name": spec.name,
+            "description": spec.description,
+            "spec_path": spec.source_path,
+            "started_at": started_at,
+            "enforcement": spec.enforcement,
+            "models": {"indexing": spec.indexing_model(), "query": spec.query_model()},
+            "graph": spec.graph or "",
+            "database": ctx.database,
+            "workspace_id": spec.resolved_workspace_id(),
+        }
+    }
+
+    phase_count = 2 if not only and not spec.index_only() else 1
+    phase = 1
+    durations: Dict[str, float] = {}
+
+    if only in (None, "index"):
+        _emit(quiet, f"Phase {phase}/{phase_count}: Indexing ({ctx.documents_path})")
+        started = time.monotonic()
+        payload["indexing"] = _run_index_phase(ctx, force=force, quiet=quiet)
+        durations["index_s"] = round(time.monotonic() - started, 2)
+        phase += 1
+        _emit(quiet)
+
+    if only in (None, "query") and not spec.index_only():
+        mode = build_agent_config(spec).execution_mode
+        _emit(quiet, f"Phase {phase}/{phase_count}: Querying ({len(spec.questions)} questions, mode={mode})")
+        started = time.monotonic()
+        payload["queries"] = _run_query_phase(ctx, quiet=quiet)
+        durations["query_s"] = round(time.monotonic() - started, 2)
+        _emit(quiet)
+
+    payload["run"]["finished_at"] = datetime.now().isoformat(timespec="seconds")
+    payload["run"]["durations"] = durations
+
+    ctx.output_dir.mkdir(parents=True, exist_ok=True)
+    report_json = ctx.output_dir / "report.json"
+    report_md = ctx.output_dir / "report.md"
+    report_json.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    report_md.write_text(_render_report_md(payload), encoding="utf-8")
+
+    if not quiet:
+        _print_summary(payload)
+        print(f"Report: {report_md}")
+        print(f"        {report_json}")
+
+    return RunReport(payload=payload, report_json=report_json, report_md=report_md)
+
+
+def _print_summary(payload: Dict[str, Any]) -> None:
+    indexing = payload.get("indexing")
+    queries = payload.get("queries")
+    print("Summary")
+    if indexing:
+        print(
+            f"  index: {indexing.get('files_found', 0)} files, "
+            f"{indexing.get('total_nodes', 0)} nodes, "
+            f"{indexing.get('total_relationships', 0)} rels"
+        )
+    if queries is not None:
+        answered = sum(1 for item in queries if not item.get("error") and not item.get("empty"))
+        empty = sum(1 for item in queries if item.get("empty"))
+        errored = sum(1 for item in queries if item.get("error"))
+        line = f"  query: {answered}/{len(queries)} answered"
+        if empty:
+            line += f", {empty} empty"
+        if errored:
+            line += f", {errored} errors"
+        print(line)
+    print()
+
+
+def run_from_config(
+    config_path: "str | Path",
+    *,
+    dry_run: bool = False,
+    only: Optional[str] = None,
+    output_dir: Optional[str] = None,
+    force: bool = False,
+    json_output: bool = False,
+) -> int:
+    """CLI-facing orchestration: load spec → preflight → build → run.
+
+    Exit codes: 0 ok, 1 runtime/preflight failure, 2 invalid config.
+    """
+    try:
+        spec = load_run_spec(config_path)
+    except RunSpecError as exc:
+        count = len(exc.errors)
+        print(f"{config_path}: {count} config error{'s' if count != 1 else ''}", file=sys.stderr)
+        for error in exc.errors:
+            print(f"  {error}", file=sys.stderr)
+        return 2
+    if output_dir:
+        spec.output_dir = output_dir
+
+    quiet = json_output
+    _emit(quiet, f"SEOCHO run: {spec.name} ({config_path})")
+    _emit(quiet, "=" * 70)
+    _emit(quiet, "Preflight")
+    report = run_preflight(spec, online=not dry_run)
+    _emit(quiet, report.render())
+    _emit(quiet)
+    if not report.ok:
+        if json_output:
+            print(json.dumps({"ok": False, "preflight": [
+                {"name": c.name, "status": c.status, "detail": c.detail} for c in report.checks
+            ]}, ensure_ascii=False))
+        else:
+            print(f"Preflight failed ({len(report.failures())} checks). Nothing was run.", file=sys.stderr)
+        return 1
+
+    if dry_run:
+        _emit(quiet, "Dry run: config valid, preflight passed. Resolved plan:")
+        _emit(quiet, f"  models: indexing={spec.indexing_model()}, query={spec.query_model()}")
+        _emit(quiet, f"  enforcement: {spec.enforcement} (strict_validation={spec.strict_validation()})")
+        _emit(quiet, f"  graph: {spec.graph or 'embedded ladybug (.seocho/local.lbug)'}")
+        _emit(quiet, f"  workspace: {spec.resolved_workspace_id()}")
+        _emit(quiet, f"  questions: {len(spec.questions)}")
+        if json_output:
+            print(json.dumps({
+                "ok": True,
+                "dry_run": True,
+                "models": {"indexing": spec.indexing_model(), "query": spec.query_model()},
+                "enforcement": spec.enforcement,
+                "questions": len(spec.questions),
+            }, ensure_ascii=False))
+        return 0
+
+    ctx = build(spec)
+    try:
+        result = run(ctx, only=only, force=force, quiet=quiet)
+    finally:
+        ctx.close()
+
+    if json_output:
+        print(json.dumps(result.payload, indent=2, ensure_ascii=False))
+    return 0 if result.ok else 1
+
+
+__all__ = [
+    "RunContext",
+    "RunReport",
+    "build",
+    "build_agent_config",
+    "run",
+    "run_from_config",
+]

--- a/src/seocho/index/file_reader.py
+++ b/src/seocho/index/file_reader.py
@@ -357,6 +357,7 @@ class FileIndexer:
         category: Optional[str] = None,
         force: bool = False,
         tracker: Optional[FileTracker] = None,
+        strict_validation: Optional[bool] = None,
     ) -> FileIndexResult:
         """Index a single file.
 
@@ -372,6 +373,10 @@ class FileIndexer:
             If True, re-index even if the file hasn't changed.
         tracker:
             File tracker for incremental indexing.
+        strict_validation:
+            When set, temporarily overrides the pipeline's
+            ``strict_validation`` flag for this file (set/restore, same
+            pattern as the ingestion facade).
 
         Returns
         -------
@@ -418,26 +423,33 @@ class FileIndexer:
 
         # Index each record
         total_result = IndexingResult()
-        for record in records:
-            content = record.get("content", "")
-            metadata = record.get("metadata", {})
-            if not content.strip():
-                continue
+        original_strict = getattr(self.pipeline, "strict_validation", None)
+        if strict_validation is not None:
+            self.pipeline.strict_validation = bool(strict_validation)
+        try:
+            for record in records:
+                content = record.get("content", "")
+                metadata = record.get("metadata", {})
+                if not content.strip():
+                    continue
 
-            result = self.pipeline.index(
-                content,
-                database=db,
-                category=cat,
-                metadata=metadata,
-            )
-            total_result.chunks_processed += result.chunks_processed
-            total_result.total_nodes += result.total_nodes
-            total_result.total_relationships += result.total_relationships
-            total_result.validation_errors.extend(result.validation_errors)
-            total_result.write_errors.extend(result.write_errors)
-            total_result.skipped_chunks += result.skipped_chunks
-            if not total_result.source_id:
-                total_result.source_id = result.source_id
+                result = self.pipeline.index(
+                    content,
+                    database=db,
+                    category=cat,
+                    metadata=metadata,
+                )
+                total_result.chunks_processed += result.chunks_processed
+                total_result.total_nodes += result.total_nodes
+                total_result.total_relationships += result.total_relationships
+                total_result.validation_errors.extend(result.validation_errors)
+                total_result.write_errors.extend(result.write_errors)
+                total_result.skipped_chunks += result.skipped_chunks
+                if not total_result.source_id:
+                    total_result.source_id = result.source_id
+        finally:
+            if strict_validation is not None:
+                self.pipeline.strict_validation = original_strict
 
         # Track
         if tracker:
@@ -462,6 +474,7 @@ class FileIndexer:
         recursive: bool = True,
         force: bool = False,
         on_file: Optional[Callable[[str, int, int], None]] = None,
+        strict_validation: Optional[bool] = None,
     ) -> DirectoryIndexResult:
         """Index all supported files in a directory.
 
@@ -475,6 +488,9 @@ class FileIndexer:
             If True, re-index all files (ignore change tracking).
         on_file:
             Progress callback ``(file_path, current, total)``.
+        strict_validation:
+            When set, overrides the pipeline's ``strict_validation``
+            flag for every file in this directory.
 
         Returns
         -------
@@ -515,6 +531,7 @@ class FileIndexer:
                 category=category,
                 force=force,
                 tracker=tracker,
+                strict_validation=strict_validation,
             )
             result.results.append(file_result)
 

--- a/src/seocho/run_preflight.py
+++ b/src/seocho/run_preflight.py
@@ -1,0 +1,295 @@
+"""Preflight checks for ``seocho run``.
+
+Collects every check before reporting (no fail-fast), so one invocation
+tells the user everything that needs fixing. Each failure message names
+what failed, why, and one copy-pasteable fix.
+
+Offline checks (also what ``--dry-run`` runs) touch only the local
+filesystem and environment variables. Online checks add a graph
+connection attempt before a real run spends LLM tokens.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+from .run_spec import RunSpec, parse_model_ref
+
+
+@dataclass(slots=True)
+class PreflightCheck:
+    name: str
+    status: str  # "ok" | "fail"
+    detail: str = ""
+    fix: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+    def render(self) -> str:
+        mark = "ok  " if self.ok else "FAIL"
+        line = f"  {mark}  {self.name} — {self.detail}" if self.detail else f"  {mark}  {self.name}"
+        if not self.ok and self.fix:
+            line += f"\n        fix: {self.fix}"
+        return line
+
+
+@dataclass(slots=True)
+class PreflightReport:
+    checks: List[PreflightCheck] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return all(check.ok for check in self.checks)
+
+    def render(self) -> str:
+        return "\n".join(check.render() for check in self.checks)
+
+    def failures(self) -> List[PreflightCheck]:
+        return [check for check in self.checks if not check.ok]
+
+
+def _base_dir(spec: RunSpec) -> Path:
+    return Path(spec.source_path).parent if spec.source_path else Path(".")
+
+
+def _resolve(spec: RunSpec, raw_path: str) -> Path:
+    """Resolve a spec-relative path against the config file's directory."""
+    path = Path(raw_path)
+    return path if path.is_absolute() else _base_dir(spec) / path
+
+
+def _check_ontology(spec: RunSpec) -> PreflightCheck:
+    path = _resolve(spec, spec.ontology_path)
+    if not path.exists():
+        return PreflightCheck(
+            name="ontology",
+            status="fail",
+            detail=f"{path} does not exist.",
+            fix="create one with: seocho init",
+        )
+    try:
+        from .ontology import Ontology
+
+        ontology = Ontology.load(path)
+    except Exception as exc:
+        return PreflightCheck(
+            name="ontology",
+            status="fail",
+            detail=f"{path} failed to load: {exc}",
+            fix=f"debug with: seocho ontology check --schema {path}",
+        )
+    return PreflightCheck(
+        name="ontology",
+        status="ok",
+        detail=(
+            f"{path} ({len(ontology.nodes)} node types, "
+            f"{len(ontology.relationships)} relationships, mode={spec.enforcement})"
+        ),
+    )
+
+
+def _check_documents(spec: RunSpec) -> PreflightCheck:
+    from .index.file_reader import SUPPORTED_EXTENSIONS
+
+    path = _resolve(spec, spec.documents_path)
+    if not path.exists():
+        return PreflightCheck(
+            name="documents",
+            status="fail",
+            detail=f"{path} does not exist.",
+            fix="point documents at a folder or file of .txt/.md/.csv/.json/.jsonl/.pdf content",
+        )
+    if path.is_file():
+        if path.suffix.lower() in SUPPORTED_EXTENSIONS:
+            return PreflightCheck(name="documents", status="ok", detail=f"{path} (1 file)")
+        return PreflightCheck(
+            name="documents",
+            status="fail",
+            detail=f"{path} has unsupported extension {path.suffix}.",
+            fix=f"supported: {' '.join(sorted(SUPPORTED_EXTENSIONS))}",
+        )
+
+    pattern = "**/*" if spec.documents_recursive else "*"
+    supported: Counter = Counter()
+    unsupported: Counter = Counter()
+    for item in path.glob(pattern):
+        if not item.is_file():
+            continue
+        if item.suffix.lower() in SUPPORTED_EXTENSIONS:
+            supported[item.suffix.lower()] += 1
+        elif item.suffix:
+            unsupported[item.suffix.lower()] += 1
+    total = sum(supported.values())
+    if total == 0:
+        found = ", ".join(f"{ext} ({count})" for ext, count in unsupported.most_common(3))
+        return PreflightCheck(
+            name="documents",
+            status="fail",
+            detail=(
+                f"{path} — 0 supported files "
+                f"(looked for {' '.join(sorted(SUPPORTED_EXTENSIONS))}, "
+                f"recursive={str(spec.documents_recursive).lower()})."
+                + (f" Found unsupported: {found}." if found else "")
+            ),
+            fix="add supported documents or fix the documents path",
+        )
+    breakdown = ", ".join(f"{count} {ext}" for ext, count in supported.most_common())
+    return PreflightCheck(
+        name="documents", status="ok", detail=f"{path} ({total} supported files: {breakdown})"
+    )
+
+
+def _check_design(spec: RunSpec, *, section: str) -> "PreflightCheck | None":
+    design = getattr(spec, section).get("design")
+    if not design:
+        return None
+    if isinstance(design, dict):
+        loader = _design_loader(section)
+        try:
+            loader["from_dict"](design)
+        except Exception as exc:
+            return PreflightCheck(
+                name=f"{section}.design",
+                status="fail",
+                detail=f"inline design is invalid: {exc}",
+            )
+        return PreflightCheck(name=f"{section}.design", status="ok", detail="inline design valid")
+    path = _resolve(spec, str(design))
+    if not path.exists():
+        return PreflightCheck(
+            name=f"{section}.design",
+            status="fail",
+            detail=f"{path} does not exist.",
+            fix=f"fix the {section}.design path or remove the key",
+        )
+    loader = _design_loader(section)
+    try:
+        loader["from_yaml"](path)
+    except Exception as exc:
+        return PreflightCheck(
+            name=f"{section}.design", status="fail", detail=f"{path} failed to load: {exc}"
+        )
+    return PreflightCheck(name=f"{section}.design", status="ok", detail=str(path))
+
+
+def _design_loader(section: str) -> dict:
+    if section == "agent":
+        from .agent_design import AgentDesignSpec
+
+        return {"from_yaml": AgentDesignSpec.from_yaml, "from_dict": AgentDesignSpec.from_dict}
+    from .indexing_design import IndexingDesignSpec
+
+    return {"from_yaml": IndexingDesignSpec.from_yaml, "from_dict": IndexingDesignSpec.from_dict}
+
+
+def _check_models(spec: RunSpec) -> List[PreflightCheck]:
+    import os
+
+    from .store.llm import get_provider_spec
+
+    checks: List[PreflightCheck] = []
+    seen = set()
+    for phase, ref in (("indexing", spec.indexing_model()), ("query", spec.query_model())):
+        if ref in seen:
+            continue
+        seen.add(ref)
+        errors: List[str] = []
+        provider, _model = parse_model_ref(ref, where=f"models.{phase}", errors=errors)
+        try:
+            provider_spec = get_provider_spec(provider)
+        except ValueError as exc:
+            checks.append(PreflightCheck(name=f"llm {ref}", status="fail", detail=str(exc)))
+            continue
+        env_names = (provider_spec.api_key_env, *provider_spec.api_key_env_aliases)
+        if any(os.getenv(name, "").strip() for name in env_names):
+            checks.append(
+                PreflightCheck(
+                    name=f"llm {ref}", status="ok", detail=f"{provider_spec.api_key_env} set"
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name=f"llm {ref}",
+                    status="fail",
+                    detail=f"{provider_spec.api_key_env} is not set.",
+                    fix=(
+                        f"export {provider_spec.api_key_env}=..., "
+                        "or switch provider in the config (models.default)"
+                    ),
+                )
+            )
+    return checks
+
+
+def _check_graph(spec: RunSpec, *, online: bool) -> PreflightCheck:
+    target = spec.graph
+    if not target or not target.startswith(("bolt://", "neo4j://", "neo4j+s://", "bolt+s://")):
+        path = target or ".seocho/local.lbug"
+        try:
+            import real_ladybug  # noqa: F401
+        except ImportError:
+            return PreflightCheck(
+                name="graph",
+                status="fail",
+                detail=f"embedded ladybug ({path}) — the 'real_ladybug' package is not installed.",
+                fix="pip install 'seocho[local]', or set graph: bolt://... to use Neo4j/DozerDB",
+            )
+        return PreflightCheck(name="graph", status="ok", detail=f"embedded ladybug ({path})")
+    if not online:
+        return PreflightCheck(
+            name="graph", status="ok", detail=f"{target} (connection not checked in dry-run)"
+        )
+    try:
+        from .store.graph import Neo4jGraphStore
+
+        store = Neo4jGraphStore(target, spec.graph_user, spec.graph_password)
+        try:
+            store.query("RETURN 1 AS ok")
+        finally:
+            store.close()
+    except Exception as exc:
+        return PreflightCheck(
+            name="graph",
+            status="fail",
+            detail=f"{target} — {exc}",
+            fix=(
+                "start the stack with 'seocho serve', or remove the 'graph:' key "
+                "to use the embedded engine (no server needed)"
+            ),
+        )
+    return PreflightCheck(name="graph", status="ok", detail=f"{target} connected")
+
+
+def run_preflight(spec: RunSpec, *, online: bool = False) -> PreflightReport:
+    """Run all preflight checks for a run spec.
+
+    ``online=False`` (dry-run) stays filesystem/env only; ``online=True``
+    additionally attempts a graph connection.
+    """
+    report = PreflightReport()
+    report.checks.append(_check_ontology(spec))
+    report.checks.append(_check_documents(spec))
+    for section in ("indexing", "agent"):
+        check = _check_design(spec, section=section)
+        if check is not None:
+            report.checks.append(check)
+    report.checks.extend(_check_models(spec))
+    report.checks.append(_check_graph(spec, online=online))
+    if spec.index_only():
+        report.checks.append(
+            PreflightCheck(name="questions", status="ok", detail="none (index-only run)")
+        )
+    else:
+        report.checks.append(
+            PreflightCheck(name="questions", status="ok", detail=f"{len(spec.questions)} questions")
+        )
+    return report
+
+
+__all__ = ["PreflightCheck", "PreflightReport", "run_preflight"]

--- a/src/seocho/run_spec.py
+++ b/src/seocho/run_spec.py
@@ -1,0 +1,438 @@
+"""Run spec: the YAML contract behind ``seocho run``.
+
+A run spec declares one end-to-end run — which documents to index, which
+ontology to bind, which models drive each phase, and which questions to
+ask — without writing Python. This module is the pure spec layer: parsing,
+env interpolation, and validation only. No store, LLM, or graph imports.
+
+Design vocabulary stays in :mod:`seocho.agent_design` and
+:mod:`seocho.indexing_design`; a run spec references or embeds those
+documents instead of redefining their keys.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import yaml
+
+DEFAULT_RUN_SPEC_FILENAME = "seocho.run.yaml"
+DEFAULT_MODEL = "mara/MiniMax-M2.5"
+
+_ALLOWED_ENFORCEMENT_MODES = {"strict", "guided", "open"}
+_ALLOWED_EXECUTION_MODES = {"pipeline", "agent", "supervisor"}
+_ALLOWED_ROUTING_POLICIES = {"fast", "balanced", "thorough"}
+_ALLOWED_ANSWER_STYLES = {"concise", "evidence", "table"}
+
+_TOP_LEVEL_KEYS = {
+    "name",
+    "description",
+    "ontology",
+    "documents",
+    "models",
+    "graph",
+    "graph_user",
+    "graph_password",
+    "database",
+    "workspace_id",
+    "indexing",
+    "agent",
+    "query",
+    "questions",
+    "output",
+}
+_SECTION_KEYS: Dict[str, set] = {
+    "ontology": {"path", "enforcement"},
+    "documents": {"path", "recursive"},
+    "models": {"default", "indexing", "query"},
+    "indexing": {"design", "category", "force"},
+    "agent": {"design", "execution_mode", "routing_policy"},
+    "query": {"reasoning_mode", "repair_budget", "answer_style", "limit"},
+    "output": {"dir"},
+}
+
+_ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+class RunSpecError(ValueError):
+    """Raised when a run spec fails to parse or validate.
+
+    ``errors`` keeps the individual messages so callers (the CLI) can
+    print one error per line.
+    """
+
+    def __init__(self, errors: List[str]) -> None:
+        self.errors = list(errors)
+        super().__init__("\n".join(self.errors))
+
+
+def _interpolate_env(value: Any, *, errors: List[str], where: str) -> Any:
+    """Resolve ``${VAR}`` / ``${VAR:-default}`` in string values, recursively."""
+    if isinstance(value, str):
+        def _resolve(match: "re.Match[str]") -> str:
+            name, default = match.group(1), match.group(2)
+            resolved = os.environ.get(name)
+            if resolved is not None:
+                return resolved
+            if default is not None:
+                return default
+            errors.append(
+                f"at {where}: environment variable {name} is not set. "
+                f"Export it or use ${{{name}:-fallback}}."
+            )
+            return ""
+        return _ENV_PATTERN.sub(_resolve, value)
+    if isinstance(value, dict):
+        return {
+            key: _interpolate_env(item, errors=errors, where=f"{where}.{key}" if where else str(key))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _interpolate_env(item, errors=errors, where=f"{where}[{idx}]")
+            for idx, item in enumerate(value)
+        ]
+    return value
+
+
+def _string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _suggest(key: str, allowed: set) -> str:
+    matches = difflib.get_close_matches(key, sorted(allowed), n=1)
+    return f" Did you mean '{matches[0]}'?" if matches else ""
+
+
+def _check_unknown_keys(
+    payload: Mapping[str, Any],
+    *,
+    allowed: set,
+    where: str,
+    errors: List[str],
+) -> None:
+    for key in payload:
+        if key not in allowed:
+            errors.append(f"at {where}: unknown key '{key}'.{_suggest(str(key), allowed)}")
+
+
+def _section(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    errors: List[str],
+) -> Dict[str, Any]:
+    """Return a section as a dict, validating its keys. Accepts absent sections."""
+    value = payload.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        errors.append(f"at {key}: must be a mapping.")
+        return {}
+    _check_unknown_keys(value, allowed=_SECTION_KEYS[key], where=key, errors=errors)
+    return dict(value)
+
+
+def parse_model_ref(value: str, *, where: str, errors: List[str]) -> Tuple[str, str]:
+    """Parse ``provider/model`` into a (provider, model) pair."""
+    text = _string(value)
+    if "/" not in text:
+        errors.append(
+            f"at {where}: model must be 'provider/model' (e.g. 'mara/MiniMax-M2.5'), got {text!r}."
+        )
+        return ("", text)
+    provider, model = text.split("/", 1)
+    provider, model = provider.strip().lower(), model.strip()
+    if not provider or not model:
+        errors.append(f"at {where}: model must be 'provider/model', got {text!r}.")
+    return (provider, model)
+
+
+@dataclass(slots=True)
+class QuestionSpec:
+    """One query-phase question; ``expect`` is recorded, never auto-graded."""
+
+    question: str
+    expect: str = ""
+    question_id: str = ""
+
+
+@dataclass(slots=True)
+class RunSpec:
+    """Validated, env-resolved run configuration for ``seocho run``."""
+
+    name: str
+    ontology_path: str
+    documents_path: str
+    enforcement: str = "guided"
+    description: str = ""
+    documents_recursive: bool = True
+    models: Dict[str, str] = field(default_factory=dict)
+    graph: str = ""
+    graph_user: str = "neo4j"
+    graph_password: str = "password"
+    database: str = ""
+    workspace_id: str = ""
+    indexing: Dict[str, Any] = field(default_factory=dict)
+    agent: Dict[str, Any] = field(default_factory=dict)
+    query: Dict[str, Any] = field(default_factory=dict)
+    questions: List[QuestionSpec] = field(default_factory=list)
+    output_dir: str = "runs"
+    source_path: str = ""
+
+    # -- model resolution ------------------------------------------------
+
+    def default_model(self) -> str:
+        return _string(self.models.get("default")) or DEFAULT_MODEL
+
+    def indexing_model(self) -> str:
+        return _string(self.models.get("indexing")) or self.default_model()
+
+    def query_model(self) -> str:
+        return _string(self.models.get("query")) or self.default_model()
+
+    def uses_split_models(self) -> bool:
+        return self.indexing_model() != self.query_model()
+
+    # -- enforcement mapping (v1: rides on strict_validation) -------------
+
+    def strict_validation(self) -> bool:
+        """v1 mapping: ``strict`` rejects SHACL-failing chunks; ``guided``
+        and ``open`` keep today's warn-and-continue behavior. Full
+        closed-vocabulary semantics land separately (seocho-snt)."""
+        return self.enforcement == "strict"
+
+    def resolved_workspace_id(self) -> str:
+        return self.workspace_id or re.sub(r"[^a-z0-9_]", "_", self.name.lower())
+
+    def index_only(self) -> bool:
+        return not self.questions
+
+
+def _parse_questions(value: Any, *, errors: List[str]) -> List[QuestionSpec]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        errors.append("at questions: must be a list of strings or mappings.")
+        return []
+    questions: List[QuestionSpec] = []
+    for idx, item in enumerate(value):
+        where = f"questions[{idx}]"
+        if isinstance(item, str):
+            if item.strip():
+                questions.append(QuestionSpec(question=item.strip()))
+            continue
+        if isinstance(item, Mapping):
+            _check_unknown_keys(
+                item, allowed={"question", "expect", "id"}, where=where, errors=errors
+            )
+            text = _string(item.get("question"))
+            if not text:
+                errors.append(f"at {where}: mapping form requires a 'question' key.")
+                continue
+            questions.append(
+                QuestionSpec(
+                    question=text,
+                    expect=_string(item.get("expect")),
+                    question_id=_string(item.get("id")),
+                )
+            )
+            continue
+        errors.append(f"at {where}: must be a string or a mapping with 'question'.")
+    return questions
+
+
+def _path_or_mapping(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    errors: List[str],
+) -> Dict[str, Any]:
+    """``ontology`` / ``documents`` accept a bare path string or a mapping."""
+    value = payload.get(key)
+    if isinstance(value, str):
+        return {"path": value.strip()}
+    return _section(payload, key, errors=errors)
+
+
+def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
+    """Parse and validate a run spec payload. Raises :class:`RunSpecError`."""
+    errors: List[str] = []
+    if not isinstance(payload, Mapping):
+        raise RunSpecError(["run spec must be a YAML mapping."])
+
+    payload = _interpolate_env(dict(payload), errors=errors, where="")
+    _check_unknown_keys(payload, allowed=_TOP_LEVEL_KEYS, where="top level", errors=errors)
+
+    ontology = _path_or_mapping(payload, "ontology", errors=errors)
+    documents = _path_or_mapping(payload, "documents", errors=errors)
+
+    models_value = payload.get("models")
+    if isinstance(models_value, str):
+        models: Dict[str, str] = {"default": models_value.strip()}
+    else:
+        models = {k: _string(v) for k, v in _section(payload, "models", errors=errors).items()}
+
+    indexing = _section(payload, "indexing", errors=errors)
+    agent = _section(payload, "agent", errors=errors)
+    query = _section(payload, "query", errors=errors)
+    output = _section(payload, "output", errors=errors)
+
+    default_name = Path(source_path).stem if source_path else "seocho-run"
+    spec = RunSpec(
+        name=_string(payload.get("name")) or default_name,
+        description=_string(payload.get("description")),
+        ontology_path=_string(ontology.get("path")),
+        enforcement=_string(ontology.get("enforcement")).lower() or "guided",
+        documents_path=_string(documents.get("path")),
+        documents_recursive=bool(documents.get("recursive", True)),
+        models=models,
+        graph=_string(payload.get("graph")),
+        graph_user=_string(payload.get("graph_user")) or "neo4j",
+        graph_password=_string(payload.get("graph_password")) or "password",
+        database=_string(payload.get("database")),
+        workspace_id=_string(payload.get("workspace_id")),
+        indexing=indexing,
+        agent=agent,
+        query=query,
+        questions=_parse_questions(payload.get("questions"), errors=errors),
+        output_dir=_string(output.get("dir")) or "runs",
+        source_path=source_path,
+    )
+
+    if not spec.ontology_path:
+        errors.append("at ontology: a run spec requires ontology (path or mapping with 'path').")
+    if not spec.documents_path:
+        errors.append("at documents: a run spec requires documents (path or mapping with 'path').")
+    if spec.enforcement not in _ALLOWED_ENFORCEMENT_MODES:
+        errors.append(
+            "at ontology.enforcement: must be one of: "
+            f"{', '.join(sorted(_ALLOWED_ENFORCEMENT_MODES))}; got {spec.enforcement!r}."
+        )
+
+    for key in ("default", "indexing", "query"):
+        if _string(spec.models.get(key)):
+            parse_model_ref(spec.models[key], where=f"models.{key}", errors=errors)
+
+    execution_mode = _string(spec.agent.get("execution_mode")).lower()
+    if execution_mode and execution_mode not in _ALLOWED_EXECUTION_MODES:
+        errors.append(
+            "at agent.execution_mode: must be one of: "
+            f"{', '.join(sorted(_ALLOWED_EXECUTION_MODES))}; got {execution_mode!r}."
+        )
+    routing_policy = _string(spec.agent.get("routing_policy")).lower()
+    if routing_policy and routing_policy not in _ALLOWED_ROUTING_POLICIES:
+        errors.append(
+            "at agent.routing_policy: must be one of: "
+            f"{', '.join(sorted(_ALLOWED_ROUTING_POLICIES))}; got {routing_policy!r}."
+        )
+    answer_style = _string(spec.query.get("answer_style")).lower()
+    if answer_style and answer_style not in _ALLOWED_ANSWER_STYLES:
+        errors.append(
+            "at query.answer_style: must be one of: "
+            f"{', '.join(sorted(_ALLOWED_ANSWER_STYLES))}; got {answer_style!r}."
+        )
+    repair_budget = spec.query.get("repair_budget")
+    if repair_budget is not None and not isinstance(repair_budget, int):
+        errors.append("at query.repair_budget: must be an integer.")
+    limit = spec.query.get("limit")
+    if limit is not None and not isinstance(limit, int):
+        errors.append("at query.limit: must be an integer.")
+
+    if errors:
+        raise RunSpecError(errors)
+    return spec
+
+
+def load_run_spec(path: "str | Path") -> RunSpec:
+    """Load, env-resolve, and validate a run spec YAML file."""
+    spec_path = Path(path)
+    if not spec_path.exists():
+        raise RunSpecError(
+            [
+                f"run spec not found: {spec_path}. "
+                "Create one with: seocho run --init"
+            ]
+        )
+    with spec_path.open("r", encoding="utf-8") as handle:
+        try:
+            payload = yaml.safe_load(handle) or {}
+        except yaml.YAMLError as exc:
+            raise RunSpecError([f"invalid YAML in {spec_path}: {exc}"]) from exc
+    return parse_run_spec(payload, source_path=str(spec_path))
+
+
+RUN_SPEC_TEMPLATE = """\
+# seocho.run.yaml — one yaml, one end-to-end run: seocho run
+# Minimal config: an ontology, a documents folder, and your questions.
+ontology: ./schema.yaml
+documents: ./docs/
+questions:
+  - Which companies reported revenue growth?
+  - Who is the CEO of Acme?
+
+# --- Everything below is optional (defaults shown) ---------------------
+# name: my-run                      # default: config filename stem
+#
+# ontology:
+#   path: ./schema.yaml             # YAML / JSON-LD / TTL
+#   enforcement: guided             # strict | guided | open
+#                                   #   strict: reject chunks failing ontology validation
+#                                   #   guided: ontology guides extraction (default)
+#                                   #   open:   accept everything
+#
+# documents:
+#   path: ./docs/                   # .txt .md .csv .json .jsonl .pdf
+#   recursive: true
+#
+# models:
+#   default: mara/MiniMax-M2.5      # provider/model for both phases
+#   indexing: mara/MiniMax-M2       # per-phase override
+#   query: mara/MiniMax-M2.5
+#
+# graph: bolt://localhost:7687      # omit for embedded LadybugDB (no server)
+# graph_user: neo4j
+# graph_password: ${NEO4J_PASSWORD:-password}
+# database: neo4j                   # omit to derive from the ontology name
+# workspace_id: my_run
+#
+# indexing:
+#   design: ./indexing_design.yaml  # optional IndexingDesignSpec
+#   category: file
+#   force: false
+#
+# agent:
+#   design: ./agent_design.yaml     # optional AgentDesignSpec
+#   execution_mode: pipeline        # pipeline | agent | supervisor
+#   routing_policy: balanced        # fast | balanced | thorough
+#
+# query:
+#   reasoning_mode: true
+#   repair_budget: 1
+#   answer_style: concise           # concise | evidence | table
+#
+# questions:                        # strings, or mappings with expected answers
+#   - question: Who is the CEO of Acme?
+#     expect: Jane Park             # recorded in the report, not auto-graded
+#
+# output:
+#   dir: runs                       # report lands in runs/<name>-<timestamp>/
+"""
+
+
+__all__ = [
+    "DEFAULT_MODEL",
+    "DEFAULT_RUN_SPEC_FILENAME",
+    "QuestionSpec",
+    "RUN_SPEC_TEMPLATE",
+    "RunSpec",
+    "RunSpecError",
+    "load_run_spec",
+    "parse_model_ref",
+    "parse_run_spec",
+]

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1068,6 +1068,8 @@ _LADYBUG_COMMON_NODE_STRING_COLUMNS = (
     "_ontology_version",
     "_ontology_profile",
     "_ontology_graph_model",
+    "_ontology_schema_fingerprint",
+    "_ontology_version_valid",
     "_workspace_id",
     "_source_id",
 )
@@ -1086,6 +1088,8 @@ _LADYBUG_COMMON_REL_STRING_COLUMNS = (
     "_ontology_version",
     "_ontology_profile",
     "_ontology_graph_model",
+    "_ontology_schema_fingerprint",
+    "_ontology_version_valid",
 )
 _LADYBUG_NODE_PROJECTION_KEYS = (
     "id",

--- a/tests/seocho/test_e2e_runner.py
+++ b/tests/seocho/test_e2e_runner.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from typing import Any, Dict, List
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+from seocho import e2e
+from seocho.run_spec import parse_run_spec
+
+
+class _DummyGraphStore:
+    def ensure_constraints(self, ontology: Any) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _DummyLLM:
+    def __init__(self, ref: str) -> None:
+        self.ref = ref
+
+
+def _ontology() -> Ontology:
+    return Ontology(
+        name="run_demo",
+        graph_model="lpg",
+        nodes={
+            "Company": NodeDef(properties={"name": P(str, unique=True)}),
+            "Person": NodeDef(properties={"name": P(str, unique=True)}),
+        },
+        relationships={"CEO_OF": RelDef(source="Person", target="Company")},
+    )
+
+
+def _write_fixture(tmp_path) -> Dict[str, Any]:
+    _ontology().to_yaml(tmp_path / "schema.yaml")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "acme.md").write_text("Jane Park is the CEO of Acme.", encoding="utf-8")
+    return {
+        "ontology": "schema.yaml",
+        "documents": "docs",
+        "questions": ["Who is the CEO of Acme?"],
+    }
+
+
+def _patch_backends(monkeypatch) -> Dict[str, Any]:
+    created: Dict[str, Any] = {"llms": [], "stores": []}
+
+    def fake_llm(ref: str) -> _DummyLLM:
+        llm = _DummyLLM(ref)
+        created["llms"].append(llm)
+        return llm
+
+    def fake_store(spec: Any, ontology: Any) -> _DummyGraphStore:
+        store = _DummyGraphStore()
+        created["stores"].append(store)
+        return store
+
+    monkeypatch.setattr(e2e, "_build_llm", fake_llm)
+    monkeypatch.setattr(e2e, "_build_graph_store", fake_store)
+    return created
+
+
+def test_build_single_client_when_models_match(tmp_path, monkeypatch) -> None:
+    created = _patch_backends(monkeypatch)
+    payload = _write_fixture(tmp_path)
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+
+    ctx = e2e.build(spec)
+    try:
+        assert ctx.index_client is ctx.query_client
+        assert len(created["llms"]) == 1
+        assert len(created["stores"]) == 1
+        assert ctx.index_client.workspace_id == "run"
+    finally:
+        ctx.close()
+
+
+def test_build_two_clients_share_store_and_workspace(tmp_path, monkeypatch) -> None:
+    created = _patch_backends(monkeypatch)
+    payload = _write_fixture(tmp_path)
+    payload["models"] = {"indexing": "mara/MiniMax-M2", "query": "mara/MiniMax-M2.5"}
+    payload["workspace_id"] = "shared_ws"
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+
+    ctx = e2e.build(spec)
+    try:
+        assert ctx.index_client is not ctx.query_client
+        assert len(created["llms"]) == 2
+        assert {llm.ref for llm in created["llms"]} == {"mara/MiniMax-M2", "mara/MiniMax-M2.5"}
+        assert len(created["stores"]) == 1
+        assert ctx.index_client.graph_store is ctx.query_client.graph_store
+        assert ctx.index_client.workspace_id == "shared_ws"
+        assert ctx.query_client.workspace_id == "shared_ws"
+    finally:
+        ctx.close()
+
+
+def test_build_agent_config_inline_overrides() -> None:
+    spec = parse_run_spec(
+        {
+            "ontology": "schema.yaml",
+            "documents": "docs",
+            "agent": {"execution_mode": "supervisor", "routing_policy": "thorough"},
+            "query": {"reasoning_mode": False, "repair_budget": 7, "answer_style": "table"},
+        }
+    )
+    config = e2e.build_agent_config(spec)
+    assert config.execution_mode == "supervisor"
+    assert config.handoff is True
+    assert config.reasoning_mode is False
+    assert config.repair_budget == 7
+    assert config.answer_style == "table"
+    assert config.routing_policy is not None
+
+
+def test_build_agent_config_strict_defaults_validation_to_reject() -> None:
+    base = {"ontology": {"path": "s.yaml", "enforcement": "strict"}, "documents": "docs"}
+    config = e2e.build_agent_config(parse_run_spec(base))
+    assert config.validation_on_fail == "reject"
+
+    guided = {"ontology": {"path": "s.yaml", "enforcement": "guided"}, "documents": "docs"}
+    assert e2e.build_agent_config(parse_run_spec(guided)).validation_on_fail == "warn"
+
+
+def test_build_agent_config_from_design_with_inline_override(tmp_path) -> None:
+    design = tmp_path / "agent_design.yaml"
+    design.write_text(
+        textwrap.dedent(
+            """
+            name: demo-pattern
+            pattern: memory_tool_use
+            ontology:
+              profile: demo
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    spec = parse_run_spec(
+        {
+            "ontology": "schema.yaml",
+            "documents": "docs",
+            "agent": {"design": "agent_design.yaml", "execution_mode": "pipeline"},
+        },
+        source_path=str(tmp_path / "run.yaml"),
+    )
+    config = e2e.build_agent_config(spec)
+    # pattern default (memory_tool_use -> agent) overridden by inline key
+    assert config.execution_mode == "pipeline"
+    assert config.extra.get("agent_design_pattern") == "memory_tool_use"
+
+
+class _FakeClient:
+    def __init__(self, answers: Dict[str, Any]) -> None:
+        self.answers = answers
+        self.index_calls: List[Dict[str, Any]] = []
+        self.ask_calls: List[Dict[str, Any]] = []
+        self.workspace_id = "fake"
+
+    def index_directory(self, directory: str, **kwargs: Any) -> Dict[str, Any]:
+        self.index_calls.append({"directory": directory, **kwargs})
+        return {
+            "directory": directory,
+            "files_found": 2,
+            "files_indexed": 2,
+            "files_skipped": 0,
+            "files_failed": 0,
+            "files_unchanged": 0,
+            "results": [
+                {"path": "a.md", "status": "indexed",
+                 "indexing": {"total_nodes": 3, "total_relationships": 2, "validation_errors": []}},
+                {"path": "b.md", "status": "indexed",
+                 "indexing": {"total_nodes": 1, "total_relationships": 0, "validation_errors": ["warn"]}},
+            ],
+        }
+
+    def ask(self, question: str, **kwargs: Any) -> str:
+        self.ask_calls.append({"question": question, **kwargs})
+        answer = self.answers[question]
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+    def close(self) -> None:
+        pass
+
+
+def _fake_context(tmp_path, spec, client) -> e2e.RunContext:
+    return e2e.RunContext(
+        spec=spec,
+        ontology=_ontology(),
+        graph_store=_DummyGraphStore(),
+        index_client=client,
+        query_client=client,
+        database="rundemolpg",
+        documents_path=tmp_path / "docs",
+        output_dir=tmp_path / "out",
+    )
+
+
+def test_run_produces_report_and_continues_on_question_error(tmp_path) -> None:
+    payload = _write_fixture(tmp_path)
+    payload["questions"] = ["good?", "boom?", "empty?"]
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+    client = _FakeClient(
+        {"good?": "Jane Park", "boom?": RuntimeError("backend down"), "empty?": ""}
+    )
+    ctx = _fake_context(tmp_path, spec, client)
+
+    report = e2e.run(ctx, quiet=True)
+
+    assert report.report_json is not None and report.report_json.exists()
+    assert report.report_md is not None and report.report_md.exists()
+    payload = json.loads(report.report_json.read_text(encoding="utf-8"))
+    assert payload["indexing"]["total_nodes"] == 4
+    assert payload["indexing"]["total_relationships"] == 2
+    assert payload["indexing"]["validation_errors_count"] == 1
+    queries = payload["queries"]
+    assert len(queries) == 3
+    assert queries[0]["answer"] == "Jane Park"
+    assert "backend down" in queries[1]["error"]
+    assert queries[2]["empty"] is True
+    # a question error means the run is reported as failed
+    assert report.ok is False
+    # strict_validation passthrough reaches the indexing call
+    assert client.index_calls[0]["strict_validation"] is False
+
+
+def test_run_strict_enforcement_passes_strict_validation(tmp_path) -> None:
+    payload = _write_fixture(tmp_path)
+    payload["ontology"] = {"path": "schema.yaml", "enforcement": "strict"}
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+    client = _FakeClient({"Who is the CEO of Acme?": "Jane Park"})
+    ctx = _fake_context(tmp_path, spec, client)
+
+    report = e2e.run(ctx, quiet=True)
+    assert client.index_calls[0]["strict_validation"] is True
+    assert report.ok is True
+
+
+def test_run_index_only_when_no_questions(tmp_path) -> None:
+    payload = _write_fixture(tmp_path)
+    payload.pop("questions")
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+    client = _FakeClient({})
+    ctx = _fake_context(tmp_path, spec, client)
+
+    report = e2e.run(ctx, quiet=True)
+    assert "queries" not in report.payload
+    assert client.ask_calls == []
+    assert report.ok is True
+    assert "Index-only run" in report.report_md.read_text(encoding="utf-8")
+
+
+def test_run_only_index_skips_query_phase(tmp_path) -> None:
+    payload = _write_fixture(tmp_path)
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+    client = _FakeClient({"Who is the CEO of Acme?": "Jane Park"})
+    ctx = _fake_context(tmp_path, spec, client)
+
+    report = e2e.run(ctx, only="index", quiet=True)
+    assert client.ask_calls == []
+    assert "indexing" in report.payload
+    assert "queries" not in report.payload
+
+
+def test_run_query_params_forwarded(tmp_path) -> None:
+    payload = _write_fixture(tmp_path)
+    payload["query"] = {"reasoning_mode": False, "repair_budget": 3, "limit": 9}
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+    client = _FakeClient({"Who is the CEO of Acme?": "Jane Park"})
+    ctx = _fake_context(tmp_path, spec, client)
+
+    e2e.run(ctx, only="query", quiet=True)
+    call = client.ask_calls[0]
+    assert call["reasoning_mode"] is False
+    assert call["repair_budget"] == 3
+    assert call["limit"] == 9
+    assert call["database"] == "rundemolpg"
+
+
+def test_file_indexer_strict_validation_set_and_restored(tmp_path) -> None:
+    """The passthrough must set/restore the pipeline flag (facade pattern)."""
+    from seocho.index.file_reader import FileIndexer
+
+    class _RecordingPipeline:
+        def __init__(self) -> None:
+            self.strict_validation = False
+            self.seen: List[bool] = []
+
+        def index(self, content: str, **kwargs: Any) -> Any:
+            from seocho.index.pipeline import IndexingResult
+
+            self.seen.append(self.strict_validation)
+            return IndexingResult(source_id="s1", chunks_processed=1, total_nodes=1)
+
+    pipeline = _RecordingPipeline()
+    indexer = FileIndexer(pipeline)
+    doc = tmp_path / "doc.md"
+    doc.write_text("Acme content", encoding="utf-8")
+
+    result = indexer.index_file(doc, strict_validation=True)
+    assert result.status == "indexed"
+    assert pipeline.seen == [True]
+    assert pipeline.strict_validation is False  # restored
+
+    indexer.index_file(doc)
+    assert pipeline.seen == [True, False]  # default untouched

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -558,3 +558,22 @@ class TestSeochoLocalWithLadybug:
             assert s._local_mode is True
             assert s.graph_store.__class__.__name__ == "LadybugGraphStore"
             s.close()
+
+
+class TestOntologyContextColumnContract:
+    """Every property stamped by ontology_context_graph_properties must be a
+    declared Ladybug column, or node/rel writes fail with a Binder exception
+    (regression: _ontology_schema_fingerprint / _ontology_version_valid were
+    missing; the write path itself is covered by
+    test_write_accepts_ontology_context_properties)."""
+
+    def test_stamped_context_properties_are_declared_columns(self):
+        from seocho.ontology_context import ontology_context_graph_properties
+        from seocho.store.graph import (
+            _LADYBUG_COMMON_NODE_STRING_COLUMNS,
+            _LADYBUG_COMMON_REL_STRING_COLUMNS,
+        )
+
+        stamped = set(ontology_context_graph_properties({}))
+        assert stamped <= set(_LADYBUG_COMMON_NODE_STRING_COLUMNS)
+        assert stamped <= set(_LADYBUG_COMMON_REL_STRING_COLUMNS)

--- a/tests/seocho/test_run_spec.py
+++ b/tests/seocho/test_run_spec.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from seocho.run_spec import (
+    DEFAULT_MODEL,
+    RUN_SPEC_TEMPLATE,
+    RunSpecError,
+    load_run_spec,
+    parse_model_ref,
+    parse_run_spec,
+)
+
+
+def _minimal_payload() -> dict:
+    return {
+        "ontology": "./schema.yaml",
+        "documents": "./docs/",
+        "questions": ["Who is the CEO of Acme?"],
+    }
+
+
+def test_minimal_spec_defaults() -> None:
+    spec = parse_run_spec(_minimal_payload(), source_path="demo.yaml")
+    assert spec.name == "demo"
+    assert spec.ontology_path == "./schema.yaml"
+    assert spec.documents_path == "./docs/"
+    assert spec.enforcement == "guided"
+    assert spec.strict_validation() is False
+    assert spec.indexing_model() == DEFAULT_MODEL
+    assert spec.query_model() == DEFAULT_MODEL
+    assert spec.uses_split_models() is False
+    assert spec.output_dir == "runs"
+    assert len(spec.questions) == 1
+
+
+def test_template_round_trip() -> None:
+    import yaml
+
+    spec = parse_run_spec(yaml.safe_load(RUN_SPEC_TEMPLATE), source_path="seocho.run.yaml")
+    assert spec.ontology_path == "./schema.yaml"
+    assert len(spec.questions) == 2
+
+
+def test_unknown_top_level_key_suggests_fix() -> None:
+    payload = _minimal_payload()
+    payload["qestions"] = payload.pop("questions")
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_run_spec(payload)
+    assert "unknown key 'qestions'" in str(excinfo.value)
+    assert "Did you mean 'questions'?" in str(excinfo.value)
+
+
+def test_unknown_section_key_rejected() -> None:
+    payload = _minimal_payload()
+    payload["query"] = {"reasoning": True}
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_run_spec(payload)
+    assert "at query: unknown key 'reasoning'" in str(excinfo.value)
+    assert "reasoning_mode" in str(excinfo.value)
+
+
+def test_errors_are_collected_not_fail_fast() -> None:
+    payload = {
+        "ontology": {"path": "a.yaml", "enforcement": "rigid"},
+        "documents": "d/",
+        "agent": {"execution_mode": "banana"},
+        "models": {"default": "no-slash"},
+    }
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_run_spec(payload)
+    message = str(excinfo.value)
+    assert "ontology.enforcement" in message
+    assert "agent.execution_mode" in message
+    assert "models.default" in message
+
+
+@pytest.mark.parametrize(
+    ("enforcement", "strict"),
+    [("strict", True), ("guided", False), ("open", False)],
+)
+def test_enforcement_maps_to_strict_validation(enforcement: str, strict: bool) -> None:
+    payload = _minimal_payload()
+    payload["ontology"] = {"path": "./schema.yaml", "enforcement": enforcement}
+    spec = parse_run_spec(payload)
+    assert spec.enforcement == enforcement
+    assert spec.strict_validation() is strict
+
+
+def test_models_section_split_and_bare_string() -> None:
+    payload = _minimal_payload()
+    payload["models"] = {"default": "mara/MiniMax-M2.5", "indexing": "mara/MiniMax-M2"}
+    spec = parse_run_spec(payload)
+    assert spec.indexing_model() == "mara/MiniMax-M2"
+    assert spec.query_model() == "mara/MiniMax-M2.5"
+    assert spec.uses_split_models() is True
+
+    payload["models"] = "kimi/kimi-k2.5"
+    spec = parse_run_spec(payload)
+    assert spec.indexing_model() == "kimi/kimi-k2.5"
+    assert spec.query_model() == "kimi/kimi-k2.5"
+
+
+def test_model_ref_requires_provider_prefix() -> None:
+    errors: list = []
+    provider, model = parse_model_ref("mara/MiniMax-M2.5", where="models.default", errors=errors)
+    assert (provider, model) == ("mara", "MiniMax-M2.5")
+    assert errors == []
+
+    parse_model_ref("gpt-4o", where="models.default", errors=errors)
+    assert any("provider/model" in item for item in errors)
+
+
+def test_env_interpolation_with_default_and_failure(monkeypatch) -> None:
+    monkeypatch.setenv("RUN_SPEC_TEST_PASSWORD", "hunter2")
+    payload = _minimal_payload()
+    payload["graph_password"] = "${RUN_SPEC_TEST_PASSWORD}"
+    payload["database"] = "${RUN_SPEC_TEST_UNSET:-fallbackdb}"
+    spec = parse_run_spec(payload)
+    assert spec.graph_password == "hunter2"
+    assert spec.database == "fallbackdb"
+
+    monkeypatch.delenv("RUN_SPEC_TEST_PASSWORD")
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_run_spec(payload)
+    assert "RUN_SPEC_TEST_PASSWORD is not set" in str(excinfo.value)
+
+
+def test_questions_accept_strings_and_mappings() -> None:
+    payload = _minimal_payload()
+    payload["questions"] = [
+        "Plain question?",
+        {"question": "With expectation?", "expect": "Jane Park", "id": "q2"},
+    ]
+    spec = parse_run_spec(payload)
+    assert spec.questions[0].question == "Plain question?"
+    assert spec.questions[1].expect == "Jane Park"
+    assert spec.questions[1].question_id == "q2"
+
+    payload["questions"] = [{"expect": "missing question"}]
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_run_spec(payload)
+    assert "requires a 'question' key" in str(excinfo.value)
+
+
+def test_index_only_run_when_questions_absent() -> None:
+    payload = {"ontology": "./schema.yaml", "documents": "./docs/"}
+    spec = parse_run_spec(payload)
+    assert spec.index_only() is True
+
+
+def test_missing_required_paths() -> None:
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_run_spec({"questions": ["q"]})
+    message = str(excinfo.value)
+    assert "requires ontology" in message
+    assert "requires documents" in message
+
+
+def test_workspace_id_derived_from_name() -> None:
+    payload = _minimal_payload()
+    payload["name"] = "Filings Demo-1"
+    spec = parse_run_spec(payload)
+    assert spec.resolved_workspace_id() == "filings_demo_1"
+    payload["workspace_id"] = "explicit_ws"
+    assert parse_run_spec(payload).resolved_workspace_id() == "explicit_ws"
+
+
+def test_load_run_spec_from_file(tmp_path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            ontology: ./schema.yaml
+            documents: ./docs/
+            questions:
+              - Who is the CEO of Acme?
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    spec = load_run_spec(path)
+    assert spec.name == "run"
+    assert spec.source_path == str(path)
+
+
+def test_load_run_spec_missing_file() -> None:
+    with pytest.raises(RunSpecError) as excinfo:
+        load_run_spec("/nonexistent/run.yaml")
+    assert "seocho run --init" in str(excinfo.value)


### PR DESCRIPTION
## What

One YAML declares an end-to-end run — ontology, documents, per-phase models, agent pattern, enforcement mode, questions — and `seocho run` executes **index → query → report**:

```yaml
ontology: ./schema.yaml
documents: ./docs/
questions:
  - Who is the CEO of Acme?
```

```
seocho run [CONFIG] [--init|--dry-run|--only index|query|-o DIR|--force|--output-json]
exit codes: 0 ok · 1 runtime/preflight failure · 2 invalid config
```

## Design decisions

- **No third config dialect.** `RunSpec` (`src/seocho/run_spec.py`) owns only run-scoped vocabulary (models, graph connection, inputs, output). Agent/ingestion behavior is referenced or embedded via the existing `AgentDesignSpec` / `IndexingDesignSpec` documents, compiled through their own `to_agent_config()` / `client_kwargs()` (Track B construction: plain `Seocho(...)`, no new deprecated-style factory).
- **Per-phase models without per-call plumbing.** `models.indexing` ≠ `models.query` builds two clients sharing one graph store, ontology, and workspace (`src/seocho/e2e.py`). Env routing (`SEOCHO_MODEL_ROUTING`) stays orthogonal.
- **`ontology.enforcement: strict | guided | open`** — named as an extraction *admission policy*, not CWA/OWA inference semantics. v1: `strict` → `strict_validation=True` + `validation_on_fail=reject` default; `guided` (default) = today's behavior. Full closed-vocabulary semantics (no Entity fallback, relaxed-retry off, endpoint conformance) are scoped in **seocho-snt** and will not change this YAML surface.
- **Preflight before tokens.** Collect-all checks (ontology loads, documents scanned + format counts, provider key env present, graph reachable/importable) with what/why/fix messages; `--dry-run` is the offline subset.
- **Honest reporting.** `report.json` + `report.md` per run; per-question errors recorded without aborting; empty answers surfaced; index-only runs supported.

## SDK changes

- `Seocho.index_directory/index_file` + `FileIndexer`: `strict_validation` passthrough (set/restore pattern from `ingestion_facade.py`).
- **Bugfix (separate commit):** Ladybug common columns never declared `_ontology_schema_fingerprint` / `_ontology_version_valid`, so every context-stamped write failed with a Binder exception — the previously failing `test_write_accepts_ontology_context_properties` now passes, plus a column-coverage regression test.

## Validation

- `bash scripts/ci/run_basic_ci.sh` — **533 passed, 5 skipped** (28 new tests in `test_run_spec.py` / `test_e2e_runner.py`, both registered in basic CI).
- Live run (MARA `MiniMax-M2.5`, embedded LadybugDB, no server): `seocho run examples/run/quickstart.yaml` → **3/3 questions answered from the graph** (CEO, acquisition, product), `--dry-run`/`--init`/exit codes verified manually.
- Known gaps surfaced during live verification, ticketed not papered over: **seocho-8ct** (Ladybug cross-doc name-PK collision → one demo file reports failed), **seocho-g85** (pre-existing `real_ladybug` 0.15.3 parameter asserts, 2 main-branch test failures outside basic CI).

## Docs

`docs/RUN_SPECS.md` (full schema + mapping), README "one YAML, one command" quickstart section, `examples/run/` runnable example, `seocho run --init` template generator.

Beads: seocho-0u7 (this PR) · seocho-snt (enforcement follow-up) · seocho-8ct / seocho-g85 (surfaced bugs)