### PR TITLE
chore(skills): track shared Claude Code skills under .claude/skills (ADR-0113)

### DIFF
--- a/.claude/skills/seocho-e2e/SKILL.md
+++ b/.claude/skills/seocho-e2e/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: seocho-e2e
+description: Author and run SEOCHO end-to-end YAML runs (seocho run / seocho sweep) over a user's documents — scaffold the ontology + run spec, dry-run to validate, execute index→query→report, and compare configuration variants. Use when the user wants to index their own documents into SEOCHO and ask questions, build/edit a seocho.run.yaml or seocho.sweep.yaml, compare models/enforcement/agent patterns, or run an ontology-aligned graph-RAG e2e without writing Python.
+---
+
+# SEOCHO e2e (run / sweep)
+
+Drive SEOCHO's YAML-declared e2e: one ontology + one documents folder + questions
+→ index → query → report. No Python; everything is a `seocho run` or `seocho sweep`
+invocation over a run spec. This skill scaffolds the YAML, validates it offline,
+runs it, and reads the report back.
+
+The YAML is **orchestration only**. Extraction prompts come from the ontology
+(node/relationship descriptions) plus optional design specs; the agent pattern is
+a config key. Keep that separation — do not hand-write prompt strings into the run
+spec.
+
+## 0. Resolve the CLI first (do this before any seocho command)
+
+The global `seocho` on PATH is often a stale build without `run`/`sweep`. Prefer the
+editable venv in the repo:
+
+```bash
+SEOCHO_BIN=/home/hadry/lab/seocho/.venv/bin/seocho
+[ -x "$SEOCHO_BIN" ] || SEOCHO_BIN=seocho
+"$SEOCHO_BIN" run --help >/dev/null 2>&1 || echo "needs: cd /home/hadry/lab/seocho && uv sync --extra local --extra ci"
+```
+
+If `run --help` fails (old build), tell the user to run
+`cd /home/hadry/lab/seocho && uv sync --extra local --extra ci` and stop — do not
+fall back to the stale global binary.
+
+Load the API key the same way the repo does (MARA-first):
+```bash
+set -a && source /home/hadry/lab/seocho/.env && set +a   # exports MARA_API_KEY
+```
+Embeddings/LLM default to MARA + local fastembed (bge). Do not introduce OpenAI
+unless the user asks.
+
+## 1. Understand the request, then scaffold
+
+Establish three things before writing YAML:
+
+1. **Documents** — a folder (or file) of `.txt/.md/.csv/.json/.jsonl/.pdf`. If the
+   user has none, point them at the bundled demo (`examples/run/`).
+2. **Ontology** — the node/relationship types to extract. If absent, draft a
+   small `schema.yaml` from the user's domain (see §2), or run `seocho init` for
+   the interactive builder.
+3. **Intent knobs** — model(s), enforcement mode, agent pattern, questions (§3).
+
+Fastest start (bundled, zero setup) — use this to confirm the toolchain works:
+```bash
+"$SEOCHO_BIN" run /home/hadry/lab/seocho/examples/run/quickstart.yaml --dry-run
+```
+
+`seocho run --init` writes a fully commented `seocho.run.yaml` template into the
+current directory — read it for the authoritative key list before editing.
+
+## 2. Ontology (schema.yaml)
+
+Separate file the run spec points at. YAML / JSON-LD / TTL. The descriptions are
+load-bearing — they become the extraction prompt.
+
+```yaml
+name: my-domain
+nodes:
+  Company:
+    description: A business organization        # ← travels into the prompt
+    properties:
+      name: { type: STRING, constraint: UNIQUE }
+  Person:
+    properties:
+      name: { type: STRING, constraint: UNIQUE }
+relationships:
+  CEO_OF:
+    source: Person
+    target: Company
+    description: Person leads the company as chief executive
+```
+
+Validate an ontology on its own: `"$SEOCHO_BIN" ontology check --schema schema.yaml`.
+
+## 3. Run spec (seocho.run.yaml)
+
+Every key maps to an SDK parameter. Minimal is three keys:
+
+```yaml
+ontology: ./schema.yaml
+documents: ./docs/
+questions:
+  - Who is the CEO of Acme?
+```
+
+Full surface (only add what the user's intent needs):
+
+```yaml
+name: my-run
+ontology:
+  path: ./schema.yaml
+  enforcement: guided          # guided (default) | strict | open  — see §6
+documents: { path: ./docs/, recursive: true }
+models:
+  default: mara/MiniMax-M2.5   # provider/model; MARA-first
+  indexing: mara/MiniMax-M2    # optional per-phase override (cheaper indexing)
+  query: mara/MiniMax-M2.5
+graph: bolt://localhost:7687   # omit → embedded LadybugDB (no server). Or mapping:
+graph:
+  kind: dozerdb                # neo4j | dozerdb | ladybug
+  uri: bolt://localhost:7687
+  password: ${NEO4J_PASSWORD}  # secrets via ${ENV}, never inline
+vector:                        # optional hybrid search; omit for graph-only
+  kind: faiss                  # faiss (in-memory) | lancedb (on-disk)
+  embedding: fastembed         # local bge default | provider preset
+agent:
+  execution_mode: pipeline     # pipeline (default) | agent | supervisor
+  routing_policy: balanced     # fast | balanced | thorough
+  design: ./agent_designs/x.yaml      # optional AgentDesignSpec (pattern)
+indexing:
+  design: ./indexing_designs/x.yaml   # optional IndexingDesignSpec (extraction strategy)
+query:
+  reasoning_mode: true
+  repair_budget: 1
+  answer_style: concise        # concise | evidence | table
+questions:
+  - What product does Acme offer?
+  - question: Who is the CEO of Acme?
+    expect: Jane Park          # recorded in report, not auto-graded
+```
+
+Agent patterns (via `agent.design` → an AgentDesignSpec; bundled in
+`examples/agent_designs/`): `reflection_chain`, `planning_multi_agent`,
+`memory_tool_use`. Extraction strategy/domain presets live in an IndexingDesignSpec
+(`examples/indexing_designs/`, `ingestion.extraction_strategy: general|domain|multi_pass`).
+Reference these files rather than re-deriving their internals.
+
+## 4. Validate, then run
+
+Always dry-run first — it runs the full preflight (ontology loads, documents
+scanned, API key present, graph reachable, vector deps) with **no LLM calls**:
+
+```bash
+"$SEOCHO_BIN" run seocho.run.yaml --dry-run
+```
+
+Fix whatever preflight reports (its messages name the exact fix), then run:
+
+```bash
+"$SEOCHO_BIN" run seocho.run.yaml
+```
+
+Report lands at `runs/<name>-<timestamp>/report.md` (+ `report.json`). Read
+`report.md` and summarize: files indexed, nodes/relationships, and per-question
+answers — flag any `empty` answer or `error`.
+
+Useful flags: `--only index` / `--only query` (reuse the existing graph),
+`--force` (re-index unchanged files), `-o DIR`, `--output-json`.
+Exit codes: `0` ok · `1` runtime/preflight failure · `2` invalid config.
+
+Templating: a `*.yaml.j2` run spec is rendered with Jinja2 — pass `--var key=value`
+(dotted keys, YAML values) / `--vars file.yaml`, and `--show-rendered` to inspect.
+Secrets stay in `${ENV}`, resolved after rendering.
+
+## 5. Compare variants — seocho sweep
+
+When the user wants to compare configurations (models, enforcement, prompts), use a
+sweep: one `run.yaml.j2` template × N named variants → N isolated runs → one table.
+
+```bash
+"$SEOCHO_BIN" sweep --init     # writes seocho.sweep.yaml + run.yaml.j2
+"$SEOCHO_BIN" sweep examples/run/sweep-enforcement/sweep.yaml --dry-run
+"$SEOCHO_BIN" sweep examples/run/sweep-enforcement/sweep.yaml
+```
+
+```yaml
+# seocho.sweep.yaml
+template: ./run.yaml.j2
+vars: { model: mara/MiniMax-M2.5 }   # shared
+variants:
+  - name: guided
+    vars: { enforcement: guided }
+  - name: strict
+    vars: { enforcement: strict }
+```
+
+Each variant gets an isolated graph, workspace, and `runs/<sweep>-<ts>/<variant>/`
+dir; the summary table compares files/nodes/answered/empty/errors. Flags:
+`--only-variant NAME`, `--fail-fast` (default keeps going), `--var`/`--vars`.
+Variants run sequentially. Use `seocho sweep`, not `seocho experiment` (that one is
+extraction-only, no query phase).
+
+## 6. Ontology enforcement (the most-asked knob)
+
+`ontology.enforcement` is the admission policy for extracted data:
+
+- **guided** (default) — ontology guides extraction, off-ontology material is
+  written with a warning. Max recall; most QA workloads.
+- **strict** — closed vocabulary: only declared types admitted, chunks with
+  validation errors rejected, no `Entity` fallback. Trust > recall (audit/regulated).
+  Expect fewer nodes than guided.
+- **open** — admit everything, but stamp out-of-vocabulary nodes/relationships with
+  `_out_of_ontology: "true"` — the signal for "what should I add to the schema?".
+
+Full reference: https://seocho.blog/sdk/enforcement-modes/
+
+## Guardrails
+
+- Resolve `$SEOCHO_BIN` and verify `run --help` works before any run (§0).
+- Always `--dry-run` before a real run; never claim a run succeeded without showing
+  the report or the exit code.
+- MARA-first: don't switch to OpenAI embeddings/models unless asked.
+- Don't invent prompt text in the run spec — prompts come from the ontology +
+  design specs.
+- Secrets go through `${ENV}`; never write a literal key into YAML.
+- If preflight fails, surface its message verbatim and fix that — don't bypass it.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,11 @@ runs/
 # Public middleware code should not track editor/agent state directories.
 .agents/
 .beads/
-.claude/
+# .claude/ stays untracked EXCEPT shared project skills (ADR-0113): those are
+# version-controlled team tooling, so ignore everything under .claude/ and
+# re-include only .claude/skills/.
+.claude/*
+!.claude/skills/
 .githooks/
 .jules/
 .serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,10 @@ These are intentionally not tracked public surfaces:
 
 - `.agents/`
 - `.beads/`
-- `.claude/`
+- `.claude/` — **except `.claude/skills/`**, which is version-controlled
+  shared project tooling (ADR-0113). Claude Code auto-loads project skills
+  from there on clone; everything else under `.claude/` (settings, local
+  state) stays untracked.
 - `.githooks/`
 - `.jules/`
 - `.serena/`
@@ -121,6 +124,7 @@ These are intentionally not tracked public surfaces:
 - root `dataset/`, `images/`, `ontology/`, or `seocho/`
 
 Use `scripts/`, `examples/`, `docs/`, `.github/`, or `src/seocho/` instead.
+Shareable Claude Code skills go in `.claude/skills/<name>/SKILL.md`.
 
 ## Landing
 

--- a/docs/decisions/ADR-0113-track-claude-skills-in-repo.md
+++ b/docs/decisions/ADR-0113-track-claude-skills-in-repo.md
@@ -1,0 +1,52 @@
+# ADR-0113: Version-control shared Claude Code skills under `.claude/skills/`
+
+Date: 2026-06-13
+
+Status: Accepted
+
+## Context
+
+`.claude/` has been an intentionally untracked surface (Public Repo Hygiene
+in `CLAUDE.md`, `.gitignore`, and the root-hierarchy contract
+`scripts/ci/check-root-hierarchy-contract.sh`). That blanket exclusion was
+written for **editor/agent local state** — `settings.local.json`, caches,
+transient session data — which must not leak into a public middleware repo.
+
+Claude Code **skills** (`.claude/skills/<name>/SKILL.md`) are a different
+kind of artifact: reusable, reviewable team tooling that encodes how to drive
+the product (e.g. `seocho-e2e` authors and runs `seocho run` / `seocho sweep`
+flows). Today they live only in each developer's user-global
+`~/.claude/skills/`, so they are invisible to review, drift per-machine, and
+do not travel with the codebase. Keeping product-operation knowledge out of
+the repo contradicts the "SEOCHO is middleware, public code should help users
+build with it" framing.
+
+Claude Code auto-loads project skills from a repo's `.claude/skills/` on
+clone. So the only mechanism that makes a skill both **tracked** and
+**zero-install** is to track that one subdirectory.
+
+## Decision
+
+Track **`.claude/skills/`** in the repo; keep the rest of `.claude/`
+untracked.
+
+- `.gitignore`: replace `.claude/` with `.claude/*` + `!.claude/skills/`.
+- `scripts/ci/check-root-hierarchy-contract.sh`: remove `.claude` from the
+  generic forbidden list and add a dedicated check that flags any tracked
+  file under `.claude/` **except** `.claude/skills/`.
+- `CLAUDE.md` Public Repo Hygiene: document the `.claude/skills/` exception.
+
+Skills live at `.claude/skills/<name>/SKILL.md` (+ optional `scripts/`),
+matching the user-global layout, so a skill can be moved between the two
+without edits.
+
+## Consequences
+
+- Skills are reviewed in PRs, version with the code, and activate on clone
+  with no install step.
+- Local agent state (`settings.local.json`, etc.) stays untracked — the
+  original hygiene intent is preserved; only the skills subtree is exempted.
+- The contract still fails the build if anything **other than** skills is
+  committed under `.claude/`, so the exception cannot silently widen.
+- First skill landed under this policy: `seocho-e2e` (author + run SEOCHO
+  YAML e2e flows).

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -5,6 +5,13 @@ Each entry must link to a full ADR when impact is non-trivial.
 
 ## 2026-06-13
 
+- [Accepted] ADR-0113 track-claude-skills-in-repo
+  - version-control shared Claude Code skills under `.claude/skills/` while the
+    rest of `.claude/` (local agent/editor state) stays untracked; gitignore
+    re-includes only that subtree and the root-hierarchy contract gained a
+    skills-scoped exception so anything else under `.claude/` still fails CI
+  - first skill landed: `seocho-e2e` (author + run `seocho run` / `seocho sweep`)
+
 - [Proposed] ADR-0112 graph-rag-where-it-wins-governance-not-quality
   - synthesis of the content-vs-context arc: retrieval-quality TIE (graph ≈ vector)
     generalizes across 2 GraphRAG-Bench domains (novel + medical, 2-judge); the

--- a/scripts/ci/check-root-hierarchy-contract.sh
+++ b/scripts/ci/check-root-hierarchy-contract.sh
@@ -18,7 +18,9 @@ tracked_existing_under() {
 forbidden_tracked_paths=(
   ".agents"
   ".beads"
-  ".claude"
+  # ".claude" is checked separately below — .claude/skills/ is intentionally
+  # tracked (shared project skills, ADR-0113); everything else under .claude/
+  # stays forbidden.
   ".githooks"
   ".github/README.md"
   ".gitattributes"
@@ -41,6 +43,14 @@ for path in "${forbidden_tracked_paths[@]}"; do
     exit 1
   fi
 done
+
+# .claude/ is untracked EXCEPT .claude/skills/ (ADR-0113). Flag any tracked
+# file under .claude/ that is not a shared skill.
+claude_forbidden="$(git ls-files -- ".claude" ":(exclude).claude/skills" ":(exclude).claude/skills/**" 2>/dev/null | head -1)"
+if [ -n "$claude_forbidden" ]; then
+  echo "Forbidden tracked path under .claude/ (only .claude/skills/ may be tracked): $claude_forbidden" >&2
+  exit 1
+fi
 
 required_paths=(
   "src/seocho/__init__.py"


### PR DESCRIPTION
## Why

Claude Code **skills** (`.claude/skills/<name>/SKILL.md`) are reusable team tooling — they encode how to drive the product (e.g. authoring + running `seocho run` / `seocho sweep` flows). Until now they lived only in each developer's user-global `~/.claude/skills/`: invisible to review, drifting per-machine, and not shipped with the code.

`.claude/` was a blanket-untracked surface, but that exclusion was written for **local agent/editor state** (settings, caches), not for shareable skills. This carves out the one subtree that should travel with the repo.

## What

- **`.gitignore`**: `.claude/` → `.claude/*` + `!.claude/skills/` (re-include only the skills subtree).
- **`scripts/ci/check-root-hierarchy-contract.sh`**: drop `.claude` from the generic forbidden list; add a skills-scoped check that still fails CI for any tracked file under `.claude/` **other than** `.claude/skills/`.
- **`CLAUDE.md`** Public Repo Hygiene: document the exception.
- **ADR-0113** + DECISION_LOG entry (governance change, recorded).
- First skill landed: **`.claude/skills/seocho-e2e`** — scaffolds an ontology + run spec, dry-runs to validate, executes index→query→report, and compares variants via `seocho sweep`.

Skills use the same layout as the user-global dir, so a skill moves between the two without edits, and project skills auto-load on clone with no install step.

## Verified

- `check-root-hierarchy-contract.sh` — passes with `.claude/skills/` tracked, **and** rejects a non-skill `.claude/settings.local.json` (tested both directions).
- `gitignore` — `.claude/skills/...` trackable ✓, `.claude/settings.local.json` still ignored ✓.
- `check-doc-contracts.sh` — passes.

Establishes the mechanism for "skills ship with the repo going forward."