### PR TITLE
fix(security): apply least privilege to read-only endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1430,7 +1430,7 @@ async def semantic_runs_list(
     intent_id: Optional[str] = Query(default=None),
 ):
     try:
-        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_semantic_runs", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 
@@ -1456,7 +1456,7 @@ async def semantic_runs_get(
     workspace_id: str = Query(default="default", pattern=WORKSPACE_ID_PATTERN),
 ):
     try:
-        require_runtime_permission(role="user", action="run_agent", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_semantic_runs", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 
@@ -1802,7 +1802,7 @@ async def rules_profiles_list(
 ):
     """List saved rule profiles in a workspace."""
     try:
-        require_runtime_permission(role="user", action="manage_rule_profiles", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_rule_profiles", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
     return read_rule_profiles(workspace_id=workspace_id)
@@ -1816,7 +1816,7 @@ async def rules_profiles_get(
 ):
     """Read one saved rule profile."""
     try:
-        require_runtime_permission(role="user", action="manage_rule_profiles", workspace_id=workspace_id)
+        require_runtime_permission(role="user", action="read_rule_profiles", workspace_id=workspace_id)
     except PermissionError as e:
         raise HTTPException(status_code=403, detail=str(e))
 
@@ -1925,7 +1925,7 @@ async def semantic_artifacts_list(
     try:
         require_runtime_permission(
             role="user",
-            action="manage_semantic_artifacts",
+            action="read_semantic_artifacts",
             workspace_id=workspace_id,
         )
     except PermissionError as e:
@@ -1945,7 +1945,7 @@ async def semantic_artifacts_get(
     try:
         require_runtime_permission(
             role="user",
-            action="manage_semantic_artifacts",
+            action="read_semantic_artifacts",
             workspace_id=workspace_id,
         )
     except PermissionError as e:

--- a/runtime/policy.py
+++ b/runtime/policy.py
@@ -40,9 +40,10 @@ _WORKSPACE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{1,63}$")
 # user set equal to this preserves behaviour when auth is enabled.
 _OPERATIONAL: Set[str] = {
     "run_agent", "run_debate", "read_databases", "read_agents",
-    "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles",
+    "infer_rules", "validate_rules", "assess_rules", "manage_rule_profiles", "read_rule_profiles",
     "export_rules", "manage_indexes", "run_platform", "ingest_raw",
-    "manage_semantic_artifacts", "manage_memories",
+    "manage_semantic_artifacts", "read_semantic_artifacts", "manage_memories",
+    "read_semantic_runs",
 }
 # Reserved for cross-tenant / policy operations — admin only.
 _ADMIN_ONLY: Set[str] = {"manage_tenants", "manage_policy"}
@@ -61,7 +62,7 @@ class RuntimePolicyEngine:
         self._role_permissions: Dict[str, Set[str]] = {
             "admin": _OPERATIONAL | _ADMIN_ONLY,   # strict superset
             "user": set(_OPERATIONAL),
-            "viewer": {"read_databases", "read_agents"},
+            "viewer": {"read_databases", "read_agents", "read_semantic_runs", "read_rule_profiles", "read_semantic_artifacts"},
         }
 
     def validate_workspace_id(self, workspace_id: str) -> PolicyDecision:


### PR DESCRIPTION
## Severity
Medium

## Vulnerability
Overly permissive authorization. Read-only endpoints for telemetry, rules, and semantic artifacts (e.g., `semantic_runs_list`, `rules_profiles_get`) were incorrectly guarded by execution-level or management permissions (e.g., `run_agent`, `manage_rule_profiles`).

## Impact
Violates the principle of least privilege. Users or services that only require read-only access to historical data or rule profiles are forced to hold execution or management privileges, broadening the attack surface if those credentials are compromised.

## Fix
1. Updated `require_runtime_permission` checks in `runtime/agent_server.py` to use granular, read-only actions: `read_semantic_runs`, `read_rule_profiles`, and `read_semantic_artifacts` for respective GET endpoints.
2. Registered these new actions in `runtime/policy.py` by adding them to the base `_OPERATIONAL` permission set and granting them to the non-destructive `viewer` role.

## Validation
- Executed `bash scripts/ci/run_basic_ci.sh` to ensure no regressions in core test suites or linting.
- Executed targeted tests (`uv run pytest extraction/tests/test_policy.py`) to confirm policy mappings.

## Risks
Low. Existing operational roles (e.g., `user`, `admin`) retain their previous access because the new granular permissions were strictly appended to the base `_OPERATIONAL` set. It merely allows more precise scoping for read-only credentials moving forward.

---
*PR created automatically by Jules for task [1226531699612047791](https://jules.google.com/task/1226531699612047791) started by @tteon*