### PR TITLE
feat(ontology,index): closed-vocabulary enforcement — strict/guided/open (seocho-snt)

### DIFF
--- a/docs/AGENT_DESIGN_SPECS.md
+++ b/docs/AGENT_DESIGN_SPECS.md
@@ -84,6 +84,33 @@ print(config.execution_mode)
 print(spec.client_kwargs()["ontology_profile"])
 ```
 
+## Ontology Enforcement
+
+The `ontology:` binding may declare how strictly the binding is honored
+during indexing (seocho-snt):
+
+```yaml
+ontology:
+  required: true
+  profile: finance-core
+  enforcement: strict   # strict | guided | open (default: guided)
+```
+
+- `strict` — closed vocabulary: strict extraction prompt line, no relaxed
+  retry, no `Entity`/heuristic fallback, closed validation (endpoint and
+  domain/range conformance), chunks with errors rejected. Default
+  `indexing.validation_on_fail` becomes `reject`; declaring `relax` or
+  `warn` alongside `strict` is rejected as incoherent.
+- `guided` — default: the ontology guides extraction; errors warn.
+- `open` — admit everything; out-of-vocabulary elements are stamped with
+  `_out_of_ontology: "true"` for governance triage. `validation_on_fail:
+  reject` is rejected as incoherent.
+
+The value compiles into `AgentConfig.ontology_enforcement` and is applied
+by the indexing pipeline via `seocho.EnforcementPolicy`. See
+[RUN_SPECS.md](RUN_SPECS.md) for how `seocho run` layers its own
+`ontology.enforcement` on top.
+
 The same `reasoning_cycle` block becomes the default for:
 
 - `client.semantic(...)`

--- a/docs/RUN_SPECS.md
+++ b/docs/RUN_SPECS.md
@@ -99,16 +99,18 @@ Omitting `questions` entirely makes the run index-only.
 `ontology.enforcement` declares the admission policy for extracted graph
 data against the ontology vocabulary:
 
-| Mode | Behavior today (v1) |
+| Mode | Behavior |
 | --- | --- |
-| `strict` | Chunks failing SHACL validation are rejected, not written (`strict_validation=True`; default `validation_on_fail` becomes `reject`). |
-| `guided` | Default. The ontology guides extraction prompts; validation errors are reported but content is written. |
-| `open` | Same write behavior as `guided`; reserved for open-vocabulary admission with out-of-ontology annotation. |
+| `strict` | Closed vocabulary. A constant closed-vocabulary instruction is appended to extraction prompts; the relaxed retry and the `Entity`/heuristic fallbacks are disabled (an empty extraction is a legitimate outcome); validation runs closed (no `Entity` exemption, dangling-endpoint and domain/range conformance checks via the `broader` chain); chunks with errors are rejected, not written; linking output is re-checked and reverted on regression. Default `validation_on_fail` becomes `reject` (`relax`/`warn` are rejected as incoherent). |
+| `guided` | Default — the tuned behavior the FinDER experiments validated. The ontology guides extraction prompts; relaxed retry and `Entity` fallback stay available; validation errors are reported but content is written. |
+| `open` | Admit everything: same write behavior as `guided`, plus every out-of-vocabulary node/relationship is stamped with `_out_of_ontology: "true"` — the triage signal for offline ontology-evolution governance. `validation_on_fail: reject` is rejected as incoherent. |
 
-Full closed-vocabulary semantics for `strict` (no `Entity` fallback, no
-relaxed retry, endpoint conformance) and `_out_of_ontology` annotation for
-`open` are tracked in `seocho-snt` and will tighten these modes without
-changing the YAML surface.
+The policy is compiled by `seocho.EnforcementPolicy` from
+`AgentConfig.ontology_enforcement`; agent design specs may declare
+`ontology.enforcement` too, and an explicit run-spec value overrides the
+design (the implicit `guided` default never does). These are admission
+policies for extracted data — not CWA/OWA inference semantics; query-time
+entailment is unchanged in every mode.
 
 ## Per-phase models
 

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -52,6 +52,8 @@ python3 -m py_compile \
   src/seocho/query/cypher_builder.py \
   src/seocho/index/extraction_engine.py \
   src/seocho/index/file_reader.py \
+  src/seocho/index/enforcement.py \
+  src/seocho/index/pipeline.py \
   src/seocho/run_spec.py \
   src/seocho/run_preflight.py \
   src/seocho/e2e.py \
@@ -117,6 +119,7 @@ uv run pytest \
   tests/seocho/test_ontology_iso704_cq.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \
+  tests/seocho/test_ontology_enforcement.py \
   -q
 
 git diff --check

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -135,6 +135,9 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
         "ArtifactValidationMessage",
         "ArtifactValidationResult",
     ],
+    ".index.enforcement": [
+        "EnforcementPolicy",
+    ],
     ".indexing": [
         "BatchIndexingResult",
         "IndexingResult",

--- a/src/seocho/agent_config.py
+++ b/src/seocho/agent_config.py
@@ -403,6 +403,14 @@ class AgentConfig:
     extraction_max_retries: int = 2
     linking_strategy: str = "llm"
     validation_on_fail: str = "warn"
+    # seocho-snt: ontology admission policy for the indexing path.
+    # "strict"  — closed vocabulary: strict prompt line, no relaxed retry,
+    #             no Entity/heuristic fallback, closed validation, chunks
+    #             with errors rejected.
+    # "guided"  — default: ontology guides extraction, errors warn.
+    # "open"    — admit everything; out-of-vocabulary elements get an
+    #             _out_of_ontology annotation for governance triage.
+    ontology_enforcement: str = "guided"  # "strict" | "guided" | "open"
 
     # --- Query agent ---
     query_strategy: str = "llm_cypher"

--- a/src/seocho/agent_design.py
+++ b/src/seocho/agent_design.py
@@ -20,6 +20,7 @@ _ALLOWED_VALIDATION_MODES = {"reject", "retry", "relax", "warn"}
 _ALLOWED_QUERY_STRATEGIES = {"llm_cypher", "template", "hybrid"}
 _ALLOWED_ANSWER_STYLES = {"concise", "evidence", "table"}
 _ALLOWED_EXECUTION_MODES = {"pipeline", "agent", "supervisor"}
+_ALLOWED_ENFORCEMENT_MODES = {"strict", "guided", "open"}
 
 _PATTERN_DEFAULTS: Dict[str, Dict[str, Any]] = {
     "planning_multi_agent": {
@@ -97,6 +98,10 @@ class OntologyBinding:
     ontology_id: str = ""
     package_id: str = ""
     path: str = ""
+    # seocho-snt: how the binding is honored during indexing — strict
+    # (closed vocabulary) | guided (default) | open (annotate). Empty means
+    # unset and resolves to "guided".
+    enforcement: str = ""
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "OntologyBinding":
@@ -106,9 +111,15 @@ class OntologyBinding:
             ontology_id=_string(payload.get("ontology_id")),
             package_id=_string(payload.get("package_id")),
             path=_string(payload.get("path")),
+            enforcement=_string(payload.get("enforcement")).lower(),
         )
 
     def validate(self) -> None:
+        if self.enforcement and self.enforcement not in _ALLOWED_ENFORCEMENT_MODES:
+            raise ValueError(
+                "ontology.enforcement must be one of: "
+                f"{', '.join(sorted(_ALLOWED_ENFORCEMENT_MODES))}."
+            )
         if not self.required:
             return
         if any((self.profile, self.ontology_id, self.package_id, self.path)):
@@ -120,6 +131,9 @@ class OntologyBinding:
 
     def resolved_profile(self) -> str:
         return self.profile or "default"
+
+    def resolved_enforcement(self) -> str:
+        return self.enforcement or "guided"
 
 
 @dataclass(slots=True)
@@ -209,6 +223,24 @@ class AgentDesignSpec:
 
         _routing_policy(_string(self.agent.get("routing_policy")))
 
+        # seocho-snt coherence: the enforcement preset and the violation
+        # action must not contradict each other. strict admission cannot
+        # relax or merely warn; open admission cannot reject.
+        enforcement = self.ontology.resolved_enforcement()
+        validation_on_fail = _string(self.indexing.get("validation_on_fail")).lower()
+        if enforcement == "strict" and validation_on_fail in {"relax", "warn"}:
+            raise ValueError(
+                "ontology.enforcement: strict is incoherent with "
+                f"indexing.validation_on_fail: {validation_on_fail}. "
+                "Use reject (default) or retry."
+            )
+        if enforcement == "open" and validation_on_fail == "reject":
+            raise ValueError(
+                "ontology.enforcement: open is incoherent with "
+                "indexing.validation_on_fail: reject. Use warn (default), "
+                "retry, or relax."
+            )
+
     def to_agent_config(self) -> AgentConfig:
         payload: Dict[str, Any] = dict(_PATTERN_DEFAULTS[self.pattern])
 
@@ -239,6 +271,16 @@ class AgentDesignSpec:
             if key in self.query:
                 payload[key] = self.query[key]
 
+        # seocho-snt: enforcement-derived default for the violation action.
+        # An explicit validation_on_fail (from the YAML or the pattern
+        # defaults) wins; coherence was checked in validate().
+        enforcement = self.ontology.resolved_enforcement()
+        if "validation_on_fail" not in self.indexing:
+            if enforcement == "strict":
+                payload["validation_on_fail"] = "reject"
+            elif enforcement == "open":
+                payload["validation_on_fail"] = "warn"
+
         config_payload: MutableMapping[str, Any] = {
             "execution_mode": _string(payload.get("execution_mode")) or "pipeline",
             "handoff": bool(payload.get("handoff", False)),
@@ -251,6 +293,7 @@ class AgentDesignSpec:
             "extraction_retry_on_low_quality": bool(payload.get("extraction_retry_on_low_quality", False)),
             "linking_strategy": _string(payload.get("linking_strategy")) or "llm",
             "validation_on_fail": _string(payload.get("validation_on_fail")) or "warn",
+            "ontology_enforcement": enforcement,
             "routing_policy": _routing_policy(_string(payload.get("routing_policy"))),
             "extra": {
                 "agent_design_name": self.name,
@@ -265,6 +308,7 @@ class AgentDesignSpec:
                     "ontology_id": self.ontology.ontology_id,
                     "package_id": self.ontology.package_id,
                     "path": self.ontology.path,
+                    "enforcement": enforcement,
                 },
             },
         }

--- a/src/seocho/e2e.py
+++ b/src/seocho/e2e.py
@@ -102,7 +102,14 @@ def build_agent_config(spec: RunSpec) -> Any:
         overrides["repair_budget"] = int(spec.query["repair_budget"])
     if "answer_style" in spec.query:
         overrides["answer_style"] = str(spec.query["answer_style"]).strip().lower()
-    if spec.strict_validation() and config.validation_on_fail == "warn":
+    # ontology.enforcement: an explicit run-spec value overrides the agent
+    # design; the implicit "guided" default never does.
+    if spec.enforcement_set or agent_design is None:
+        overrides["ontology_enforcement"] = spec.enforcement
+    effective_enforcement = overrides.get(
+        "ontology_enforcement", getattr(config, "ontology_enforcement", "guided")
+    )
+    if effective_enforcement == "strict" and config.validation_on_fail == "warn":
         overrides["validation_on_fail"] = "reject"
 
     return dataclasses.replace(config, **overrides) if overrides else config

--- a/src/seocho/index/enforcement.py
+++ b/src/seocho/index/enforcement.py
@@ -1,0 +1,140 @@
+"""Ontology enforcement policy for the indexing path (seocho-snt).
+
+``EnforcementPolicy`` names the admission policy applied to extracted graph
+data against the ontology vocabulary. The three preset modes are the only
+YAML/design surface; the individual knobs exist so the presets stay
+coherent in one place (a strict prompt combined with an Entity fallback is
+an incoherent state we never want expressible from config).
+
+Deliberately NOT named closed-world/open-world: CWA/OWA are inference
+regimes, and nothing here changes query-time entailment. ``strict`` is
+closed-*vocabulary* admission in the spirit of SHACL closed shapes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ENFORCEMENT_MODES = ("strict", "guided", "open")
+
+
+@dataclass(frozen=True, slots=True)
+class EnforcementPolicy:
+    """Compiled admission policy for one indexing pipeline.
+
+    mode:
+        The preset name this policy was derived from.
+    prompt_strict:
+        Append the constant closed-vocabulary instruction to extraction
+        prompts. The line is ontology-independent by design — the
+        extraction firewall (FinDER r=-0.76) forbids ontology richness
+        from entering prompts.
+    allow_relaxed_retry:
+        Permit the empty-extraction relaxed retry ("use closest label or
+        generic Entity"). That instruction is the negation of closed
+        admission, so strict disables it: an empty extraction is a
+        legitimate outcome for out-of-vocabulary text.
+    allow_entity_fallback:
+        Treat the generic ``Entity`` label as valid even when the ontology
+        does not declare it.
+    allow_heuristic_fallback:
+        Permit the capitalized-token heuristic fallback that manufactures
+        ``Entity``/``MENTIONS`` structure when extraction fails or returns
+        empty. Strict refuses fabricated out-of-vocabulary structure.
+    violation_action:
+        ``"reject"`` skips chunks with validation errors (maps onto
+        ``IndexingPipeline.strict_validation``); ``"warn"`` records the
+        errors and writes anyway.
+    closed_validation:
+        Run :meth:`Ontology.validate_extraction` in closed mode (no Entity
+        exemption, dangling-endpoint and domain/range conformance checks).
+    annotate_out_of_ontology:
+        Stamp ``_out_of_ontology: "true"`` on nodes/relationships whose
+        label or type is not declared by the ontology. Open-mode signal
+        for offline governance triage (schema-induction candidates).
+    """
+
+    mode: str
+    prompt_strict: bool
+    allow_relaxed_retry: bool
+    allow_entity_fallback: bool
+    allow_heuristic_fallback: bool
+    violation_action: str
+    closed_validation: bool
+    annotate_out_of_ontology: bool
+
+    @classmethod
+    def from_mode(cls, mode: str) -> "EnforcementPolicy":
+        normalized = str(mode or "guided").strip().lower() or "guided"
+        if normalized == "strict":
+            return cls(
+                mode="strict",
+                prompt_strict=True,
+                allow_relaxed_retry=False,
+                allow_entity_fallback=False,
+                allow_heuristic_fallback=False,
+                violation_action="reject",
+                closed_validation=True,
+                annotate_out_of_ontology=False,
+            )
+        if normalized == "open":
+            return cls(
+                mode="open",
+                prompt_strict=False,
+                allow_relaxed_retry=True,
+                allow_entity_fallback=True,
+                allow_heuristic_fallback=True,
+                violation_action="warn",
+                closed_validation=False,
+                annotate_out_of_ontology=True,
+            )
+        if normalized != "guided":
+            raise ValueError(
+                f"Unknown enforcement mode {mode!r}. "
+                f"Allowed: {', '.join(ENFORCEMENT_MODES)}."
+            )
+        # guided — today's tuned default (the mode the FinDER experiments
+        # validated): ontology guides prompts, relaxed retry and Entity
+        # fallback stay available, validation errors warn.
+        return cls(
+            mode="guided",
+            prompt_strict=False,
+            allow_relaxed_retry=True,
+            allow_entity_fallback=True,
+            allow_heuristic_fallback=True,
+            violation_action="warn",
+            closed_validation=False,
+            annotate_out_of_ontology=False,
+        )
+
+
+def annotate_out_of_ontology(
+    ontology,
+    nodes,
+    relationships,
+) -> int:
+    """Stamp ``_out_of_ontology`` on out-of-vocabulary elements (open mode).
+
+    Mutates properties in place; returns the number of annotated elements.
+    Unknown ≠ wrong under open admission, but a graph that cannot
+    distinguish sanctioned from unsanctioned assertions is unauditable —
+    and the annotation is exactly the signal the offline governance path
+    needs for ontology-evolution triage.
+    """
+    annotated = 0
+    declared_labels = set(getattr(ontology, "nodes", {}) or {})
+    declared_rels = set(getattr(ontology, "relationships", {}) or {})
+    for node in nodes or []:
+        label = str(node.get("label", "") or "")
+        if label and label not in declared_labels:
+            node.setdefault("properties", {})["_out_of_ontology"] = "true"
+            annotated += 1
+    for rel in relationships or []:
+        rtype = str(rel.get("type", "") or "")
+        if rtype and rtype not in declared_rels:
+            rel.setdefault("properties", {})["_out_of_ontology"] = "true"
+            annotated += 1
+    return annotated
+
+
+__all__ = ["ENFORCEMENT_MODES", "EnforcementPolicy", "annotate_out_of_ontology"]

--- a/src/seocho/index/extraction_engine.py
+++ b/src/seocho/index/extraction_engine.py
@@ -26,6 +26,17 @@ _ONTOLOGY_RELAXED_RETRY_GUIDANCE = (
     "the closest supported label or a generic Entity node. When the text names "
     "concrete entities, emit at least one useful node."
 )
+# seocho-snt: strict-mode closed-vocabulary instruction. Deliberately a
+# CONSTANT, ontology-independent line — the extraction firewall (FinDER
+# r=-0.76 between ontology richness and answer quality) forbids deriving
+# prompt content from ontology structure, and a byte-identical line across
+# ontologies cannot leak richness.
+_STRICT_VOCABULARY_GUIDANCE = (
+    "Closed vocabulary: only use the entity and relationship types listed "
+    "above. If something in the text does not fit a listed type, omit it. "
+    "Never use the generic 'Entity' label. An empty result is acceptable "
+    "when nothing in the text fits the listed types."
+)
 
 
 class CanonicalExtractionEngine:
@@ -39,11 +50,15 @@ class CanonicalExtractionEngine:
         extraction_prompt: Optional[Any] = None,
         custom_prompts: Optional[Dict[str, str]] = None,
         linking_prompt: Optional[str] = None,
+        enforcement: str = "guided",
     ) -> None:
+        from seocho.index.enforcement import EnforcementPolicy
+
         self.ontology = ontology
         self.llm = llm
         self.custom_prompts = dict(custom_prompts or {})
         self.linking_prompt = linking_prompt
+        self.enforcement_policy = EnforcementPolicy.from_mode(enforcement)
         self._extraction = (
             ExtractionStrategy(ontology, extraction_prompt=extraction_prompt)
             if ontology is not None
@@ -67,6 +82,8 @@ class CanonicalExtractionEngine:
             metadata=metadata,
             extra_context=extra_context,
         )
+        if self.enforcement_policy.prompt_strict and self.ontology is not None:
+            system = f"{system}\n\n{_STRICT_VOCABULARY_GUIDANCE}"
         response = complete_with_task_hints(
             self.llm,
             system=system,
@@ -155,6 +172,12 @@ class CanonicalExtractionEngine:
         normalized: Dict[str, Any],
         extra_context: Optional[Dict[str, Any]],
     ) -> bool:
+        # seocho-snt: the relaxed retry instructs "use the closest supported
+        # label or a generic Entity node" — the negation of closed
+        # admission. Under strict enforcement an empty extraction is a
+        # legitimate outcome for out-of-vocabulary text.
+        if not self.enforcement_policy.allow_relaxed_retry:
+            return False
         if normalized.get("nodes") or normalized.get("relationships"):
             return False
         if self.ontology is not None:
@@ -347,15 +370,27 @@ class CanonicalExtractionEngine:
         if self.ontology is None:
             return ""
         node_count = len(getattr(self.ontology, "nodes", {}) or {})
+        if self.enforcement_policy.prompt_strict:
+            # Constant text — strict mode swaps the generic-label fallback
+            # rule for closed-vocabulary omission without deriving anything
+            # from the ontology (extraction-firewall safe).
+            fallback_rule = (
+                "  2. Omit entities that fit no listed class. Never use the "
+                "generic 'Entity' label."
+            )
+        else:
+            fallback_rule = (
+                "  2. Only fall back to a generic label when no domain-specific "
+                "class clearly applies. Never default to 'Entity' when the "
+                "ontology offers a domain label that matches."
+            )
         base = (
             "Label selection rules:\n"
             "  1. Use the most-specific class that matches the entity. "
             "If both an abstract base (e.g. FinancialMetric) and a concrete "
             "subclass (Revenue, OperatingIncome, NetIncome, EPS, GrossProfit, "
             "OperatingMargin) are listed, pick the subclass.\n"
-            "  2. Only fall back to a generic label when no domain-specific "
-            "class clearly applies. Never default to 'Entity' when the "
-            "ontology offers a domain label that matches."
+            + fallback_rule
         )
         if node_count >= 10:
             base += (

--- a/src/seocho/index/file_reader.py
+++ b/src/seocho/index/file_reader.py
@@ -425,7 +425,10 @@ class FileIndexer:
         total_result = IndexingResult()
         original_strict = getattr(self.pipeline, "strict_validation", None)
         if strict_validation is not None:
-            self.pipeline.strict_validation = bool(strict_validation)
+            # seocho-snt: never downgrade below the enforcement-policy floor.
+            policy = getattr(self.pipeline, "enforcement_policy", None)
+            policy_floor = bool(policy is not None and policy.violation_action == "reject")
+            self.pipeline.strict_validation = bool(strict_validation) or policy_floor
         try:
             for record in records:
                 content = record.get("content", "")

--- a/src/seocho/index/ingestion_facade.py
+++ b/src/seocho/index/ingestion_facade.py
@@ -46,7 +46,12 @@ class IngestionFacade:
 
         original_strict = getattr(self._indexing_pipeline, "strict_validation", None)
         if original_strict is not None:
-            self._indexing_pipeline.strict_validation = bool(request.strict_validation)
+            # seocho-snt: a per-request strict_validation=False must not
+            # downgrade a pipeline whose enforcement policy rejects on
+            # violation — strict enforcement keeps its floor.
+            policy = getattr(self._indexing_pipeline, "enforcement_policy", None)
+            policy_floor = bool(policy is not None and policy.violation_action == "reject")
+            self._indexing_pipeline.strict_validation = bool(request.strict_validation) or policy_floor
 
         result = self._indexing_pipeline.index(
             request.content,

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -228,7 +228,9 @@ class IndexingPipeline:
         on_after_validate: Optional[Callable] = None,
         on_before_write: Optional[Callable] = None,
         on_after_write: Optional[Callable] = None,
+        enforcement: str = "guided",
     ) -> None:
+        from seocho.index.enforcement import EnforcementPolicy
         from seocho.ontology import Ontology
         from seocho.query.strategy import ExtractionStrategy, LinkingStrategy
 
@@ -236,7 +238,13 @@ class IndexingPipeline:
         self.graph_store = graph_store
         self.llm = llm
         self.workspace_id = workspace_id
-        self.strict_validation = strict_validation
+        # seocho-snt: the enforcement preset compiles the admission policy;
+        # strict implies rejecting chunks with validation errors, which is
+        # what strict_validation already meant. Either switch may force it on.
+        self.enforcement_policy = EnforcementPolicy.from_mode(enforcement)
+        self.strict_validation = bool(
+            strict_validation or self.enforcement_policy.violation_action == "reject"
+        )
         self.max_chunk_chars = max_chunk_chars
         self.enable_dedup = enable_dedup
         self.enable_rule_constraints = enable_rule_constraints
@@ -267,6 +275,7 @@ class IndexingPipeline:
             ontology=ontology,
             llm=llm,
             extraction_prompt=extraction_prompt,
+            enforcement=self.enforcement_policy.mode,
         )
 
     @staticmethod
@@ -730,6 +739,17 @@ class IndexingPipeline:
                 )
                 extracted = response
             except Exception as exc:
+                if not self.enforcement_policy.allow_heuristic_fallback:
+                    # seocho-snt strict: an LLM transport failure becomes a
+                    # recorded error, not fabricated out-of-vocabulary graph
+                    # structure.
+                    logger.warning("LLM extraction failed for chunk %d (strict, no fallback): %s", i, exc)
+                    result.write_errors.append(
+                        f"Chunk {i}: extraction failed under strict enforcement: "
+                        f"{type(exc).__name__}: {str(exc)[:200]}"
+                    )
+                    result.skipped_chunks += 1
+                    continue
                 logger.warning(
                     "LLM extraction failed for chunk %d, using heuristic fallback: %s",
                     i, exc,
@@ -746,6 +766,12 @@ class IndexingPipeline:
             rels = extracted.get("relationships", [])
 
             if not nodes and not rels:
+                if not self.enforcement_policy.allow_heuristic_fallback:
+                    # Strict: an empty extraction is a legitimate outcome for
+                    # out-of-vocabulary text — the Entity/MENTIONS heuristic
+                    # would manufacture exactly the structure strict forbids.
+                    result.skipped_chunks += 1
+                    continue
                 logger.warning(
                     "LLM extraction returned an empty graph for chunk %d, using heuristic fallback.",
                     i,
@@ -819,7 +845,9 @@ class IndexingPipeline:
                         break
 
             # Validate with SHACL
-            errors = self.ontology.validate_with_shacl(extracted)
+            errors = self.ontology.validate_with_shacl(
+                extracted, closed=self.enforcement_policy.closed_validation
+            )
 
             # --- Callback: on_after_validate ---
             if self.on_after_validate:
@@ -832,8 +860,17 @@ class IndexingPipeline:
                     result.skipped_chunks += 1
                     continue
 
+            # seocho-snt open mode: admit everything, but stamp
+            # out-of-vocabulary elements so sanctioned and unsanctioned
+            # assertions stay distinguishable (governance triage signal).
+            if self.enforcement_policy.annotate_out_of_ontology:
+                from seocho.index.enforcement import annotate_out_of_ontology
+
+                annotate_out_of_ontology(self.ontology, nodes, rels)
+
             # Link (deduplicate entities within chunk)
             if nodes:
+                pre_link_nodes, pre_link_rels = nodes, rels
                 try:
                     linked = self._graph_extraction.link(
                         {"nodes": nodes, "relationships": rels},
@@ -847,6 +884,21 @@ class IndexingPipeline:
                         rels = linked_rels
                 except Exception as exc:
                     logger.warning("Linking failed for chunk %d, using raw extraction: %s", i, exc)
+
+                # seocho-snt strict: linking runs after validation and can
+                # reintroduce out-of-vocabulary labels/types; re-run the
+                # cheap closed check and fall back to the validated
+                # pre-link payload on regression.
+                if self.enforcement_policy.closed_validation and nodes is not pre_link_nodes:
+                    post_link_errors = self.ontology.validate_extraction(
+                        {"nodes": nodes, "relationships": rels}, closed=True
+                    )
+                    if post_link_errors:
+                        logger.warning(
+                            "Chunk %d: linking regressed closed validation, reverting: %s",
+                            i, post_link_errors,
+                        )
+                        nodes, rels = pre_link_nodes, pre_link_rels
 
             chunk_records.append(
                 {
@@ -1023,7 +1075,9 @@ class IndexingPipeline:
         validation_payload = {"nodes": all_nodes, "relationships": all_rels}
         result.observed_nodes = copy.deepcopy(all_nodes)
         result.observed_relationships = copy.deepcopy(all_rels)
-        errors = self.ontology.validate_with_shacl(validation_payload)
+        errors = self.ontology.validate_with_shacl(
+            validation_payload, closed=self.enforcement_policy.closed_validation
+        )
         if self.on_after_validate:
             all_nodes, all_rels, errors = self.on_after_validate(all_nodes, all_rels, errors)
         if errors:
@@ -1031,6 +1085,10 @@ class IndexingPipeline:
             if self.strict_validation:
                 result.skipped_chunks = 1
                 return result
+        if self.enforcement_policy.annotate_out_of_ontology:
+            from seocho.index.enforcement import annotate_out_of_ontology
+
+            annotate_out_of_ontology(self.ontology, all_nodes, all_rels)
 
         if not all_nodes and not all_rels:
             result.write_errors.append("Structured graph payload produced no nodes or relationships.")

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -95,6 +95,7 @@ class _LocalEngine:
             embedding_backend=embedding_backend,
             ontology_profile=self.ontology_profile,
             ontology_context_cache=self._ontology_context_cache,
+            enforcement=getattr(self.agent_config, "ontology_enforcement", "guided"),
         )
         self._indexing._quality_threshold = self.agent_config.extraction_quality_threshold
         self._indexing._max_retries = self.agent_config.extraction_max_retries
@@ -366,6 +367,7 @@ class _LocalEngine:
                 enable_rule_constraints=True,
                 ontology_profile=self.ontology_profile,
                 ontology_context_cache=self._ontology_context_cache,
+                enforcement=getattr(self.agent_config, "ontology_enforcement", "guided"),
             )
             ingestion = IngestionFacade(pipeline, publisher=self._events)
         else:
@@ -417,12 +419,15 @@ class _LocalEngine:
                 enable_rule_constraints=True,
                 ontology_profile=self.ontology_profile,
                 ontology_context_cache=self._ontology_context_cache,
+                enforcement=getattr(self.agent_config, "ontology_enforcement", "guided"),
             )
         else:
             pipeline = self._indexing
 
         original_strict = pipeline.strict_validation
-        pipeline.strict_validation = bool(strict_validation)
+        policy = getattr(pipeline, "enforcement_policy", None)
+        policy_floor = bool(policy is not None and policy.violation_action == "reject")
+        pipeline.strict_validation = bool(strict_validation) or policy_floor
         try:
             result = pipeline.index_graph(
                 graph_data,

--- a/src/seocho/ontology.py
+++ b/src/seocho/ontology.py
@@ -1137,7 +1137,7 @@ class Ontology:
             source_summary=source_summary,
         )
 
-    def validate_with_shacl(self, data: Dict[str, Any]) -> List[str]:
+    def validate_with_shacl(self, data: Dict[str, Any], *, closed: bool = False) -> List[str]:
         """Validate extracted data against SHACL shapes derived from
         this ontology.
 
@@ -1148,12 +1148,15 @@ class Ontology:
         ----------
         data:
             Dict with ``"nodes"`` and ``"relationships"`` lists.
+        closed:
+            Forwarded to :meth:`validate_extraction` — closed-vocabulary
+            admission (no ``Entity`` exemption, endpoint checks).
 
         Returns
         -------
         List of validation error strings (empty = valid).
         """
-        errors = list(self.validate_extraction(data))
+        errors = list(self.validate_extraction(data, closed=closed))
         shacl = self.to_shacl()
 
         # Build shape lookup: targetClass -> shape
@@ -1717,7 +1720,7 @@ class Ontology:
                     stack.extend(p for p in cur_nd.broader if p in self.nodes)
         return errors
 
-    def validate_extraction(self, data: Dict[str, Any]) -> List[str]:
+    def validate_extraction(self, data: Dict[str, Any], *, closed: bool = False) -> List[str]:
         """Validate extracted graph data against this ontology.
 
         Parameters
@@ -1725,6 +1728,17 @@ class Ontology:
         data:
             Dict with ``"nodes"`` and ``"relationships"`` lists as
             produced by the LLM extraction step.
+        closed:
+            Closed-vocabulary admission (seocho-snt). When True:
+
+            - the generic ``Entity`` label loses its exemption unless the
+              ontology actually declares it,
+            - relationship endpoints must reference extracted nodes
+              (dangling-endpoint check), and
+            - endpoint labels must conform to the relationship's declared
+              source/target (``Any`` wildcard, exact match, or subsumption
+              via the ``broader`` chain — author-time richness belongs in
+              validation, never in extraction prompts).
 
         Returns
         -------
@@ -1732,13 +1746,15 @@ class Ontology:
         """
         errors: List[str] = []
         known_ids: Set[str] = set()
+        label_by_id: Dict[str, str] = {}
 
         for node in data.get("nodes", []):
             nid = node.get("id", "")
             label = node.get("label", "")
             known_ids.add(nid)
+            label_by_id[nid] = label
 
-            if label not in self.nodes and label != "Entity":
+            if label not in self.nodes and (closed or label != "Entity"):
                 errors.append(f"Node '{nid}' has unknown label '{label}'")
                 continue
 
@@ -1756,8 +1772,51 @@ class Ontology:
             tgt = rel.get("target", "")
             if rtype not in self.relationships:
                 errors.append(f"Unknown relationship type '{rtype}'")
+                continue
+            if not closed:
+                continue
+            rd = self.relationships[rtype]
+            for endpoint, endpoint_id in (("source", src), ("target", tgt)):
+                if endpoint_id not in known_ids:
+                    errors.append(
+                        f"Relationship [{rtype}] {endpoint} '{endpoint_id}' "
+                        "does not reference an extracted node"
+                    )
+                    continue
+                declared = rd.source if endpoint == "source" else rd.target
+                actual = label_by_id.get(endpoint_id, "")
+                if not self._label_conforms(actual, declared):
+                    errors.append(
+                        f"Relationship [{rtype}] {endpoint} '{endpoint_id}' has label "
+                        f"'{actual}' but the ontology declares {endpoint} '{declared}'"
+                    )
 
         return errors
+
+    def _label_conforms(self, label: str, declared: str) -> bool:
+        """True when ``label`` satisfies a declared endpoint class.
+
+        Conformance = ``Any`` wildcard, exact match, or ``declared`` being
+        reachable through ``label``'s transitive ``broader`` chain
+        (subsumption).
+        """
+        if declared in ("", "Any") or label == declared:
+            return True
+        seen: Set[str] = set()
+        frontier = [label]
+        while frontier:
+            current = frontier.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            nd = self.nodes.get(current)
+            if nd is None:
+                continue
+            for parent in nd.broader or []:
+                if parent == declared:
+                    return True
+                frontier.append(parent)
+        return False
 
     def score_extraction(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Score the quality of extracted graph data against this ontology.
@@ -1887,11 +1946,20 @@ class Ontology:
     # Label safety
     # ------------------------------------------------------------------
 
-    def is_valid_label(self, label: str) -> bool:
-        return label in self._allowed_labels or label == "Entity"
+    def is_valid_label(self, label: str, *, allow_entity_fallback: bool = True) -> bool:
+        if label in self._allowed_labels:
+            return True
+        return allow_entity_fallback and label == "Entity"
 
-    def sanitize_label(self, label: str) -> str:
-        return label if self.is_valid_label(label) else "Entity"
+    def sanitize_label(self, label: str, *, allow_entity_fallback: bool = True) -> str:
+        if self.is_valid_label(label, allow_entity_fallback=allow_entity_fallback):
+            return label
+        if allow_entity_fallback:
+            return "Entity"
+        raise ValueError(
+            f"Label '{label}' is not declared by ontology '{self.name}' "
+            "and Entity fallback is disabled (strict enforcement)."
+        )
 
     # ------------------------------------------------------------------
     # Render cache — avoids recomputing identical string outputs

--- a/src/seocho/run_spec.py
+++ b/src/seocho/run_spec.py
@@ -170,6 +170,10 @@ class RunSpec:
     ontology_path: str
     documents_path: str
     enforcement: str = "guided"
+    # True when the YAML declared ontology.enforcement explicitly — an
+    # explicit value overrides an agent design's enforcement; the default
+    # never does.
+    enforcement_set: bool = False
     description: str = ""
     documents_recursive: bool = True
     models: Dict[str, str] = field(default_factory=dict)
@@ -199,12 +203,14 @@ class RunSpec:
     def uses_split_models(self) -> bool:
         return self.indexing_model() != self.query_model()
 
-    # -- enforcement mapping (v1: rides on strict_validation) -------------
+    # -- enforcement mapping ----------------------------------------------
 
     def strict_validation(self) -> bool:
-        """v1 mapping: ``strict`` rejects SHACL-failing chunks; ``guided``
-        and ``open`` keep today's warn-and-continue behavior. Full
-        closed-vocabulary semantics land separately (seocho-snt)."""
+        """``strict`` rejects chunks with validation errors. The full
+        admission policy (prompt line, no relaxed retry/Entity fallback,
+        closed validation) is compiled by
+        :class:`seocho.index.enforcement.EnforcementPolicy` from
+        ``AgentConfig.ontology_enforcement``."""
         return self.enforcement == "strict"
 
     def resolved_workspace_id(self) -> str:
@@ -289,6 +295,7 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
         description=_string(payload.get("description")),
         ontology_path=_string(ontology.get("path")),
         enforcement=_string(ontology.get("enforcement")).lower() or "guided",
+        enforcement_set=bool(_string(ontology.get("enforcement"))),
         documents_path=_string(documents.get("path")),
         documents_recursive=bool(documents.get("recursive", True)),
         models=models,

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1070,6 +1070,7 @@ _LADYBUG_COMMON_NODE_STRING_COLUMNS = (
     "_ontology_graph_model",
     "_ontology_schema_fingerprint",
     "_ontology_version_valid",
+    "_out_of_ontology",
     "_workspace_id",
     "_source_id",
 )
@@ -1090,6 +1091,7 @@ _LADYBUG_COMMON_REL_STRING_COLUMNS = (
     "_ontology_graph_model",
     "_ontology_schema_fingerprint",
     "_ontology_version_valid",
+    "_out_of_ontology",
 )
 _LADYBUG_NODE_PROJECTION_KEYS = (
     "id",

--- a/tests/seocho/test_ontology_enforcement.py
+++ b/tests/seocho/test_ontology_enforcement.py
@@ -1,0 +1,466 @@
+"""seocho-snt: closed-vocabulary enforcement semantics (strict/guided/open).
+
+Covers the EnforcementPolicy presets, closed validation in Ontology,
+strict gating in the extraction engine and pipeline, the strict_validation
+floor, open-mode annotation, and the agent-design / run-spec wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from seocho.agent_design import AgentDesignSpec
+from seocho.index.enforcement import EnforcementPolicy, annotate_out_of_ontology
+from seocho.index.extraction_engine import CanonicalExtractionEngine
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+
+
+def _ontology() -> Ontology:
+    return Ontology(
+        name="enforcement_demo",
+        nodes={
+            "Company": NodeDef(properties={"name": P(str, unique=True)}),
+            "Bank": NodeDef(
+                properties={"name": P(str, unique=True)},
+                broader=["Company"],
+            ),
+            "Person": NodeDef(properties={"name": P(str, unique=True)}),
+        },
+        relationships={
+            "CEO_OF": RelDef(source="Person", target="Company"),
+            "MENTIONS": RelDef(source="Any", target="Any"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# EnforcementPolicy presets
+# ---------------------------------------------------------------------------
+
+
+def test_policy_presets() -> None:
+    strict = EnforcementPolicy.from_mode("strict")
+    assert strict.prompt_strict
+    assert not strict.allow_relaxed_retry
+    assert not strict.allow_entity_fallback
+    assert not strict.allow_heuristic_fallback
+    assert strict.violation_action == "reject"
+    assert strict.closed_validation
+    assert not strict.annotate_out_of_ontology
+
+    guided = EnforcementPolicy.from_mode("guided")
+    assert not guided.prompt_strict
+    assert guided.allow_relaxed_retry
+    assert guided.violation_action == "warn"
+    assert EnforcementPolicy.from_mode("") == guided
+    assert EnforcementPolicy.from_mode(None) == guided
+
+    open_mode = EnforcementPolicy.from_mode("open")
+    assert open_mode.annotate_out_of_ontology
+    assert open_mode.violation_action == "warn"
+
+    with pytest.raises(ValueError, match="Unknown enforcement mode"):
+        EnforcementPolicy.from_mode("rigid")
+
+
+# ---------------------------------------------------------------------------
+# Ontology closed validation
+# ---------------------------------------------------------------------------
+
+
+def test_closed_validation_drops_entity_exemption() -> None:
+    onto = _ontology()
+    data = {"nodes": [{"id": "x", "label": "Entity", "properties": {"name": "X"}}],
+            "relationships": []}
+    assert onto.validate_extraction(data) == []
+    closed_errors = onto.validate_extraction(data, closed=True)
+    assert any("unknown label 'Entity'" in e for e in closed_errors)
+
+
+def test_closed_validation_flags_dangling_endpoints() -> None:
+    onto = _ontology()
+    data = {
+        "nodes": [{"id": "p1", "label": "Person", "properties": {"name": "Jane"}}],
+        "relationships": [
+            {"source": "p1", "target": "ghost", "type": "CEO_OF", "properties": {}},
+        ],
+    }
+    assert onto.validate_extraction(data) == []  # open: endpoints unchecked
+    closed_errors = onto.validate_extraction(data, closed=True)
+    assert any("does not reference an extracted node" in e for e in closed_errors)
+
+
+def test_closed_validation_checks_domain_range_with_broader_subsumption() -> None:
+    onto = _ontology()
+    # Bank broader-chains to Company, so Bank is a valid CEO_OF target.
+    ok = {
+        "nodes": [
+            {"id": "p1", "label": "Person", "properties": {"name": "Jane"}},
+            {"id": "b1", "label": "Bank", "properties": {"name": "Acme Bank"}},
+        ],
+        "relationships": [
+            {"source": "p1", "target": "b1", "type": "CEO_OF", "properties": {}},
+        ],
+    }
+    assert onto.validate_extraction(ok, closed=True) == []
+
+    # Person as CEO_OF target violates the declared range.
+    bad = {
+        "nodes": [
+            {"id": "p1", "label": "Person", "properties": {"name": "Jane"}},
+            {"id": "p2", "label": "Person", "properties": {"name": "Kim"}},
+        ],
+        "relationships": [
+            {"source": "p1", "target": "p2", "type": "CEO_OF", "properties": {}},
+        ],
+    }
+    errors = onto.validate_extraction(bad, closed=True)
+    assert any("declares target 'Company'" in e for e in errors)
+
+
+def test_closed_validation_any_wildcard_endpoints() -> None:
+    onto = _ontology()
+    data = {
+        "nodes": [
+            {"id": "p1", "label": "Person", "properties": {"name": "Jane"}},
+            {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},
+        ],
+        "relationships": [
+            {"source": "c1", "target": "p1", "type": "MENTIONS", "properties": {}},
+        ],
+    }
+    assert onto.validate_extraction(data, closed=True) == []
+
+
+def test_validate_with_shacl_threads_closed() -> None:
+    onto = _ontology()
+    data = {"nodes": [{"id": "x", "label": "Entity", "properties": {"name": "X"}}],
+            "relationships": []}
+    assert onto.validate_with_shacl(data) == []
+    assert onto.validate_with_shacl(data, closed=True)
+
+
+def test_sanitize_label_strict_raises_instead_of_entity() -> None:
+    onto = _ontology()
+    assert onto.sanitize_label("Spaceship") == "Entity"
+    assert onto.is_valid_label("Entity")
+    assert not onto.is_valid_label("Entity", allow_entity_fallback=False)
+    with pytest.raises(ValueError, match="strict enforcement"):
+        onto.sanitize_label("Spaceship", allow_entity_fallback=False)
+
+
+def test_annotate_out_of_ontology_marks_unknown_elements() -> None:
+    onto = _ontology()
+    nodes = [
+        {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},
+        {"id": "x1", "label": "Spaceship", "properties": {"name": "X"}},
+    ]
+    rels = [
+        {"source": "c1", "target": "x1", "type": "LAUNCHED", "properties": {}},
+        {"source": "x1", "target": "c1", "type": "MENTIONS", "properties": {}},
+    ]
+    count = annotate_out_of_ontology(onto, nodes, rels)
+    assert count == 2
+    assert "_out_of_ontology" not in nodes[0]["properties"]
+    assert nodes[1]["properties"]["_out_of_ontology"] == "true"
+    assert rels[0]["properties"]["_out_of_ontology"] == "true"
+    assert "_out_of_ontology" not in rels[1]["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Extraction engine gating
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._payload = payload
+        self.text = ""
+
+    def json(self) -> Dict[str, Any]:
+        return dict(self._payload)
+
+
+class _RecordingLLM:
+    """Captures every completion call the engine makes."""
+
+    def __init__(self, payloads: List[Dict[str, Any]]) -> None:
+        self.payloads = list(payloads)
+        self.calls: List[Dict[str, str]] = []
+
+    def complete(self, *, system: str, user: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append({"system": system, "user": user})
+        payload = self.payloads.pop(0) if self.payloads else {"nodes": [], "relationships": []}
+        return _FakeResponse(payload)
+
+
+def test_strict_disables_relaxed_retry_and_adds_constant_prompt_line() -> None:
+    llm = _RecordingLLM([{"nodes": [], "relationships": []}])
+    engine = CanonicalExtractionEngine(ontology=_ontology(), llm=llm, enforcement="strict")
+    result = engine.extract("Nothing in vocabulary here.")
+    assert result == {"nodes": [], "relationships": []}
+    assert len(llm.calls) == 1  # no relaxed retry call
+    assert "Closed vocabulary" in llm.calls[0]["system"]
+    assert "Never use the generic 'Entity' label" in llm.calls[0]["system"]
+
+
+def test_guided_keeps_relaxed_retry_and_plain_prompt() -> None:
+    llm = _RecordingLLM([
+        {"nodes": [], "relationships": []},
+        {"nodes": [{"id": "c1", "label": "Company", "properties": {"name": "Acme"}}],
+         "relationships": []},
+    ])
+    engine = CanonicalExtractionEngine(ontology=_ontology(), llm=llm, enforcement="guided")
+    result = engine.extract("Acme did things.")
+    assert len(llm.calls) == 2  # relaxed retry happened
+    assert "Closed vocabulary" not in llm.calls[0]["system"]
+    assert result["nodes"]
+
+
+def test_strict_prompt_line_is_ontology_independent() -> None:
+    """Extraction-firewall guard: the strict line must not derive from the
+    ontology (byte-identical across ontologies)."""
+    other = Ontology(
+        name="other",
+        nodes={"Planet": NodeDef(properties={"name": P(str, unique=True)},
+                                 broader=["CelestialBody"], same_as="schema:Planet")},
+        relationships={},
+    )
+    lines = []
+    for onto in (_ontology(), other):
+        llm = _RecordingLLM([{"nodes": [], "relationships": []}])
+        CanonicalExtractionEngine(ontology=onto, llm=llm, enforcement="strict").extract("x")
+        system = llm.calls[0]["system"]
+        start = system.index("Closed vocabulary")
+        lines.append(system[start:])
+    assert lines[0] == lines[1]
+    assert "broader" not in lines[0]
+    assert "same_as" not in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline gating
+# ---------------------------------------------------------------------------
+
+
+class _NullStore:
+    def write(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"nodes_created": 0, "relationships_created": 0, "errors": []}
+
+    def ensure_constraints(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"success": 0, "errors": []}
+
+
+def _pipeline(enforcement: str, llm: Any):
+    from seocho.index.pipeline import IndexingPipeline
+
+    return IndexingPipeline(
+        ontology=_ontology(),
+        graph_store=_NullStore(),
+        llm=llm,
+        enforcement=enforcement,
+    )
+
+
+class _ExplodingLLM:
+    def complete(self, **kwargs: Any) -> Any:
+        raise RuntimeError("backend down")
+
+
+def test_strict_pipeline_records_error_instead_of_heuristic_fallback() -> None:
+    pipeline = _pipeline("strict", _ExplodingLLM())
+    result = pipeline.index("Acme Corp launched AcmeCloud.", source_id="s1")
+    assert result.fallback_used is False
+    assert result.total_nodes == 0
+    assert any("strict enforcement" in e for e in result.write_errors)
+    assert result.skipped_chunks >= 1
+
+
+def test_guided_pipeline_keeps_heuristic_fallback() -> None:
+    pipeline = _pipeline("guided", _ExplodingLLM())
+    result = pipeline.index("Acme Corp launched AcmeCloud.", source_id="s1")
+    assert result.fallback_used is True
+    assert len(result.nodes) > 0  # Entity/MENTIONS structure manufactured
+
+
+def test_strict_pipeline_skips_empty_extraction_quietly() -> None:
+    llm = _RecordingLLM([{"nodes": [], "relationships": []}])
+    pipeline = _pipeline("strict", llm)
+    result = pipeline.index("Out of vocabulary text.", source_id="s1")
+    assert result.fallback_used is False
+    assert result.write_errors == []
+    assert result.skipped_chunks == 1
+
+
+def test_strict_enforcement_forces_strict_validation_floor() -> None:
+    from seocho.index.ingestion_facade import IngestRequest, IngestionFacade
+
+    llm = _RecordingLLM([{"nodes": [], "relationships": []}])
+    pipeline = _pipeline("strict", llm)
+    assert pipeline.strict_validation is True
+
+    facade = IngestionFacade(pipeline)
+    facade.ingest(
+        IngestRequest(content="text", workspace_id="w", strict_validation=False)
+    )
+    # the per-request False must not have downgraded the strict floor
+    assert pipeline.strict_validation is True
+
+
+def test_open_pipeline_annotates_out_of_ontology_nodes() -> None:
+    llm = _RecordingLLM([
+        {
+            "nodes": [
+                {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},
+                {"id": "x1", "label": "Spaceship", "properties": {"name": "Falcon"}},
+            ],
+            "relationships": [],
+        }
+    ])
+    pipeline = _pipeline("open", llm)
+    result = pipeline.index("Acme launched Falcon.", source_id="s1")
+    by_label = {n["label"]: n for n in result.nodes}
+    assert "_out_of_ontology" not in by_label["Company"].get("properties", {})
+    assert by_label["Spaceship"]["properties"]["_out_of_ontology"] == "true"
+    # open mode warns, never rejects
+    assert result.skipped_chunks == 0
+
+
+def test_strict_pipeline_rejects_chunk_with_unknown_labels() -> None:
+    llm = _RecordingLLM([
+        {
+            "nodes": [{"id": "x1", "label": "Spaceship", "properties": {"name": "Falcon"}}],
+            "relationships": [],
+        }
+    ])
+    pipeline = _pipeline("strict", llm)
+    result = pipeline.index("Falcon launch.", source_id="s1")
+    assert result.skipped_chunks == 1
+    assert result.total_nodes == 0
+    assert any("unknown label 'Spaceship'" in e for e in result.validation_errors)
+
+
+# ---------------------------------------------------------------------------
+# Agent design wiring
+# ---------------------------------------------------------------------------
+
+
+def _design_payload(**overrides: Any) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "name": "demo",
+        "pattern": "memory_tool_use",
+        "ontology": {"profile": "demo"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_agent_design_parses_enforcement_and_derives_validation_action() -> None:
+    spec = AgentDesignSpec.from_dict(
+        _design_payload(ontology={"profile": "demo", "enforcement": "strict"})
+    )
+    config = spec.to_agent_config()
+    assert config.ontology_enforcement == "strict"
+    assert config.validation_on_fail == "reject"
+    assert config.extra["agent_design_ontology"]["enforcement"] == "strict"
+
+    open_spec = AgentDesignSpec.from_dict(
+        _design_payload(ontology={"profile": "demo", "enforcement": "open"})
+    )
+    open_config = open_spec.to_agent_config()
+    assert open_config.ontology_enforcement == "open"
+    assert open_config.validation_on_fail == "warn"
+
+    default_config = AgentDesignSpec.from_dict(_design_payload()).to_agent_config()
+    assert default_config.ontology_enforcement == "guided"
+
+
+def test_agent_design_rejects_incoherent_enforcement_combos() -> None:
+    with pytest.raises(ValueError, match="incoherent"):
+        AgentDesignSpec.from_dict(
+            _design_payload(
+                ontology={"profile": "demo", "enforcement": "strict"},
+                indexing={"validation_on_fail": "warn"},
+            )
+        )
+    with pytest.raises(ValueError, match="incoherent"):
+        AgentDesignSpec.from_dict(
+            _design_payload(
+                ontology={"profile": "demo", "enforcement": "open"},
+                indexing={"validation_on_fail": "reject"},
+            )
+        )
+    # strict + retry stays coherent
+    AgentDesignSpec.from_dict(
+        _design_payload(
+            ontology={"profile": "demo", "enforcement": "strict"},
+            indexing={"validation_on_fail": "retry"},
+        )
+    )
+    with pytest.raises(ValueError, match="enforcement must be one of"):
+        AgentDesignSpec.from_dict(
+            _design_payload(ontology={"profile": "demo", "enforcement": "rigid"})
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run-spec / e2e wiring
+# ---------------------------------------------------------------------------
+
+
+def test_run_spec_enforcement_overrides_design_only_when_explicit(tmp_path) -> None:
+    import textwrap
+
+    from seocho import e2e
+    from seocho.run_spec import parse_run_spec
+
+    design = tmp_path / "design.yaml"
+    design.write_text(
+        textwrap.dedent(
+            """
+            name: strict-design
+            pattern: memory_tool_use
+            ontology:
+              profile: demo
+              enforcement: strict
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    base = {
+        "ontology": "schema.yaml",
+        "documents": "docs",
+        "agent": {"design": "design.yaml"},
+    }
+    # implicit guided default must NOT override the design's strict
+    spec = parse_run_spec(dict(base), source_path=str(tmp_path / "run.yaml"))
+    assert spec.enforcement_set is False
+    config = e2e.build_agent_config(spec)
+    assert config.ontology_enforcement == "strict"
+    assert config.validation_on_fail == "reject"
+
+    # explicit open overrides the design
+    explicit = dict(base)
+    explicit["ontology"] = {"path": "schema.yaml", "enforcement": "open"}
+    spec = parse_run_spec(explicit, source_path=str(tmp_path / "run.yaml"))
+    assert spec.enforcement_set is True
+    config = e2e.build_agent_config(spec)
+    assert config.ontology_enforcement == "open"
+
+
+def test_run_spec_inline_enforcement_lands_on_agent_config() -> None:
+    from seocho import e2e
+    from seocho.run_spec import parse_run_spec
+
+    spec = parse_run_spec(
+        {
+            "ontology": {"path": "s.yaml", "enforcement": "strict"},
+            "documents": "docs",
+        }
+    )
+    config = e2e.build_agent_config(spec)
+    assert config.ontology_enforcement == "strict"
+    assert config.validation_on_fail == "reject"


### PR DESCRIPTION
## What

Completes the `ontology.enforcement` axis the YAML e2e runner (#279) declared. The three modes are extraction **admission policies** (SHACL closed-shape spirit) — deliberately not named CWA/OWA, since query-time entailment is unchanged in every mode.

| Mode | Semantics |
| --- | --- |
| `strict` | Closed vocabulary: constant strict prompt line, relaxed retry **off**, `Entity`/heuristic fallbacks **off** (empty extraction is a legitimate outcome; LLM failure → recorded error, not fabricated structure), closed validation (no `Entity` exemption, dangling-endpoint + domain/range conformance via the `broader` chain), chunk-level rejection, post-link closed re-validation with revert. |
| `guided` | Default — today's tuned behavior (the mode the FinDER experiments validated). Unchanged. |
| `open` | Admit everything; out-of-vocabulary nodes/rels stamped `_out_of_ontology: "true"` — the triage signal for offline ontology-evolution governance. |

## Design notes

- **One `EnforcementPolicy` (frozen) with three presets** (`src/seocho/index/enforcement.py`). The real degrees of freedom live as internal knobs; only the preset enum is config-expressible, so incoherent states (strict prompt + Entity fallback) can't be declared. Coherence is also validated at the design layer: `strict` forbids `validation_on_fail: relax|warn`, `open` forbids `reject`.
- **Extraction firewall preserved.** The strict prompt line is a constant, ontology-independent string; the `ontology_guidance` fallback rule swap is constant too. `broader`/`same_as` still never render into prompts — they now participate in **validation** (subsumption for domain/range), which is exactly where author-time richness belongs. `test_ontology_extraction_firewall.py` green, plus a new byte-identical-across-ontologies guard.
- **`strict_validation` floor.** The set/restore sites (ingestion facade, `add_graph`, `FileIndexer`) previously let a per-request `strict_validation=False` silently downgrade the policy; they now floor at the policy's `reject` action.
- **Wiring**: `AgentConfig.ontology_enforcement` → `_LocalEngine` → `IndexingPipeline`/`CanonicalExtractionEngine`. Agent design specs accept `ontology.enforcement` (compiled into the config + extra); run specs track explicit-vs-default so an **explicit** run value overrides a design and the implicit `guided` default never does. No YAML surface change vs. #279.
- Chunk stays the rejection unit (no silent element drops); run-level failure thresholds remain the runner's job, as designed.

## Validation

- `bash scripts/ci/run_basic_ci.sh` — **568 passed, 5 skipped** (21 new tests in `tests/seocho/test_ontology_enforcement.py`: presets, closed validation incl. subsumption/wildcards/dangling endpoints, engine gating, pipeline gating both fallback sites, validation floor, open annotation, design coherence, run-spec layering)
- Live strict run (MARA + embedded LadybugDB): `seocho run` with `enforcement: strict` → extraction stayed in-vocabulary, **0 validation errors**, question answered. (The one failed file in that run is the seocho-8ct PK collision, fixed in #282.)

Docs: `RUN_SPECS.md` enforcement table rewritten for the full semantics; `AGENT_DESIGN_SPECS.md` gains the enforcement section.

Beads: seocho-snt. Independent of #282 (touches different surfaces); both branch from current main.