### PR TITLE
fix(store): Ladybug cross-document entity upsert — MERGE on declared PK (seocho-8ct)

### DIFF
--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1354,6 +1354,12 @@ class LadybugGraphStore(GraphStore):
         self._declared_rel_tables: set = set()
         self._semantic_rel_types: set = set()
         self._rel_signature_to_table: Dict[tuple[str, str, str], str] = {}
+        # seocho-8ct: PRIMARY KEY column per node table. MERGE must key on
+        # the declared PK — Ladybug rejects MERGE on a non-key column, and
+        # the CREATE fallback then collides when two documents mention the
+        # same entity under different LLM-generated ids. Tables discovered
+        # from an existing database file fall back to "id".
+        self._node_table_pk: Dict[str, str] = {}
         self._load_existing_schema()
 
     def _locked_execute(self, *args, **kwargs):
@@ -1404,6 +1410,7 @@ class LadybugGraphStore(GraphStore):
                 f"CREATE NODE TABLE IF NOT EXISTS `{label}` ({col_list}, PRIMARY KEY (`{pk}`))"
             )
             self._declared_node_tables.add(label)
+            self._node_table_pk[label] = pk
         except Exception as exc:
             logger.warning("Failed to create node table %s: %s", label, exc)
 
@@ -1478,20 +1485,36 @@ class LadybugGraphStore(GraphStore):
             node_label_by_id[node_id] = label
 
             prop_keys = [k for k in props if _LABEL_RE.match(k)]
-            set_clause = ", ".join(f"`{k}`: $p_{i}" for i, k in enumerate(prop_keys))
-            params = {f"p_{i}": props[k] for i, k in enumerate(prop_keys)}
+            # seocho-8ct: MERGE on the table's declared PRIMARY KEY column.
+            # Two documents mention the same entity under different
+            # LLM-generated ids (company_1 vs company1); keyed on id the
+            # MERGE misses and the CREATE fallback violates the name PK.
+            # Keyed on the PK (usually name) the second write upserts.
+            pk_col = self._node_table_pk.get(label, "id")
+            merge_val = props.get(pk_col)
+            if merge_val is None or not _LABEL_RE.match(pk_col):
+                pk_col, merge_val = "id", node_id
+            # Ladybug rejects SET on the PRIMARY KEY column ("Cannot set
+            # property ... used as primary key"); the MERGE pattern already
+            # pins it, so exclude it from the update map.
+            set_keys = [k for k in prop_keys if k != pk_col]
+            set_clause = ", ".join(f"`{k}`: $p_{i}" for i, k in enumerate(set_keys))
+            set_params = {f"p_{i}": props[k] for i, k in enumerate(set_keys)}
+            merge_stmt = f"MERGE (n:`{label}` {{`{pk_col}`: $merge_val}})"
+            if set_clause:
+                merge_stmt += f" SET n = {{{set_clause}}}"
             try:
-                self._locked_execute(
-                    f"MERGE (n:`{label}` {{id: $id}}) SET n = {{{set_clause}}}",
-                    {"id": node_id, **params},
-                )
+                self._locked_execute(merge_stmt, {"merge_val": merge_val, **set_params})
                 summary["nodes_created"] += 1
             except Exception:
-                # Fallback: CREATE if MERGE dialect differs
+                # Fallback: CREATE if MERGE dialect differs. Creation may
+                # (and must) carry the PK in its property map.
+                create_clause = ", ".join(f"`{k}`: $c_{i}" for i, k in enumerate(prop_keys))
+                create_params = {f"c_{i}": props[k] for i, k in enumerate(prop_keys)}
                 try:
                     self._locked_execute(
-                        f"CREATE (n:`{label}` {{{set_clause}}})",
-                        params,
+                        f"CREATE (n:`{label}` {{{create_clause}}})",
+                        create_params,
                     )
                     summary["nodes_created"] += 1
                 except Exception as exc:
@@ -1654,6 +1677,7 @@ class LadybugGraphStore(GraphStore):
                     f"({', '.join(cols)}, PRIMARY KEY (`{pk_col}`))"
                 )
                 self._declared_node_tables.add(label)
+                self._node_table_pk[label] = pk_col
                 summary["success"] += 1
             except Exception as exc:
                 summary["errors"].append(f"Node table {label}: {exc}")

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -186,6 +186,42 @@ class TestLadybugStore:
         finally:
             store.close()
 
+    def test_cross_document_entity_upserts_despite_different_llm_ids(self, store):
+        """seocho-8ct: two documents mention the same entity under different
+        LLM-generated ids (company_1 vs company1). The write must upsert into
+        one row instead of violating the name PRIMARY KEY and failing the file."""
+        first = store.write(
+            nodes=[{"id": "company_1", "label": "Company",
+                    "properties": {"name": "Acme Corp"}}],
+            relationships=[],
+            source_id="doc1",
+        )
+        assert first["errors"] == []
+
+        second = store.write(
+            nodes=[
+                {"id": "company1", "label": "Company",
+                 "properties": {"name": "Acme Corp"}},
+                {"id": "person_7", "label": "Person",
+                 "properties": {"name": "Jo", "age": 41}},
+            ],
+            relationships=[
+                {"source": "person_7", "target": "company1",
+                 "type": "WORKS_AT", "properties": {}},
+            ],
+            source_id="doc2",
+        )
+        assert second["errors"] == []
+        assert second["relationships_created"] == 1
+
+        rows = store.query("MATCH (c:Company) RETURN c.name AS name")
+        assert [r["name"] for r in rows] == ["Acme Corp"]
+
+        linked = store.query(
+            "MATCH (p:Person)-[:WORKS_AT]->(c:Company) RETURN p.name AS p, c.name AS c"
+        )
+        assert len(linked) == 1 and linked[0]["c"] == "Acme Corp"
+
     def test_delete_by_source_removes_written_nodes(self, store):
         store.write(
             nodes=[


### PR DESCRIPTION
## Feature

Cross-document entity upsert for `LadybugGraphStore.write()`: MERGE now keys
on the table's declared PRIMARY KEY column instead of always `{id:}`, and the
merge key is excluded from the property-update map.

## Why

`ensure_constraints` declares the first unique ontology property (usually
`name`) as the Ladybug table PRIMARY KEY, while `write()` MERGEd on `id`.
Ladybug additionally rejects `SET` on a PK column, so every MERGE raised and
silently fell back to CREATE. When two documents mentioned the same entity
under different LLM-generated ids (`company_1` vs `company1`), that CREATE
violated the name PK and the whole file was reported failed
(`seocho run examples/run/quickstart.yaml` — sector_notes.md, "Found
duplicated primary key value Acme Corp"). Found during seocho-0u7 live e2e
verification; ticket seocho-8ct.

## Design

- `_node_table_pk` records the PK per node table in both creation paths
  (`ensure_constraints`, `_ensure_node_table`); tables discovered from an
  existing DB file default to `id`.
- `write()` MERGEs on the PK column when the node carries it, else `id`.
- The merge key is excluded from `SET n = {...}` (dialect probe confirmed
  Ladybug errors with "Cannot set property ... used as primary key"); the
  MERGE pattern pins it.
- The CREATE fallback keeps the full property map — creation must carry the PK.

## Expected Effect

Two documents mentioning the same entity upsert into one row; cross-document
relationships bind; per-file ingest no longer fails on the name-PK collision.

## Impact Results

- New repro test passes: doc1 (`company_1`) + doc2 (`company1`) for
  "Acme Corp" → exactly one Company row, `WORKS_AT` relationship created,
  zero errors.
- MERGE now actually merges (previously every MERGE fell back to CREATE).

## Validation

- `pytest tests/seocho/test_ladybug_store.py` → 17 passed, 2 failed — the 2
  failures are the pre-existing real_ladybug 0.15.3 parameter-expression
  regression tracked as seocho-g85, unrelated to this change (same 2 fail on
  main).
- `pytest tests/seocho/test_graph_ensure_database.py
  tests/seocho/test_graph_writer_lww.py tests/seocho/test_extraction_engine.py
  tests/seocho/test_e2e_runner.py tests/seocho/test_run_spec.py` →
  39 passed, 1 skipped.
- `py_compile src/seocho/store/graph.py` OK.
- Skipped: full `run_basic_ci.sh` locally (subset above covers the touched
  surface); ruff (not in venv).

## Risks

Low-medium. MERGE semantics change from "always CREATE via fallback" to true
upsert — node counts in `nodes_created` now count matched-and-updated rows
too (same as before, both paths incremented). Same-name nodes across labels
still resolve per-label tables. Pre-existing DB files (PK unknown) keep the
old id-keyed behavior.
