### PR TITLE
docs: uv-first stance across remaining onboarding docs

### DIFF
--- a/docs/BEGINNER_GUIDE.md
+++ b/docs/BEGINNER_GUIDE.md
@@ -112,9 +112,9 @@ internal seams.
 
 | Path | Use when | Requirement |
 |---|---|---|
-| Embedded local SDK | You want the fastest learning loop | `pip install "seocho[local]"` and an LLM key |
+| Embedded local SDK | You want the fastest learning loop | `uv pip install "seocho[local]"` and an LLM key |
 | Local platform stack | You want UI, API docs, and DozerDB together | `make setup-env && make up` |
-| Remote HTTP client | Someone else is running SEOCHO | `pip install seocho` and `base_url` |
+| Remote HTTP client | Someone else is running SEOCHO | `uv pip install seocho` and `base_url` |
 
 Start with embedded local SDK unless you explicitly need the UI or HTTP APIs.
 

--- a/docs/PYTHON_INTERFACE_QUICKSTART.md
+++ b/docs/PYTHON_INTERFACE_QUICKSTART.md
@@ -19,37 +19,41 @@ If your first question is how to measure quality or latency, read
 
 Pick the mode first:
 
+SEOCHO standardizes on [uv](https://docs.astral.sh/uv/); the `uv pip` forms
+below work in any environment, and plain `pip` is a drop-in if you are not on
+uv.
+
 - HTTP client mode only:
 
 ```bash
-pip install seocho
+uv pip install seocho
 ```
 
 - local SDK engine from the published package:
 
 ```bash
-pip install "seocho[local]"
+uv pip install "seocho[local]"
 ```
 
 - repository development or local CLI authoring from a clone:
 
 ```bash
-pip install -e ".[dev]"
+uv sync --extra dev      # then prefix commands with `uv run` (no venv to activate)
 ```
 
 - offline ontology governance helpers:
 
 ```bash
-pip install "seocho[ontology]"
+uv pip install "seocho[ontology]"
 ```
 
 Important:
 
-- `pip install seocho` is enough for remote HTTP client mode.
-- `pip install "seocho[local]"` is the simplest published-package path for `Seocho.local(...)`.
+- `uv pip install seocho` is enough for remote HTTP client mode.
+- `uv pip install "seocho[local]"` is the simplest published-package path for `Seocho.local(...)`.
 - `Seocho.local(ontology)` defaults to embedded LadybugDB, so a Neo4j/DozerDB server is optional for hello world.
 - pass `graph="bolt://..."` or `Neo4jGraphStore(...)` when you want the production DozerDB/Neo4j path.
-- `pip install -e ".[dev]"` remains the right path when you are editing the repo itself.
+- `uv sync --extra dev` (then `uv run …`) is the right path when you are editing the repo itself.
 
 If you are iterating on schema evolution, use the offline governance CLI:
 

--- a/docs/RUNTIME_DEPLOYMENT.md
+++ b/docs/RUNTIME_DEPLOYMENT.md
@@ -24,7 +24,7 @@ basic verification.
 
 Important:
 
-- `pip install seocho` alone does not provision DozerDB/Neo4j for you.
+- `uv pip install seocho` alone does not provision DozerDB/Neo4j for you.
 - local runtime success still depends on the graph backend being reachable.
 - `make up` starts the core local stack, not every legacy service in the repo.
 - `make up` rebuilds an image-backed `extraction-service`, so `localhost:8001`
@@ -72,17 +72,17 @@ If you explicitly want a live bind-mounted edit loop instead:
 make up-live
 ```
 
-Or through the local CLI:
+Or through the local CLI (from a clone):
 
 ```bash
-pip install -e ".[dev]"
-seocho serve
+uv sync --extra dev
+uv run seocho serve
 ```
 
 Published-package local engine path:
 
 ```bash
-pip install "seocho[local]"
+uv pip install "seocho[local]"
 ```
 
 The default core stack is:
@@ -348,14 +348,14 @@ docker compose up -d neo4j
 **Load the FIBO-lite test corpus** (idempotent, workspace-scoped):
 
 ```bash
-NEO4J_PASSWORD=... python -m scripts.eval.load_gopts_fibo_corpus
-# tear down: python -m scripts.eval.load_gopts_fibo_corpus --teardown
+NEO4J_PASSWORD=... uv run python -m scripts.eval.load_gopts_fibo_corpus
+# tear down: uv run python -m scripts.eval.load_gopts_fibo_corpus --teardown
 ```
 
 **Run the live Layer-1 integration test**:
 
 ```bash
-NEO4J_PASSWORD=... pytest -m integration_gopts tests/seocho/integration/
+NEO4J_PASSWORD=... uv run pytest -m integration_gopts tests/seocho/integration/
 ```
 
 The test session auto-loads the corpus on entry and tears it down on
@@ -384,7 +384,7 @@ on `FinancialMetric.name` (and similar metric subclasses). The Layer-1
 live runner filters out fixtures 05/06 (`finance_metric_lookup`,
 `finance_metric_delta`) because they need multi-year metric rows that
 the constraint forbids loading. Mock-oracle Layer-1
-(`pytest tests/seocho/test_gopts_ranking.py`) still covers them.
+(`uv run pytest tests/seocho/test_gopts_ranking.py`) still covers them.
 
 ## 13. Read Next
 

--- a/docs/SDK_CONTRACT.md
+++ b/docs/SDK_CONTRACT.md
@@ -1,6 +1,6 @@
 # SEOCHO SDK Contract
 
-What `pip install seocho` promises, what it explicitly does not, and where
+What `uv pip install seocho` promises, what it explicitly does not, and where
 each promise is enforced. This document is the user-facing contract for
 fine-grained SDK use — composing `Session`, individual tools, and stores
 without going through the HTTP runtime.

--- a/docs/USECASES.md
+++ b/docs/USECASES.md
@@ -20,7 +20,7 @@ which incident, which control."
 
 **Try it**: [`examples/finance-compliance/`](../examples/finance-compliance/)
 — 6 mock documents, 6 entity types, runs in under a minute on
-`pip install "seocho[local]"`.
+`uv pip install "seocho[local]"`.
 
 **What you will see**: The ontology declares the entities and relationships
 you already think in (`Company → SUBJECT_TO → Regulation → ENFORCED_BY →
@@ -68,7 +68,7 @@ actually runs. The order of work is:
 
 1. Open a draft PR that adds `examples/<your-usecase>/` with at minimum a
    starter ontology, 5–10 sample docs, and a `quickstart.py` that runs
-   end-to-end on `pip install "seocho[local]"`.
+   end-to-end on `uv pip install "seocho[local]"`.
 2. Have one other contributor run the quickstart against a fresh clone.
 3. Add the usecase section to this file.
 4. (Optional but encouraged) Drop a narrative walk-through into the blog.


### PR DESCRIPTION
## What

Follow-up to #300 — finishes the uv-first stance across the remaining **living** onboarding docs:

- **BEGINNER_GUIDE** — runtime-table install cells → `uv pip install`
- **PYTHON_INTERFACE_QUICKSTART** — install block → `uv pip install` / `uv sync --extra dev` (+ a `uv run` note); "Important" bullets aligned
- **USECASES** — prose install mentions → `uv pip install`
- **RUNTIME_DEPLOYMENT** — local-CLI + published-package installs → `uv sync --extra dev` / `uv pip install`; repo-checkout `python -m …` / `pytest …` → `uv run python` / `uv run pytest`
- **SDK_CONTRACT** — opening line → `uv pip install seocho`

## Scope

- Bare `seocho …` CLI lines are **kept** — correct for an installed package; prefix with `uv run` from a clone, exactly as README/RUN_SPECS now state.
- **Untouched:** historical ADRs and `DECISION_LOG` (immutable records); `docs/architecture-deck/index.html` (slide deck) is out of scope.
- After this, **no living onboarding doc uses bare `pip install`**.

## Verified

`scripts/ci/check-doc-contracts.sh` passes.

Note: `PYTHON_INTERFACE_QUICKSTART.md` is mirrored to seocho.blog (`python_sdk`); its blog mirror resyncs from main on the next doc-sync pass.