### PR TITLE
perf: Optimize JSONL parsing memory overhead in test context events

### DIFF
--- a/extraction/tests/test_context_event_scripts.py
+++ b/extraction/tests/test_context_event_scripts.py
@@ -32,8 +32,13 @@ ALLOWED_EVENT_TYPES = {
 
 
 def _read_events(events_file: Path) -> list[dict[str, object]]:
-    lines = [line.strip() for line in events_file.read_text().splitlines() if line.strip()]
-    return [json.loads(line) for line in lines]
+    events = []
+    with events_file.open("r", encoding="utf-8") as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped:
+                events.append(json.loads(stripped))
+    return events
 
 
 def _assert_event_contract(event: dict[str, object]) -> None:


### PR DESCRIPTION
### What
Optimized file reading in `extraction/tests/test_context_event_scripts.py` to use a lazy file iterator instead of loading the entire file into memory as an array of strings.

### Why
The original code `events_file.read_text().splitlines()` reads the entire file into memory, which can cause significant memory overhead and I/O bottlenecks when processing large JSONL files (a key performance constraint in this repo). Using a lazy iterator (`with path.open("r") as f: for line in f:`) mitigates this.

### Expected Impact
Lower memory footprint and faster parsing time when executing context event trace scripts locally and in CI, particularly on larger JSONL outputs.

### Validation
Verified the tests pass correctly using `PYTHONPATH=. uv run pytest extraction/tests/test_context_event_scripts.py`.

### Risks
Extremely low risk; strictly preserves existing behavior.

---
*PR created automatically by Jules for task [2955475762709900285](https://jules.google.com/task/2955475762709900285) started by @tteon*