### PR TITLE
feat(sdk,cli): Jinja2 run-spec templates + seocho sweep variant matrix (seocho-aoa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ export MARA_API_KEY=...
 seocho run examples/run/quickstart.yaml
 ```
 
-`seocho run --init` writes a commented template. See
-[docs/RUN_SPECS.md](docs/RUN_SPECS.md) for per-phase models, agent patterns,
-and ontology enforcement modes.
+`seocho run --init` writes a commented template. To compare N configurations
+(models, enforcement modes, agent patterns) in one table, declare them as
+variants of a Jinja2 template and run `seocho sweep` — see
+[docs/RUN_SPECS.md](docs/RUN_SPECS.md) for templates, sweeps, per-phase
+models, and ontology enforcement modes.
 
 ## How SEOCHO Works
 

--- a/docs/RUN_SPECS.md
+++ b/docs/RUN_SPECS.md
@@ -131,10 +131,13 @@ env var (`MARA_API_KEY`, `OPENAI_API_KEY`, ...).
 ```
 seocho run [CONFIG] [options]
 
-  CONFIG            Run spec YAML (default: ./seocho.run.yaml)
+  CONFIG            Run spec YAML, or a Jinja2 template (*.yaml.j2)
   --init            Write a commented template and exit (refuses to overwrite)
   --dry-run         Validate config + offline preflight; no LLM calls
   --only index|query  Run a single phase (query reuses the existing graph)
+  --var KEY=VALUE   Template variable (*.j2 only; repeatable, dotted keys)
+  --vars FILE       YAML file of template variables (repeatable)
+  --show-rendered   Print the rendered YAML (pre-${ENV}) and exit
   -o, --output DIR  Report directory (default: runs/<name>-<timestamp>/)
   --force           Re-index files even if unchanged
   --output-json     Machine-readable output
@@ -155,3 +158,105 @@ indexing stats, per-question records with latency and errors) and
 answers and per-question errors are surfaced in the summary table; a
 question error marks the run as failed (exit 1) without aborting remaining
 questions.
+
+## Templates and sweeps
+
+Doctrine:
+
+- `run` — one resolved spec, one report. A spec may be a Jinja2 template;
+  rendering produces the one spec.
+- `sweep` — one template × N variable sets → N runs → one comparison summary.
+- `experiment` — extraction-only micro-benchmark over a single text/dir
+  (no query phase, no run reports).
+
+### Two substitution layers
+
+| Layer | Syntax | Resolved | Use for |
+| --- | --- | --- | --- |
+| Jinja2 | `{{ var }}`, `{% for %}` | authoring/render time, before YAML parse | parameters, variants, structure |
+| Env | `${VAR}`, `${VAR:-default}` | load time, after rendering | secrets — never persisted into artifacts |
+
+Rendering is decided by **file extension only** (`*.j2`); plain `.yaml`
+configs never touch the template layer, so question text containing `{{`
+stays untouched (use `{% raw %}` for literal braces inside templates).
+Supplying `--var`/`--vars` for a non-template config is an error.
+
+Authoring rule: **quote every string substitution** (`"{{ model }}"`),
+**never quote numeric/boolean ones** (`{{ limit | default(5) }}`) — this
+avoids YAML flow-mapping breakage and the Norway problem in one rule.
+
+Variable precedence (low → high): template `| default(...)` < sweep `vars:`
+< variant `vars:` < `--vars` files (in order) < `--var` flags. Mappings
+deep-merge; scalars and lists are replaced. `--var` keys may be dotted
+(`models.indexing=...`) and values are YAML-parsed (`limit=10` → int).
+`variant` and `sweep` are reserved names — `seocho sweep` injects
+`variant.name`, `variant.index`, and `sweep.name` per variant.
+
+### Sweep file
+
+```yaml
+# seocho.sweep.yaml
+name: enforcement-shootout      # default: filename stem
+template: ./run.yaml.j2         # required; rendered once per variant
+vars:                           # shared by every variant (optional)
+  model: mara/MiniMax-M2.5
+variants:                       # required, non-empty; unique names
+  - name: guided
+    vars: { enforcement: guided }
+  - name: strict
+    vars: { enforcement: strict }
+output:
+  dir: runs
+```
+
+```
+seocho sweep [SWEEP] [options]
+
+  SWEEP                  Sweep spec YAML (default: ./seocho.sweep.yaml)
+  --init                 Write seocho.sweep.yaml + run.yaml.j2 and exit
+  --dry-run              Render + validate every variant + offline preflight
+  --show-rendered [NAME] Print rendered YAML (one variant, or all) and exit
+  --only-variant NAME    Run a subset (repeatable)
+  --var / --vars         Variable overrides applied to ALL variants
+  --fail-fast            Stop at the first failed variant (default: keep going)
+  -o, --output DIR       Sweep root (default: runs/<name>-<timestamp>/)
+
+Exit codes: 0 all variants ok · 1 any variant failed · 2 config error
+```
+
+Config errors are collected across **all** variants up front and nothing
+runs (exit 2); runtime failures keep going by default and the comparison
+table marks them (exit 1).
+
+### Variant isolation
+
+Each variant is fully isolated, automatically:
+
+- blank `graph:` → its own embedded store at `<sweep>/<variant>/graph.lbug`
+  (one `.lbug` file is one graph — paths isolate, names do not);
+- `bolt://` targets keep the URI but get a per-variant `database` when blank;
+- `workspace_id` is **always** suffixed with the variant name — the response
+  cache is keyed by workspace, so two variants differing only by model would
+  otherwise serve each other's cached answers;
+- `.seocho_index` change tracking is disabled (`track=False`), so variant
+  N+1 never skips files as "unchanged" and your docs directory stays clean.
+
+Variants run sequentially: the embedded store is a single-writer engine and
+parallel variants would mostly time-slice the same LLM rate limit.
+
+### Sweep artifacts
+
+```
+runs/<sweep-name>-<timestamp>/
+  summary.json / summary.md     # comparison table + per-variant status
+  <variant>/
+    rendered.yaml               # resolved spec (pre-${ENV}, paths absolutized)
+                                #   reproduce standalone: seocho run rendered.yaml
+    report.json / report.md
+    graph.lbug
+```
+
+A runnable example lives at
+[examples/run/sweep-enforcement/](../examples/run/sweep-enforcement/) —
+the quickstart documents indexed under `guided`, `strict`, and `open`
+enforcement, compared in one table.

--- a/examples/run/sweep-enforcement/run.yaml.j2
+++ b/examples/run/sweep-enforcement/run.yaml.j2
@@ -1,0 +1,17 @@
+# Jinja2 run-spec template for the enforcement shootout sweep.
+# Reuses the quickstart schema and documents one directory up.
+name: enforcement-demo
+
+ontology:
+  path: ../schema.yaml
+  enforcement: "{{ enforcement | default('guided') }}"
+
+documents: ../docs/
+
+models:
+  default: "{{ model | default('mara/MiniMax-M2.5') }}"
+
+questions:
+  - What product does Acme Corp offer?
+  - Who is the CEO of Acme Corp?
+  - What did Beta Industries acquire?

--- a/examples/run/sweep-enforcement/sweep.yaml
+++ b/examples/run/sweep-enforcement/sweep.yaml
@@ -1,0 +1,21 @@
+# Enforcement shootout — the same documents and questions indexed under all
+# three ontology enforcement modes, compared in one table:
+#
+#   export MARA_API_KEY=...
+#   seocho sweep examples/run/sweep-enforcement/sweep.yaml
+#
+# Each variant gets an isolated embedded graph, workspace, and report under
+# runs/enforcement-shootout-<timestamp>/<variant>/.
+name: enforcement-shootout
+template: ./run.yaml.j2
+
+vars:
+  model: mara/MiniMax-M2.5
+
+variants:
+  - name: guided
+    vars: { enforcement: guided }
+  - name: strict
+    vars: { enforcement: strict }
+  - name: open
+    vars: { enforcement: open }

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -55,6 +55,7 @@ python3 -m py_compile \
   src/seocho/index/enforcement.py \
   src/seocho/index/pipeline.py \
   src/seocho/run_spec.py \
+  src/seocho/run_template.py \
   src/seocho/run_preflight.py \
   src/seocho/e2e.py \
   src/seocho/cli.py
@@ -120,6 +121,8 @@ uv run pytest \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \
   tests/seocho/test_ontology_enforcement.py \
+  tests/seocho/test_run_template.py \
+  tests/seocho/test_sweep.py \
   -q
 
 git diff --check

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -114,6 +114,7 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
     ],
     ".e2e": [
         "run_from_config",
+        "run_sweep_from_config",
     ],
     ".http_runtime": [
         "create_bundle_runtime_app",
@@ -185,6 +186,12 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
         "enforce_drift_policy",
         "ontology_context_graph_properties",
         "query_ontology_context_mismatch",
+    ],
+    ".run_template": [
+        "SweepSpec",
+        "load_sweep_spec",
+        "load_templated_run_spec",
+        "render_run_template",
     ],
     ".run_spec": [
         "RunSpec",

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -238,7 +238,10 @@ def build_parser() -> argparse.ArgumentParser:
     compare_parser.add_argument("--model-b", default=None, help="LLM model for config B (default: same as A)")
     compare_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
-    experiment_parser = subparsers.add_parser("experiment", help="Run multi-axis parameter exploration")
+    experiment_parser = subparsers.add_parser(
+        "experiment",
+        help="Run extraction-only multi-axis exploration (full e2e variants: see seocho sweep)",
+    )
     experiment_parser.add_argument("--input", required=True, help="Input text, @file, or directory path")
     experiment_parser.add_argument("--ontology", action="append", default=[], help="Ontology files to vary (repeat for multiple)")
     experiment_parser.add_argument("--model", action="append", default=[], help="LLM models to vary")
@@ -358,7 +361,67 @@ def build_parser() -> argparse.ArgumentParser:
         "--force", action="store_true",
         help="Re-index files even if unchanged",
     )
+    run_parser.add_argument(
+        "--var", action="append", dest="var_flags", default=None, metavar="KEY=VALUE",
+        help="Template variable for *.j2 configs (repeatable; dotted keys, YAML values)",
+    )
+    run_parser.add_argument(
+        "--vars", action="append", dest="vars_files", default=None, metavar="FILE",
+        help="YAML file of template variables (repeatable; --var overrides)",
+    )
+    run_parser.add_argument(
+        "--show-rendered", action="store_true",
+        help="Print the rendered YAML (pre-${ENV}) to stdout and exit",
+    )
     run_parser.add_argument("--output-json", action="store_true", help="Emit JSON")
+
+    sweep_parser = subparsers.add_parser(
+        "sweep",
+        help="Run one Jinja2 run-spec template across N variants and compare the outcomes",
+    )
+    sweep_parser.add_argument(
+        "config",
+        nargs="?",
+        default="seocho.sweep.yaml",
+        help="Sweep spec YAML (default: ./seocho.sweep.yaml)",
+    )
+    sweep_parser.add_argument(
+        "--init", action="store_true",
+        help="Write seocho.sweep.yaml + run.yaml.j2 templates and exit",
+    )
+    sweep_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Render + validate every variant and run offline preflight; no LLM calls",
+    )
+    sweep_parser.add_argument(
+        "--show-rendered", nargs="?", const="", default=None, metavar="VARIANT",
+        help="Print rendered YAML (one variant, or all when no name given) and exit",
+    )
+    sweep_parser.add_argument(
+        "--only-variant", action="append", dest="only_variants", default=None,
+        metavar="NAME", help="Run a subset of variants (repeatable)",
+    )
+    sweep_parser.add_argument(
+        "--var", action="append", dest="var_flags", default=None, metavar="KEY=VALUE",
+        help="Variable override applied to ALL variants (repeatable)",
+    )
+    sweep_parser.add_argument(
+        "--vars", action="append", dest="vars_files", default=None, metavar="FILE",
+        help="Shared variables YAML file (repeatable)",
+    )
+    sweep_parser.add_argument(
+        "--fail-fast", action="store_true",
+        help="Stop at the first failed variant (default: keep going)",
+    )
+    sweep_parser.add_argument(
+        "-o", "--output", default=None,
+        help="Sweep directory root (default: runs/<name>-<timestamp>/)",
+    )
+    sweep_parser.add_argument(
+        "--force", action="store_true",
+        help="Re-index files even if unchanged",
+    )
+    sweep_parser.add_argument("--output-json", action="store_true", help="Emit JSON")
 
     traces_parser = subparsers.add_parser(
         "traces",
@@ -393,7 +456,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-LOCAL_COMMANDS = {"init", "index", "local-ask", "status", "compare", "experiment", "bundle", "ontology", "serve-http", "traces", "run"}
+LOCAL_COMMANDS = {"init", "index", "local-ask", "status", "compare", "experiment", "bundle", "ontology", "serve-http", "traces", "run", "sweep"}
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -834,6 +897,8 @@ def _dispatch_local(args: argparse.Namespace) -> int:
         return _cmd_traces(args)
     if args.command == "run":
         return _cmd_run(args)
+    if args.command == "sweep":
+        return _cmd_sweep(args)
     raise SeochoError(f"Unknown local command: {args.command}")
 
 
@@ -1069,6 +1134,43 @@ def _cmd_run(args: argparse.Namespace) -> int:
         output_dir=args.output,
         force=args.force,
         json_output=getattr(args, "output_json", False),
+        vars_files=getattr(args, "vars_files", None),
+        var_flags=getattr(args, "var_flags", None),
+        show_rendered=getattr(args, "show_rendered", False),
+    )
+
+
+def _cmd_sweep(args: argparse.Namespace) -> int:
+    """Run a sweep (or write the sweep + template pair with --init)."""
+    if args.init:
+        from .run_template import RUN_J2_TEMPLATE, SWEEP_TEMPLATE
+
+        sweep_target = Path(args.config)
+        template_target = sweep_target.parent / "run.yaml.j2"
+        for target in (sweep_target, template_target):
+            if target.exists():
+                print(f"{target} already exists — refusing to overwrite.", file=sys.stderr)
+                return 1
+        sweep_target.write_text(SWEEP_TEMPLATE, encoding="utf-8")
+        template_target.write_text(RUN_J2_TEMPLATE, encoding="utf-8")
+        print(f"Sweep spec written to {sweep_target}")
+        print(f"Run template written to {template_target}")
+        print("Edit the variants and template, then: seocho sweep")
+        return 0
+
+    from .e2e import run_sweep_from_config
+
+    return run_sweep_from_config(
+        args.config,
+        vars_files=getattr(args, "vars_files", None),
+        var_flags=getattr(args, "var_flags", None),
+        dry_run=args.dry_run,
+        only_variants=getattr(args, "only_variants", None),
+        fail_fast=args.fail_fast,
+        output_dir=args.output,
+        force=args.force,
+        json_output=getattr(args, "output_json", False),
+        show_rendered=getattr(args, "show_rendered", None),
     )
 
 

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1331,6 +1331,7 @@ class Seocho:
         force: bool = False,
         on_file: Optional[Any] = None,
         strict_validation: Optional[bool] = None,
+        track: bool = True,
     ) -> Dict[str, Any]:
         """Index all supported files in a directory.
 
@@ -1351,6 +1352,10 @@ class Seocho:
         strict_validation:
             When True, chunks failing SHACL validation are rejected
             (not written). Defaults to the pipeline's configured flag.
+        track:
+            When False, skip ``.seocho_index`` change tracking entirely
+            (no reads, no writes) — every file indexes fresh. Used by
+            ``seocho sweep`` so variants never skip each other's files.
 
         Returns
         -------
@@ -1365,7 +1370,7 @@ class Seocho:
         result = indexer.index_directory(
             directory, database=database, category=category,
             recursive=recursive, force=force, on_file=on_file,
-            strict_validation=strict_validation,
+            strict_validation=strict_validation, track=track,
         )
         return result.to_dict()
 

--- a/src/seocho/e2e.py
+++ b/src/seocho/e2e.py
@@ -21,7 +21,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .run_spec import RunSpec, RunSpecError, load_run_spec, parse_model_ref
 from .run_preflight import run_preflight
@@ -207,7 +207,9 @@ def _emit(quiet: bool, message: str = "") -> None:
         print(message)
 
 
-def _run_index_phase(ctx: RunContext, *, force: bool, quiet: bool) -> Dict[str, Any]:
+def _run_index_phase(
+    ctx: RunContext, *, force: bool, quiet: bool, track: bool = True
+) -> Dict[str, Any]:
     spec = ctx.spec
     path = ctx.documents_path
     strict = spec.strict_validation()
@@ -242,6 +244,7 @@ def _run_index_phase(ctx: RunContext, *, force: bool, quiet: bool) -> Dict[str, 
             force=force or bool(spec.indexing.get("force", False)),
             on_file=None if quiet else _on_file,
             strict_validation=strict,
+            track=track,
         )
 
     total_nodes = 0
@@ -364,6 +367,7 @@ def run(
     only: Optional[str] = None,
     force: bool = False,
     quiet: bool = False,
+    track: bool = True,
 ) -> RunReport:
     """Execute the run: index → query → report. ``only`` limits to one phase."""
     spec = ctx.spec
@@ -389,7 +393,7 @@ def run(
     if only in (None, "index"):
         _emit(quiet, f"Phase {phase}/{phase_count}: Indexing ({ctx.documents_path})")
         started = time.monotonic()
-        payload["indexing"] = _run_index_phase(ctx, force=force, quiet=quiet)
+        payload["indexing"] = _run_index_phase(ctx, force=force, quiet=quiet, track=track)
         durations["index_s"] = round(time.monotonic() - started, 2)
         phase += 1
         _emit(quiet)
@@ -442,6 +446,35 @@ def _print_summary(payload: Dict[str, Any]) -> None:
     print()
 
 
+def run_spec_once(
+    spec: RunSpec,
+    *,
+    only: Optional[str] = None,
+    force: bool = False,
+    quiet: bool = False,
+    track: bool = True,
+    output_dir_override: "Optional[str | Path]" = None,
+) -> RunReport:
+    """Build and execute one already-validated spec (preflight is the
+    caller's responsibility). ``output_dir_override`` places the report
+    exactly there instead of the derived ``<output>/<name>-<ts>/`` dir —
+    sweeps use it to land artifacts in their per-variant directory."""
+    ctx = build(spec)
+    if output_dir_override is not None:
+        ctx.output_dir = Path(output_dir_override)
+    try:
+        return run(ctx, only=only, force=force, quiet=quiet, track=track)
+    finally:
+        ctx.close()
+
+
+def _print_config_errors(config_path: Any, errors: List[str]) -> None:
+    count = len(errors)
+    print(f"{config_path}: {count} config error{'s' if count != 1 else ''}", file=sys.stderr)
+    for error in errors:
+        print(f"  {error}", file=sys.stderr)
+
+
 def run_from_config(
     config_path: "str | Path",
     *,
@@ -450,19 +483,41 @@ def run_from_config(
     output_dir: Optional[str] = None,
     force: bool = False,
     json_output: bool = False,
+    vars_files: Optional[List[str]] = None,
+    var_flags: Optional[List[str]] = None,
+    show_rendered: bool = False,
 ) -> int:
     """CLI-facing orchestration: load spec → preflight → build → run.
 
+    ``*.j2`` configs are rendered with Jinja2 (variables from ``--vars``
+    files and ``--var`` flags) before parsing; plain YAML configs never
+    touch the template layer, and supplying vars for one is an error.
+
     Exit codes: 0 ok, 1 runtime/preflight failure, 2 invalid config.
     """
+    from .run_template import collect_cli_vars, is_template_path, load_templated_run_spec
+
+    rendered_text: Optional[str] = None
     try:
-        spec = load_run_spec(config_path)
+        cli_vars = collect_cli_vars(vars_files, var_flags)
+        if is_template_path(str(config_path)):
+            spec, rendered_text = load_templated_run_spec(config_path, cli_vars)
+        else:
+            if cli_vars or show_rendered:
+                raise RunSpecError(
+                    [
+                        "--var/--vars/--show-rendered require a Jinja2 template; "
+                        f"{config_path} is not a .j2 file. Rename it to "
+                        "<name>.yaml.j2 to opt into templating."
+                    ]
+                )
+            spec = load_run_spec(config_path)
     except RunSpecError as exc:
-        count = len(exc.errors)
-        print(f"{config_path}: {count} config error{'s' if count != 1 else ''}", file=sys.stderr)
-        for error in exc.errors:
-            print(f"  {error}", file=sys.stderr)
+        _print_config_errors(config_path, exc.errors)
         return 2
+    if show_rendered:
+        print(rendered_text, end="" if str(rendered_text).endswith("\n") else "\n")
+        return 0
     if output_dir:
         spec.output_dir = output_dir
 
@@ -499,15 +554,333 @@ def run_from_config(
             }, ensure_ascii=False))
         return 0
 
-    ctx = build(spec)
-    try:
-        result = run(ctx, only=only, force=force, quiet=quiet)
-    finally:
-        ctx.close()
+    result = run_spec_once(spec, only=only, force=force, quiet=quiet)
 
     if json_output:
         print(json.dumps(result.payload, indent=2, ensure_ascii=False))
     return 0 if result.ok else 1
+
+
+# ---------------------------------------------------------------------------
+# Sweep: one template × N variants → N runs → one comparison summary
+# ---------------------------------------------------------------------------
+
+
+def _sweep_row(variant_name: str, status: str, payload: Optional[Dict[str, Any]] = None,
+               detail: str = "") -> Dict[str, Any]:
+    row: Dict[str, Any] = {"variant": variant_name, "status": status}
+    if detail:
+        row["detail"] = detail
+    if not payload:
+        return row
+    indexing = payload.get("indexing") or {}
+    queries = payload.get("queries")
+    durations = (payload.get("run") or {}).get("durations") or {}
+    row.update(
+        {
+            "files_found": int(indexing.get("files_found", 0)),
+            "files_indexed": int(indexing.get("files_indexed", 0)),
+            "files_failed": int(indexing.get("files_failed", 0)),
+            "nodes": int(indexing.get("total_nodes", 0)),
+            "rels": int(indexing.get("total_relationships", 0)),
+            "validation_errors": int(indexing.get("validation_errors_count", 0)),
+            "index_s": durations.get("index_s"),
+            "query_s": durations.get("query_s"),
+        }
+    )
+    if queries is not None:
+        row["questions"] = len(queries)
+        row["answered"] = sum(
+            1 for item in queries if not item.get("error") and not item.get("empty")
+        )
+        row["empty"] = sum(1 for item in queries if item.get("empty"))
+        row["query_errors"] = sum(1 for item in queries if item.get("error"))
+    return row
+
+
+def _format_sweep_table(rows: List[Dict[str, Any]]) -> List[str]:
+    headers = ("variant", "files", "nodes", "rels", "answered", "empty", "errors",
+               "index_s", "query_s", "")
+    table_rows: List[Tuple[str, ...]] = []
+    for row in rows:
+        if row.get("files_found") is not None and row["status"] in ("ok", "failed"):
+            answered = (
+                f"{row.get('answered', 0)}/{row.get('questions', 0)}"
+                if row.get("questions") is not None
+                else "-"
+            )
+            table_rows.append(
+                (
+                    str(row["variant"]),
+                    f"{row.get('files_indexed', 0)}/{row.get('files_found', 0)}",
+                    str(row.get("nodes", 0)),
+                    str(row.get("rels", 0)),
+                    answered,
+                    str(row.get("empty", 0)),
+                    str(row.get("query_errors", 0)),
+                    str(row.get("index_s", "-")),
+                    str(row.get("query_s", "-")),
+                    "" if row["status"] == "ok" else "FAILED",
+                )
+            )
+        else:
+            table_rows.append(
+                (str(row["variant"]), "-", "-", "-", "-", "-", "-", "-", "-",
+                 row["status"].upper())
+            )
+    widths = [
+        max(len(headers[col]), *(len(item[col]) for item in table_rows))
+        for col in range(len(headers))
+    ]
+    lines = [
+        "  " + "  ".join(headers[col].ljust(widths[col]) for col in range(len(headers))).rstrip(),
+        "  " + "─" * (sum(widths) + 2 * (len(headers) - 1)),
+    ]
+    for item in table_rows:
+        lines.append(
+            "  " + "  ".join(item[col].ljust(widths[col]) for col in range(len(headers))).rstrip()
+        )
+    return lines
+
+
+def _render_sweep_summary_md(sweep_payload: Dict[str, Any]) -> str:
+    info = sweep_payload.get("sweep", {})
+    rows = sweep_payload.get("variants", [])
+    lines = [
+        f"# SEOCHO sweep: {info.get('name', '')}",
+        "",
+        f"- template: {info.get('template', '')}",
+        f"- started: {info.get('started_at', '')}",
+        f"- variants: {len(rows)}",
+        "",
+        "| variant | status | files | nodes | rels | answered | empty | errors | index_s | query_s |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        answered = (
+            f"{row.get('answered', 0)}/{row.get('questions', 0)}"
+            if row.get("questions") is not None
+            else "-"
+        )
+        lines.append(
+            f"| {row['variant']} | {row['status']} "
+            f"| {row.get('files_indexed', '-')}/{row.get('files_found', '-')} "
+            f"| {row.get('nodes', '-')} | {row.get('rels', '-')} "
+            f"| {answered} | {row.get('empty', '-')} | {row.get('query_errors', '-')} "
+            f"| {row.get('index_s', '-')} | {row.get('query_s', '-')} |"
+        )
+    lines += [
+        "",
+        "Per-variant artifacts: `<variant>/report.md`, `<variant>/report.json`, "
+        "`<variant>/rendered.yaml` (reproduce standalone with `seocho run rendered.yaml`).",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def run_sweep_from_config(
+    config_path: "str | Path",
+    *,
+    vars_files: Optional[List[str]] = None,
+    var_flags: Optional[List[str]] = None,
+    dry_run: bool = False,
+    only_variants: Optional[List[str]] = None,
+    fail_fast: bool = False,
+    output_dir: Optional[str] = None,
+    force: bool = False,
+    json_output: bool = False,
+    show_rendered: Optional[str] = None,
+) -> int:
+    """Execute a sweep: render every variant up front (config errors are
+    collected across ALL variants and nothing runs — exit 2), then run
+    variants sequentially with per-variant isolation, keep-going by
+    default (``fail_fast`` stops at the first failure — exit 1 if any
+    variant failed), and write ``summary.json``/``summary.md``.
+    """
+    from .run_template import (
+        absolutized_rendered_text,
+        collect_cli_vars,
+        derive_variant_isolation,
+        load_sweep_spec,
+        parse_rendered_run_spec,
+        render_run_template,
+    )
+
+    try:
+        sweep = load_sweep_spec(config_path)
+        cli_vars = collect_cli_vars(vars_files, var_flags)
+    except RunSpecError as exc:
+        _print_config_errors(config_path, exc.errors)
+        return 2
+    if output_dir:
+        sweep.output_dir = output_dir
+
+    template_path = sweep.template_path()
+    if not template_path.exists():
+        _print_config_errors(config_path, [f"at template: {template_path} does not exist."])
+        return 2
+    template_text = template_path.read_text(encoding="utf-8")
+
+    selected = sweep.variants
+    if only_variants:
+        known = {variant.name for variant in sweep.variants}
+        unknown = [name for name in only_variants if name not in known]
+        if unknown:
+            _print_config_errors(
+                config_path,
+                [
+                    f"at --only-variant: unknown variant(s) {', '.join(unknown)}. "
+                    f"Declared: {', '.join(sorted(known))}."
+                ],
+            )
+            return 2
+        selected = [variant for variant in sweep.variants if variant.name in set(only_variants)]
+
+    base_dir = Path(sweep.source_path).parent if sweep.source_path else Path(".")
+    output_root = Path(sweep.output_dir)
+    if not output_root.is_absolute():
+        output_root = base_dir / output_root
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    sweep_run_dir = output_root / f"{sweep.name}-{timestamp}"
+
+    # --- Stage 1: render + validate + derive isolation for EVERY variant.
+    prepared: List[Tuple[Any, RunSpec, str]] = []
+    stage1_errors: List[str] = []
+    for index, variant in enumerate(selected):
+        variables = sweep.variant_variables(variant, index, cli_vars)
+        source = f"{template_path} (variant {variant.name})"
+        try:
+            rendered = render_run_template(template_text, variables, source=source)
+            spec = parse_rendered_run_spec(rendered, source=str(template_path))
+            derive_variant_isolation(
+                spec, variant_name=variant.name, sweep_run_dir=sweep_run_dir
+            )
+            prepared.append((variant, spec, rendered))
+        except RunSpecError as exc:
+            stage1_errors.extend(f"variant {variant.name}: {error}" for error in exc.errors)
+    if stage1_errors:
+        _print_config_errors(config_path, stage1_errors)
+        return 2
+
+    if show_rendered is not None:
+        for variant, _spec, rendered in prepared:
+            if show_rendered not in ("", variant.name):
+                continue
+            print(f"# ─── variant: {variant.name} " + "─" * 40)
+            print(rendered, end="" if rendered.endswith("\n") else "\n")
+        return 0
+
+    quiet = json_output
+    _emit(quiet, f"SEOCHO sweep: {sweep.name} ({config_path})")
+    _emit(quiet, "=" * 70)
+    _emit(
+        quiet,
+        f"Template: {sweep.template} — {len(prepared)} variants: "
+        + ", ".join(variant.name for variant, _s, _r in prepared),
+    )
+    _emit(quiet)
+
+    if dry_run:
+        any_failed = False
+        for variant, spec, _rendered in prepared:
+            _emit(quiet, f"[{variant.name}]")
+            report = run_preflight(spec, online=False)
+            _emit(quiet, report.render())
+            _emit(quiet, f"  plan  models={spec.indexing_model()}/{spec.query_model()} "
+                         f"enforcement={spec.enforcement} workspace={spec.resolved_workspace_id()}")
+            _emit(quiet, f"        graph={spec.graph}")
+            _emit(quiet)
+            any_failed = any_failed or not report.ok
+        if json_output:
+            print(json.dumps({"ok": not any_failed, "dry_run": True,
+                              "variants": [v.name for v, _s, _r in prepared]},
+                             ensure_ascii=False))
+        return 1 if any_failed else 0
+
+    # --- Stage 2: sequential execution, keep-going by default.
+    rows: List[Dict[str, Any]] = []
+    failed: List[str] = []
+    started_at = datetime.now().isoformat(timespec="seconds")
+    for position, (variant, spec, rendered) in enumerate(prepared, start=1):
+        _emit(quiet, f"[{position}/{len(prepared)}] {variant.name}")
+        preflight = run_preflight(spec, online=True)
+        if not preflight.ok:
+            _emit(quiet, preflight.render())
+            _emit(quiet, f"  variant PREFLIGHT FAILED — "
+                         f"{'stopping (--fail-fast)' if fail_fast else 'continuing'}")
+            _emit(quiet)
+            rows.append(_sweep_row(
+                variant.name, "preflight_failed",
+                detail="; ".join(check.detail for check in preflight.failures()),
+            ))
+            failed.append(variant.name)
+            if fail_fast:
+                break
+            continue
+
+        variant_dir = sweep_run_dir / variant.slug
+        variant_dir.mkdir(parents=True, exist_ok=True)
+        (variant_dir / "rendered.yaml").write_text(
+            absolutized_rendered_text(
+                rendered,
+                template_path=template_path,
+                provenance=(
+                    f"rendered by seocho sweep from {template_path} "
+                    f"(sweep {sweep.name}, variant {variant.name})"
+                ),
+            ),
+            encoding="utf-8",
+        )
+        try:
+            result = run_spec_once(
+                spec, force=force, quiet=quiet, track=False,
+                output_dir_override=variant_dir,
+            )
+            status = "ok" if result.ok else "failed"
+            rows.append(_sweep_row(variant.name, status, result.payload))
+        except Exception as exc:  # one broken variant must not sink the sweep
+            status = "error"
+            rows.append(_sweep_row(variant.name, "error", detail=str(exc)))
+            _emit(quiet, f"  variant ERROR: {exc}")
+        if status != "ok":
+            failed.append(variant.name)
+            if fail_fast:
+                _emit(quiet, "  stopping (--fail-fast)")
+                _emit(quiet)
+                break
+        _emit(quiet)
+
+    sweep_payload = {
+        "sweep": {
+            "name": sweep.name,
+            "spec_path": str(config_path),
+            "template": str(sweep.template),
+            "started_at": started_at,
+            "finished_at": datetime.now().isoformat(timespec="seconds"),
+            "failed_variants": failed,
+        },
+        "variants": rows,
+    }
+    sweep_run_dir.mkdir(parents=True, exist_ok=True)
+    (sweep_run_dir / "summary.json").write_text(
+        json.dumps(sweep_payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    (sweep_run_dir / "summary.md").write_text(
+        _render_sweep_summary_md(sweep_payload), encoding="utf-8"
+    )
+
+    if json_output:
+        print(json.dumps(sweep_payload, indent=2, ensure_ascii=False))
+    else:
+        print("Sweep summary")
+        for line in _format_sweep_table(rows):
+            print(line)
+        print()
+        if failed:
+            print(f"{len(failed)} of {len(rows)} variants failed: {', '.join(failed)}")
+        print(f"Sweep dir: {sweep_run_dir}")
+        print("  summary: summary.md · summary.json · per-variant report.md + rendered.yaml")
+    return 1 if failed else 0
 
 
 __all__ = [
@@ -517,4 +890,6 @@ __all__ = [
     "build_agent_config",
     "run",
     "run_from_config",
+    "run_spec_once",
+    "run_sweep_from_config",
 ]

--- a/src/seocho/index/file_reader.py
+++ b/src/seocho/index/file_reader.py
@@ -478,6 +478,7 @@ class FileIndexer:
         force: bool = False,
         on_file: Optional[Callable[[str, int, int], None]] = None,
         strict_validation: Optional[bool] = None,
+        track: bool = True,
     ) -> DirectoryIndexResult:
         """Index all supported files in a directory.
 
@@ -494,6 +495,13 @@ class FileIndexer:
         strict_validation:
             When set, overrides the pipeline's ``strict_validation``
             flag for every file in this directory.
+        track:
+            When False, no ``.seocho_index`` tracking state is read or
+            written — every file is indexed fresh and the docs directory
+            stays untouched. Sweeps use this so variant N+1 is not
+            skipped as "unchanged" and the tracker is not rebound to a
+            variant-local graph. (``force`` is not a substitute: it still
+            records tracking state.)
 
         Returns
         -------
@@ -503,7 +511,7 @@ class FileIndexer:
         if not directory.is_dir():
             return DirectoryIndexResult(directory=str(directory))
 
-        tracker = FileTracker(directory)
+        tracker = FileTracker(directory) if track else None
 
         # Discover files
         files: List[Path] = []
@@ -547,5 +555,6 @@ class FileIndexer:
             elif file_result.status == "unchanged":
                 result.files_unchanged += 1
 
-        tracker.save()
+        if tracker is not None:
+            tracker.save()
         return result

--- a/src/seocho/run_template.py
+++ b/src/seocho/run_template.py
@@ -1,0 +1,570 @@
+"""Jinja2-templated run specs and sweep specs for ``seocho run`` / ``seocho sweep``.
+
+Pure layer: jinja2 + yaml + :mod:`seocho.run_spec` only — no store, LLM, or
+graph imports (same doctrine as ``run_spec.py``).
+
+Two distinct substitution layers, resolved in a fixed order:
+
+1. **Jinja2** (``{{ var }}``, ``{% for %}``) — authoring-time variables,
+   rendered before YAML parsing. Whether rendering happens is decided by
+   the file extension (``*.j2``) only; plain ``.yaml`` files never touch
+   this module, so question text containing ``{{`` stays untouched.
+2. **``${ENV}``** interpolation — load-time secrets, resolved inside
+   :func:`seocho.run_spec.parse_run_spec` *after* rendering. Artifacts
+   persist the pre-``${ENV}`` rendered text, so secrets never land on disk.
+
+Authoring rule (documented in the templates): quote every string
+substitution, never quote numeric/boolean ones — this avoids both the
+YAML flow-mapping breakage and the Norway problem in one rule.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import yaml
+
+from .run_spec import (
+    RunSpec,
+    RunSpecError,
+    _check_unknown_keys,
+    _string,
+    parse_run_spec,
+)
+
+#: Variable names injected per variant by ``seocho sweep`` — reserved.
+RESERVED_VAR_NAMES = ("variant", "sweep")
+
+DEFAULT_SWEEP_SPEC_FILENAME = "seocho.sweep.yaml"
+
+_SWEEP_TOP_LEVEL_KEYS = {"name", "template", "vars", "variants", "output"}
+_SWEEP_VARIANT_KEYS = {"name", "vars"}
+_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+_DB_SAFE_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(text: str) -> str:
+    return _SLUG_RE.sub("_", str(text).strip().lower()).strip("_")
+
+
+def render_run_template(
+    text: str,
+    variables: Mapping[str, Any],
+    *,
+    source: str = "<template>",
+) -> str:
+    """Render a Jinja2 run-spec template with collect-all missing-variable
+    reporting.
+
+    Variables with an inline ``| default(...)`` are fine; every *used*
+    undefined variable is collected (string substitutions all in one pass;
+    a structural use such as looping over a missing list stops the pass)
+    and reported together via :class:`RunSpecError` (CLI exit 2).
+    """
+    from jinja2 import Environment, StrictUndefined, TemplateSyntaxError
+    from jinja2.exceptions import UndefinedError
+
+    missing: List[str] = []
+
+    class _CollectingUndefined(StrictUndefined):
+        # NOTE: StrictUndefined binds its protocol methods (__iter__,
+        # __len__, ...) to Undefined._fail_with_undefined_error at class
+        # creation, so overriding that method here only affects new
+        # call sites; structural uses still raise UndefinedError, which
+        # the render loop below catches and records.
+        def _remember(self) -> str:
+            name = self._undefined_name or "<expression>"
+            if name not in missing:
+                missing.append(name)
+            return name
+
+        def __str__(self) -> str:
+            self._remember()
+            return ""
+
+    env = Environment(
+        undefined=_CollectingUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        autoescape=False,
+    )
+    # Deliberately no os.environ global — secrets stay in the ${ENV} layer.
+    try:
+        template = env.from_string(text)
+    except TemplateSyntaxError as exc:
+        raise RunSpecError(
+            [f"at template {source}:{exc.lineno}: template syntax error: {exc.message}."]
+        ) from exc
+
+    rendered = ""
+    try:
+        rendered = template.render(**dict(variables))
+    except UndefinedError as exc:
+        # Structural use of a missing variable (loop/attribute) — record
+        # it; string substitutions were already collected by __str__.
+        match = re.search(r"'([^']+)' is undefined", str(exc))
+        name = match.group(1) if match else str(exc)
+        if name not in missing:
+            missing.append(name)
+    except TemplateSyntaxError as exc:
+        raise RunSpecError(
+            [f"at template {source}:{exc.lineno}: template syntax error: {exc.message}."]
+        ) from exc
+
+    if missing:
+        names = ", ".join(f"'{name}'" for name in missing)
+        raise RunSpecError(
+            [
+                f"at template {source}: undefined variable(s) {names}. "
+                "Pass --var <name>=..., add them to a --vars file, or give "
+                'a default in the template: {{ <name> | default("...") }}.'
+            ]
+        )
+    return rendered
+
+
+def parse_var_assignment(text: str) -> Tuple[List[str], Any]:
+    """Parse one ``--var key=value`` assignment.
+
+    Keys may be dotted (``models.indexing=...`` → nested mapping). Values
+    are YAML-parsed so ``limit=10`` is an int and ``force=true`` a bool;
+    force a string with explicit quotes: ``--var 'name="2024"'``.
+    """
+    if "=" not in text:
+        raise RunSpecError(
+            [f"at --var: expected key=value, got {text!r}."]
+        )
+    raw_key, raw_value = text.split("=", 1)
+    key_path = [part.strip() for part in raw_key.strip().split(".")]
+    if not all(key_path):
+        raise RunSpecError([f"at --var: invalid key {raw_key!r}."])
+    try:
+        value = yaml.safe_load(raw_value)
+    except yaml.YAMLError:
+        value = raw_value
+    return key_path, value
+
+
+def _nest(key_path: List[str], value: Any) -> Dict[str, Any]:
+    nested: Dict[str, Any] = {}
+    cursor = nested
+    for part in key_path[:-1]:
+        cursor[part] = {}
+        cursor = cursor[part]
+    cursor[key_path[-1]] = value
+    return nested
+
+
+def merge_vars(*layers: Mapping[str, Any]) -> Dict[str, Any]:
+    """Deep-merge variable layers (later wins). Mappings merge recursively;
+    scalars and lists are replaced — never concatenated."""
+    merged: Dict[str, Any] = {}
+    for layer in layers:
+        for key, value in (layer or {}).items():
+            if isinstance(value, Mapping) and isinstance(merged.get(key), dict):
+                merged[key] = merge_vars(merged[key], value)
+            elif isinstance(value, Mapping):
+                merged[key] = merge_vars({}, value)
+            else:
+                merged[key] = value
+    return merged
+
+
+def load_vars_file(path: "str | Path") -> Dict[str, Any]:
+    """Load one ``--vars`` YAML file (must be a mapping)."""
+    vars_path = Path(path)
+    if not vars_path.exists():
+        raise RunSpecError([f"at --vars: file not found: {vars_path}."])
+    with vars_path.open("r", encoding="utf-8") as handle:
+        try:
+            payload = yaml.safe_load(handle) or {}
+        except yaml.YAMLError as exc:
+            raise RunSpecError([f"at --vars {vars_path}: invalid YAML: {exc}."]) from exc
+    if not isinstance(payload, Mapping):
+        raise RunSpecError([f"at --vars {vars_path}: must be a YAML mapping."])
+    return dict(payload)
+
+
+def collect_cli_vars(
+    vars_files: Optional[List[str]] = None,
+    var_flags: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Assemble CLI-supplied variables: ``--vars`` files in order, then
+    ``--var`` flags (highest precedence)."""
+    layers: List[Mapping[str, Any]] = [load_vars_file(path) for path in (vars_files or [])]
+    for assignment in var_flags or []:
+        key_path, value = parse_var_assignment(assignment)
+        layers.append(_nest(key_path, value))
+    return merge_vars(*layers) if layers else {}
+
+
+def _check_reserved(variables: Mapping[str, Any], *, where: str, errors: List[str]) -> None:
+    for reserved in RESERVED_VAR_NAMES:
+        if reserved in (variables or {}):
+            errors.append(
+                f"at {where}: '{reserved}' is a reserved variable name "
+                "(injected per variant by seocho sweep)."
+            )
+
+
+def is_template_path(path: "str | Path") -> bool:
+    """Rendering is decided by extension only (``*.j2``)."""
+    return str(path).endswith(".j2")
+
+
+def _rendered_yaml_payload(rendered: str, *, source: str) -> Any:
+    try:
+        return yaml.safe_load(rendered) or {}
+    except yaml.YAMLError as exc:
+        excerpt_lines: List[str] = []
+        mark = getattr(exc, "problem_mark", None)
+        if mark is not None:
+            lines = rendered.splitlines()
+            start = max(0, mark.line - 1)
+            for index in range(start, min(len(lines), mark.line + 2)):
+                excerpt_lines.append(f"    {index + 1}: {lines[index]}")
+        excerpt = ("\n" + "\n".join(excerpt_lines)) if excerpt_lines else ""
+        raise RunSpecError(
+            [
+                f"rendered YAML from {source} is invalid: {exc}. "
+                "Note: line numbers refer to the RENDERED text, not the .j2 "
+                f"source — inspect it with --show-rendered.{excerpt}"
+            ]
+        ) from exc
+
+
+def parse_rendered_run_spec(rendered: str, *, source: str) -> RunSpec:
+    """Parse rendered template text into a validated :class:`RunSpec`."""
+    payload = _rendered_yaml_payload(rendered, source=source)
+    return parse_run_spec(payload, source_path=source)
+
+
+def load_templated_run_spec(
+    path: "str | Path",
+    variables: Mapping[str, Any],
+) -> Tuple[RunSpec, str]:
+    """Load a ``.j2`` run-spec template: render → YAML → ``parse_run_spec``.
+
+    Returns ``(spec, rendered_text)`` — the rendered text is pre-``${ENV}``
+    and safe to persist as an artifact.
+    """
+    template_path = Path(path)
+    if not template_path.exists():
+        raise RunSpecError([f"template not found: {template_path}."])
+    text = template_path.read_text(encoding="utf-8")
+    rendered = render_run_template(text, variables, source=str(template_path))
+    return parse_rendered_run_spec(rendered, source=str(template_path)), rendered
+
+
+# ---------------------------------------------------------------------------
+# Sweep spec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class SweepVariant:
+    name: str
+    vars: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def slug(self) -> str:
+        return _slug(self.name)
+
+
+@dataclass(slots=True)
+class SweepSpec:
+    """One template × N named variable sets → N runs → one summary."""
+
+    name: str
+    template: str
+    variants: List[SweepVariant]
+    vars: Dict[str, Any] = field(default_factory=dict)
+    output_dir: str = "runs"
+    source_path: str = ""
+
+    def template_path(self) -> Path:
+        path = Path(self.template)
+        if path.is_absolute():
+            return path
+        base = Path(self.source_path).parent if self.source_path else Path(".")
+        return base / path
+
+    def variant_variables(
+        self,
+        variant: SweepVariant,
+        index: int,
+        cli_vars: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Effective variables for one variant. Precedence (low→high):
+        sweep ``vars`` < variant ``vars`` < CLI vars < injected built-ins."""
+        return merge_vars(
+            self.vars,
+            variant.vars,
+            dict(cli_vars or {}),
+            {
+                "variant": {"name": variant.name, "index": index},
+                "sweep": {"name": self.name},
+            },
+        )
+
+
+def parse_sweep_spec(payload: Any, *, source_path: str = "") -> SweepSpec:
+    errors: List[str] = []
+    if not isinstance(payload, Mapping):
+        raise RunSpecError(["sweep spec must be a YAML mapping."])
+
+    _check_unknown_keys(payload, allowed=_SWEEP_TOP_LEVEL_KEYS, where="top level", errors=errors)
+
+    output = payload.get("output")
+    output_dir = "runs"
+    if output is not None:
+        if isinstance(output, Mapping):
+            _check_unknown_keys(output, allowed={"dir"}, where="output", errors=errors)
+            output_dir = _string(output.get("dir")) or "runs"
+        else:
+            errors.append("at output: must be a mapping with 'dir'.")
+
+    shared_vars = payload.get("vars") or {}
+    if not isinstance(shared_vars, Mapping):
+        errors.append("at vars: must be a mapping.")
+        shared_vars = {}
+    _check_reserved(shared_vars, where="vars", errors=errors)
+
+    variants: List[SweepVariant] = []
+    raw_variants = payload.get("variants")
+    if not isinstance(raw_variants, list) or not raw_variants:
+        errors.append("at variants: a sweep requires a non-empty list of variants.")
+        raw_variants = []
+    seen_slugs: Dict[str, str] = {}
+    for index, item in enumerate(raw_variants):
+        where = f"variants[{index}]"
+        if not isinstance(item, Mapping):
+            errors.append(f"at {where}: must be a mapping with 'name' (and optional 'vars').")
+            continue
+        _check_unknown_keys(item, allowed=_SWEEP_VARIANT_KEYS, where=where, errors=errors)
+        name = _string(item.get("name"))
+        if not name:
+            errors.append(f"at {where}: requires a non-empty 'name'.")
+            continue
+        slug = _slug(name)
+        if not slug:
+            errors.append(f"at {where}: name {name!r} has no filesystem-safe characters.")
+            continue
+        if slug in seen_slugs:
+            errors.append(
+                f"at {where}: name {name!r} collides with variant "
+                f"{seen_slugs[slug]!r} (both slug to '{slug}')."
+            )
+            continue
+        seen_slugs[slug] = name
+        variant_vars = item.get("vars") or {}
+        if not isinstance(variant_vars, Mapping):
+            errors.append(f"at {where}.vars: must be a mapping.")
+            variant_vars = {}
+        _check_reserved(variant_vars, where=f"{where}.vars", errors=errors)
+        variants.append(SweepVariant(name=name, vars=dict(variant_vars)))
+
+    default_name = Path(source_path).stem.replace(".sweep", "") if source_path else "sweep"
+    spec = SweepSpec(
+        name=_string(payload.get("name")) or default_name,
+        template=_string(payload.get("template")),
+        variants=variants,
+        vars=dict(shared_vars),
+        output_dir=output_dir,
+        source_path=source_path,
+    )
+    if not spec.template:
+        errors.append("at template: a sweep requires a 'template' path (.yaml.j2).")
+
+    if errors:
+        raise RunSpecError(errors)
+    return spec
+
+
+def load_sweep_spec(path: "str | Path") -> SweepSpec:
+    sweep_path = Path(path)
+    if not sweep_path.exists():
+        raise RunSpecError(
+            [f"sweep spec not found: {sweep_path}. Create one with: seocho sweep --init"]
+        )
+    with sweep_path.open("r", encoding="utf-8") as handle:
+        try:
+            payload = yaml.safe_load(handle) or {}
+        except yaml.YAMLError as exc:
+            raise RunSpecError([f"invalid YAML in {sweep_path}: {exc}"]) from exc
+    return parse_sweep_spec(payload, source_path=str(sweep_path))
+
+
+# ---------------------------------------------------------------------------
+# Variant isolation
+# ---------------------------------------------------------------------------
+
+_BOLT_SCHEMES = ("bolt://", "neo4j://", "neo4j+s://", "bolt+s://")
+
+
+def _database_safe(text: str) -> str:
+    """Pure local equivalent of the store's database-name sanitizer
+    (``^[a-z][a-z0-9]{2,62}$``) — this module must not import the store."""
+    cleaned = _DB_SAFE_RE.sub("", str(text).lower())
+    if not cleaned or not cleaned[0].isalpha():
+        cleaned = f"db{cleaned}"
+    return cleaned[:63]
+
+
+def derive_variant_isolation(
+    spec: RunSpec,
+    *,
+    variant_name: str,
+    sweep_run_dir: Path,
+) -> RunSpec:
+    """Apply per-variant isolation defaults (mutates and returns ``spec``).
+
+    Fills blanks only — an explicit ``graph:``/``database:`` from the
+    rendered template is never overridden. The ``workspace_id`` suffix is
+    UNCONDITIONAL: the response cache key is (workspace, database,
+    ontology hash, question), so two variants differing only by model
+    would otherwise serve each other's cached answers.
+    """
+    slug = _slug(variant_name)
+    variant_dir = sweep_run_dir / slug
+
+    spec.workspace_id = f"{spec.resolved_workspace_id()}_{slug}"
+    spec.name = f"{spec.name}-{slug}"
+
+    if not spec.graph:
+        # Embedded ladybug: one .lbug file = one graph; the `database`
+        # parameter does not partition storage — only the path does.
+        spec.graph = str(variant_dir / "graph.lbug")
+    elif spec.graph.startswith(_BOLT_SCHEMES) and not spec.database:
+        spec.database = _database_safe(f"{spec.name}")
+
+    return spec
+
+
+def absolutized_rendered_text(
+    rendered: str,
+    *,
+    template_path: Path,
+    provenance: str,
+) -> str:
+    """Rewrite relative input paths in rendered YAML to absolute ones so the
+    persisted ``rendered.yaml`` reproduces the variant standalone via
+    ``seocho run rendered.yaml``. Pre-``${ENV}`` strings pass through
+    untouched (secrets never resolve into artifacts)."""
+    payload = yaml.safe_load(rendered) or {}
+    if not isinstance(payload, dict):
+        return rendered
+    base = template_path.parent.resolve()
+
+    def _absolutize(value: Any) -> Any:
+        if isinstance(value, str) and value.strip() and not Path(value).is_absolute():
+            return str((base / value).resolve())
+        return value
+
+    for key in ("ontology", "documents"):
+        section = payload.get(key)
+        if isinstance(section, str):
+            payload[key] = _absolutize(section)
+        elif isinstance(section, dict) and "path" in section:
+            section["path"] = _absolutize(section["path"])
+    for key in ("indexing", "agent"):
+        section = payload.get(key)
+        if isinstance(section, dict) and isinstance(section.get("design"), str):
+            section["design"] = _absolutize(section["design"])
+
+    header = f"# {provenance}\n"
+    return header + yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+
+
+# ---------------------------------------------------------------------------
+# --init templates
+# ---------------------------------------------------------------------------
+
+RUN_J2_TEMPLATE = """\
+# run.yaml.j2 — Jinja2 run-spec template for `seocho run` / `seocho sweep`.
+#
+{% raw %}
+# Two substitution layers (resolved in this order):
+#   {{ var }}      Jinja2, authoring-time — supplied via --var/--vars or sweep variants
+#   ${ENV_VAR}     load-time secrets — resolved when the spec is loaded, never persisted
+#
+# Quoting rule: QUOTE every string substitution ("{{ model }}"), never quote
+# numbers/booleans ({{ limit | default(5) }}).
+{% endraw %}
+# seocho sweep suffixes the variant name onto name/workspace automatically —
+# no need to interpolate {{ '{{' }} variant.name {{ '}}' }} yourself.
+name: demo
+
+ontology:
+  path: ./schema.yaml
+  enforcement: "{{ enforcement | default('guided') }}"   # strict | guided | open
+
+documents: ./docs/
+
+models:
+  default: "{{ model | default('mara/MiniMax-M2.5') }}"
+
+query:
+  limit: {{ limit | default(5) }}
+
+questions:
+{% for q in questions %}
+  - "{{ q }}"
+{% endfor %}
+"""
+
+SWEEP_TEMPLATE = """\
+# seocho.sweep.yaml — one template x N variants -> one comparison table.
+#
+#   seocho sweep                # runs every variant sequentially
+#   seocho sweep --dry-run      # render + validate + preflight, no LLM calls
+#   seocho sweep --show-rendered strict   # inspect one variant's YAML
+#
+# Each variant gets an isolated graph, workspace, and output directory.
+name: enforcement-shootout
+template: ./run.yaml.j2
+
+vars:                         # shared by every variant (variant vars override)
+  model: mara/MiniMax-M2.5
+  questions:
+    - Who is the CEO of Acme Corp?
+    - What did Beta Industries acquire?
+
+variants:
+  - name: guided
+    vars: { enforcement: guided }
+  - name: strict
+    vars: { enforcement: strict }
+  - name: open
+    vars: { enforcement: open }
+
+output:
+  dir: runs                   # summary + per-variant artifacts land in
+                              # runs/<name>-<timestamp>/
+"""
+
+
+__all__ = [
+    "DEFAULT_SWEEP_SPEC_FILENAME",
+    "RESERVED_VAR_NAMES",
+    "RUN_J2_TEMPLATE",
+    "SWEEP_TEMPLATE",
+    "SweepSpec",
+    "SweepVariant",
+    "absolutized_rendered_text",
+    "collect_cli_vars",
+    "derive_variant_isolation",
+    "is_template_path",
+    "load_sweep_spec",
+    "load_templated_run_spec",
+    "load_vars_file",
+    "merge_vars",
+    "parse_rendered_run_spec",
+    "parse_sweep_spec",
+    "parse_var_assignment",
+    "render_run_template",
+]

--- a/tests/seocho/test_run_template.py
+++ b/tests/seocho/test_run_template.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from seocho.run_spec import RunSpecError, parse_run_spec
+from seocho.run_template import (
+    RUN_J2_TEMPLATE,
+    SWEEP_TEMPLATE,
+    absolutized_rendered_text,
+    collect_cli_vars,
+    derive_variant_isolation,
+    is_template_path,
+    load_templated_run_spec,
+    merge_vars,
+    parse_rendered_run_spec,
+    parse_sweep_spec,
+    parse_var_assignment,
+    render_run_template,
+)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_substitutes_and_defaults() -> None:
+    out = render_run_template(
+        'name: "{{ name }}"\nlimit: {{ limit | default(3) }}',
+        {"name": "x"},
+        source="t.j2",
+    )
+    assert 'name: "x"' in out
+    assert "limit: 3" in out
+
+
+def test_render_collects_all_missing_string_vars() -> None:
+    with pytest.raises(RunSpecError) as excinfo:
+        render_run_template(
+            'a: "{{ foo }}"\nb: "{{ bar }}"\nc: {{ ok | default(1) }}',
+            {},
+            source="t.j2",
+        )
+    message = str(excinfo.value)
+    assert "'foo'" in message and "'bar'" in message
+    assert "'ok'" not in message  # defaulted vars are fine
+    assert "--var" in message and "default(" in message
+
+
+def test_render_reports_structural_missing_var() -> None:
+    with pytest.raises(RunSpecError) as excinfo:
+        render_run_template(
+            "qs:\n{% for q in questions %}\n  - \"{{ q }}\"\n{% endfor %}",
+            {},
+            source="t.j2",
+        )
+    assert "'questions'" in str(excinfo.value)
+
+
+def test_render_syntax_error_includes_line() -> None:
+    with pytest.raises(RunSpecError) as excinfo:
+        render_run_template("a: 1\nb: {% if %}", {}, source="t.j2")
+    assert "t.j2:2" in str(excinfo.value)
+    assert "syntax error" in str(excinfo.value)
+
+
+def test_rendered_yaml_error_points_at_rendered_text() -> None:
+    rendered = render_run_template("a: {{ v }}", {"v": "[unclosed"}, source="t.j2")
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_rendered_run_spec(rendered, source="t.j2")
+    message = str(excinfo.value)
+    assert "RENDERED" in message
+    assert "--show-rendered" in message
+
+
+def test_env_interpolation_happens_after_render(monkeypatch) -> None:
+    monkeypatch.setenv("RUN_TEMPLATE_TEST_DB", "secretdb")
+    rendered = render_run_template(
+        textwrap.dedent(
+            """
+            ontology: "{{ schema }}"
+            documents: ./docs/
+            database: ${RUN_TEMPLATE_TEST_DB}
+            """
+        ),
+        {"schema": "./s.yaml"},
+        source="t.j2",
+    )
+    # the rendered artifact text keeps the placeholder (secret-safe)
+    assert "${RUN_TEMPLATE_TEST_DB}" in rendered
+    spec = parse_rendered_run_spec(rendered, source="t.j2")
+    assert spec.database == "secretdb"
+
+
+def test_is_template_path_by_extension_only() -> None:
+    assert is_template_path("run.yaml.j2")
+    assert is_template_path("x.j2")
+    assert not is_template_path("run.yaml")
+    assert not is_template_path("braces{{}}.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+
+
+def test_parse_var_assignment_types_and_dotted_keys() -> None:
+    assert parse_var_assignment("query.limit=10") == (["query", "limit"], 10)
+    assert parse_var_assignment("force=true") == (["force"], True)
+    assert parse_var_assignment('name="2024"') == (["name"], "2024")
+    with pytest.raises(RunSpecError):
+        parse_var_assignment("no-equals")
+
+
+def test_merge_vars_deep_merges_maps_replaces_lists() -> None:
+    merged = merge_vars(
+        {"a": {"x": 1, "keep": True}, "l": [1, 2]},
+        {"a": {"y": 2}, "l": [9]},
+    )
+    assert merged == {"a": {"x": 1, "keep": True, "y": 2}, "l": [9]}
+
+
+def test_collect_cli_vars_precedence(tmp_path) -> None:
+    vars_file = tmp_path / "vars.yaml"
+    vars_file.write_text("model: from_file\nlimit: 1\n", encoding="utf-8")
+    merged = collect_cli_vars([str(vars_file)], ["model=from_flag"])
+    assert merged["model"] == "from_flag"  # --var beats --vars file
+    assert merged["limit"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Sweep spec
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_template_round_trip() -> None:
+    sweep = parse_sweep_spec(yaml.safe_load(SWEEP_TEMPLATE), source_path="seocho.sweep.yaml")
+    assert sweep.name == "enforcement-shootout"
+    assert [variant.name for variant in sweep.variants] == ["guided", "strict", "open"]
+    rendered = render_run_template(
+        RUN_J2_TEMPLATE,
+        sweep.variant_variables(sweep.variants[1], 1),
+        source="run.yaml.j2",
+    )
+    spec = parse_rendered_run_spec(rendered, source="run.yaml.j2")
+    assert spec.enforcement == "strict"
+
+
+def test_sweep_spec_validation_collects_errors() -> None:
+    with pytest.raises(RunSpecError) as excinfo:
+        parse_sweep_spec(
+            {
+                "templte": "x.j2",
+                "vars": {"variant": 1},
+                "variants": [{"name": "a b"}, {"name": "A/B"}, {"nam": "x"}],
+            }
+        )
+    message = str(excinfo.value)
+    assert "Did you mean 'template'" in message
+    assert "reserved variable" in message
+    assert "collides" in message
+    assert "requires a 'template' path" in message
+
+
+def test_sweep_spec_requires_variants() -> None:
+    with pytest.raises(RunSpecError, match="non-empty list of variants"):
+        parse_sweep_spec({"template": "x.j2"})
+
+
+def test_variant_variables_precedence_and_builtins() -> None:
+    sweep = parse_sweep_spec(
+        {
+            "name": "s",
+            "template": "t.j2",
+            "vars": {"model": "shared", "limit": 1},
+            "variants": [{"name": "v1", "vars": {"model": "variant"}}],
+        }
+    )
+    merged = sweep.variant_variables(sweep.variants[0], 0, {"limit": 9})
+    assert merged["model"] == "variant"  # variant beats shared
+    assert merged["limit"] == 9  # CLI beats shared
+    assert merged["variant"] == {"name": "v1", "index": 0}
+    assert merged["sweep"] == {"name": "s"}
+
+
+# ---------------------------------------------------------------------------
+# Isolation derivation
+# ---------------------------------------------------------------------------
+
+
+def _spec(**overrides):
+    payload = {"ontology": "s.yaml", "documents": "docs", "name": "base"}
+    payload.update(overrides)
+    return parse_run_spec(payload, source_path="run.yaml.j2")
+
+
+def test_isolation_fills_blank_graph_with_variant_path(tmp_path) -> None:
+    spec = derive_variant_isolation(_spec(), variant_name="strict", sweep_run_dir=tmp_path)
+    assert spec.graph == str(tmp_path / "strict" / "graph.lbug")
+    assert spec.workspace_id.endswith("_strict")
+    assert spec.name == "base-strict"
+
+
+def test_isolation_never_overrides_explicit_graph(tmp_path) -> None:
+    spec = derive_variant_isolation(
+        _spec(graph="bolt://localhost:7687", database="explicitdb"),
+        variant_name="v1",
+        sweep_run_dir=tmp_path,
+    )
+    assert spec.graph == "bolt://localhost:7687"
+    assert spec.database == "explicitdb"
+
+
+def test_isolation_fills_blank_database_for_bolt(tmp_path) -> None:
+    spec = derive_variant_isolation(
+        _spec(graph="bolt://localhost:7687"), variant_name="v1", sweep_run_dir=tmp_path
+    )
+    assert spec.database
+    assert spec.database != "neo4j"
+
+
+def test_isolation_workspace_suffix_is_unconditional(tmp_path) -> None:
+    """Response-cache key invariant: two variants differing only by model
+    must land in distinct workspaces, or one serves the other's cached
+    answers."""
+    spec_a = derive_variant_isolation(
+        _spec(workspace_id="shared"), variant_name="model-a", sweep_run_dir=tmp_path
+    )
+    spec_b = derive_variant_isolation(
+        _spec(workspace_id="shared"), variant_name="model-b", sweep_run_dir=tmp_path
+    )
+    assert spec_a.workspace_id != spec_b.workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Templated run spec loading + artifact text
+# ---------------------------------------------------------------------------
+
+
+def test_load_templated_run_spec(tmp_path) -> None:
+    template = tmp_path / "run.yaml.j2"
+    template.write_text(
+        textwrap.dedent(
+            """
+            ontology: ./schema.yaml
+            documents: ./docs/
+            models:
+              default: "{{ model }}"
+            questions:
+              - Who is the CEO?
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    spec, rendered = load_templated_run_spec(template, {"model": "mara/MiniMax-M2"})
+    assert spec.indexing_model() == "mara/MiniMax-M2"
+    assert "mara/MiniMax-M2" in rendered
+
+
+def test_absolutized_rendered_text(tmp_path) -> None:
+    rendered = textwrap.dedent(
+        """
+        ontology:
+          path: ./schema.yaml
+        documents: ./docs/
+        graph_password: ${SECRET:-pw}
+        agent:
+          design: ./design.yaml
+        """
+    ).strip()
+    text = absolutized_rendered_text(
+        rendered, template_path=tmp_path / "run.yaml.j2", provenance="prov line"
+    )
+    assert text.startswith("# prov line\n")
+    payload = yaml.safe_load(text.split("\n", 1)[1])
+    assert Path(payload["ontology"]["path"]).is_absolute()
+    assert Path(payload["documents"]).is_absolute()
+    assert Path(payload["agent"]["design"]).is_absolute()
+    # secrets stay as unresolved placeholders
+    assert payload["graph_password"] == "${SECRET:-pw}"

--- a/tests/seocho/test_sweep.py
+++ b/tests/seocho/test_sweep.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from seocho import e2e
+
+
+class _DummyGraphStore:
+    def ensure_constraints(self, ontology: Any) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _DummyLLM:
+    def __init__(self, ref: str) -> None:
+        self.ref = ref
+
+
+class _FakeClient:
+    """Stands in for both index and query clients per variant."""
+
+    instances: List["_FakeClient"] = []
+
+    def __init__(self, *, fail_query: bool = False) -> None:
+        self.fail_query = fail_query
+        self.index_calls: List[Dict[str, Any]] = []
+        self.ask_calls: List[Dict[str, Any]] = []
+        self.workspace_id = "fake"
+        _FakeClient.instances.append(self)
+
+    def index_directory(self, directory: str, **kwargs: Any) -> Dict[str, Any]:
+        self.index_calls.append({"directory": directory, **kwargs})
+        return {
+            "directory": directory,
+            "files_found": 1,
+            "files_indexed": 1,
+            "files_skipped": 0,
+            "files_failed": 0,
+            "files_unchanged": 0,
+            "results": [
+                {"path": "a.md", "status": "indexed",
+                 "indexing": {"total_nodes": 2, "total_relationships": 1,
+                              "validation_errors": []}},
+            ],
+        }
+
+    def ask(self, question: str, **kwargs: Any) -> str:
+        self.ask_calls.append({"question": question, **kwargs})
+        if self.fail_query:
+            raise RuntimeError("query backend down")
+        return "answer"
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_instances():
+    _FakeClient.instances = []
+    yield
+    _FakeClient.instances = []
+
+
+def _write_sweep(tmp_path, *, variants=("alpha", "beta"), template_extra="") -> Path:
+    (tmp_path / "schema.yaml").write_text(
+        textwrap.dedent(
+            """
+            name: sweepdemo
+            nodes:
+              Company:
+                properties:
+                  name:
+                    type: STRING
+                    constraint: UNIQUE
+            relationships: {}
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    docs = tmp_path / "docs"
+    docs.mkdir(exist_ok=True)
+    (docs / "a.md").write_text("Acme is a company.", encoding="utf-8")
+
+    template = tmp_path / "run.yaml.j2"
+    template.write_text(
+        textwrap.dedent(
+            f"""
+            name: demo
+            ontology: ./schema.yaml
+            documents: ./docs/
+            models:
+              default: "{{{{ model | default('mara/MiniMax-M2.5') }}}}"
+            questions:
+              - Who is the CEO?
+            {template_extra}
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+    sweep = tmp_path / "seocho.sweep.yaml"
+    variant_lines = "\n".join(f"  - name: {name}" for name in variants)
+    sweep.write_text(
+        f"name: demo-sweep\ntemplate: ./run.yaml.j2\nvariants:\n{variant_lines}\n",
+        encoding="utf-8",
+    )
+    return sweep
+
+
+def _patch_backends(monkeypatch, *, fail_variant: str = "") -> Dict[str, Any]:
+    created: Dict[str, Any] = {"graphs": [], "specs": []}
+
+    def fake_llm(ref: str) -> _DummyLLM:
+        return _DummyLLM(ref)
+
+    def fake_store(spec: Any, ontology: Any) -> _DummyGraphStore:
+        created["graphs"].append(spec.graph)
+        created["specs"].append(spec)
+        return _DummyGraphStore()
+
+    real_build = e2e.build
+
+    def tracked_build(spec):
+        ctx = real_build(spec)
+        fail = fail_variant and fail_variant in spec.name
+        client = _FakeClient(fail_query=bool(fail))
+        ctx.index_client = client
+        ctx.query_client = client
+        return ctx
+
+    monkeypatch.setattr(e2e, "_build_llm", fake_llm)
+    monkeypatch.setattr(e2e, "_build_graph_store", fake_store)
+    monkeypatch.setattr(e2e, "build", tracked_build)
+    # preflight: skip the real API-key/graph checks for unit tests
+    monkeypatch.setattr(
+        e2e, "run_preflight",
+        lambda spec, online=False: type(
+            "R", (), {"ok": True, "render": lambda self: "  ok    (stubbed)",
+                      "failures": lambda self: []}
+        )(),
+    )
+    return created
+
+
+def test_sweep_variants_are_isolated(tmp_path, monkeypatch) -> None:
+    created = _patch_backends(monkeypatch)
+    sweep_path = _write_sweep(tmp_path)
+
+    code = e2e.run_sweep_from_config(sweep_path, json_output=True)
+    assert code == 0
+
+    # distinct graph paths under the sweep run dir, one per variant
+    assert len(created["graphs"]) == 2
+    assert created["graphs"][0] != created["graphs"][1]
+    assert all("graph.lbug" in graph for graph in created["graphs"])
+    # distinct workspaces (response-cache key invariant)
+    workspaces = [spec.workspace_id for spec in created["specs"]]
+    assert workspaces[0] != workspaces[1]
+    # tracking disabled for every variant index call
+    for client in _FakeClient.instances:
+        for call in client.index_calls:
+            assert call["track"] is False
+
+
+def test_sweep_writes_summary_and_artifacts(tmp_path, monkeypatch) -> None:
+    _patch_backends(monkeypatch)
+    sweep_path = _write_sweep(tmp_path)
+
+    code = e2e.run_sweep_from_config(sweep_path, json_output=True)
+    assert code == 0
+
+    run_dirs = list((tmp_path / "runs").iterdir())
+    assert len(run_dirs) == 1
+    sweep_dir = run_dirs[0]
+    summary = json.loads((sweep_dir / "summary.json").read_text(encoding="utf-8"))
+    assert [row["variant"] for row in summary["variants"]] == ["alpha", "beta"]
+    assert all(row["status"] == "ok" for row in summary["variants"])
+    md = (sweep_dir / "summary.md").read_text(encoding="utf-8")
+    assert "| alpha | ok |" in md
+    for variant in ("alpha", "beta"):
+        assert (sweep_dir / variant / "rendered.yaml").exists()
+        assert (sweep_dir / variant / "report.json").exists()
+        rendered = (sweep_dir / variant / "rendered.yaml").read_text(encoding="utf-8")
+        assert str(tmp_path) in rendered  # paths absolutized for reproduction
+
+
+def test_sweep_keeps_going_after_variant_failure(tmp_path, monkeypatch) -> None:
+    _patch_backends(monkeypatch, fail_variant="alpha")
+    sweep_path = _write_sweep(tmp_path)
+
+    code = e2e.run_sweep_from_config(sweep_path, json_output=True)
+    assert code == 1  # one variant failed
+
+    sweep_dir = next((tmp_path / "runs").iterdir())
+    summary = json.loads((sweep_dir / "summary.json").read_text(encoding="utf-8"))
+    by_name = {row["variant"]: row for row in summary["variants"]}
+    assert by_name["alpha"]["status"] == "failed"  # query error -> RunReport.ok False
+    assert by_name["beta"]["status"] == "ok"  # still executed
+    assert summary["sweep"]["failed_variants"] == ["alpha"]
+
+
+def test_sweep_fail_fast_stops_after_first_failure(tmp_path, monkeypatch) -> None:
+    _patch_backends(monkeypatch, fail_variant="alpha")
+    sweep_path = _write_sweep(tmp_path)
+
+    code = e2e.run_sweep_from_config(sweep_path, json_output=True, fail_fast=True)
+    assert code == 1
+    sweep_dir = next((tmp_path / "runs").iterdir())
+    summary = json.loads((sweep_dir / "summary.json").read_text(encoding="utf-8"))
+    assert [row["variant"] for row in summary["variants"]] == ["alpha"]
+
+
+def test_sweep_only_variant_subset(tmp_path, monkeypatch) -> None:
+    _patch_backends(monkeypatch)
+    sweep_path = _write_sweep(tmp_path, variants=("alpha", "beta", "gamma"))
+
+    code = e2e.run_sweep_from_config(
+        sweep_path, json_output=True, only_variants=["beta"]
+    )
+    assert code == 0
+    sweep_dir = next((tmp_path / "runs").iterdir())
+    summary = json.loads((sweep_dir / "summary.json").read_text(encoding="utf-8"))
+    assert [row["variant"] for row in summary["variants"]] == ["beta"]
+
+    assert e2e.run_sweep_from_config(
+        sweep_path, json_output=True, only_variants=["nope"]
+    ) == 2
+
+
+def test_sweep_stage1_config_error_runs_nothing(tmp_path, monkeypatch, capsys) -> None:
+    created = _patch_backends(monkeypatch)
+    sweep_path = _write_sweep(tmp_path)
+    # break the template for every variant
+    (tmp_path / "run.yaml.j2").write_text(
+        'ontology: ./schema.yaml\ndocuments: ./docs/\nmodels:\n  default: "{{ missing_model }}"\n',
+        encoding="utf-8",
+    )
+
+    code = e2e.run_sweep_from_config(sweep_path, json_output=True)
+    assert code == 2
+    assert created["graphs"] == []  # nothing was built
+    err = capsys.readouterr().err
+    assert "variant alpha" in err and "variant beta" in err
+    assert "missing_model" in err
+
+
+def test_sweep_var_flag_applies_to_all_variants(tmp_path, monkeypatch) -> None:
+    created = _patch_backends(monkeypatch)
+    sweep_path = _write_sweep(tmp_path)
+
+    code = e2e.run_sweep_from_config(
+        sweep_path, json_output=True, var_flags=["model=kimi/kimi-k2.5"]
+    )
+    assert code == 0
+    assert all(
+        spec.indexing_model() == "kimi/kimi-k2.5" for spec in created["specs"]
+    )
+
+
+def test_run_from_config_rejects_vars_for_plain_yaml(tmp_path, capsys) -> None:
+    config = tmp_path / "run.yaml"
+    config.write_text("ontology: s.yaml\ndocuments: docs\n", encoding="utf-8")
+    code = e2e.run_from_config(config, var_flags=["a=1"])
+    assert code == 2
+    assert ".j2" in capsys.readouterr().err
+
+
+def test_run_from_config_show_rendered(tmp_path, capsys) -> None:
+    (tmp_path / "schema.yaml").write_text("name: t\nnodes: {}\nrelationships: {}\n")
+    template = tmp_path / "run.yaml.j2"
+    template.write_text(
+        'ontology: ./schema.yaml\ndocuments: ./docs/\nmodels:\n  default: "{{ model }}"\n',
+        encoding="utf-8",
+    )
+    code = e2e.run_from_config(
+        template, var_flags=["model=mara/MiniMax-M2"], show_rendered=True
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "mara/MiniMax-M2" in out
+
+
+def test_file_indexer_track_false_leaves_no_state(tmp_path) -> None:
+    from seocho.index.file_reader import FileIndexer
+    from seocho.index.pipeline import IndexingResult
+
+    class _RecordingPipeline:
+        strict_validation = False
+
+        def index(self, content: str, **kwargs: Any) -> IndexingResult:
+            return IndexingResult(source_id="s", chunks_processed=1, total_nodes=1)
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("content", encoding="utf-8")
+
+    indexer = FileIndexer(_RecordingPipeline())
+    first = indexer.index_directory(docs, track=False)
+    assert first.files_indexed == 1
+    assert not (docs / ".seocho_index").exists()
+
+    second = indexer.index_directory(docs, track=False)
+    assert second.files_indexed == 1  # no "unchanged" skips
+    assert second.files_unchanged == 0
+
+    tracked = indexer.index_directory(docs)  # default behavior unchanged
+    assert (docs / ".seocho_index").exists()
+    again = indexer.index_directory(docs)
+    assert again.files_unchanged == 1


### PR DESCRIPTION
## What

One Jinja2 template × N named variable sets → N **isolated** e2e runs → one comparison table. Designed by a three-perspective panel (template-DSL, CLI/UX, systems architecture) with the user-approved interface decisions: new `seocho sweep` subcommand, explicit named variants, sequential v1.

```yaml
# seocho.sweep.yaml
template: ./run.yaml.j2
variants:
  - name: guided
    vars: { enforcement: guided }
  - name: strict
    vars: { enforcement: strict }
  - name: open
    vars: { enforcement: open }
```

```
Sweep summary
  variant  files  nodes  rels  answered  empty  errors  index_s  query_s
  ────────────────────────────────────────────────────────────────────────
  guided   3/3    23     44    3/3       0      0       10.3     7.9
  strict   3/3    22     41    3/3       0      0       9.38     7.6
  open     3/3    23     44    3/3       0      0       10.08    7.48
```

Doctrine (in docs): **run** = one resolved spec, one report (a spec may be a `.j2` template) · **sweep** = template × variable sets → comparison · **experiment** = extraction-only micro-benchmark (unchanged, help now cross-references sweep).

## Design decisions

- **Two substitution layers with fixed order.** Jinja renders **before** the existing `${ENV}` interpolation: `{{ var }}` = authoring-time parameters, `${ENV}` = load-time secrets. Per-variant `rendered.yaml` artifacts persist the pre-`${ENV}` text — secrets never land on disk, and `seocho run rendered.yaml` reproduces a variant standalone (input paths absolutized).
- **Extension decides rendering** (`*.j2` only). Plain `.yaml` never touches the template layer — question text containing `{{` stays untouched. Supplying `--var` for a non-template is exit-2, not a silent no-op.
- **Collect-all everywhere.** Missing template variables are reported together (with the three remedies; `| default()` exempt); sweep stage 1 renders + validates **all** variants up front — a broken variant 3 means variant 1 never spends tokens (exit 2). Runtime failures keep going by default (`--fail-fast` opt-in), table marks them, exit 1.
- **Variant isolation (the correctness core):**
  - blank `graph:` → per-variant `<sweep>/<variant>/graph.lbug` (one `.lbug` file = one graph; paths isolate, the `database` param does not)
  - `workspace_id` suffix is **unconditional** — the response cache is keyed by (workspace, database, ontology hash, question), so two variants differing only by model would otherwise serve each other's cached answers
  - new `track=False` threading (`FileIndexer.index_directory` hardcoded its tracker): no `.seocho_index` reads/writes in sweeps, so variant N+1 never skips files as "unchanged" and the user's docs directory stays clean. `force` is not a substitute — it still records tracker state pointing at a variant-local graph.

## Surface

- `seocho run` gains `--var k=v` (dotted keys, YAML values) / `--vars FILE` / `--show-rendered` for `.j2` configs.
- New `seocho sweep [SWEEP] [--init|--dry-run|--show-rendered [NAME]|--only-variant|--var|--vars|--fail-fast|-o|--force|--output-json]`; `--init` writes the `seocho.sweep.yaml` + `run.yaml.j2` pair.
- `src/seocho/run_template.py` (pure layer, mirrors `run_spec.py` doctrine), `e2e.py` `run_spec_once` factor + `run_sweep_from_config`, `examples/run/sweep-enforcement/`, RUN_SPECS.md "Templates and sweeps" section.

## Validation

- `bash scripts/ci/run_basic_ci.sh` — **598 passed, 5 skipped** (30 new tests: render collect-all, var precedence, sweep parsing, isolation invariants incl. the unconditional-workspace cache test, keep-going/fail-fast/subset/stage-1 semantics, FileTracker no-state test)
- Live sweep (MARA + embedded LadybugDB, no server): 3 enforcement variants, all 3/3 answered from isolated graphs; the table shows `strict` yielding fewer nodes/rels — the comparison telling a real story
- `seocho run <variant>/rendered.yaml --dry-run` standalone reproduction passes; plain-yaml quickstart path byte-for-byte unchanged (`--var` on it → exit 2 with guidance)
- Rebased onto latest main (81d7810) post-#289; suites re-run green

**v1 cut (deliberate):** cartesian `axes:` sugar, `--parallel`, `expect` auto-grading, experiment integration, sweep resume, j2 `{% include %}`.

Beads: seocho-aoa