### PR TITLE
feat(sdk): run-spec vector store section + explicit graph backend kinds (seocho-32r)

### DIFF
--- a/docs/RUN_SPECS.md
+++ b/docs/RUN_SPECS.md
@@ -66,6 +66,22 @@ graph_password: ${NEO4J_PASSWORD:-password}
 database: neo4j                     # omit to derive from the ontology name
 workspace_id: filings_demo          # default: derived from name
 
+# graph also accepts a mapping with an explicit backend kind:
+# graph:
+#   kind: dozerdb                   # neo4j | dozerdb | ladybug
+#   uri: bolt://localhost:7687      # ladybug uses `path:` instead
+#   user: neo4j
+#   password: ${NEO4J_PASSWORD}
+#   database: mydb
+
+vector:                             # optional hybrid-search vector store
+  kind: faiss                       # faiss (in-memory) | lancedb (on-disk)
+  embedding: fastembed              # local bge (default, no network) or an
+                                    #   LLM provider preset (mara, openai, ...)
+  # embedding_model: BAAI/bge-small-en-v1.5
+  # uri: ./.lancedb                 # lancedb only
+  # table_name: seocho_vectors      # lancedb only
+
 indexing:
   design: ./indexing_design.yaml    # optional IndexingDesignSpec (path or inline)
   category: filing
@@ -111,6 +127,30 @@ The policy is compiled by `seocho.EnforcementPolicy` from
 design (the implicit `guided` default never does). These are admission
 policies for extracted data — not CWA/OWA inference semantics; query-time
 entailment is unchanged in every mode.
+
+## Storage backends
+
+The graph store is selected by `graph.kind` (or inferred from a bare
+string: bolt-scheme URI → Neo4j/DozerDB, anything else → embedded
+LadybugDB path). The optional `vector:` section adds a hybrid-search
+vector store (`Seocho(vector_store=...)` / `search_similar()`):
+
+| Backend | Key | Notes |
+| --- | --- | --- |
+| LadybugDB (embedded) | `graph.kind: ladybug` / blank | zero-infra default; one file = one graph |
+| Neo4j / DozerDB | `graph.kind: neo4j\|dozerdb` + `uri:` | per-`database` isolation on one server |
+| FAISS (vector) | `vector.kind: faiss` | in-memory, rebuilt per run |
+| LanceDB (vector) | `vector.kind: lancedb` + `uri:` | on-disk; sweeps isolate the uri per variant |
+
+`vector.embedding` defaults to `fastembed` (local bge, no network, 384-dim
+auto-derived); set it to a provider preset (`mara`, `openai`, ...) for
+HTTP embeddings. RDBMS backends are not supported — the SDK's `GraphStore`
+contract has no relational implementation today.
+
+In sweeps, on-disk vector stores get the same isolation as embedded
+graphs (blank lancedb `uri` → `<sweep>/<variant>/vectors.lancedb`), and a
+bolt graph shared by multiple variants prints a note that isolation rides
+on per-variant database/workspace only.
 
 ## Per-phase models
 

--- a/src/seocho/e2e.py
+++ b/src/seocho/e2e.py
@@ -126,7 +126,9 @@ def _build_llm(model_ref: str) -> Any:
 
 
 def _build_graph_store(spec: RunSpec, ontology: Any) -> Any:
-    if spec.graph and spec.graph.startswith(_BOLT_SCHEMES):
+    # Backend selection: explicit graph.kind wins; a bare string falls back
+    # to URI inference (bolt scheme → Neo4j/DozerDB, else embedded path).
+    if spec.resolved_graph_kind() in ("neo4j", "dozerdb"):
         from .store.graph import Neo4jGraphStore
 
         return Neo4jGraphStore(spec.graph, spec.graph_user, spec.graph_password)
@@ -138,6 +140,50 @@ def _build_graph_store(spec: RunSpec, ontology: Any) -> Any:
     except Exception:
         pass
     return store
+
+
+def _build_vector_store(spec: RunSpec) -> Optional[Any]:
+    """Build the optional hybrid-search vector store from the ``vector:``
+    section. Embedding defaults to local fastembed (bge) per the MARA-first
+    policy; any other value is an LLM provider preset."""
+    if not spec.uses_vector_store():
+        return None
+    from .store.vector import create_vector_store
+
+    embedding = spec.vector_embedding()
+    embedding_model = str(spec.vector.get("embedding_model") or "").strip()
+    if embedding == "fastembed":
+        from .store.fastembed_backend import make_fastembed_backend
+
+        backend = (
+            make_fastembed_backend(embedding_model)
+            if embedding_model
+            else make_fastembed_backend()
+        )
+        if backend is None:
+            raise RuntimeError(
+                "vector.embedding: fastembed is unavailable (pip install fastembed), "
+                "or the bge model could not load. Alternatively set "
+                "vector.embedding to an LLM provider preset (e.g. mara)."
+            )
+        # bge-small embeds at 384 dims; the factory default (1536) is the
+        # OpenAI shape, so derive unless the spec pins one.
+        dimension = int(spec.vector.get("dimension") or len(backend.embed(["probe"])[0]))
+    else:
+        from .store.llm import create_embedding_backend
+
+        backend = create_embedding_backend(
+            provider=embedding, model=embedding_model or None
+        )
+        dimension = int(spec.vector.get("dimension") or 1536)
+
+    return create_vector_store(
+        kind=spec.vector_kind(),
+        embedding_backend=backend,
+        dimension=dimension,
+        uri=str(spec.vector.get("uri") or "./.lancedb"),
+        table_name=str(spec.vector.get("table_name") or "seocho_vectors"),
+    )
 
 
 def build(spec: RunSpec) -> RunContext:
@@ -160,6 +206,9 @@ def build(spec: RunSpec) -> RunContext:
 
     graph_store = _build_graph_store(spec, ontology)
     client_kwargs["graph_store"] = graph_store
+    vector_store = _build_vector_store(spec)
+    if vector_store is not None:
+        client_kwargs["vector_store"] = vector_store
 
     index_client = Seocho(llm=_build_llm(spec.indexing_model()), **client_kwargs)
     if spec.uses_split_models():
@@ -381,6 +430,8 @@ def run(
             "enforcement": spec.enforcement,
             "models": {"indexing": spec.indexing_model(), "query": spec.query_model()},
             "graph": spec.graph or "",
+            "graph_kind": spec.resolved_graph_kind(),
+            "vector": spec.vector_kind() if spec.uses_vector_store() else "",
             "database": ctx.database,
             "workspace_id": spec.resolved_workspace_id(),
         }
@@ -541,7 +592,10 @@ def run_from_config(
         _emit(quiet, "Dry run: config valid, preflight passed. Resolved plan:")
         _emit(quiet, f"  models: indexing={spec.indexing_model()}, query={spec.query_model()}")
         _emit(quiet, f"  enforcement: {spec.enforcement} (strict_validation={spec.strict_validation()})")
-        _emit(quiet, f"  graph: {spec.graph or 'embedded ladybug (.seocho/local.lbug)'}")
+        _emit(quiet, f"  graph: {spec.resolved_graph_kind()} "
+                     f"({spec.graph or '.seocho/local.lbug'})")
+        if spec.uses_vector_store():
+            _emit(quiet, f"  vector: {spec.vector_kind()} (embedding={spec.vector_embedding()})")
         _emit(quiet, f"  workspace: {spec.resolved_workspace_id()}")
         _emit(quiet, f"  questions: {len(spec.questions)}")
         if json_output:
@@ -796,6 +850,19 @@ def run_sweep_from_config(
                               "variants": [v.name for v, _s, _r in prepared]},
                              ensure_ascii=False))
         return 1 if any_failed else 0
+
+    # Shared-server note: bolt variants coexist on one server — isolation
+    # rides on per-variant database/workspace only (panel-recommended warning).
+    bolt_variants = [v.name for v, s, _r in prepared if s.resolved_graph_kind() != "ladybug"]
+    if len(bolt_variants) > 1:
+        _emit(
+            quiet,
+            "note: variants "
+            + ", ".join(bolt_variants)
+            + " share one graph server — isolation relies on per-variant "
+            "database/workspace_id; data coexists on the server.",
+        )
+        _emit(quiet)
 
     # --- Stage 2: sequential execution, keep-going by default.
     rows: List[Dict[str, Any]] = []

--- a/src/seocho/run_preflight.py
+++ b/src/seocho/run_preflight.py
@@ -229,7 +229,7 @@ def _check_models(spec: RunSpec) -> List[PreflightCheck]:
 
 def _check_graph(spec: RunSpec, *, online: bool) -> PreflightCheck:
     target = spec.graph
-    if not target or not target.startswith(("bolt://", "neo4j://", "neo4j+s://", "bolt+s://")):
+    if spec.resolved_graph_kind() == "ladybug":
         path = target or ".seocho/local.lbug"
         try:
             import real_ladybug  # noqa: F401
@@ -241,9 +241,11 @@ def _check_graph(spec: RunSpec, *, online: bool) -> PreflightCheck:
                 fix="pip install 'seocho[local]', or set graph: bolt://... to use Neo4j/DozerDB",
             )
         return PreflightCheck(name="graph", status="ok", detail=f"embedded ladybug ({path})")
+    kind = spec.resolved_graph_kind()
     if not online:
         return PreflightCheck(
-            name="graph", status="ok", detail=f"{target} (connection not checked in dry-run)"
+            name="graph", status="ok",
+            detail=f"{kind} {target} (connection not checked in dry-run)",
         )
     try:
         from .store.graph import Neo4jGraphStore
@@ -266,6 +268,56 @@ def _check_graph(spec: RunSpec, *, online: bool) -> PreflightCheck:
     return PreflightCheck(name="graph", status="ok", detail=f"{target} connected")
 
 
+def _check_vector(spec: RunSpec) -> "PreflightCheck | None":
+    if not spec.uses_vector_store():
+        return None
+    kind = spec.vector_kind()
+    module = "faiss" if kind == "faiss" else "lancedb"
+    try:
+        __import__(module)
+    except ImportError:
+        return PreflightCheck(
+            name=f"vector {kind}",
+            status="fail",
+            detail=f"the '{module}' package is not installed.",
+            fix=f"pip install {'faiss-cpu' if kind == 'faiss' else 'lancedb'}",
+        )
+    embedding = spec.vector_embedding()
+    if embedding == "fastembed":
+        try:
+            __import__("fastembed")
+        except ImportError:
+            return PreflightCheck(
+                name=f"vector {kind}",
+                status="fail",
+                detail="embedding=fastembed but the 'fastembed' package is not installed.",
+                fix="pip install fastembed, or set vector.embedding to a provider (e.g. mara)",
+            )
+        return PreflightCheck(
+            name=f"vector {kind}", status="ok", detail="embedding=fastembed (local bge)"
+        )
+    import os
+
+    from .store.llm import get_provider_spec
+
+    try:
+        provider_spec = get_provider_spec(embedding)
+    except ValueError as exc:
+        return PreflightCheck(name=f"vector {kind}", status="fail", detail=str(exc))
+    env_names = (provider_spec.api_key_env, *provider_spec.api_key_env_aliases)
+    if any(os.getenv(name, "").strip() for name in env_names):
+        return PreflightCheck(
+            name=f"vector {kind}", status="ok",
+            detail=f"embedding={embedding} ({provider_spec.api_key_env} set)",
+        )
+    return PreflightCheck(
+        name=f"vector {kind}",
+        status="fail",
+        detail=f"embedding={embedding} but {provider_spec.api_key_env} is not set.",
+        fix=f"export {provider_spec.api_key_env}=..., or use vector.embedding: fastembed",
+    )
+
+
 def run_preflight(spec: RunSpec, *, online: bool = False) -> PreflightReport:
     """Run all preflight checks for a run spec.
 
@@ -281,6 +333,9 @@ def run_preflight(spec: RunSpec, *, online: bool = False) -> PreflightReport:
             report.checks.append(check)
     report.checks.extend(_check_models(spec))
     report.checks.append(_check_graph(spec, online=online))
+    vector_check = _check_vector(spec)
+    if vector_check is not None:
+        report.checks.append(vector_check)
     if spec.index_only():
         report.checks.append(
             PreflightCheck(name="questions", status="ok", detail="none (index-only run)")

--- a/src/seocho/run_spec.py
+++ b/src/seocho/run_spec.py
@@ -28,6 +28,9 @@ _ALLOWED_ENFORCEMENT_MODES = {"strict", "guided", "open"}
 _ALLOWED_EXECUTION_MODES = {"pipeline", "agent", "supervisor"}
 _ALLOWED_ROUTING_POLICIES = {"fast", "balanced", "thorough"}
 _ALLOWED_ANSWER_STYLES = {"concise", "evidence", "table"}
+_ALLOWED_GRAPH_KINDS = {"neo4j", "dozerdb", "ladybug"}
+_ALLOWED_VECTOR_KINDS = {"faiss", "lancedb"}
+_BOLT_SCHEMES = ("bolt://", "neo4j://", "neo4j+s://", "bolt+s://")
 
 _TOP_LEVEL_KEYS = {
     "name",
@@ -43,6 +46,7 @@ _TOP_LEVEL_KEYS = {
     "indexing",
     "agent",
     "query",
+    "vector",
     "questions",
     "output",
 }
@@ -50,9 +54,11 @@ _SECTION_KEYS: Dict[str, set] = {
     "ontology": {"path", "enforcement"},
     "documents": {"path", "recursive"},
     "models": {"default", "indexing", "query"},
+    "graph": {"kind", "uri", "path", "user", "password", "database"},
     "indexing": {"design", "category", "force"},
     "agent": {"design", "execution_mode", "routing_policy"},
     "query": {"reasoning_mode", "repair_budget", "answer_style", "limit"},
+    "vector": {"kind", "embedding", "embedding_model", "dimension", "uri", "table_name"},
     "output": {"dir"},
 }
 
@@ -178,6 +184,10 @@ class RunSpec:
     documents_recursive: bool = True
     models: Dict[str, str] = field(default_factory=dict)
     graph: str = ""
+    # Optional explicit backend kind (neo4j | dozerdb | ladybug). Empty means
+    # infer from the graph value: bolt-scheme URI → Neo4j/DozerDB, anything
+    # else (or blank) → embedded LadybugDB path.
+    graph_kind: str = ""
     graph_user: str = "neo4j"
     graph_password: str = "password"
     database: str = ""
@@ -185,6 +195,9 @@ class RunSpec:
     indexing: Dict[str, Any] = field(default_factory=dict)
     agent: Dict[str, Any] = field(default_factory=dict)
     query: Dict[str, Any] = field(default_factory=dict)
+    # Optional hybrid-search vector store: {kind, embedding, embedding_model,
+    # dimension, uri, table_name}. Absent section → no vector store.
+    vector: Dict[str, Any] = field(default_factory=dict)
     questions: List[QuestionSpec] = field(default_factory=list)
     output_dir: str = "runs"
     source_path: str = ""
@@ -218,6 +231,27 @@ class RunSpec:
 
     def index_only(self) -> bool:
         return not self.questions
+
+    # -- backend resolution -------------------------------------------------
+
+    def resolved_graph_kind(self) -> str:
+        if self.graph_kind:
+            return self.graph_kind
+        if self.graph and self.graph.startswith(_BOLT_SCHEMES):
+            return "neo4j"
+        return "ladybug"
+
+    def uses_vector_store(self) -> bool:
+        return bool(self.vector)
+
+    def vector_kind(self) -> str:
+        return _string(self.vector.get("kind")).lower()
+
+    def vector_embedding(self) -> str:
+        """Embedding source for the vector store. Default ``fastembed``
+        (local bge, no network) per the MARA-first policy; any other value
+        is treated as an LLM provider preset name."""
+        return _string(self.vector.get("embedding")).lower() or "fastembed"
 
 
 def _parse_questions(value: Any, *, errors: List[str]) -> List[QuestionSpec]:
@@ -287,7 +321,28 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
     indexing = _section(payload, "indexing", errors=errors)
     agent = _section(payload, "agent", errors=errors)
     query = _section(payload, "query", errors=errors)
+    vector = _section(payload, "vector", errors=errors)
     output = _section(payload, "output", errors=errors)
+
+    # ``graph`` accepts a bare string (bolt URI or ladybug path — inferred)
+    # or a mapping with an explicit backend kind. The mapping form
+    # normalizes into the flat fields so everything downstream is unchanged.
+    graph_value = payload.get("graph")
+    graph_kind = ""
+    if isinstance(graph_value, Mapping):
+        graph_section = _section(payload, "graph", errors=errors)
+        graph_kind = _string(graph_section.get("kind")).lower()
+        graph_target = _string(graph_section.get("uri")) or _string(graph_section.get("path"))
+        graph_user = _string(graph_section.get("user"))
+        graph_password = _string(graph_section.get("password"))
+        graph_database = _string(graph_section.get("database"))
+        if _string(graph_section.get("uri")) and _string(graph_section.get("path")):
+            errors.append("at graph: declare either 'uri' (bolt) or 'path' (ladybug), not both.")
+    else:
+        graph_target = _string(graph_value)
+        graph_user = ""
+        graph_password = ""
+        graph_database = ""
 
     default_name = Path(source_path).stem if source_path else "seocho-run"
     spec = RunSpec(
@@ -299,14 +354,16 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
         documents_path=_string(documents.get("path")),
         documents_recursive=bool(documents.get("recursive", True)),
         models=models,
-        graph=_string(payload.get("graph")),
-        graph_user=_string(payload.get("graph_user")) or "neo4j",
-        graph_password=_string(payload.get("graph_password")) or "password",
-        database=_string(payload.get("database")),
+        graph=graph_target,
+        graph_kind=graph_kind,
+        graph_user=graph_user or _string(payload.get("graph_user")) or "neo4j",
+        graph_password=graph_password or _string(payload.get("graph_password")) or "password",
+        database=graph_database or _string(payload.get("database")),
         workspace_id=_string(payload.get("workspace_id")),
         indexing=indexing,
         agent=agent,
         query=query,
+        vector=vector,
         questions=_parse_questions(payload.get("questions"), errors=errors),
         output_dir=_string(output.get("dir")) or "runs",
         source_path=source_path,
@@ -350,6 +407,36 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
     limit = spec.query.get("limit")
     if limit is not None and not isinstance(limit, int):
         errors.append("at query.limit: must be an integer.")
+
+    if spec.graph_kind:
+        if spec.graph_kind not in _ALLOWED_GRAPH_KINDS:
+            errors.append(
+                "at graph.kind: must be one of: "
+                f"{', '.join(sorted(_ALLOWED_GRAPH_KINDS))}; got {spec.graph_kind!r}."
+            )
+        else:
+            is_bolt = spec.graph.startswith(_BOLT_SCHEMES)
+            if spec.graph_kind in ("neo4j", "dozerdb") and not is_bolt:
+                errors.append(
+                    f"at graph: kind {spec.graph_kind!r} requires a bolt:// (or neo4j://) "
+                    f"uri; got {spec.graph!r}."
+                )
+            if spec.graph_kind == "ladybug" and is_bolt:
+                errors.append(
+                    "at graph: kind 'ladybug' is the embedded engine and takes a file "
+                    f"path, not a bolt uri; got {spec.graph!r}."
+                )
+
+    if spec.vector:
+        vector_kind = spec.vector_kind()
+        if vector_kind not in _ALLOWED_VECTOR_KINDS:
+            errors.append(
+                "at vector.kind: must be one of: "
+                f"{', '.join(sorted(_ALLOWED_VECTOR_KINDS))}; got {vector_kind!r}."
+            )
+        dimension = spec.vector.get("dimension")
+        if dimension is not None and not isinstance(dimension, int):
+            errors.append("at vector.dimension: must be an integer.")
 
     if errors:
         raise RunSpecError(errors)
@@ -407,6 +494,21 @@ questions:
 # graph_password: ${NEO4J_PASSWORD:-password}
 # database: neo4j                   # omit to derive from the ontology name
 # workspace_id: my_run
+#
+# graph:                            # mapping form with an explicit backend
+#   kind: dozerdb                   # neo4j | dozerdb | ladybug
+#   uri: bolt://localhost:7687      # (ladybug uses `path:` instead)
+#   user: neo4j
+#   password: ${NEO4J_PASSWORD}
+#   database: mydb
+#
+# vector:                           # optional hybrid-search vector store
+#   kind: faiss                     # faiss (in-memory) | lancedb (on-disk)
+#   embedding: fastembed            # local bge (default, no network) or an
+#                                   #   LLM provider preset (mara, openai, ...)
+#   embedding_model: BAAI/bge-small-en-v1.5
+#   uri: ./.lancedb                 # lancedb only
+#   table_name: seocho_vectors      # lancedb only
 #
 # indexing:
 #   design: ./indexing_design.yaml  # optional IndexingDesignSpec

--- a/src/seocho/run_template.py
+++ b/src/seocho/run_template.py
@@ -442,6 +442,13 @@ def derive_variant_isolation(
     elif spec.graph.startswith(_BOLT_SCHEMES) and not spec.database:
         spec.database = _database_safe(f"{spec.name}")
 
+    # On-disk vector stores share the same comparison-poisoning hazard as
+    # graph.lbug — variant 2 would retrieve variant 1's chunks. Fill a blank
+    # lancedb uri with a variant-local path (explicit values untouched;
+    # faiss is in-memory and rebuilt per variant, nothing to isolate).
+    if spec.vector and spec.vector_kind() == "lancedb" and not str(spec.vector.get("uri") or "").strip():
+        spec.vector["uri"] = str(variant_dir / "vectors.lancedb")
+
     return spec
 
 

--- a/tests/seocho/test_e2e_runner.py
+++ b/tests/seocho/test_e2e_runner.py
@@ -311,3 +311,93 @@ def test_file_indexer_strict_validation_set_and_restored(tmp_path) -> None:
 
     indexer.index_file(doc)
     assert pipeline.seen == [True, False]  # default untouched
+
+
+def test_build_graph_store_respects_explicit_kind(monkeypatch) -> None:
+    """graph.kind dispatches the backend even without URI sniffing."""
+    import seocho.store.graph as graph_mod
+
+    captured: Dict[str, Any] = {}
+
+    class _FakeNeo4j:
+        def __init__(self, uri: str, user: str, password: str) -> None:
+            captured["neo4j"] = (uri, user, password)
+
+    class _FakeLadybug:
+        def __init__(self, path: str) -> None:
+            captured["ladybug"] = path
+
+        def ensure_constraints(self, ontology: Any) -> None:
+            pass
+
+    monkeypatch.setattr(graph_mod, "Neo4jGraphStore", _FakeNeo4j)
+    monkeypatch.setattr(graph_mod, "LadybugGraphStore", _FakeLadybug)
+
+    bolt_spec = parse_run_spec(
+        {"ontology": "s.yaml", "documents": "d/",
+         "graph": {"kind": "dozerdb", "uri": "bolt://h:7687", "user": "u", "password": "p"}}
+    )
+    e2e._build_graph_store(bolt_spec, _ontology())
+    assert captured["neo4j"] == ("bolt://h:7687", "u", "p")
+
+    embedded_spec = parse_run_spec({"ontology": "s.yaml", "documents": "d/"})
+    e2e._build_graph_store(embedded_spec, _ontology())
+    assert captured["ladybug"] == ".seocho/local.lbug"
+
+
+def test_build_vector_store_absent_section_returns_none() -> None:
+    spec = parse_run_spec({"ontology": "s.yaml", "documents": "d/"})
+    assert e2e._build_vector_store(spec) is None
+
+
+def test_build_vector_store_fastembed_default(monkeypatch) -> None:
+    import seocho.store.fastembed_backend as fe_mod
+    import seocho.store.vector as vec_mod
+
+    class _FakeEmbedding:
+        def embed(self, texts):
+            return [[0.0] * 384 for _ in texts]
+
+    captured: Dict[str, Any] = {}
+
+    def fake_create(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "VECTOR_STORE"
+
+    monkeypatch.setattr(fe_mod, "make_fastembed_backend", lambda *a, **k: _FakeEmbedding())
+    monkeypatch.setattr(vec_mod, "create_vector_store", fake_create)
+
+    spec = parse_run_spec(
+        {"ontology": "s.yaml", "documents": "d/", "vector": {"kind": "faiss"}}
+    )
+    assert e2e._build_vector_store(spec) == "VECTOR_STORE"
+    assert captured["kind"] == "faiss"
+    assert captured["dimension"] == 384  # derived from the probe embedding
+    assert isinstance(captured["embedding_backend"], _FakeEmbedding)
+
+
+def test_build_vector_store_fastembed_missing_is_loud(monkeypatch) -> None:
+    import seocho.store.fastembed_backend as fe_mod
+
+    monkeypatch.setattr(fe_mod, "make_fastembed_backend", lambda *a, **k: None)
+    spec = parse_run_spec(
+        {"ontology": "s.yaml", "documents": "d/", "vector": {"kind": "faiss"}}
+    )
+    with pytest.raises(RuntimeError, match="fastembed is unavailable"):
+        e2e._build_vector_store(spec)
+
+
+def test_build_passes_vector_store_to_clients(tmp_path, monkeypatch) -> None:
+    created = _patch_backends(monkeypatch)
+    monkeypatch.setattr(e2e, "_build_vector_store", lambda spec: "SHARED_VECTORS")
+    payload = _write_fixture(tmp_path)
+    payload["vector"] = {"kind": "faiss"}
+    spec = parse_run_spec(payload, source_path=str(tmp_path / "run.yaml"))
+
+    ctx = e2e.build(spec)
+    try:
+        assert ctx.index_client.vector_store == "SHARED_VECTORS"
+        assert ctx.query_client.vector_store == "SHARED_VECTORS"
+        assert created["stores"], "graph store still built"
+    finally:
+        ctx.close()

--- a/tests/seocho/test_run_spec.py
+++ b/tests/seocho/test_run_spec.py
@@ -190,3 +190,67 @@ def test_load_run_spec_missing_file() -> None:
     with pytest.raises(RunSpecError) as excinfo:
         load_run_spec("/nonexistent/run.yaml")
     assert "seocho run --init" in str(excinfo.value)
+
+
+def test_graph_mapping_form_with_kind() -> None:
+    spec = parse_run_spec(
+        {
+            "ontology": "s.yaml",
+            "documents": "d/",
+            "graph": {
+                "kind": "dozerdb",
+                "uri": "bolt://host:7687",
+                "user": "u",
+                "password": "pw",
+                "database": "db1",
+            },
+        }
+    )
+    assert spec.graph == "bolt://host:7687"
+    assert spec.graph_kind == "dozerdb"
+    assert spec.resolved_graph_kind() == "dozerdb"
+    assert spec.graph_user == "u"
+    assert spec.graph_password == "pw"
+    assert spec.database == "db1"
+
+
+def test_graph_bare_string_back_compat() -> None:
+    spec = parse_run_spec(
+        {"ontology": "s.yaml", "documents": "d/", "graph": "bolt://host:7687"}
+    )
+    assert spec.graph_kind == ""
+    assert spec.resolved_graph_kind() == "neo4j"  # inferred from bolt scheme
+    blank = parse_run_spec({"ontology": "s.yaml", "documents": "d/"})
+    assert blank.resolved_graph_kind() == "ladybug"
+
+
+def test_graph_kind_coherence_errors() -> None:
+    base = {"ontology": "s.yaml", "documents": "d/"}
+    with pytest.raises(RunSpecError, match="requires a bolt"):
+        parse_run_spec({**base, "graph": {"kind": "neo4j", "path": "./g.lbug"}})
+    with pytest.raises(RunSpecError, match="embedded engine"):
+        parse_run_spec({**base, "graph": {"kind": "ladybug", "uri": "bolt://h:7687"}})
+    with pytest.raises(RunSpecError, match="graph.kind"):
+        parse_run_spec({**base, "graph": {"kind": "postgres", "uri": "bolt://h:7687"}})
+    with pytest.raises(RunSpecError, match="not both"):
+        parse_run_spec(
+            {**base, "graph": {"kind": "ladybug", "uri": "x", "path": "y"}}
+        )
+
+
+def test_vector_section_parse_and_defaults() -> None:
+    base = {"ontology": "s.yaml", "documents": "d/"}
+    spec = parse_run_spec({**base, "vector": {"kind": "lancedb", "uri": "./v"}})
+    assert spec.uses_vector_store()
+    assert spec.vector_kind() == "lancedb"
+    assert spec.vector_embedding() == "fastembed"  # MARA-first default
+
+    none_spec = parse_run_spec(base)
+    assert not none_spec.uses_vector_store()
+
+    with pytest.raises(RunSpecError, match="vector.kind"):
+        parse_run_spec({**base, "vector": {"kind": "pinecone"}})
+    with pytest.raises(RunSpecError, match="vector.dimension"):
+        parse_run_spec({**base, "vector": {"kind": "faiss", "dimension": "big"}})
+    with pytest.raises(RunSpecError, match="unknown key"):
+        parse_run_spec({**base, "vector": {"kind": "faiss", "embeding": "x"}})

--- a/tests/seocho/test_run_template.py
+++ b/tests/seocho/test_run_template.py
@@ -282,3 +282,22 @@ def test_absolutized_rendered_text(tmp_path) -> None:
     assert Path(payload["agent"]["design"]).is_absolute()
     # secrets stay as unresolved placeholders
     assert payload["graph_password"] == "${SECRET:-pw}"
+
+
+def test_isolation_fills_blank_lancedb_uri(tmp_path) -> None:
+    spec = derive_variant_isolation(
+        _spec(vector={"kind": "lancedb"}), variant_name="v1", sweep_run_dir=tmp_path
+    )
+    assert spec.vector["uri"] == str(tmp_path / "v1" / "vectors.lancedb")
+
+    explicit = derive_variant_isolation(
+        _spec(vector={"kind": "lancedb", "uri": "/data/shared.lancedb"}),
+        variant_name="v1",
+        sweep_run_dir=tmp_path,
+    )
+    assert explicit.vector["uri"] == "/data/shared.lancedb"
+
+    faiss = derive_variant_isolation(
+        _spec(vector={"kind": "faiss"}), variant_name="v1", sweep_run_dir=tmp_path
+    )
+    assert "uri" not in faiss.vector  # in-memory: nothing to isolate


### PR DESCRIPTION
## What

User-surfaced gap after #290: the YAML e2e surface only reached **graph** backends, while the SDK already ships FAISS/LanceDB vector stores and `Seocho(vector_store=...)` hybrid search. This exposes both axes declaratively. **RDBMS is explicitly excluded** (per user) — no relational `GraphStore` implementation exists in the SDK; documented in RUN_SPECS.md.

### `vector:` section (new)

```yaml
vector:
  kind: faiss            # faiss (in-memory) | lancedb (on-disk)
  embedding: fastembed   # local bge default (MARA-first, no network) | provider preset (mara, openai, ...)
```

- Wired through `create_vector_store()` into **both** clients (index + query share one instance, like the graph store).
- `dimension` auto-derived from a probe embedding — bge-small is 384, not the factory's OpenAI-shaped 1536 default.
- Missing `fastembed` is loud at **preflight** (import check + actionable fix) and at build, never a silent no-vector run.

### `graph:` mapping form with explicit `kind`

```yaml
graph:
  kind: dozerdb          # neo4j | dozerdb | ladybug
  uri: bolt://localhost:7687
  user: neo4j
  password: ${NEO4J_PASSWORD}
  database: mydb
```

Bare-string back-compat unchanged (bolt URI → Neo4j/DozerDB, else embedded path). kind/uri coherence validated (neo4j/dozerdb require bolt; ladybug takes a path; `uri`+`path` together is an error). `_build_graph_store` now dispatches on the resolved kind instead of URI sniffing — the extension point future backends plug into.

### Sweep isolation extended

- Blank lancedb `uri` → `<sweep>/<variant>/vectors.lancedb` — on-disk vector stores carry the same comparison-poisoning hazard as `graph.lbug` (variant 2 retrieving variant 1's chunks). Explicit uris untouched; FAISS is in-memory per variant (nothing to isolate).
- bolt + multi-variant sweeps now print the shared-server note the architecture panel recommended (dropped in #290): isolation rides on per-variant database/workspace only.

## Validation

- `bash scripts/ci/run_basic_ci.sh` — **611 passed, 5 skipped** (+13 tests: graph mapping/coherence, vector parse/validation, builder kind dispatch, fastembed default + loud-missing, shared vector_store, lancedb uri isolation)
- Live run (MARA + FAISS + fastembed bge, no network embeddings): preflight `vector faiss — embedding=fastembed (local bge)` ok → 3 files indexed → 1/1 answered
- DozerDB mapping form dry-run resolves the kind correctly; missing-fastembed preflight failure verified with the pip/provider fix text

Beads: seocho-32r