### PR TITLE
fix(store): surface merge_conflicts on silent single-key MERGE overwrites (seocho-uxs.1)

### DIFF
--- a/docs/GRAPH_MODEL_STRATEGY.md
+++ b/docs/GRAPH_MODEL_STRATEGY.md
@@ -202,9 +202,16 @@ mentions the same real-world entity?
 
 The structural end-state for metrics is the reified Observation model with
 explicit dimensions (ADR-0103 H4); `identity_keys` is the general-purpose
-contract that works for any entity type today. The remaining safety net —
-surfacing a `merge_conflicts` signal when a single-key MERGE would silently
-overwrite a differing value — is tracked as a follow-up (seocho-uxs.1).
+contract that works for any entity type today.
+
+**Safety net (seocho-uxs.1).** For node types *without* declared
+`identity_keys`, a single-key MERGE still silently last-writer-wins on a value
+clash. Both stores now surface this: when a MERGE lands on an existing node
+whose user-facing property already holds a different non-empty value, the
+write summary carries a non-fatal `merge_conflicts` entry
+(`{label, key, property, existing, incoming, source_id}`), propagated to
+`IndexingResult.merge_conflicts`. Ingestion still succeeds — the signal is
+advisory, so silent divergence becomes auditable instead of invisible.
 
 ## 9. Immediate Build Order
 

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -107,6 +107,10 @@ class IndexingResult:
     total_relationships: int = 0
     validation_errors: List[str] = field(default_factory=list)
     write_errors: List[str] = field(default_factory=list)
+    # seocho-uxs.1: non-fatal value-divergence signals from the store's
+    # single-key MERGE (an existing node's property differed from the
+    # incoming write). Advisory — ingestion still succeeds.
+    merge_conflicts: List[Dict[str, Any]] = field(default_factory=list)
     skipped_chunks: int = 0
     deduplicated: bool = False
     rule_profile: Optional[Dict[str, Any]] = None
@@ -139,6 +143,7 @@ class IndexingResult:
             "total_relationships": self.total_relationships,
             "validation_errors": self.validation_errors,
             "write_errors": self.write_errors,
+            "merge_conflicts": self.merge_conflicts,
             "skipped_chunks": self.skipped_chunks,
             "deduplicated": self.deduplicated,
             "ok": self.ok,
@@ -629,6 +634,7 @@ class IndexingPipeline:
         result.total_nodes = summary.get("nodes_created", 0)
         result.total_relationships = summary.get("relationships_created", 0)
         result.write_errors = summary.get("errors", [])
+        result.merge_conflicts = summary.get("merge_conflicts", [])
 
         if not result.write_errors and self.vector_store is not None and chunk_records:
             try:

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -386,7 +386,15 @@ class Neo4jGraphStore(GraphStore):
         if graph_model == "rdf" and triples:
             return self._write_rdf(triples, database=database, source_id=source_id)
 
-        summary = {"nodes_created": 0, "relationships_created": 0, "errors": []}
+        # seocho-uxs.1: merge_conflicts surfaces value divergence when a MERGE
+        # lands on an existing node whose user-facing property already holds a
+        # different value (audit signal for silent overwrites).
+        summary = {
+            "nodes_created": 0,
+            "relationships_created": 0,
+            "errors": [],
+            "merge_conflicts": [],
+        }
 
         # seocho-4rg (Lamport): stamp a writer timestamp so concurrent/replayed
         # writes are last-writer-wins by time rather than by arrival order. The
@@ -446,24 +454,53 @@ class Neo4jGraphStore(GraphStore):
                     "WHEN NOT {p}._source_id IN n._sources THEN n._sources + {p}._source_id "
                     "ELSE n._sources END"
                 )
+                # seocho-uxs.1: compute conflicts BEFORE the SET, so n[k] is
+                # the pre-write value. A conflict = a user-facing (non
+                # ``_``-prefixed) property whose stored non-null value differs
+                # from the incoming one. ``{P}`` is the props expression in
+                # scope (row.props for the batch, $props for the fallback).
+                def _conflict_with(prop_expr: str, carry: str) -> str:
+                    return (
+                        f" WITH {carry}, ["
+                        f"k IN keys({prop_expr}) WHERE NOT k STARTS WITH '_' "
+                        f"AND k <> 'id' "
+                        f"AND n[k] IS NOT NULL AND n[k] <> {prop_expr}[k] "
+                        f"| {{property: k, existing: toString(n[k]), incoming: toString({prop_expr}[k])}}"
+                        "] AS _conflicts"
+                    )
+
+                def _collect_conflicts(record: Any) -> None:
+                    for c in (record["conflicts"] or []):
+                        summary["merge_conflicts"].append(
+                            {"label": label, "key": record["id"], **c, "source_id": source_id}
+                        )
+
                 batch_q = (
-                    f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id}}) "
-                    "SET n += CASE WHEN n._writer_ts IS NULL "
+                    f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id}})"
+                    + _conflict_with("row.props", "n, row")
+                    + " SET n += CASE WHEN n._writer_ts IS NULL "
                     "OR n._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
                     + sources_clause.format(p="row.props")
+                    + " RETURN row.id AS id, _conflicts AS conflicts"
                 )
                 try:
-                    session.run(batch_q, rows=rows)
-                    summary["nodes_created"] += len(rows)
+                    for record in session.run(batch_q, rows=rows):
+                        summary["nodes_created"] += 1
+                        _collect_conflicts(record)
                 except Exception:
                     for row in rows:
                         try:
-                            session.run(
-                                f"MERGE (n:{label} {{id: $id}}) SET n += CASE WHEN "
+                            single_q = (
+                                f"MERGE (n:{label} {{id: $id}})"
+                                + _conflict_with("$props", "n")
+                                + " SET n += CASE WHEN "
                                 "n._writer_ts IS NULL OR n._writer_ts <= $props._writer_ts "
                                 "THEN $props ELSE {} END"
-                                + sources_clause.format(p="$props"),
-                                id=row["id"], props=row["props"])
+                                + sources_clause.format(p="$props")
+                                + " RETURN $id AS id, _conflicts AS conflicts"
+                            )
+                            for record in session.run(single_q, id=row["id"], props=row["props"]):
+                                _collect_conflicts(record)
                             summary["nodes_created"] += 1
                         except Exception as exc:
                             summary["errors"].append(f"Node {row['id']}: {exc}")
@@ -1634,6 +1671,58 @@ class LadybugGraphStore(GraphStore):
             sources.append(source_id)
         return self._encode_sources(sources)
 
+    def _detect_merge_conflicts(
+        self,
+        label: str,
+        merge_col: str,
+        merge_value: Any,
+        props: Dict[str, Any],
+        *,
+        source_id: str,
+    ) -> List[Dict[str, Any]]:
+        """seocho-uxs.1: value-divergence on an upsert target.
+
+        When this MERGE lands on an existing node and a user-facing property
+        already holds a different non-empty value, the single-key MERGE would
+        silently last-writer-wins. Returns one record per diverging property
+        so the caller can surface it instead of overwriting blind. Empty when
+        the node is new or nothing diverges. Internal (``_``-prefixed) and the
+        merge key itself are not compared.
+        """
+        compare_keys = [
+            k for k in props
+            if _LABEL_RE.match(k) and not k.startswith("_")
+            and k not in (merge_col, "id")
+        ]
+        if not compare_keys:
+            return []
+        projection = ", ".join(f"n.`{k}`" for k in compare_keys)
+        try:
+            rows = self._locked_execute(
+                f"MATCH (n:`{label}` {{`{merge_col}`: $v}}) RETURN {projection}",
+                {"v": merge_value},
+            )
+        except Exception:
+            return []
+        conflicts: List[Dict[str, Any]] = []
+        for row in rows:
+            row_list = row if isinstance(row, list) else list(row)
+            for key, existing in zip(compare_keys, row_list):
+                incoming = props.get(key)
+                if existing in (None, "") or incoming in (None, ""):
+                    continue
+                if str(existing) != str(incoming):
+                    conflicts.append({
+                        "label": label,
+                        "key": str(merge_value),
+                        "property": key,
+                        "existing": str(existing),
+                        "incoming": str(incoming),
+                        "source_id": source_id,
+                    })
+            break  # PK MERGE target is unique — one row at most
+        return conflicts
+
     def write(
         self,
         nodes: Sequence[Dict[str, Any]],
@@ -1644,7 +1733,14 @@ class LadybugGraphStore(GraphStore):
         source_id: str = "",
         **_kwargs: Any,
     ) -> Dict[str, Any]:
-        summary = {"nodes_created": 0, "relationships_created": 0, "errors": []}
+        # seocho-uxs.1: merge_conflicts surfaces silent last-writer-wins
+        # value divergence on single-key MERGE targets (audit signal).
+        summary = {
+            "nodes_created": 0,
+            "relationships_created": 0,
+            "errors": [],
+            "merge_conflicts": [],
+        }
         node_label_by_id: Dict[str, str] = {}
 
         for node in nodes:
@@ -1681,6 +1777,12 @@ class LadybugGraphStore(GraphStore):
             # filters working) while _sources is a JSON-encoded list of every
             # document that mentioned this node.
             self._ensure_sources_column(label)
+            # seocho-uxs.1: detect divergence BEFORE the SET overwrites it.
+            summary["merge_conflicts"].extend(
+                self._detect_merge_conflicts(
+                    label, merge_col, merge_value, props, source_id=source_id
+                )
+            )
             props["_sources"] = self._accumulated_sources_json(
                 label, merge_col, merge_value, source_id
             )

--- a/tests/seocho/test_graph_writer_lww.py
+++ b/tests/seocho/test_graph_writer_lww.py
@@ -191,3 +191,58 @@ def test_delete_by_source_retires_before_deleting():
     assert "n._sources IS NULL AND n._source_id = $sid" in delete[0]
     # retire runs before delete
     assert calls.index(retire[0]) < calls.index(delete[0])
+
+
+# --------------------------------------------------------------------------- #
+# seocho-uxs.1 — merge_conflicts surfacing on the node MERGE
+# --------------------------------------------------------------------------- #
+
+class _ConflictRec(_Rec):
+    """Fake whose node-MERGE returns one conflict record."""
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        is_node_merge = "MERGE (n:" in query and "RETURN row.id AS id" in query
+
+        class _R:
+            def single(self_inner):
+                return None
+
+            def __iter__(self_inner):
+                if is_node_merge:
+                    return iter([
+                        {"id": "c1", "conflicts": [
+                            {"property": "value", "existing": "2.1B", "incoming": "96.8B"}
+                        ]}
+                    ])
+                return iter([])
+
+        return _R()
+
+
+def test_node_merge_query_computes_and_returns_conflicts():
+    store = _store_with_fake()
+    store.write(
+        [{"id": "c1", "label": "Company", "properties": {"name": "ACME", "value": "96.8B"}}],
+        [], database="testdb", source_id="doc-b",
+    )
+    node_calls = [c for c in store._driver.rec.calls if "MERGE (n:" in c[0]]
+    query = node_calls[0][0]
+    # conflict pre-SET capture + RETURN are wired into the batch query
+    assert "_conflicts" in query and "RETURN row.id AS id" in query
+    assert "k <> 'id'" in query and "NOT k STARTS WITH '_'" in query
+
+
+def test_merge_conflicts_collected_into_summary():
+    store = Neo4jGraphStore("bolt://unit-test:7687", "neo4j", "p")
+    store._driver = _FakeDriver()
+    store._driver.rec = _ConflictRec()
+    summary = store.write(
+        [{"id": "c1", "label": "Company", "properties": {"name": "ACME", "value": "96.8B"}}],
+        [], database="testdb", source_id="doc-b",
+    )
+    assert summary["merge_conflicts"] == [
+        {"label": "Company", "key": "c1", "property": "value",
+         "existing": "2.1B", "incoming": "96.8B", "source_id": "doc-b"}
+    ]
+    assert summary["nodes_created"] == 1

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -773,3 +773,40 @@ class TestCrossDocumentEntityMerge:
             }
         finally:
             store.close()
+
+    # -- seocho-uxs.1: merge-conflict surfacing -----------------------------
+
+    def test_merge_conflict_surfaced_on_silent_overwrite(self, store):
+        """Without composite identity, a second write to the same name-PK node
+        with a different value would silently last-writer-win. The write must
+        report it in summary['merge_conflicts'] (advisory, non-fatal)."""
+        first = store.write(
+            nodes=[{"id": "p1", "label": "Person",
+                    "properties": {"name": "Sam", "age": 30}}],
+            relationships=[], source_id="doc-a",
+        )
+        assert first["merge_conflicts"] == []  # new node, nothing to diverge
+
+        second = store.write(
+            nodes=[{"id": "p2", "label": "Person",
+                    "properties": {"name": "Sam", "age": 41}}],
+            relationships=[], source_id="doc-b",
+        )
+        assert second["errors"] == []
+        conflicts = second["merge_conflicts"]
+        assert len(conflicts) == 1
+        c = conflicts[0]
+        assert c["label"] == "Person" and c["property"] == "age"
+        assert c["existing"] == "30" and c["incoming"] == "41"
+        assert c["source_id"] == "doc-b"
+
+    def test_no_merge_conflict_when_value_unchanged(self, store):
+        store.write(
+            nodes=[{"id": "p1", "label": "Person", "properties": {"name": "Kim", "age": 5}}],
+            relationships=[], source_id="doc-a",
+        )
+        again = store.write(
+            nodes=[{"id": "p2", "label": "Person", "properties": {"name": "Kim", "age": 5}}],
+            relationships=[], source_id="doc-b",
+        )
+        assert again["merge_conflicts"] == []


### PR DESCRIPTION
## Feature

`merge_conflicts` — both graph stores now surface value divergence when a
single-key MERGE lands on an existing node whose user-facing property already
holds a different value, instead of silently last-writer-winning. Propagated
to `IndexingResult.merge_conflicts`.

## Why

The safety net half of the entity-identity work (seocho-uxs). Composite
`identity_keys` (PR #296) *prevents* homonym collapse for node types that
declare them. For every other node type, a single-key MERGE still silently
overwrites a clashing value — the original danger the user flagged ("PTC
reports Tesla's revenue"). Without surfacing, that overwrite is invisible.
Ticket seocho-uxs.1.

## Design

A conflict = a user-facing property whose stored non-empty value differs from
the incoming write, on a MERGE that matched an existing node. Internal
(`_`-prefixed) properties and the structural `id` / merge key are excluded.

- **Neo4jGraphStore.write** — the node batch MERGE computes conflicts in a
  `WITH` *before* the `SET` (so `n[k]` is the pre-write value), and `RETURN`s
  them in one round-trip; collected from both the batch and the per-row
  fallback. Relationship writes are unchanged.
- **LadybugGraphStore.write** — `_detect_merge_conflicts` reads the PK
  target's user-facing columns before the `SET` overwrites them (one read; the
  PK MERGE target is unique). Pairs with the existing pre-MERGE `_sources`
  read.
- `summary["merge_conflicts"]` is always present (additive — no caller
  asserts a full-dict write summary), and the pipeline copies it to
  `IndexingResult.merge_conflicts` + `to_dict`, so it is visible through the
  SDK and the `seocho run` report.

Advisory and non-fatal: ingestion still succeeds. The conflict signal covers
both genuine homonym collisions and legitimate cross-version value updates —
it is an audit signal, and downstream consumers decide what to do.

## Expected Effect

Silent value divergence on un-keyed node types becomes auditable. Operators
and the e2e report can see "doc-b overwrote `age` 30 → 41 on Person:Sam".

## Impact Results

- Ladybug: a second write of `name=Sam, age=41` over `age=30` returns
  `merge_conflicts=[{property: age, existing: "30", incoming: "41", ...}]`;
  identical re-writes report none.
- Neo4j: the node MERGE query computes + returns conflicts; collected into the
  summary (mock-asserted).

## Validation

- **633 passed, 1 skipped** running the `scripts/ci/run_basic_ci.sh` test list
  in CI collection order (against the worktree source).
- New tests: Ladybug e2e (`test_ladybug_store.py`) conflict surfaced /
  not-surfaced; Neo4j mock (`test_graph_writer_lww.py`) query shape + summary
  collection.
- `py_compile` (store/graph.py, pipeline.py) OK; `git diff --check` clean;
  module-ownership + root-hierarchy + docs contracts pass.
- Note: an unrelated pre-existing cross-module test-pollution
  (`neo4j.GraphDatabase` patched without restore in some module) makes
  Neo4jGraphStore construction fail under *arbitrary* ad-hoc module orderings;
  it does not occur in the CI fixed order (633 pass) and is independent of this
  change (reproduced on clean origin/main).
- Skipped: live DozerDB (Neo4j conflict path mock-asserted; Ladybug path is
  real-embedded-DB e2e); ruff (not in venv).

## Risks

Low. Additive: the Neo4j node MERGE now returns rows (consumed for the count,
identical totals); one extra local read per node on Ladybug. No relationship
or delete path changes. The signal is advisory — no ingestion behavior changes
on conflict.
