### PR TITLE
fix(extraction): coerce bare-array LLM payloads instead of silent heuristic fallback

### DIFF
--- a/src/seocho/index/extraction_engine.py
+++ b/src/seocho/index/extraction_engine.py
@@ -235,8 +235,31 @@ class CanonicalExtractionEngine:
                 lines.append(f"{label}: {value}")
         return "\n".join(lines)
 
-    def normalize_payload(self, extracted: Dict[str, Any]) -> Dict[str, Any]:
+    def normalize_payload(self, extracted: Any) -> Dict[str, Any]:
         """Normalize arbitrary LLM payloads into the graph write contract."""
+
+        # Some models (e.g. MiniMax) occasionally return a bare JSON array instead
+        # of the {nodes, relationships} object the prompt requests. Coerce it so a
+        # malformed-but-useful response is not silently dropped to the heuristic
+        # fallback (§18 no-silent-fallback): triple-shaped items -> relationships,
+        # everything else -> nodes.
+        if isinstance(extracted, list):
+            def _is_triple(item: Any) -> bool:
+                if not isinstance(item, dict):
+                    return False
+                keys = set(item)
+                return bool(
+                    {"subject", "object"} <= keys
+                    or {"source", "target"} <= keys
+                    or {"from", "to"} <= keys
+                    or {"head", "tail"} <= keys
+                )
+
+            rels = [x for x in extracted if _is_triple(x)]
+            nodes = [x for x in extracted if isinstance(x, dict) and not _is_triple(x)]
+            extracted = {"nodes": nodes, "relationships": rels}
+        elif not isinstance(extracted, dict):
+            extracted = {}
 
         raw_nodes = list(extracted.get("nodes", []) or [])
         raw_relationships = list(extracted.get("relationships", []) or [])

--- a/tests/seocho/test_extraction_engine.py
+++ b/tests/seocho/test_extraction_engine.py
@@ -154,3 +154,33 @@ def test_canonical_extraction_engine_retries_in_relaxed_mode_after_empty_ontolog
     assert "Retry once in relaxed mode" in llm.calls[1]["system"]
     assert llm.calls[1]["reasoning_mode"] is False
     assert llm.calls[1]["task_hint"] == "json_extraction_retry"
+
+
+def test_normalize_payload_coerces_bare_node_list():
+    # Some models (e.g. MiniMax) return a bare JSON array of entities instead of
+    # the {nodes, relationships} object. It must not crash into the heuristic
+    # fallback (§18) — coerce a node-shaped list to nodes.
+    engine = CanonicalExtractionEngine(ontology=None, llm=None)
+    out = engine.normalize_payload(
+        [
+            {"name": "Basal cell carcinoma", "label": "Disease"},
+            {"name": "skin", "label": "Anatomy"},
+        ]
+    )
+    assert len(out["nodes"]) == 2
+    assert out["relationships"] == []
+
+
+def test_normalize_payload_coerces_bare_triple_list():
+    engine = CanonicalExtractionEngine(ontology=None, llm=None)
+    out = engine.normalize_payload(
+        [{"subject": "BCC", "predicate": "IS_A", "object": "skin cancer"}]
+    )
+    assert len(out["relationships"]) == 1
+    assert out["relationships"][0]["type"] == "IS_A"
+
+
+def test_normalize_payload_tolerates_non_mapping():
+    engine = CanonicalExtractionEngine(ontology=None, llm=None)
+    assert engine.normalize_payload(None) == {"nodes": [], "relationships": []}
+    assert engine.normalize_payload("garbage") == {"nodes": [], "relationships": []}


### PR DESCRIPTION
## Feature
`CanonicalExtractionEngine.normalize_payload` now tolerates a bare JSON **array** payload from the extraction LLM, instead of crashing into the silent heuristic fallback.

## Why
The method assumed the LLM returns a `{nodes, relationships}` object. Some OpenAI-compatible models (observed: **MiniMax-M2.5**) occasionally return a bare JSON array of entities. `extracted.get(...)` then raised `'list' object has no attribute 'get'`, which `pipeline.py` swallowed into `_fallback_extract` — silently degrading the graph to capitalized-token `Entity` nodes. That is a **§18 no-silent-fallback violation**: installing/using such a model quietly produces a garbage graph with no error surfaced.

Reproduced on the GraphRAG-Bench **medical** corpus (every chunk fell back; 0 real extraction) while the same model was clean on the novel corpus — i.e. content/chunk-size-dependent and easy to miss.

## Design
- If the payload is a `list`: partition items — triple-shaped (`subject/object`, `source/target`, `from/to`, `head/tail`) → `relationships`; everything else → `nodes`.
- If the payload is neither dict nor list → empty graph (no crash).
- Dict payloads are unchanged (existing path).

## Expected Effect
Models that emit a bare array now produce a real typed graph instead of a heuristic-token graph; no behavior change for well-formed dict responses.

## Validation
`tests/seocho/test_extraction_engine.py`: 3 new unit tests (bare node list, bare triple list, non-mapping) + existing 4 — **7 passed**.

## Risks
Low. Pure input-normalization at the boundary; dict path untouched. Triple-vs-node routing is heuristic but only applies to already-malformed (list) responses that previously yielded nothing.