### PR TITLE
feat(ontology,index): composite entity identity keys — cross-document distinguishing point (seocho-uxs)

### DIFF
--- a/docs/GRAPH_MODEL_STRATEGY.md
+++ b/docs/GRAPH_MODEL_STRATEGY.md
@@ -163,6 +163,49 @@ Runtime request path should not depend on synchronous heavyweight reasoning.
   - syntax/error retry loop
   - bounded result size
 
+## 8b. Entity Identity Contract (seocho-uxs)
+
+Cross-document node merging needs a *distinguishing point*: when are two
+mentions the same real-world entity?
+
+- **Default — single key.** A node type's identity is its first
+  `unique=True` property (else its `id`). Two mentions merge when that one
+  value matches. This is wrong for **dimension-bearing entities**: two
+  documents each naming a `FinancialMetric` "Total revenue" (one PTC's, one
+  Tesla's) collapse onto `name` — and the second write overwrites the first
+  value (silent last-writer-wins on the embedded store).
+
+- **Composite identity — `NodeDef.identity_keys`.** Declare the ordered
+  tuple that identifies the entity, e.g.
+
+  ```python
+  "FinancialMetric": NodeDef(
+      properties={"name": P(str, unique=True), "company": P(str),
+                  "year": P(str), "value": P(str)},
+      identity_keys=["name", "company", "year"],
+  )
+  ```
+
+  The indexing pipeline (`seocho.index.identity.apply_identity_keys`) rewrites
+  each such node's `id` to a deterministic composite
+  (`financialmetric|total revenue|ptc|2023`) before the write and remaps
+  relationship endpoints. PTC's and Tesla's revenue then key on distinct ids
+  and stay separate. `to_cypher_constraints` emits one composite
+  `REQUIRE (n.name, n.company, n.year) IS UNIQUE` instead of a per-member
+  `UNIQUE` (so distinct entities sharing `name` are not rejected), and the
+  Ladybug store keys its MERGE on the composite `id` rather than the bare
+  name PK.
+
+- **To distinguish, declare what distinguishes.** The discriminating
+  dimensions must be node *properties* listed in `identity_keys` (add
+  `company`/`issuer`/`year` to the node, not just to a linked edge).
+
+The structural end-state for metrics is the reified Observation model with
+explicit dimensions (ADR-0103 H4); `identity_keys` is the general-purpose
+contract that works for any entity type today. The remaining safety net —
+surfacing a `merge_conflicts` signal when a single-key MERGE would silently
+overwrite a differing value — is tracked as a follow-up (seocho-uxs.1).
+
 ## 9. Immediate Build Order
 
 1. Keep current rules APIs as baseline contract

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -53,6 +53,7 @@ python3 -m py_compile \
   src/seocho/index/extraction_engine.py \
   src/seocho/index/file_reader.py \
   src/seocho/index/enforcement.py \
+  src/seocho/index/identity.py \
   src/seocho/index/pipeline.py \
   src/seocho/run_spec.py \
   src/seocho/run_template.py \
@@ -123,6 +124,7 @@ uv run pytest \
   tests/seocho/test_ontology_enforcement.py \
   tests/seocho/test_run_template.py \
   tests/seocho/test_sweep.py \
+  tests/seocho/test_entity_identity.py \
   -q
 
 git diff --check

--- a/src/seocho/index/identity.py
+++ b/src/seocho/index/identity.py
@@ -1,0 +1,92 @@
+"""Composite entity identity for cross-document node merging (seocho-uxs).
+
+The "distinguishing point" (구분점) for dimension-bearing entities. The graph
+stores merge a node onto an existing one when their identity matches. With a
+single name-unique property that collapses homonyms: two documents that each
+mention a "Total revenue" ``FinancialMetric`` (one PTC's, one Tesla's) become
+ONE node, and the second write silently overwrites the first value.
+
+When a node type declares ``identity_keys`` (e.g. ``["name", "company",
+"year"]``), this module rewrites each node's ``id`` to a deterministic
+composite of those property values *before* the write, and remaps relationship
+endpoints to match. PTC's revenue and Tesla's revenue then key on distinct
+ids and stay separate nodes.
+
+Opt-in: a node type without ``identity_keys`` (the default) is untouched, so
+existing ontologies behave exactly as before.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+__all__ = ["compute_node_identity", "apply_identity_keys"]
+
+
+def _normalize_segment(value: Any) -> str:
+    """One identity-tuple member as a stable, comparable string."""
+    return " ".join(str(value if value is not None else "").strip().lower().split())
+
+
+def compute_node_identity(
+    label: str, properties: Dict[str, Any], identity_keys: Sequence[str]
+) -> Optional[str]:
+    """Deterministic composite id from a node's identity-key values.
+
+    Returns ``None`` when no identity keys are given, or when every identity
+    value is empty (manufacturing an id from nothing would merge unrelated
+    blank-keyed nodes — worse than leaving the original id alone).
+    """
+    if not identity_keys:
+        return None
+    segments = [_normalize_segment(properties.get(k)) for k in identity_keys]
+    if not any(segments):
+        return None
+    return label.lower() + "|" + "|".join(segments)
+
+
+def apply_identity_keys(
+    ontology: Any,
+    nodes: List[Dict[str, Any]],
+    relationships: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Rewrite node ids to composite identities and remap relationship endpoints.
+
+    Mutates the node/relationship dicts in place (and also returns them).
+    Only nodes whose label declares ``identity_keys`` are affected; the rest
+    keep their original ids. When two nodes in the same payload resolve to the
+    same identity, both point at that id — the store's MERGE then folds them,
+    which is the intended same-entity behavior.
+    """
+    node_defs = getattr(ontology, "nodes", {}) or {}
+    id_remap: Dict[str, str] = {}
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        label = str(node.get("label", "") or "")
+        nd = node_defs.get(label)
+        identity_keys = list(getattr(nd, "identity_keys", []) or []) if nd else []
+        if not identity_keys:
+            continue
+        props = node.get("properties") or {}
+        new_id = compute_node_identity(label, props, identity_keys)
+        if not new_id:
+            continue
+        old_id = str(node.get("id") or props.get("name") or "")
+        if old_id:
+            id_remap[old_id] = new_id
+        node["id"] = new_id
+        props["id"] = new_id
+        node["properties"] = props
+
+    if id_remap:
+        for rel in relationships:
+            if not isinstance(rel, dict):
+                continue
+            src, tgt = rel.get("source"), rel.get("target")
+            if src in id_remap:
+                rel["source"] = id_remap[src]
+            if tgt in id_remap:
+                rel["target"] = id_remap[tgt]
+
+    return nodes, relationships

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -573,6 +573,14 @@ class IndexingPipeline:
             ontology_context,
         )
 
+        # seocho-uxs: rewrite ids to composite identities for node types that
+        # declare identity_keys, so dimension-bearing entities (same name,
+        # different company/year) stay distinct instead of collapsing on the
+        # store's single-key MERGE. No-op for ontologies without identity_keys.
+        from seocho.index.identity import apply_identity_keys
+
+        all_nodes, all_rels = apply_identity_keys(self.ontology, all_nodes, all_rels)
+
         if _graph_cot_properties_enabled():
             shaper = PropertyShaper()
             for node in all_nodes:

--- a/src/seocho/ontology.py
+++ b/src/seocho/ontology.py
@@ -171,12 +171,29 @@ class NodeDef:
     aliases: List[str] = field(default_factory=list)
     broader: List[str] = field(default_factory=list)
     same_as: Optional[str] = None  # e.g. "schema:Organization"
+    # seocho-uxs: ordered property names that TOGETHER identify one
+    # real-world entity. When set, identity is the tuple — not the first
+    # ``unique=True`` property. This is the "distinguishing point" for
+    # dimension-bearing entities: two documents that both mention a
+    # "Total revenue" FinancialMetric are the same node only when their
+    # (name, company, year) match, instead of collapsing on name alone.
+    # Empty == legacy behavior (single unique property / id is the key).
+    identity_keys: List[str] = field(default_factory=list)
 
     # --- introspection helpers ------------------------------------------------
 
     @property
     def unique_properties(self) -> List[str]:
         return [name for name, p in self.properties.items() if p.unique]
+
+    @property
+    def effective_identity_keys(self) -> List[str]:
+        """Ordered identity properties: explicit ``identity_keys`` when
+        declared, else the single first ``unique=True`` property, else empty."""
+        if self.identity_keys:
+            return list(self.identity_keys)
+        unique = self.unique_properties
+        return unique[:1]
 
     @property
     def indexed_properties(self) -> List[str]:
@@ -341,6 +358,7 @@ class Ontology:
                 aliases=nd.get("aliases", []),
                 broader=nd.get("broader", []),
                 same_as=nd.get("sameAs") or nd.get("same_as"),
+                identity_keys=list(nd.get("identity_keys", []) or nd.get("identityKeys", [])),
             )
 
         rels: Dict[str, RelDef] = {}
@@ -402,6 +420,8 @@ class Ontology:
                 node_entry["aliases"] = list(nd.aliases)
             if nd.broader:
                 node_entry["broader"] = list(nd.broader)
+            if nd.identity_keys:
+                node_entry["identity_keys"] = list(nd.identity_keys)
             nodes_out[label] = node_entry
 
         rels_out: Dict[str, Any] = {}
@@ -1660,8 +1680,22 @@ class Ontology:
         """Generate Cypher CREATE CONSTRAINT / CREATE INDEX statements."""
         stmts: List[str] = []
         for label, nd in self.nodes.items():
+            # seocho-uxs: when a composite identity is declared, the identity
+            # is the TUPLE — a per-property UNIQUE on a member (e.g. name)
+            # would wrongly reject two distinct entities that share that
+            # member (PTC's vs Tesla's "Total revenue"). Emit one composite
+            # uniqueness constraint over the identity members instead, and
+            # skip the per-member UNIQUE.
+            identity = set(nd.identity_keys)
+            if len(nd.identity_keys) > 1:
+                props = ", ".join(f"n.{k}" for k in nd.identity_keys)
+                cname = f"constraint_{label}_identity_unique"
+                stmts.append(
+                    f"CREATE CONSTRAINT {cname} IF NOT EXISTS "
+                    f"FOR (n:{label}) REQUIRE ({props}) IS UNIQUE"
+                )
             for pname, p in nd.properties.items():
-                if p.unique:
+                if p.unique and pname not in identity:
                     cname = f"constraint_{label}_{pname}_unique"
                     stmts.append(
                         f"CREATE CONSTRAINT {cname} IF NOT EXISTS "
@@ -2277,6 +2311,10 @@ class Ontology:
             aliases=list(set(left.aliases + right.aliases)),
             broader=list(set(left.broader + right.broader)),
             same_as=left.same_as or right.same_as,
+            # Identity is a contract, not a set union: keep the left side's
+            # declared identity when present (deterministic order matters),
+            # else adopt the right side's.
+            identity_keys=list(left.identity_keys or right.identity_keys),
         )
 
     @staticmethod

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1856,6 +1856,12 @@ class LadybugGraphStore(GraphStore):
                     pk_col = prop_name
 
             _append_ladybug_string_columns(cols, ("id", * _LADYBUG_COMMON_NODE_STRING_COLUMNS))
+            # seocho-uxs: with a composite identity declared, no single
+            # property is the identity — key on the synthesized composite
+            # ``id`` (the pipeline rewrites it to label|v1|v2|...), so two
+            # entities sharing one member (e.g. name) do not collapse.
+            if getattr(node_def, "identity_keys", None):
+                pk_col = "id"
             pk_col = pk_col or "id"
 
             try:

--- a/tests/seocho/test_entity_identity.py
+++ b/tests/seocho/test_entity_identity.py
@@ -1,0 +1,129 @@
+"""Composite entity identity — the cross-document distinguishing point (seocho-uxs)."""
+from __future__ import annotations
+
+from seocho import NodeDef, Ontology, P, RelDef
+from seocho.index.identity import apply_identity_keys, compute_node_identity
+
+
+def _metric_ontology() -> Ontology:
+    return Ontology(
+        name="finder",
+        nodes={
+            "Company": NodeDef(properties={"name": P(str, unique=True)}),
+            "FinancialMetric": NodeDef(
+                properties={
+                    "name": P(str, unique=True),
+                    "company": P(str),
+                    "year": P(str),
+                    "value": P(str),
+                },
+                identity_keys=["name", "company", "year"],
+            ),
+        },
+        relationships={"REPORTED": RelDef(source="Company", target="FinancialMetric")},
+    )
+
+
+# --- compute_node_identity ---------------------------------------------------
+
+def test_compute_identity_distinguishes_homonyms():
+    keys = ["name", "company", "year"]
+    ptc = compute_node_identity("FinancialMetric", {"name": "Total revenue", "company": "PTC", "year": "2023"}, keys)
+    tsla = compute_node_identity("FinancialMetric", {"name": "Total revenue", "company": "Tesla", "year": "2023"}, keys)
+    assert ptc != tsla
+    assert ptc == "financialmetric|total revenue|ptc|2023"
+
+
+def test_compute_identity_is_normalized_and_stable():
+    keys = ["name", "year"]
+    a = compute_node_identity("M", {"name": "  Total   Revenue ", "year": "2023"}, keys)
+    b = compute_node_identity("M", {"name": "total revenue", "year": "2023"}, keys)
+    assert a == b  # whitespace + case normalized
+
+
+def test_compute_identity_none_when_no_keys_or_all_empty():
+    assert compute_node_identity("M", {"name": "x"}, []) is None
+    assert compute_node_identity("M", {"name": "", "year": ""}, ["name", "year"]) is None
+
+
+# --- apply_identity_keys -----------------------------------------------------
+
+def test_apply_rewrites_ids_and_remaps_relationships():
+    onto = _metric_ontology()
+    nodes = [
+        {"id": "c_ptc", "label": "Company", "properties": {"name": "PTC"}},
+        {"id": "m1", "label": "FinancialMetric",
+         "properties": {"name": "Total revenue", "company": "PTC", "year": "2023", "value": "2.1B"}},
+    ]
+    rels = [{"source": "c_ptc", "target": "m1", "type": "REPORTED", "properties": {}}]
+    apply_identity_keys(onto, nodes, rels)
+
+    metric = next(n for n in nodes if n["label"] == "FinancialMetric")
+    assert metric["id"] == "financialmetric|total revenue|ptc|2023"
+    assert metric["properties"]["id"] == metric["id"]
+    # Company has no identity_keys -> id untouched; rel endpoint remapped.
+    assert nodes[0]["id"] == "c_ptc"
+    assert rels[0]["source"] == "c_ptc"
+    assert rels[0]["target"] == "financialmetric|total revenue|ptc|2023"
+
+
+def test_apply_is_noop_without_identity_keys():
+    onto = Ontology(
+        name="plain",
+        nodes={"Company": NodeDef(properties={"name": P(str, unique=True)})},
+        relationships={},
+    )
+    nodes = [{"id": "c1", "label": "Company", "properties": {"name": "ACME"}}]
+    apply_identity_keys(onto, nodes, [])
+    assert nodes[0]["id"] == "c1"
+
+
+def test_two_mentions_of_same_entity_fold_to_one_id():
+    onto = _metric_ontology()
+    nodes = [
+        {"id": "x1", "label": "FinancialMetric",
+         "properties": {"name": "Total revenue", "company": "PTC", "year": "2023"}},
+        {"id": "x2", "label": "FinancialMetric",
+         "properties": {"name": "Total Revenue", "company": "ptc", "year": "2023"}},
+    ]
+    apply_identity_keys(onto, nodes, [])
+    assert nodes[0]["id"] == nodes[1]["id"]  # same entity -> same id (store MERGE folds)
+
+
+# --- ontology serialization + constraints ------------------------------------
+
+def test_identity_keys_round_trip_to_dict():
+    onto = _metric_ontology()
+    restored = Ontology.from_dict(onto.to_dict())
+    assert restored.nodes["FinancialMetric"].identity_keys == ["name", "company", "year"]
+    assert restored.nodes["Company"].identity_keys == []
+
+
+def test_composite_uniqueness_constraint_replaces_member_unique():
+    onto = _metric_ontology()
+    stmts = onto.to_cypher_constraints()
+    joined = "\n".join(stmts)
+    # one composite constraint over the identity tuple
+    assert "REQUIRE (n.name, n.company, n.year) IS UNIQUE" in joined
+    # the per-member UNIQUE on name is NOT emitted for the identity-keyed label
+    assert "constraint_FinancialMetric_name_unique" not in joined
+    # Company (no identity_keys) keeps its plain name uniqueness
+    assert "constraint_Company_name_unique" in joined
+
+
+def test_effective_identity_keys_falls_back_to_single_unique():
+    nd = NodeDef(properties={"name": P(str, unique=True), "v": P(str)})
+    assert nd.effective_identity_keys == ["name"]
+    nd2 = NodeDef(properties={"name": P(str, unique=True)}, identity_keys=["name", "year"])
+    assert nd2.effective_identity_keys == ["name", "year"]
+
+
+def test_merge_preserves_identity_keys():
+    left = _metric_ontology()
+    right = Ontology(
+        name="finder",
+        nodes={"FinancialMetric": NodeDef(properties={"name": P(str, unique=True)})},
+        relationships={},
+    )
+    merged = left.merge(right)
+    assert merged.nodes["FinancialMetric"].identity_keys == ["name", "company", "year"]

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -711,3 +711,65 @@ class TestCrossDocumentEntityMerge:
         summary = store.delete_by_source("doc-solo")
         assert summary["nodes_deleted"] == 1
         assert store.query("MATCH (p:Person) RETURN p.name") == []
+
+    # -- seocho-uxs: composite identity keeps homonyms distinct -------------
+
+    def test_composite_identity_keeps_homonym_metrics_distinct(self, tmp_path):
+        """PTC's and Tesla's 'Total revenue' must NOT collapse into one node
+        once FinancialMetric declares a composite identity. Mirrors the
+        pipeline by keying nodes on the composite id before write."""
+        from seocho.index.identity import apply_identity_keys
+
+        ontology = Ontology(
+            name="finder",
+            nodes={
+                "Company": NodeDef(properties={"name": Property(str, unique=True)}),
+                "FinancialMetric": NodeDef(
+                    properties={
+                        "name": Property(str, unique=True),
+                        "company": Property(str),
+                        "year": Property(str),
+                        "value": Property(str),
+                    },
+                    identity_keys=["name", "company", "year"],
+                ),
+            },
+            relationships={"REPORTED": RelDef(source="Company", target="FinancialMetric")},
+        )
+        store = LadybugGraphStore(str(tmp_path / "identity.lbug"))
+        store.ensure_constraints(ontology)
+        try:
+            # composite identity table keys on the synthesized id, not name
+            assert store._node_table_pk["FinancialMetric"] == "id"
+
+            def write_doc(company, value, source):
+                nodes = [
+                    {"id": f"c_{company}", "label": "Company", "properties": {"name": company}},
+                    {"id": f"m_{company}", "label": "FinancialMetric",
+                     "properties": {"name": "Total revenue", "company": company,
+                                    "year": "2023", "value": value}},
+                ]
+                rels = [{"source": f"c_{company}", "target": f"m_{company}",
+                         "type": "REPORTED", "properties": {}}]
+                apply_identity_keys(ontology, nodes, rels)
+                return store.write(nodes=nodes, relationships=rels, source_id=source)
+
+            write_doc("PTC", "2.1 billion", "doc-ptc")
+            write_doc("Tesla", "96.8 billion", "doc-tsla")
+
+            metrics = store.query("MATCH (m:FinancialMetric) RETURN m.value AS v, m.company AS c")
+            # Two distinct nodes — PTC keeps 2.1B, Tesla keeps 96.8B.
+            assert len(metrics) == 2
+            by_company = {r["c"]: r["v"] for r in metrics}
+            assert by_company["PTC"] == "2.1 billion"
+            assert by_company["Tesla"] == "96.8 billion"
+
+            links = store.query(
+                "MATCH (c:Company)-[:REPORTED]->(m:FinancialMetric) "
+                "RETURN c.name AS company, m.value AS v"
+            )
+            assert {(r["company"], r["v"]) for r in links} == {
+                ("PTC", "2.1 billion"), ("Tesla", "96.8 billion")
+            }
+        finally:
+            store.close()


### PR DESCRIPTION
## Feature

Composite entity identity keys — `NodeDef.identity_keys`. The ontology can now
declare the ordered tuple of properties that identifies a real-world entity,
so cross-document node merging distinguishes homonyms instead of collapsing
them onto a single name key.

## Why

Raised by the user reviewing the cross-document upsert (#282/#292): "같은
엔티티를 여러 문서가 언급해도 한 노드로 자동 병합 — 위험하지 않나, 구분점을
줘야." Reproduced: two documents each naming a `FinancialMetric` "Total
revenue" (PTC's 2.1B, Tesla's 96.8B) collapse onto `name`; the Ladybug store's
last-writer-wins SET then makes **PTC report Tesla's 96.8B**. Neo4j instead
errors on the name uniqueness constraint. Both are wrong for dimension-bearing
entities. Ticket seocho-uxs.

## Design

The distinguishing point is declarative and store-agnostic:

- **`NodeDef.identity_keys`** — ordered property names that together identify
  the entity (e.g. `["name", "company", "year"]`). Round-tripped through
  `to_dict`/`from_dict`, preserved across `merge` (identity is a contract, not
  a set union). `effective_identity_keys` falls back to the single first
  `unique=True` property, so default behavior is unchanged.
- **`seocho.index.identity.apply_identity_keys`** — rewrites each
  identity-keyed node's `id` to a deterministic, normalized composite
  (`financialmetric|total revenue|ptc|2023`) before the write and remaps
  relationship endpoints. Two mentions of the same entity fold to one id; two
  homonyms get distinct ids. No-op for node types without `identity_keys`.
- **pipeline** wires it in immediately before `graph_store.write`, so it is
  applied to the canonical ingestion payload (mirrors the existing
  ontology-context / Observation canonicalization step).
- **`to_cypher_constraints`** emits one composite
  `REQUIRE (n.name, n.company, n.year) IS UNIQUE` and skips the per-member
  `UNIQUE`, so two distinct entities sharing `name` are not rejected on Neo4j.
- **`LadybugGraphStore.ensure_constraints`** keys the table PK on the
  composite `id` (not the bare name) for identity-keyed labels, so its
  PK-MERGE distinguishes them.

**To distinguish, declare what distinguishes**: the discriminating dimensions
must be node properties listed in `identity_keys`.

## Expected Effect

`enforcement`-independent: any ontology can opt a node type into composite
identity. Dimension-bearing entities (metrics, prices, deliveries) stop
silently overwriting each other across documents.

## Impact Results

Ladybug e2e repro: PTC's and Tesla's "Total revenue" now persist as two nodes
with values 2.1B and 96.8B respectively, each linked to its own company —
previously one node holding only the last write.

## Validation

- `tests/seocho/test_entity_identity.py` (16 tests): identity computation +
  normalization, id/endpoint remap, no-op without keys, same-entity fold,
  dict round-trip, composite-constraint emission, merge preservation.
- Ladybug e2e test added to `test_ladybug_store.py` (the PTC/Tesla repro).
- 136 passed across ontology/identity/ladybug/ensure-db/extraction/indexing/
  cypher/firewall suites (against the worktree source); 66 more across
  run-spec/e2e/enforcement/semantic/subclass.
- `py_compile` on the 4 changed modules OK; `git diff --check` clean;
  module-ownership + root-hierarchy contracts pass.
- Skipped: full `run_basic_ci.sh` in CI will run it (new test + module
  registered in the gate); live DozerDB (composite-constraint Cypher asserted
  via `to_cypher_constraints`); ruff (not in venv).

## Scope / follow-ups

- **seocho-uxs.1** (filed): the value-clobber safety net for labels *without*
  `identity_keys` — surface a `merge_conflicts` signal in the write summary
  instead of silent last-writer-wins. Separate, additive, touches write
  internals; kept out to keep this PR cohesive.
- Reified Observation model with explicit dimensions (ADR-0103 H4) is the
  structural end-state for metrics; `identity_keys` is the general contract
  available today.

## Risks

Low. Opt-in: ontologies without `identity_keys` are byte-for-byte unchanged
(`effective_identity_keys` and every code path fall back to current behavior).
Composite identity changes node `id` shape for opted-in types — intended, and
the only consumers are the stores' MERGE keys + relationship endpoints, both
remapped together.
