### PR TITLE
fix(store): Ladybug PK-keyed MERGE + quantifier-param rewrites (seocho-8ct, seocho-g85)

### DIFF
--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1354,6 +1354,11 @@ class LadybugGraphStore(GraphStore):
         self._declared_rel_tables: set = set()
         self._semantic_rel_types: set = set()
         self._rel_signature_to_table: Dict[tuple[str, str, str], str] = {}
+        # seocho-8ct: node-table PRIMARY KEY column per label. MERGE must key
+        # on the declared PK — keying on ``id`` while the PK is a unique
+        # ontology property (usually ``name``) turns every cross-document
+        # re-mention of an entity into a duplicate-PK write failure.
+        self._node_table_pk: Dict[str, str] = {}
         self._load_existing_schema()
 
     def _locked_execute(self, *args, **kwargs):
@@ -1378,12 +1383,29 @@ class LadybugGraphStore(GraphStore):
                     table_type = str(row_list[2]).upper() if len(row_list) > 2 else ""
                     if "NODE" in table_type:
                         self._declared_node_tables.add(table_name)
+                        self._node_table_pk[table_name] = self._discover_table_pk(table_name)
                     elif "REL" in table_type:
                         self._declared_rel_tables.add(table_name)
                         self._semantic_rel_types.add(_ladybug_semantic_rel_type(table_name))
         except Exception:
             # CALL show_tables() may not be supported; ignore
             pass
+
+    def _discover_table_pk(self, table_name: str) -> str:
+        """Return the PRIMARY KEY column of an existing node table.
+
+        ``table_info`` rows end with a primary-key flag; if the call or the
+        shape is unsupported, fall back to ``id`` (the lazy-declared default).
+        """
+        try:
+            result = self._locked_execute(f"CALL table_info('{table_name}') RETURN *")
+            for row in result:
+                row_list = row if isinstance(row, list) else list(row)
+                if len(row_list) >= 2 and bool(row_list[-1]):
+                    return str(row_list[1])
+        except Exception:
+            pass
+        return "id"
 
     def _ensure_node_table(self, label: str, sample_props: Dict[str, Any]) -> None:
         if label in self._declared_node_tables or not _LABEL_RE.match(label):
@@ -1404,6 +1426,7 @@ class LadybugGraphStore(GraphStore):
                 f"CREATE NODE TABLE IF NOT EXISTS `{label}` ({col_list}, PRIMARY KEY (`{pk}`))"
             )
             self._declared_node_tables.add(label)
+            self._node_table_pk[label] = pk
         except Exception as exc:
             logger.warning("Failed to create node table %s: %s", label, exc)
 
@@ -1477,21 +1500,37 @@ class LadybugGraphStore(GraphStore):
             self._ensure_node_table(label, props)
             node_label_by_id[node_id] = label
 
+            # seocho-8ct: MERGE on the table's declared PRIMARY KEY. When the
+            # PK is a unique ontology property (usually ``name``), keying on
+            # ``id`` misses cross-document re-mentions of the same entity
+            # (LLM-generated ids differ per document) and the CREATE then
+            # violates the PK constraint, failing the whole file. The engine
+            # also rejects SET on the PK column, so it must stay out of the
+            # SET map (which previously pushed every MERGE into the CREATE
+            # fallback path).
+            pk_col = self._node_table_pk.get(label, "id")
+            if pk_col != "id" and props.get(pk_col):
+                merge_col, merge_value = pk_col, props[pk_col]
+            else:
+                merge_col, merge_value = "id", node_id
             prop_keys = [k for k in props if _LABEL_RE.match(k)]
-            set_clause = ", ".join(f"`{k}`: $p_{i}" for i, k in enumerate(prop_keys))
-            params = {f"p_{i}": props[k] for i, k in enumerate(prop_keys)}
+            set_keys = [k for k in prop_keys if k != merge_col]
+            set_clause = ", ".join(f"`{k}`: $p_{i}" for i, k in enumerate(set_keys))
+            set_params = {f"p_{i}": props[k] for i, k in enumerate(set_keys)}
+            create_clause = ", ".join(f"`{k}`: $c_{i}" for i, k in enumerate(prop_keys))
+            create_params = {f"c_{i}": props[k] for i, k in enumerate(prop_keys)}
+            statement = f"MERGE (n:`{label}` {{`{merge_col}`: $merge_key}})"
+            if set_clause:
+                statement += f" SET n = {{{set_clause}}}"
             try:
-                self._locked_execute(
-                    f"MERGE (n:`{label}` {{id: $id}}) SET n = {{{set_clause}}}",
-                    {"id": node_id, **params},
-                )
+                self._locked_execute(statement, {"merge_key": merge_value, **set_params})
                 summary["nodes_created"] += 1
             except Exception:
                 # Fallback: CREATE if MERGE dialect differs
                 try:
                     self._locked_execute(
-                        f"CREATE (n:`{label}` {{{set_clause}}})",
-                        params,
+                        f"CREATE (n:`{label}` {{{create_clause}}})",
+                        create_params,
                     )
                     summary["nodes_created"] += 1
                 except Exception as exc:
@@ -1654,6 +1693,7 @@ class LadybugGraphStore(GraphStore):
                     f"({', '.join(cols)}, PRIMARY KEY (`{pk_col}`))"
                 )
                 self._declared_node_tables.add(label)
+                self._node_table_pk.setdefault(label, pk_col)
                 summary["success"] += 1
             except Exception as exc:
                 summary["errors"].append(f"Node table {label}: {exc}")

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1044,6 +1044,8 @@ _LADYBUG_COMMON_NODE_STRING_COLUMNS = (
     "linked_id",
     "title",
     "uri",
+    "ticker",
+    "period",
     "description",
     "content",
     "content_preview",
@@ -1237,12 +1239,28 @@ def _rewrite_ladybug_query(cypher: str, params: Optional[Dict[str, Any]] = None)
         clause_factory=lambda key: f"toLower(coalesce(m.name, m.uri, '')) CONTAINS ${key}",
         joiner=" AND ",
     )
+    # seocho-g85: the financial-metric template moved its scope-token guard
+    # to a soft ANY(...) ranking signal in ORDER BY; expand that form too,
+    # or an empty token list reaches the engine as an untypeable [] param.
+    rewritten = _ladybug_expand_param_predicate(
+        rewritten,
+        query_params,
+        pattern=(
+            r"\(\$metric_scope_tokens\s*=\s*\[\]\s+OR\s+ANY\(\s*token\s+IN\s+\$metric_scope_tokens\s+WHERE\s+"
+            r"toLower\(coalesce\(m\.name,\s*m\.uri,\s*''\)\)\s+CONTAINS\s+token\s*\)\s*\)"
+        ),
+        param_name="metric_scope_tokens",
+        param_prefix="__ladybug_metric_scope_token_any",
+        clause_factory=lambda key: f"toLower(coalesce(m.name, m.uri, '')) CONTAINS ${key}",
+        joiner=" OR ",
+    )
     rewritten = _ladybug_expand_param_predicate(
         rewritten,
         query_params,
         pattern=(
             r"\(\$years\s*=\s*\[\]\s+OR\s+ANY\(\s*year\s+IN\s+\$years\s+WHERE\s+"
             r"coalesce\(toString\(m\.year\),\s*''\)\s*=\s*year\s+OR\s+"
+            r"(?:toLower\(coalesce\(toString\(m\.period\),\s*''\)\)\s+CONTAINS\s+year\s+OR\s+)?"
             r"toLower\(coalesce\(m\.name,\s*m\.uri,\s*''\)\)\s+CONTAINS\s+year\s*\)\s*\)"
         ),
         param_name="years",
@@ -1250,10 +1268,22 @@ def _rewrite_ladybug_query(cypher: str, params: Optional[Dict[str, Any]] = None)
         clause_factory=(
             lambda key: (
                 f"(coalesce(m.year, '') = ${key} OR "
+                f"toLower(coalesce(m.period, '')) CONTAINS ${key} OR "
                 f"toLower(coalesce(m.name, m.uri, '')) CONTAINS ${key})"
             )
         ),
         joiner=" OR ",
+    )
+    # seocho-g85: real_ladybug 0.15.3 asserts (parsed_parameter_expression.h:21,
+    # UNREACHABLE_CODE) when a $param appears inside a quantifier predicate
+    # body. labels() is scalar in ladybug (one table per node), so the
+    # membership test collapses to a top-level IN — stays fully
+    # parameterized, no literal inlining.
+    rewritten = re.sub(
+        r"ANY\(\s*(\w+)\s+IN\s+labels\((\w+)\)\s+WHERE\s+\1\s+IN\s+(\$\w+)\s*\)",
+        lambda match: f"labels({match.group(2)}) IN {match.group(3)}",
+        rewritten,
+        flags=re.IGNORECASE,
     )
     rewritten = re.sub(
         r"elementId\((\w+)\)",

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -577,3 +577,90 @@ class TestOntologyContextColumnContract:
         stamped = set(ontology_context_graph_properties({}))
         assert stamped <= set(_LADYBUG_COMMON_NODE_STRING_COLUMNS)
         assert stamped <= set(_LADYBUG_COMMON_REL_STRING_COLUMNS)
+
+
+class TestCrossDocumentEntityMerge:
+    """seocho-8ct: MERGE must key on the table's declared PRIMARY KEY.
+
+    With ontology-declared tables the PK is the unique property (name);
+    LLM-generated node ids differ per document, so id-keyed MERGE turned
+    every cross-document re-mention into a duplicate-PK write failure."""
+
+    def test_same_name_different_ids_merge_into_one_node(self, ontology, tmp_path):
+        store = LadybugGraphStore(str(tmp_path / "xdoc.lbug"))
+        try:
+            store.ensure_constraints(ontology)
+
+            doc1 = store.write(
+                nodes=[{"id": "company_1", "label": "Company",
+                        "properties": {"name": "Acme Corp"}}],
+                relationships=[],
+                source_id="doc-1",
+            )
+            assert doc1["errors"] == []
+
+            doc2 = store.write(
+                nodes=[{"id": "companyX", "label": "Company",
+                        "properties": {"name": "Acme Corp", "status": "active"}}],
+                relationships=[],
+                source_id="doc-2",
+            )
+            assert doc2["errors"] == [], doc2
+
+            rows = store.query("MATCH (c:Company) RETURN c.name, c.status, c._source_id")
+            assert len(rows) == 1
+            row = rows[0]
+            values = list(row.values()) if isinstance(row, dict) else list(row)
+            assert "Acme Corp" in values
+            assert "active" in values
+            assert "doc-2" in values  # last write wins
+        finally:
+            store.close()
+
+    def test_relationships_attach_across_documents(self, ontology, tmp_path):
+        store = LadybugGraphStore(str(tmp_path / "xdoc_rel.lbug"))
+        try:
+            store.ensure_constraints(ontology)
+            first = store.write(
+                nodes=[{"id": "c1", "label": "Company", "properties": {"name": "Acme"}}],
+                relationships=[],
+                source_id="doc-1",
+            )
+            assert first["errors"] == []
+            second = store.write(
+                nodes=[
+                    {"id": "p9", "label": "Person", "properties": {"name": "Alice"}},
+                    {"id": "c9", "label": "Company", "properties": {"name": "Acme"}},
+                ],
+                relationships=[
+                    {"source": "p9", "target": "c9", "type": "WORKS_AT", "properties": {}},
+                ],
+                source_id="doc-2",
+            )
+            assert second["errors"] == [], second
+            assert second["relationships_created"] == 1
+
+            rows = store.query(
+                "MATCH (p:Person)-[:WORKS_AT]->(c:Company) RETURN p.name, c.name"
+            )
+            assert len(rows) == 1
+        finally:
+            store.close()
+
+    def test_id_pk_tables_keep_id_keyed_merge(self, tmp_path):
+        store = LadybugGraphStore(str(tmp_path / "idpk.lbug"))
+        try:
+            # No ensure_constraints: lazy table declaration uses id as PK.
+            first = store.write(
+                nodes=[{"id": "n1", "label": "Note", "properties": {"name": "alpha"}}],
+                relationships=[], source_id="d1",
+            )
+            second = store.write(
+                nodes=[{"id": "n1", "label": "Note", "properties": {"name": "beta"}}],
+                relationships=[], source_id="d2",
+            )
+            assert first["errors"] == [] and second["errors"] == []
+            rows = store.query("MATCH (n:Note) RETURN n.name")
+            assert len(rows) == 1
+        finally:
+            store.close()


### PR DESCRIPTION
## What

Two LadybugGraphStore fixes for the gaps the #279 live verification surfaced. Both are pre-existing defects, not regressions.

### seocho-8ct — cross-document entity writes failed on the name PK

`write()` MERGEd on `id` while ontology-declared tables use the first unique property (usually `name`) as PRIMARY KEY. LLM-generated ids differ per document, so a re-mentioned entity ("Acme Corp" in a second filing) missed the MERGE and the CREATE fallback died on `Found duplicated primary key`, failing the whole file. A second compounding defect: the engine rejects `SET` on the PK column and the SET map always included it — **every** MERGE (including id-keyed ones) had been silently falling through to the CREATE fallback.

Fix: track the PK per node table (lazy declaration, `ensure_constraints`, and `table_info` discovery for reopened DBs), MERGE on that column, keep it out of the SET map. id-PK tables keep id-keyed upsert semantics.

### seocho-g85 — real_ladybug 0.15.3 parameter asserts (2 tests failing on main)

The financial-metric template drifted past the ladybug rewrites in three ways: `$param` inside an `ANY(... WHERE l IN $param)` quantifier body (C++ assert `parsed_parameter_expression.h:21 UNREACHABLE_CODE`), an ANY-form scope-token guard the ALL-form expander missed (empty list → untypeable `[]` catalog error), and an `m.period` branch the years pattern lacked. PyPI has no release newer than 0.15.3, so the SDK-side rewrite is the right fix.

Fix: collapse `ANY(l IN labels(x) WHERE l IN $p)` to top-level `labels(x) IN $p` (labels() is scalar in ladybug — stays **fully parameterized**, no literal inlining, no quoting risk); add the ANY-form scope-token expansion; extend the years pattern + expansion with the period branch; declare `ticker`/`period` on the common node columns. Caveat: `.lbug` files created before this change lack the new columns; fresh databases are unaffected.

## Validation

- `uv run pytest tests/seocho/test_ladybug_store.py` — **21 passed** (was 19 passed / 2 failed on main; +3 new `TestCrossDocumentEntityMerge` regression tests: cross-doc same-name merge, cross-doc relationship attach, id-PK upsert preserved)
- `bash scripts/ci/run_basic_ci.sh` — **547 passed, 5 skipped**
- Live e2e (MARA + embedded LadybugDB): `seocho run examples/run/quickstart.yaml` → **3/3 files indexed (was 1 failed), 3/3 questions answered**

Beads: seocho-8ct · seocho-g85