### PR TITLE
UX/Accessibility: Refactor inline hover states to CSS for Reset Trace button

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -37,9 +37,7 @@
           <span class="subtext" id="sessionMeta">Session</span>
         </div>
         <div class="status-wrap">
-          <button id="resetSessionBtn"
-            style="background:transparent; border:1px solid var(--border-color); color:var(--text-muted); padding:4px 8px; border-radius:4px; font-size:0.75rem; cursor:pointer;"
-            onmouseover="this.style.color='#fff'" onmouseout="this.style.color='var(--text-muted)'">Reset Trace</button>
+          <button id="resetSessionBtn">Reset Trace</button>
           <div class="status" id="statusPill" role="status" aria-live="polite">Initializing</div>
         </div>
       </header>

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -586,3 +586,19 @@ textarea:focus {
   box-shadow: 0 0 0 1px var(--accent-blue);
   outline: none;
 }
+
+#resetSessionBtn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+#resetSessionBtn:hover,
+#resetSessionBtn:focus-visible {
+  color: #fff;
+}


### PR DESCRIPTION
### What
Refactored the "Reset Trace" button in the Evaluation UI to remove inline styles and inline JavaScript hover states (`onmouseover`/`onmouseout`), moving the styling logic into the global `styles.css`.

### Why
Inline styles have extremely high specificity and will permanently override pseudo-class styles like `:focus-visible` or `:focus`. Additionally, using inline JavaScript for visual hover effects breaks semantic parity, as those inline scripts do not fire when a user focuses the element via a keyboard.

### Accessibility / UX Impact
Keyboard users navigating the Workflow Console now receive the exact same visual contrast changes (the text turning white) on focus as mouse users do on hover. This aligns the button's behavior with WCAG best practices for focus indicators and ensures consistency with existing global `.control input:focus-visible` outlines.

### Validation
1. Visually confirmed the button renders identically in its default state via screenshot.
2. Verified via Playwright automation that the CSS hover transition works as intended.
3. Ran full local CI `bash scripts/ci/run_basic_ci.sh` to ensure no workflow or UI build regressions were introduced. All checks passed.

### Risks
Minimal. The CSS selector targets the specific ID `#resetSessionBtn`, isolating the change to that exact button without affecting other controls.

---
*PR created automatically by Jules for task [17056358497116153769](https://jules.google.com/task/17056358497116153769) started by @tteon*