### PR TITLE
fix(store): multi-document provenance — _sources accumulation + provenance-aware delete_by_source (#183)

### DIFF
--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -21,6 +21,7 @@ Usage::
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import time
@@ -435,10 +436,21 @@ class Neo4jGraphStore(GraphStore):
                 # label validated against _LABEL_RE above; interpolated raw.
                 # LWW guard: apply incoming props only if this write is newer
                 # (or the node has no writer ts yet); stale replays no-op.
+                # issue #183: _source_id stays single-valued (LWW, keeps the
+                # delete/count filters working) while _sources accumulates
+                # every contributing document — outside the LWW guard, since
+                # a stale replay still proves that document referenced the
+                # node.
+                sources_clause = (
+                    " SET n._sources = CASE WHEN n._sources IS NULL THEN [{p}._source_id] "
+                    "WHEN NOT {p}._source_id IN n._sources THEN n._sources + {p}._source_id "
+                    "ELSE n._sources END"
+                )
                 batch_q = (
                     f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id}}) "
                     "SET n += CASE WHEN n._writer_ts IS NULL "
                     "OR n._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
+                    + sources_clause.format(p="row.props")
                 )
                 try:
                     session.run(batch_q, rows=rows)
@@ -449,7 +461,8 @@ class Neo4jGraphStore(GraphStore):
                             session.run(
                                 f"MERGE (n:{label} {{id: $id}}) SET n += CASE WHEN "
                                 "n._writer_ts IS NULL OR n._writer_ts <= $props._writer_ts "
-                                "THEN $props ELSE {} END",
+                                "THEN $props ELSE {} END"
+                                + sources_clause.format(p="$props"),
                                 id=row["id"], props=row["props"])
                             summary["nodes_created"] += 1
                         except Exception as exc:
@@ -458,10 +471,16 @@ class Neo4jGraphStore(GraphStore):
             # --- Relationships (one UNWIND per type) ---
             for rtype, rows in rels_by_type.items():
                 # rtype validated against _LABEL_RE above; interpolated raw
+                rel_sources_clause = (
+                    " SET r._sources = CASE WHEN r._sources IS NULL THEN [{p}._source_id] "
+                    "WHEN NOT {p}._source_id IN r._sources THEN r._sources + {p}._source_id "
+                    "ELSE r._sources END"
+                )
                 batch_q = (f"UNWIND $rows AS row MATCH (a {{id: row.src}}), (b {{id: row.tgt}}) "
                            f"MERGE (a)-[r:{rtype}]->(b) "
                            "SET r += CASE WHEN r._writer_ts IS NULL "
-                           "OR r._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END")
+                           "OR r._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
+                           + rel_sources_clause.format(p="row.props"))
                 try:
                     session.run(batch_q, rows=rows)
                     summary["relationships_created"] += len(rows)
@@ -472,7 +491,8 @@ class Neo4jGraphStore(GraphStore):
                                 f"MATCH (a {{id: $src}}), (b {{id: $tgt}}) "
                                 f"MERGE (a)-[r:{rtype}]->(b) SET r += CASE WHEN "
                                 "r._writer_ts IS NULL OR r._writer_ts <= $props._writer_ts "
-                                "THEN $props ELSE {} END",
+                                "THEN $props ELSE {} END"
+                                + rel_sources_clause.format(p="$props"),
                                 src=row["src"], tgt=row["tgt"], props=row["props"])
                             summary["relationships_created"] += 1
                         except Exception as exc:
@@ -855,10 +875,29 @@ class Neo4jGraphStore(GraphStore):
             except Exception as exc:
                 summary["errors"].append(f"Rel delete: {exc}")
 
-            # Delete orphaned nodes from this source
+            # issue #183: a node mentioned by several documents must survive
+            # until its LAST source is deleted. First retire this source from
+            # multi-source nodes (repointing _source_id when it was the
+            # latest), then DETACH DELETE only sole-source nodes. Legacy
+            # nodes without _sources keep the old _source_id semantics.
+            try:
+                session.run(
+                    "MATCH (n) WHERE n._sources IS NOT NULL AND $sid IN n._sources "
+                    "AND size([s IN n._sources WHERE s <> $sid]) > 0 "
+                    "WITH n, [s IN n._sources WHERE s <> $sid] AS rest LIMIT 10000 "
+                    "SET n._sources = rest, "
+                    "    n._source_id = CASE WHEN n._source_id = $sid "
+                    "THEN rest[-1] ELSE n._source_id END",
+                    sid=source_id,
+                )
+            except Exception as exc:
+                summary["errors"].append(f"Source retire: {exc}")
+
             try:
                 result = session.run(
-                    "MATCH (n) WHERE n._source_id = $sid "
+                    "MATCH (n) WHERE (n._sources IS NULL AND n._source_id = $sid) "
+                    "OR (n._sources IS NOT NULL AND $sid IN n._sources "
+                    "AND size([s IN n._sources WHERE s <> $sid]) = 0) "
                     "WITH n LIMIT 10000 DETACH DELETE n RETURN count(n) AS cnt",
                     sid=source_id,
                 )
@@ -1414,6 +1453,8 @@ class LadybugGraphStore(GraphStore):
         # ontology property (usually ``name``) turns every cross-document
         # re-mention of an entity into a duplicate-PK write failure.
         self._node_table_pk: Dict[str, str] = {}
+        # issue #183: node tables verified to carry the _sources column.
+        self._sources_column_ready: set = set()
         self._load_existing_schema()
 
     def _locked_execute(self, *args, **kwargs):
@@ -1526,6 +1567,73 @@ class LadybugGraphStore(GraphStore):
         self._rel_signature_to_table[signature] = physical_name
         return physical_name
 
+    # issue #183: Ladybug coerces string values that LOOK like JSON arrays
+    # ('["a"]' comes back as '[a]'), so the JSON list is stored behind a
+    # "json:" prefix, which round-trips verbatim.
+    _SOURCES_PREFIX = "json:"
+
+    @classmethod
+    def _encode_sources(cls, sources: List[str]) -> str:
+        return cls._SOURCES_PREFIX + json.dumps(sources)
+
+    @classmethod
+    def _decode_sources(cls, raw: Any) -> List[str]:
+        text = str(raw or "")
+        if text.startswith(cls._SOURCES_PREFIX):
+            text = text[len(cls._SOURCES_PREFIX):]
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (TypeError, ValueError):
+            return []
+        if isinstance(parsed, list):
+            return [str(s) for s in parsed if s]
+        return []
+
+    def _ensure_sources_column(self, label: str) -> None:
+        """Make sure the node table carries the ``_sources`` column.
+
+        Tables created before issue #183 lack it; Ladybug supports
+        ``ALTER TABLE ... ADD`` so it is added lazily, once per label.
+        """
+        if label in self._sources_column_ready:
+            return
+        try:
+            self._locked_execute(f"ALTER TABLE `{label}` ADD `_sources` STRING")
+        except Exception:
+            # Column already exists (new tables declare it) — fine either way.
+            pass
+        self._sources_column_ready.add(label)
+
+    def _accumulated_sources_json(
+        self, label: str, merge_col: str, merge_value: Any, source_id: str
+    ) -> str:
+        """Existing ``_sources`` of the upsert target plus ``source_id``."""
+        sources: List[str] = []
+        try:
+            rows = self._locked_execute(
+                f"MATCH (n:`{label}` {{`{merge_col}`: $v}}) "
+                "RETURN n._sources, n._source_id",
+                {"v": merge_value},
+            )
+            for row in rows:
+                row_list = row if isinstance(row, list) else list(row)
+                existing_json = row_list[0] if row_list else None
+                existing_single = row_list[1] if len(row_list) > 1 else None
+                if existing_json:
+                    sources = self._decode_sources(existing_json)
+                if not sources and existing_single:
+                    # Legacy node written before #183: seed from _source_id.
+                    sources = [str(existing_single)]
+                break
+        except Exception:
+            # No such node / legacy table — no history to merge.
+            pass
+        if source_id and source_id not in sources:
+            sources.append(source_id)
+        return self._encode_sources(sources)
+
     def write(
         self,
         nodes: Sequence[Dict[str, Any]],
@@ -1568,6 +1676,14 @@ class LadybugGraphStore(GraphStore):
                 merge_col, merge_value = pk_col, props[pk_col]
             else:
                 merge_col, merge_value = "id", node_id
+            # issue #183: accumulate multi-document provenance. _source_id
+            # stays single-valued (latest writer — keeps the count/delete
+            # filters working) while _sources is a JSON-encoded list of every
+            # document that mentioned this node.
+            self._ensure_sources_column(label)
+            props["_sources"] = self._accumulated_sources_json(
+                label, merge_col, merge_value, source_id
+            )
             prop_keys = [k for k in props if _LABEL_RE.match(k)]
             set_keys = [k for k in prop_keys if k != merge_col]
             set_clause = ", ".join(f"`{k}`: $p_{i}" for i, k in enumerate(set_keys))
@@ -1799,16 +1915,69 @@ class LadybugGraphStore(GraphStore):
         except Exception as exc:
             summary["errors"].append(f"relationship delete: {exc}")
 
-        try:
-            self._locked_execute(
-                "MATCH (n) WHERE n._source_id = $sid DETACH DELETE n",
-                {"sid": source_id},
-            )
-        except Exception as exc:
-            summary["errors"].append(f"node delete: {exc}")
+        # issue #183: a node mentioned by several documents must survive
+        # until its LAST source is deleted. Per node table: retire this
+        # source from multi-source nodes (repointing _source_id when it was
+        # the latest writer), DETACH DELETE only sole-source nodes. Legacy
+        # nodes without _sources keep the old _source_id semantics.
+        nodes_deleted = 0
+        needle = json.dumps(source_id)  # JSON-quoted match inside the list
+        for label in sorted(self._declared_node_tables):
+            pk_col = self._node_table_pk.get(label, "id")
+            if not (_LABEL_RE.match(label) and _LABEL_RE.match(pk_col)):
+                continue
+            try:
+                rows = self._locked_execute(
+                    f"MATCH (n:`{label}`) WHERE n._source_id = $sid "
+                    "OR (n._sources IS NOT NULL AND n._sources CONTAINS $needle) "
+                    f"RETURN n.`{pk_col}`, n._sources",
+                    {"sid": source_id, "needle": needle},
+                )
+                pending = [row if isinstance(row, list) else list(row) for row in rows]
+            except Exception:
+                # Legacy table without the _sources column.
+                try:
+                    rows = self._locked_execute(
+                        f"MATCH (n:`{label}`) WHERE n._source_id = $sid "
+                        f"RETURN n.`{pk_col}`",
+                        {"sid": source_id},
+                    )
+                    pending = [
+                        [(row if isinstance(row, list) else list(row))[0], None]
+                        for row in rows
+                    ]
+                except Exception as exc:
+                    summary["errors"].append(f"{label} scan: {exc}")
+                    continue
+
+            for key_value, sources_json in pending:
+                remaining = [
+                    s for s in self._decode_sources(sources_json) if s != source_id
+                ]
+                if remaining:
+                    try:
+                        self._locked_execute(
+                            f"MATCH (n:`{label}` {{`{pk_col}`: $k}}) "
+                            "SET n._sources = $srcs, n._source_id = $latest",
+                            {"k": key_value, "srcs": self._encode_sources(remaining),
+                             "latest": remaining[-1]},
+                        )
+                    except Exception as exc:
+                        summary["errors"].append(f"{label} retire: {exc}")
+                else:
+                    try:
+                        self._locked_execute(
+                            f"MATCH (n:`{label}` {{`{pk_col}`: $k}}) DETACH DELETE n",
+                            {"k": key_value},
+                        )
+                        nodes_deleted += 1
+                    except Exception as exc:
+                        summary["errors"].append(f"{label} delete: {exc}")
 
         after = self.count_by_source(source_id, database=database)
-        summary["nodes_deleted"] = max(0, before["nodes"] - after["nodes"])
+        # Retired (multi-source) nodes survive on purpose — count only the
+        # physical deletions, not the before/after _source_id diff.
+        summary["nodes_deleted"] = nodes_deleted
         summary["relationships_deleted"] = max(0, before["relationships"] - after["relationships"])
         return summary
 

--- a/tests/seocho/test_graph_writer_lww.py
+++ b/tests/seocho/test_graph_writer_lww.py
@@ -141,3 +141,53 @@ def test_stale_write_does_not_clobber_newer_live():
         with store._driver.session(database=db) as s:
             s.run("MATCH (n:_LWWTest {id:$id}) DETACH DELETE n", id=nid)
         store.close()
+
+
+# --------------------------------------------------------------------------- #
+# issue #183 — multi-document provenance (_sources accumulation + safe delete)
+# --------------------------------------------------------------------------- #
+
+def test_node_write_accumulates_sources_outside_lww_guard():
+    store = _store_with_fake()
+    store.write(
+        [{"id": "c1", "label": "Company", "properties": {"name": "ACME"}}],
+        [],
+        database="testdb",
+        source_id="doc-a",
+    )
+    node_calls = [c for c in store._driver.rec.calls if "MERGE (n:" in c[0]]
+    query, _params = node_calls[0]
+    # _sources accumulation is a separate SET after the LWW-guarded one:
+    # NULL -> seed list, missing -> append, present -> keep (idempotent).
+    assert "SET n._sources = CASE WHEN n._sources IS NULL" in query
+    assert "n._sources + row.props._source_id" in query
+
+
+def test_rel_write_accumulates_sources():
+    store = _store_with_fake()
+    store.write(
+        [{"id": "a", "label": "Company", "properties": {}},
+         {"id": "b", "label": "Company", "properties": {}}],
+        [{"source": "a", "target": "b", "type": "REPORTED", "properties": {}}],
+        database="testdb",
+        source_id="doc-a",
+    )
+    rel_calls = [c for c in store._driver.rec.calls if "MERGE (a)-[r:" in c[0]]
+    query, _params = rel_calls[0]
+    assert "SET r._sources = CASE WHEN r._sources IS NULL" in query
+
+
+def test_delete_by_source_retires_before_deleting():
+    store = _store_with_fake()
+    store.delete_by_source("doc-a", database="testdb")
+    calls = [q for q, _ in store._driver.rec.calls]
+    retire = [q for q in calls if "SET n._sources = rest" in q]
+    delete = [q for q in calls if "DETACH DELETE n" in q]
+    assert retire, "no retire pass issued"
+    assert delete, "no delete pass issued"
+    # retire only touches multi-source nodes; delete only sole-source/legacy
+    assert "size([s IN n._sources WHERE s <> $sid]) > 0" in retire[0]
+    assert "size([s IN n._sources WHERE s <> $sid]) = 0" in delete[0]
+    assert "n._sources IS NULL AND n._source_id = $sid" in delete[0]
+    # retire runs before delete
+    assert calls.index(retire[0]) < calls.index(delete[0])

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -664,3 +664,50 @@ class TestCrossDocumentEntityMerge:
             assert len(rows) == 1
         finally:
             store.close()
+
+    # -- issue #183: multi-document provenance ------------------------------
+
+    def test_shared_node_survives_deleting_one_source(self, store):
+        """A node mentioned by two documents must survive deleting one of
+        them — previously delete_by_source destroyed the other document's
+        data because _source_id was last-writer-wins (issue #183)."""
+        decode = LadybugGraphStore._decode_sources
+
+        store.write(
+            nodes=[{"id": "c_a", "label": "Company", "properties": {"name": "Acme"}}],
+            relationships=[], source_id="doc-a",
+        )
+        store.write(
+            nodes=[
+                {"id": "c_b", "label": "Company", "properties": {"name": "Acme"}},
+                {"id": "p_b", "label": "Person", "properties": {"name": "Jo", "age": 1}},
+            ],
+            relationships=[
+                {"source": "p_b", "target": "c_b", "type": "WORKS_AT", "properties": {}},
+            ],
+            source_id="doc-b",
+        )
+
+        rows = store.query("MATCH (c:Company) RETURN c._sources AS s")
+        assert len(rows) == 1
+        assert decode(rows[0]["s"]) == ["doc-a", "doc-b"]
+
+        summary = store.delete_by_source("doc-b")
+        # Person was doc-b-only (deleted); the shared Company survives.
+        assert summary["nodes_deleted"] == 1
+        survivors = store.query("MATCH (c:Company) RETURN c.name AS n, c._sources AS s, c._source_id AS sid")
+        assert len(survivors) == 1
+        assert decode(survivors[0]["s"]) == ["doc-a"]
+        assert survivors[0]["sid"] == "doc-a"
+
+        store.delete_by_source("doc-a")
+        assert store.query("MATCH (c:Company) RETURN c.name") == []
+
+    def test_sole_source_delete_unchanged(self, store):
+        store.write(
+            nodes=[{"id": "x", "label": "Person", "properties": {"name": "Solo", "age": 2}}],
+            relationships=[], source_id="doc-solo",
+        )
+        summary = store.delete_by_source("doc-solo")
+        assert summary["nodes_deleted"] == 1
+        assert store.query("MATCH (p:Person) RETURN p.name") == []


### PR DESCRIPTION
## Feature

Multi-document provenance for graph writes: nodes (and Neo4j relationships)
accumulate every contributing document in `_sources`, and `delete_by_source`
retires a source from shared nodes instead of destroying them — deleting only
sole-source nodes. Closes #183.

## Why

`_source_id` was unconditionally overwritten on every write, so a node
mentioned by N documents kept only the last document's provenance. Reproduced
worst case: two documents both mention "Total revenue" (name PK) → one merged
node; `delete_by_source("doc-tsla")` then DETACH-DELETEd it, **erasing
doc-ptc's relationships and node entirely**. Raised during the review of the
cross-document upsert (seocho-8ct / #282); reported as issue #183.

## Design

Follows the design proposed in #183: `_source_id` stays single-valued (latest
writer — keeps every existing `count_by_source`/filter working) and
`_sources` is the accumulating list.

- **Neo4jGraphStore.write()** — a second `SET` accumulates `_sources` on
  nodes and relationships (`NULL → seed`, `missing → append`, `present →
  keep`), deliberately outside the LWW guard: a stale replay still proves
  that document referenced the node.
- **Neo4jGraphStore.delete_by_source()** — retire pass first (remove `sid`
  from multi-source nodes, repointing `_source_id` when it was the latest
  writer), then `DETACH DELETE` only sole-source nodes. Legacy nodes without
  `_sources` keep the old semantics.
- **LadybugGraphStore** — `_sources` column is added lazily via
  `ALTER TABLE` (covers tables created before this change). `write()` reads
  the upsert target's history and appends. Dialect quirk found by probe: the
  engine coerces JSON-array-looking strings (`'["a"]'` comes back `'[a]'`),
  so the list is stored behind a `json:` prefix that round-trips verbatim.
  `delete_by_source()` does the same retire-or-delete per node table, keyed
  on the declared PK; `nodes_deleted` counts physical deletions only (a
  retired node is not "deleted").

Out of scope (tracked as **seocho-uxs**): last-writer-wins property clobber
on homonym merges — the identity-model question (composite keys, merge
conflict surfacing, ADR-0103 H4 Observation dimensions).

## Expected Effect

Re-indexing or deleting one document no longer destroys entities and
relationships contributed by other documents; every node carries auditable
multi-document provenance.

## Impact Results

- Repro before: `delete_by_source("doc-tsla")` left **zero** Company/metric
  rows (doc-ptc's data destroyed). After: PTC's node, metric, and REPORTED
  edge survive with `_sources == ["doc-ptc"]`; deleting doc-ptc afterwards
  removes the rest.
- `_sources` after two writes: `["doc-a", "doc-b"]`; idempotent on replays.

## Validation

- `bash scripts/ci/run_basic_ci.sh` → 581 passed, 1 skipped.
- `pytest tests/seocho/test_ladybug_store.py` → 23 passed (2 new
  provenance regression tests, including the full destroy-scenario repro).
- `pytest tests/seocho/test_graph_writer_lww.py` → 5 passed, 1 skipped
  (3 new: node/rel `_sources` Cypher, retire-before-delete ordering).
- `git diff --check` clean.
- Skipped: live DozerDB integration (mock-asserted Cypher only; existing
  `@integration` LWW test pattern covers live wiring), ruff (not in venv).

## Risks

Medium-low. Write path gains one read per node on Ladybug (embedded local
store) and one extra SET clause on Neo4j. `delete_by_source` semantics
change by design: shared nodes survive until their last source is deleted —
this is the fix, and legacy single-source behavior is regression-tested.
