### PR TITLE
feat(index,ontology): closed-vocabulary enforcement — strict/guided/open EnforcementPolicy (seocho-snt)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -50,6 +50,7 @@ python3 -m py_compile \
   src/seocho/tracing.py \
   src/seocho/store/graph.py \
   src/seocho/query/cypher_builder.py \
+  src/seocho/index/enforcement.py \
   src/seocho/index/extraction_engine.py \
   src/seocho/index/file_reader.py \
   src/seocho/run_spec.py \
@@ -117,6 +118,7 @@ uv run pytest \
   tests/seocho/test_ontology_iso704_cq.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \
+  tests/seocho/test_enforcement.py \
   -q
 
 git diff --check

--- a/src/seocho/index/__init__.py
+++ b/src/seocho/index/__init__.py
@@ -16,6 +16,7 @@ from .pipeline import (
     content_hash,
 )
 from .chunk import Chunk, build_chunk_id, chunk
+from .enforcement import GUIDED, OPEN, STRICT, EnforcementPolicy, resolve_enforcement
 from .extraction_engine import CanonicalExtractionEngine
 from .ingestion_facade import IngestRequest, IngestionFacade
 from .file_reader import (
@@ -29,6 +30,11 @@ from .file_reader import (
 __all__ = [
     "IndexingPipeline",
     "CanonicalExtractionEngine",
+    "EnforcementPolicy",
+    "resolve_enforcement",
+    "STRICT",
+    "GUIDED",
+    "OPEN",
     "IngestRequest",
     "IngestionFacade",
     "IndexingResult",

--- a/src/seocho/index/enforcement.py
+++ b/src/seocho/index/enforcement.py
@@ -1,0 +1,111 @@
+"""Closed-vocabulary ontology enforcement semantics (seocho-snt).
+
+One :class:`EnforcementPolicy` value drives every enforcement decision in the
+indexing path, replacing the single ``strict_validation`` boolean while
+remaining back-compatible with it.
+
+The three presets follow the ontology-panel design:
+
+- ``strict`` — closed vocabulary. Unknown labels/relationship types,
+  dangling endpoints, and domain/range violations reject the whole chunk
+  (no silent element drops). The relaxed retry and the heuristic
+  ``Entity``/``MENTIONS`` fallback are disabled because both emit
+  out-of-vocabulary structure. A constant, ontology-independent prompt
+  line instructs the model to stay inside the provided vocabulary — it
+  must stay ontology-independent so the extraction firewall
+  (``to_extraction_context`` byte-identity, r=-0.76 driver) holds.
+- ``guided`` — today's default behavior: validation errors are recorded
+  but do not reject, relaxed retry and fallback stay available.
+- ``open`` — like guided, but out-of-ontology elements are annotated with
+  ``_out_of_ontology: true`` instead of being treated as errors, so
+  downstream consumers can filter or study them.
+
+Run-level failure thresholds intentionally live in the e2e runner
+(``seocho run``), not here; the rejection unit at this layer is the chunk.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+__all__ = ["EnforcementPolicy", "STRICT", "GUIDED", "OPEN", "resolve_enforcement"]
+
+
+@dataclass(frozen=True)
+class EnforcementPolicy:
+    """Resolved enforcement semantics for one indexing run."""
+
+    mode: str
+    closed_vocabulary: bool
+    allow_relaxed_retry: bool
+    allow_fallback_extract: bool
+    annotate_out_of_ontology: bool
+    closed_vocab_prompt_line: bool
+    revalidate_after_link: bool
+    reject_on_validation_errors: bool
+
+
+STRICT = EnforcementPolicy(
+    mode="strict",
+    closed_vocabulary=True,
+    allow_relaxed_retry=False,
+    allow_fallback_extract=False,
+    annotate_out_of_ontology=False,
+    closed_vocab_prompt_line=True,
+    revalidate_after_link=True,
+    reject_on_validation_errors=True,
+)
+
+GUIDED = EnforcementPolicy(
+    mode="guided",
+    closed_vocabulary=False,
+    allow_relaxed_retry=True,
+    allow_fallback_extract=True,
+    annotate_out_of_ontology=False,
+    closed_vocab_prompt_line=False,
+    revalidate_after_link=False,
+    reject_on_validation_errors=False,
+)
+
+OPEN = EnforcementPolicy(
+    mode="open",
+    closed_vocabulary=False,
+    allow_relaxed_retry=True,
+    allow_fallback_extract=True,
+    annotate_out_of_ontology=True,
+    closed_vocab_prompt_line=False,
+    revalidate_after_link=False,
+    reject_on_validation_errors=False,
+)
+
+_PRESETS = {"strict": STRICT, "guided": GUIDED, "open": OPEN}
+
+
+def resolve_enforcement(
+    value: Any = None,
+    *,
+    strict_validation: Optional[bool] = None,
+) -> EnforcementPolicy:
+    """Resolve a policy from a preset name, a policy, or the legacy flag.
+
+    Precedence: an explicit ``value`` (policy instance or preset name) wins;
+    otherwise the legacy ``strict_validation`` boolean maps to
+    ``strict``/``guided``; with neither, the default is ``guided``.
+    """
+    if isinstance(value, EnforcementPolicy):
+        return value
+    if isinstance(value, str) and value.strip():
+        name = value.strip().lower()
+        if name not in _PRESETS:
+            raise ValueError(
+                f"Unknown enforcement mode {value!r}; "
+                f"expected one of: {', '.join(sorted(_PRESETS))}."
+            )
+        return _PRESETS[name]
+    if value is not None:
+        raise TypeError(
+            f"enforcement must be a str preset or EnforcementPolicy, got {type(value).__name__}"
+        )
+    if strict_validation:
+        return STRICT
+    return GUIDED

--- a/src/seocho/index/extraction_engine.py
+++ b/src/seocho/index/extraction_engine.py
@@ -28,6 +28,18 @@ _ONTOLOGY_RELAXED_RETRY_GUIDANCE = (
 )
 
 
+# seocho-snt: appended verbatim in strict mode. MUST stay constant and
+# ontology-independent — the extraction firewall (FinDER r=-0.76) forbids
+# ontology-derived richness from entering the extraction prompt surface,
+# and a constant line keeps the KV-cache prefix stable per mode.
+_CLOSED_VOCABULARY_PROMPT_LINE = (
+    "Closed vocabulary: use only the provided node labels and relationship "
+    "types, spelled exactly as given. If an entity or relationship does not "
+    "fit any provided type, omit it entirely — never invent labels, "
+    "relationship types, or generic placeholders."
+)
+
+
 class CanonicalExtractionEngine:
     """Shared extraction/linking engine for ontology-first graph construction."""
 
@@ -39,11 +51,15 @@ class CanonicalExtractionEngine:
         extraction_prompt: Optional[Any] = None,
         custom_prompts: Optional[Dict[str, str]] = None,
         linking_prompt: Optional[str] = None,
+        enforcement: Any = None,
     ) -> None:
+        from .enforcement import resolve_enforcement
+
         self.ontology = ontology
         self.llm = llm
         self.custom_prompts = dict(custom_prompts or {})
         self.linking_prompt = linking_prompt
+        self.enforcement = resolve_enforcement(enforcement)
         self._extraction = (
             ExtractionStrategy(ontology, extraction_prompt=extraction_prompt)
             if ontology is not None
@@ -67,6 +83,8 @@ class CanonicalExtractionEngine:
             metadata=metadata,
             extra_context=extra_context,
         )
+        if self.enforcement.closed_vocab_prompt_line:
+            system = f"{system}\n\n{_CLOSED_VOCABULARY_PROMPT_LINE}"
         response = complete_with_task_hints(
             self.llm,
             system=system,
@@ -155,6 +173,12 @@ class CanonicalExtractionEngine:
         normalized: Dict[str, Any],
         extra_context: Optional[Dict[str, Any]],
     ) -> bool:
+        # seocho-snt: the relaxed retry explicitly invites near-miss labels
+        # and generic Entity nodes — out-of-vocabulary by definition, so
+        # strict mode never takes it. An empty graph is the correct strict
+        # outcome for text the ontology does not cover.
+        if not self.enforcement.allow_relaxed_retry:
+            return False
         if normalized.get("nodes") or normalized.get("relationships"):
             return False
         if self.ontology is not None:

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -217,6 +217,7 @@ class IndexingPipeline:
         workspace_id: str = "default",
         extraction_prompt: Optional[Any] = None,
         strict_validation: bool = False,
+        enforcement: Optional[Any] = None,
         max_chunk_chars: int = 6000,
         enable_dedup: bool = True,
         enable_rule_constraints: bool = False,
@@ -232,11 +233,18 @@ class IndexingPipeline:
         from seocho.ontology import Ontology
         from seocho.query.strategy import ExtractionStrategy, LinkingStrategy
 
+        from seocho.index.enforcement import resolve_enforcement
+
         self.ontology: Ontology = ontology
         self.graph_store = graph_store
         self.llm = llm
         self.workspace_id = workspace_id
-        self.strict_validation = strict_validation
+        # seocho-snt: one policy drives every enforcement decision;
+        # strict_validation is exposed below as the back-compat boolean
+        # property view of it (callers like local_engine flip it directly).
+        self.enforcement = resolve_enforcement(
+            enforcement, strict_validation=strict_validation
+        )
         self.max_chunk_chars = max_chunk_chars
         self.enable_dedup = enable_dedup
         self.enable_rule_constraints = enable_rule_constraints
@@ -267,7 +275,32 @@ class IndexingPipeline:
             ontology=ontology,
             llm=llm,
             extraction_prompt=extraction_prompt,
+            enforcement=self.enforcement,
         )
+
+    @property
+    def strict_validation(self) -> bool:
+        """Back-compat boolean view of the enforcement policy."""
+        return self.enforcement.reject_on_validation_errors
+
+    @strict_validation.setter
+    def strict_validation(self, value: bool) -> None:
+        """Legacy switch: flips between the strict and guided presets.
+
+        Note this resolves to a *preset* — a custom policy assigned via
+        ``enforcement`` is replaced, not toggled. Callers that need the
+        full semantics should set ``self.enforcement`` directly.
+        """
+        from seocho.index.enforcement import resolve_enforcement
+
+        if bool(value) == self.strict_validation:
+            # No-op when the boolean view already matches — preserves a
+            # custom policy through legacy save/flip/restore patterns.
+            return
+        self.enforcement = resolve_enforcement(None, strict_validation=bool(value))
+        engine = getattr(self, "_graph_extraction", None)
+        if engine is not None:
+            engine.enforcement = self.enforcement
 
     @staticmethod
     def _fallback_extract(text: str, *, source_id: str = "fallback") -> Dict[str, Any]:
@@ -314,6 +347,23 @@ class IndexingPipeline:
             )
 
         return {"nodes": nodes, "relationships": relationships}
+
+    def _annotate_out_of_ontology(
+        self, nodes: List[Dict[str, Any]], rels: List[Dict[str, Any]]
+    ) -> None:
+        """Open enforcement (seocho-snt): mark elements outside the ontology
+        vocabulary with ``_out_of_ontology: True`` instead of erroring."""
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            label = node.get("label", "")
+            if label not in self.ontology.nodes:
+                node.setdefault("properties", {})["_out_of_ontology"] = True
+        for rel in rels:
+            if not isinstance(rel, dict):
+                continue
+            if rel.get("type", "") not in self.ontology.relationships:
+                rel.setdefault("properties", {})["_out_of_ontology"] = True
 
     def _normalize_extraction_payload(self, extracted: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize LLM extraction output into the graph write contract."""
@@ -730,6 +780,21 @@ class IndexingPipeline:
                 )
                 extracted = response
             except Exception as exc:
+                # seocho-snt: the heuristic fallback emits Entity/Document/
+                # MENTIONS structure — out-of-vocabulary by definition, so
+                # strict mode rejects the chunk instead of falling back.
+                if not self.enforcement.allow_fallback_extract:
+                    logger.warning(
+                        "LLM extraction failed for chunk %d; strict enforcement "
+                        "rejects the chunk (no heuristic fallback): %s",
+                        i, exc,
+                    )
+                    result.validation_errors.append(
+                        f"Chunk {i}: extraction failed under strict enforcement "
+                        f"({type(exc).__name__}: {str(exc)[:200]})"
+                    )
+                    result.skipped_chunks += 1
+                    continue
                 logger.warning(
                     "LLM extraction failed for chunk %d, using heuristic fallback: %s",
                     i, exc,
@@ -746,6 +811,11 @@ class IndexingPipeline:
             rels = extracted.get("relationships", [])
 
             if not nodes and not rels:
+                if not self.enforcement.allow_fallback_extract:
+                    # seocho-snt: empty is the correct strict outcome for
+                    # text the ontology does not cover — skip, don't invent.
+                    result.skipped_chunks += 1
+                    continue
                 logger.warning(
                     "LLM extraction returned an empty graph for chunk %d, using heuristic fallback.",
                     i,
@@ -818,8 +888,11 @@ class IndexingPipeline:
                     except Exception:
                         break
 
-            # Validate with SHACL
-            errors = self.ontology.validate_with_shacl(extracted)
+            # Validate with SHACL (closed vocabulary under strict — no
+            # Entity exemption, dangling endpoints and domain/range checked)
+            errors = self.ontology.validate_with_shacl(
+                extracted, closed=self.enforcement.closed_vocabulary
+            )
 
             # --- Callback: on_after_validate ---
             if self.on_after_validate:
@@ -827,10 +900,17 @@ class IndexingPipeline:
 
             if errors:
                 result.validation_errors.extend(errors)
-                if self.strict_validation:
+                if self.enforcement.reject_on_validation_errors:
+                    # Rejection unit is the chunk — never silently drop
+                    # individual elements.
                     logger.warning("Chunk %d rejected by SHACL: %s", i, errors)
                     result.skipped_chunks += 1
                     continue
+
+            # seocho-snt open mode: keep out-of-ontology elements but mark
+            # them so downstream consumers can filter or study them.
+            if self.enforcement.annotate_out_of_ontology:
+                self._annotate_out_of_ontology(nodes, rels)
 
             # Link (deduplicate entities within chunk)
             if nodes:
@@ -847,6 +927,21 @@ class IndexingPipeline:
                         rels = linked_rels
                 except Exception as exc:
                     logger.warning("Linking failed for chunk %d, using raw extraction: %s", i, exc)
+
+            # seocho-snt strict: linking can rewrite labels/endpoints, so the
+            # closed-vocabulary contract is re-checked after the link step.
+            if self.enforcement.revalidate_after_link and nodes:
+                post_link_errors = self.ontology.validate_with_shacl(
+                    {"nodes": nodes, "relationships": rels},
+                    closed=self.enforcement.closed_vocabulary,
+                )
+                if post_link_errors:
+                    result.validation_errors.extend(post_link_errors)
+                    logger.warning(
+                        "Chunk %d rejected after linking: %s", i, post_link_errors
+                    )
+                    result.skipped_chunks += 1
+                    continue
 
             chunk_records.append(
                 {

--- a/src/seocho/ontology.py
+++ b/src/seocho/ontology.py
@@ -1137,7 +1137,7 @@ class Ontology:
             source_summary=source_summary,
         )
 
-    def validate_with_shacl(self, data: Dict[str, Any]) -> List[str]:
+    def validate_with_shacl(self, data: Dict[str, Any], *, closed: bool = False) -> List[str]:
         """Validate extracted data against SHACL shapes derived from
         this ontology.
 
@@ -1148,12 +1148,14 @@ class Ontology:
         ----------
         data:
             Dict with ``"nodes"`` and ``"relationships"`` lists.
+        closed:
+            Closed-vocabulary mode — see :meth:`validate_extraction`.
 
         Returns
         -------
         List of validation error strings (empty = valid).
         """
-        errors = list(self.validate_extraction(data))
+        errors = list(self.validate_extraction(data, closed=closed))
         shacl = self.to_shacl()
 
         # Build shape lookup: targetClass -> shape
@@ -1717,7 +1719,28 @@ class Ontology:
                     stack.extend(p for p in cur_nd.broader if p in self.nodes)
         return errors
 
-    def validate_extraction(self, data: Dict[str, Any]) -> List[str]:
+    def _label_conforms(self, label: str, expected: str) -> bool:
+        """True when ``label`` is ``expected`` or reaches it via the
+        ``broader`` (subclass) chain. Cycle-safe."""
+        if label == expected:
+            return True
+        seen: Set[str] = set()
+        frontier = [label]
+        while frontier:
+            current = frontier.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            nd = self.nodes.get(current)
+            if nd is None:
+                continue
+            for parent in nd.broader:
+                if parent == expected:
+                    return True
+                frontier.append(parent)
+        return False
+
+    def validate_extraction(self, data: Dict[str, Any], *, closed: bool = False) -> List[str]:
         """Validate extracted graph data against this ontology.
 
         Parameters
@@ -1725,6 +1748,12 @@ class Ontology:
         data:
             Dict with ``"nodes"`` and ``"relationships"`` lists as
             produced by the LLM extraction step.
+        closed:
+            Closed-vocabulary mode (seocho-snt). When True the generic
+            ``Entity`` exemption is removed, relationship endpoints must
+            resolve to extracted node ids (no dangling endpoints), and
+            endpoint labels must conform to the relationship's declared
+            domain/range — directly or through the ``broader`` chain.
 
         Returns
         -------
@@ -1732,13 +1761,15 @@ class Ontology:
         """
         errors: List[str] = []
         known_ids: Set[str] = set()
+        label_by_id: Dict[str, str] = {}
 
         for node in data.get("nodes", []):
             nid = node.get("id", "")
             label = node.get("label", "")
             known_ids.add(nid)
+            label_by_id[nid] = label
 
-            if label not in self.nodes and label != "Entity":
+            if label not in self.nodes and (closed or label != "Entity"):
                 errors.append(f"Node '{nid}' has unknown label '{label}'")
                 continue
 
@@ -1756,6 +1787,24 @@ class Ontology:
             tgt = rel.get("target", "")
             if rtype not in self.relationships:
                 errors.append(f"Unknown relationship type '{rtype}'")
+                continue
+            if not closed:
+                continue
+            # Closed vocabulary: endpoints must exist and conform to the
+            # declared domain/range (broader chain counts as conformance).
+            rd = self.relationships[rtype]
+            for endpoint, role, expected in ((src, "source", rd.source), (tgt, "target", rd.target)):
+                if endpoint not in known_ids:
+                    errors.append(
+                        f"Relationship '{rtype}' has dangling {role} '{endpoint}'"
+                    )
+                    continue
+                endpoint_label = label_by_id.get(endpoint, "")
+                if expected and not self._label_conforms(endpoint_label, expected):
+                    errors.append(
+                        f"Relationship '{rtype}' {role} '{endpoint}' has label "
+                        f"'{endpoint_label}', expected '{expected}' (or narrower)"
+                    )
 
         return errors
 

--- a/tests/seocho/test_enforcement.py
+++ b/tests/seocho/test_enforcement.py
@@ -1,0 +1,267 @@
+"""Closed-vocabulary enforcement semantics (seocho-snt)."""
+from __future__ import annotations
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+from seocho.index.enforcement import (
+    GUIDED,
+    OPEN,
+    STRICT,
+    EnforcementPolicy,
+    resolve_enforcement,
+)
+from seocho.index.extraction_engine import (
+    _CLOSED_VOCABULARY_PROMPT_LINE,
+    CanonicalExtractionEngine,
+)
+from seocho.index.pipeline import IndexingPipeline
+
+
+def _ontology() -> Ontology:
+    return Ontology(
+        name="finance",
+        nodes={
+            "FinancialMetric": NodeDef(properties={"name": P(str, unique=True)}),
+            "Revenue": NodeDef(
+                properties={"name": P(str, unique=True)},
+                broader=["FinancialMetric"],
+            ),
+            "Company": NodeDef(properties={"name": P(str, unique=True)}),
+        },
+        relationships={
+            "REPORTED": RelDef(source="Company", target="FinancialMetric"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Policy resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_presets_and_legacy_flag():
+    assert resolve_enforcement("strict") is STRICT
+    assert resolve_enforcement("guided") is GUIDED
+    assert resolve_enforcement("open") is OPEN
+    assert resolve_enforcement(None) is GUIDED
+    assert resolve_enforcement(None, strict_validation=True) is STRICT
+    assert resolve_enforcement(STRICT) is STRICT
+    assert resolve_enforcement("STRICT") is STRICT  # case-insensitive
+    with pytest.raises(ValueError):
+        resolve_enforcement("lenient")
+    with pytest.raises(TypeError):
+        resolve_enforcement(42)
+
+
+def test_explicit_policy_wins_over_legacy_flag():
+    assert resolve_enforcement("open", strict_validation=True) is OPEN
+
+
+# ---------------------------------------------------------------------------
+# Closed-vocabulary validation
+# ---------------------------------------------------------------------------
+
+def test_closed_removes_entity_exemption():
+    onto = _ontology()
+    data = {"nodes": [{"id": "e1", "label": "Entity", "properties": {"name": "X"}}],
+            "relationships": []}
+    assert onto.validate_extraction(data) == []  # default keeps the exemption
+    errors = onto.validate_extraction(data, closed=True)
+    assert any("unknown label 'Entity'" in e for e in errors)
+
+
+def test_closed_flags_dangling_endpoints():
+    onto = _ontology()
+    data = {
+        "nodes": [{"id": "c1", "label": "Company", "properties": {"name": "Acme"}}],
+        "relationships": [
+            {"source": "c1", "target": "ghost", "type": "REPORTED", "properties": {}},
+        ],
+    }
+    assert onto.validate_extraction(data) == []  # open vocabulary: rel type known
+    errors = onto.validate_extraction(data, closed=True)
+    assert any("dangling target 'ghost'" in e for e in errors)
+
+
+def test_closed_domain_range_conformance_via_broader_chain():
+    onto = _ontology()
+    # Revenue is broader->FinancialMetric, so REPORTED Company->Revenue conforms.
+    ok = {
+        "nodes": [
+            {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},
+            {"id": "m1", "label": "Revenue", "properties": {"name": "FY24 revenue"}},
+        ],
+        "relationships": [
+            {"source": "c1", "target": "m1", "type": "REPORTED", "properties": {}},
+        ],
+    }
+    assert onto.validate_extraction(ok, closed=True) == []
+
+    # Company as REPORTED *target* violates the declared range.
+    bad = {
+        "nodes": [
+            {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},
+            {"id": "c2", "label": "Company", "properties": {"name": "Beta"}},
+        ],
+        "relationships": [
+            {"source": "c1", "target": "c2", "type": "REPORTED", "properties": {}},
+        ],
+    }
+    errors = onto.validate_extraction(bad, closed=True)
+    assert any("expected 'FinancialMetric'" in e for e in errors)
+
+
+def test_broader_chain_is_cycle_safe():
+    onto = Ontology(
+        name="cyclic",
+        nodes={
+            "A": NodeDef(properties={"name": P(str)}, broader=["B"]),
+            "B": NodeDef(properties={"name": P(str)}, broader=["A"]),
+        },
+        relationships={"REL": RelDef(source="A", target="C")},
+    )
+    data = {
+        "nodes": [
+            {"id": "a", "label": "A", "properties": {"name": "a"}},
+            {"id": "b", "label": "B", "properties": {"name": "b"}},
+        ],
+        "relationships": [{"source": "a", "target": "b", "type": "REL", "properties": {}}],
+    }
+    errors = onto.validate_extraction(data, closed=True)  # must terminate
+    assert any("expected 'C'" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Extraction engine: strict prompt line + relaxed retry gating
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeLLM:
+    def __init__(self, payloads):
+        self.payloads = list(payloads)
+        self.calls = []
+
+    def complete(self, *, system, user, temperature, response_format=None,
+                 reasoning_mode=None, task_hint=None):  # noqa: ANN001
+        self.calls.append({"system": system, "task_hint": task_hint})
+        return _FakeResponse(self.payloads.pop(0))
+
+
+def test_strict_appends_constant_prompt_line_and_skips_relaxed_retry():
+    llm = _FakeLLM([{"nodes": [], "relationships": []}])
+    engine = CanonicalExtractionEngine(
+        ontology=_ontology(), llm=llm, enforcement="strict"
+    )
+    out = engine.extract("Acme reported revenue.")
+    # One call only: the relaxed retry (out-of-vocabulary by design) is gated.
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["system"].endswith(_CLOSED_VOCABULARY_PROMPT_LINE)
+    assert "_retry" not in out
+
+
+def test_guided_keeps_relaxed_retry_and_plain_prompt():
+    llm = _FakeLLM([
+        {"nodes": [], "relationships": []},   # first pass: empty
+        {"nodes": [{"id": "1", "label": "Company", "properties": {"name": "Acme"}}],
+         "relationships": []},                # relaxed retry succeeds
+    ])
+    engine = CanonicalExtractionEngine(ontology=_ontology(), llm=llm)
+    out = engine.extract("Acme reported revenue.")
+    assert len(llm.calls) == 2
+    assert _CLOSED_VOCABULARY_PROMPT_LINE not in llm.calls[0]["system"]
+    assert out.get("_retry", {}).get("succeeded") is True
+
+
+def test_strict_prompt_line_is_ontology_independent():
+    # The extraction firewall (r=-0.76) requires the line to be constant —
+    # no ontology content interpolated.
+    assert "{" not in _CLOSED_VOCABULARY_PROMPT_LINE
+    assert "%s" not in _CLOSED_VOCABULARY_PROMPT_LINE
+
+
+# ---------------------------------------------------------------------------
+# Pipeline gating
+# ---------------------------------------------------------------------------
+
+class _NullStore:
+    def write(self, nodes, relationships, **kwargs):
+        return {"nodes_created": len(nodes),
+                "relationships_created": len(relationships), "errors": []}
+
+    def query(self, *a, **k):
+        return []
+
+
+class _BoomLLM:
+    def complete(self, **kwargs):
+        raise RuntimeError("LLM unavailable")
+
+
+def test_strict_pipeline_rejects_chunk_instead_of_heuristic_fallback():
+    pipeline = IndexingPipeline(
+        ontology=_ontology(), graph_store=_NullStore(), llm=_BoomLLM(),
+        enforcement="strict", enable_dedup=False,
+    )
+    result = pipeline.index("Acme Corp reported strong revenue in 2024.")
+    assert result.fallback_used is False
+    assert result.skipped_chunks >= 1
+    assert any("strict enforcement" in e for e in result.validation_errors)
+
+
+def test_guided_pipeline_still_uses_heuristic_fallback():
+    pipeline = IndexingPipeline(
+        ontology=_ontology(), graph_store=_NullStore(), llm=_BoomLLM(),
+        enforcement="guided", enable_dedup=False,
+    )
+    result = pipeline.index("Acme Corp reported strong revenue in 2024.")
+    assert result.fallback_used is True
+
+
+def test_strict_validation_property_backcompat_roundtrip():
+    pipeline = IndexingPipeline(
+        ontology=_ontology(), graph_store=_NullStore(), llm=_BoomLLM(),
+        strict_validation=True,
+    )
+    assert pipeline.enforcement is STRICT
+    assert pipeline.strict_validation is True
+    pipeline.strict_validation = False
+    assert pipeline.enforcement is GUIDED
+    assert pipeline._graph_extraction.enforcement is GUIDED
+
+
+def test_strict_validation_setter_noop_preserves_custom_policy():
+    pipeline = IndexingPipeline(
+        ontology=_ontology(), graph_store=_NullStore(), llm=_BoomLLM(),
+        enforcement="open",
+    )
+    pipeline.strict_validation = False  # boolean view already False -> no-op
+    assert pipeline.enforcement is OPEN
+
+
+def test_open_pipeline_annotates_out_of_ontology():
+    nodes = [
+        {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},
+        {"id": "x1", "label": "Spaceship", "properties": {"name": "Falcon"}},
+    ]
+    rels = [{"source": "c1", "target": "x1", "type": "PILOTS", "properties": {}}]
+    pipeline = IndexingPipeline(
+        ontology=_ontology(), graph_store=_NullStore(), llm=_BoomLLM(),
+        enforcement="open",
+    )
+    pipeline._annotate_out_of_ontology(nodes, rels)
+    assert "_out_of_ontology" not in nodes[0]["properties"]
+    assert nodes[1]["properties"]["_out_of_ontology"] is True
+    assert rels[0]["properties"]["_out_of_ontology"] is True
+
+
+def test_policy_is_frozen():
+    with pytest.raises(Exception):
+        STRICT.mode = "other"  # type: ignore[misc]
+    assert isinstance(STRICT, EnforcementPolicy)


### PR DESCRIPTION
## Feature

Closed-vocabulary ontology enforcement semantics: a frozen `EnforcementPolicy`
dataclass with `strict`/`guided`/`open` presets drives every enforcement
decision in the indexing path — prompt shaping, relaxed-retry gating,
heuristic-fallback gating, closed validation, out-of-ontology annotation, and
post-link re-validation.

## Why

Follow-up to the YAML e2e runner (seocho-0u7, PR #279): v1 mapped
`ontology.enforcement` onto the single `strict_validation` boolean, which
cannot express the panel-designed semantics — no Entity exemption, dangling
endpoints, domain/range conformance, no out-of-vocabulary fallback, and an
annotate-don't-reject open mode. Ticket seocho-snt.

## Design

- `src/seocho/index/enforcement.py`: `EnforcementPolicy` + `STRICT`/`GUIDED`/
  `OPEN` presets + `resolve_enforcement` (explicit policy or preset name wins,
  legacy `strict_validation` maps to strict/guided, default guided).
- `Ontology.validate_extraction(closed=)`: closed mode removes the `Entity`
  exemption, flags dangling endpoints via `known_ids`, and checks
  domain/range conformance through the `broader` chain (cycle-safe walk).
  `validate_with_shacl` forwards `closed`. Default behavior unchanged.
- `CanonicalExtractionEngine`: strict appends `_CLOSED_VOCABULARY_PROMPT_LINE`
  — constant and ontology-independent, so the extraction firewall
  (`to_extraction_context` byte-identity, FinDER r=-0.76 driver) holds and the
  KV-cache prefix stays stable per mode. Strict also disables the relaxed
  retry, which by design invites near-miss labels and generic Entity nodes.
- `IndexingPipeline`: strict gates `_fallback_extract` at both call sites
  (LLM failure and empty extraction) — the chunk is rejected with a recorded
  reason, never rescued with out-of-vocabulary structure. Validation runs
  `closed` under strict, and re-runs after the link step (linking can rewrite
  labels/endpoints). Rejection unit is the chunk — no silent element drops.
  Open mode annotates unknown labels/types with `_out_of_ontology: true`.
- Back-compat: `pipeline.strict_validation` is now a property over the
  policy; the setter flips strict/guided presets and no-ops when the boolean
  view already matches, preserving custom policies through the
  save/flip/restore pattern used by `local_engine`.
- Run-level failure thresholds intentionally remain in the e2e runner.

## Expected Effect

`enforcement: strict` runs produce only in-vocabulary graph structure (or
explicit chunk rejections); `open` runs keep exploratory structure but make
it filterable. `guided` is byte-for-byte today's behavior.

## Impact Results

- 15 new tests covering policy resolution, closed validation (Entity
  exemption, dangling endpoints, broader-chain domain/range, cycle safety),
  strict prompt-line + retry gating, pipeline fallback gating, open
  annotation, and the strict_validation property round-trip.
- Firewall regression suite untouched and green.

## Validation

- `bash scripts/ci/run_basic_ci.sh` → 569 passed, 1 skipped (new tests
  registered in the gate).
- `pytest tests/seocho/test_ontology_extraction_firewall.py
  tests/seocho/test_extraction_engine.py tests/seocho/test_e2e_runner.py
  tests/seocho/test_run_spec.py tests/seocho/test_ontology.py` → 77 passed.
- `git diff --check` clean.
- Skipped: ruff (not in venv); live LLM run (semantics covered by fakes).

## Risks

Medium. The indexing hot path changes for strict mode only; guided (the
default) resolves to a policy whose every gate matches current behavior, and
the full CI suite confirms no drift. The strict_validation setter replaces a
custom policy with a preset when actually toggled — documented in the
docstring, and the no-op guard covers the only in-repo flip pattern.
