### PR TITLE
feat(ontology): ontology quality scorecard + OntoClean critic + guardrail validation (ADR-0114/0115)

### DIFF
--- a/docs/decisions/ADR-0114-ontology-quality-scorecard.md
+++ b/docs/decisions/ADR-0114-ontology-quality-scorecard.md
@@ -1,0 +1,98 @@
+# ADR-0114: Ontology Quality Scorecard — a Graded Measurement Instrument for TBox Health
+
+Date: 2026-06-13
+Status: Proposed
+
+## Context
+
+SEOCHO can already *define*, *serialize*, *lint*, *diff*, and *version* an ontology, and it
+can score an *extracted graph* against one (`Ontology.score_extraction`). What it could not do
+was answer the question an ontology engineer asks first: **"is this ontology any good, and
+where is it weak?"** — before extraction runs, before a corpus exists.
+
+The two adjacent surfaces do not cover this:
+
+- `ontology_governance.build_ontology_governance_report` is a **binary promotion gate**
+  ("safe to ship?"). It bundles check + context + artifact + SHACL + synthetic-sample
+  validation and returns an `ok` boolean. It does not grade quality or rank what to fix.
+- `Ontology.score_extraction` scores **ABox instances**, not the schema itself.
+
+The pieces of an intrinsic TBox evaluation existed but were **scattered and un-graded**:
+`lint_ontology` (hygiene), `competency_question_report` / `_coverage` (functional fit). There
+was no taxonomy-health analysis at all (only cycle detection), and nothing composed these into
+a single, comparable verdict. This is the "we haven't actually verified the ontology tooling
+works" gap: with no scorecard, there is no way to know whether a schema edit (or a new version)
+is an improvement.
+
+## Decision
+
+Add `seocho.ontology_scorecard.score_ontology(ontology, *, competency_questions=None,
+weights=None) -> OntologyScorecard` — a graded, multi-dimensional quality scorecard. It is the
+**measurement instrument** that anchors the broader ontology-management roadmap (refinement
+loop, versioning-with-substance): you cannot improve what you cannot measure.
+
+Five dimensions, each scored 0.0–1.0 with explicit, sorted `WeakPoint`s:
+
+| Dimension | Source | What it measures |
+|---|---|---|
+| `structural_integrity` | composes `lint_ontology` | hygiene errors (blocking) + warnings |
+| `taxonomy_health` | **new** | orphan (disconnected) classes, flatness, degenerate single-child branches, depth |
+| `definitional_completeness` | new (uses `effective_identity_keys`) | definitions, identity coverage, bare-slot properties — the "under-specified?" signal |
+| `constraint_richness` | new | typed relationship endpoints, declared cardinality, per-class constraints — "does it actually constrain extraction?" |
+| `functional_coverage` | composes `competency_question_report` / `_coverage` | are the questions the ontology must answer expressible? (optional; skipped without CQs) |
+
+Design rules:
+
+- **Compose, do not duplicate.** Hygiene and competency analysis are reused from
+  `ontology_governance`; the genuinely new contribution is the taxonomy-health tier plus the
+  graded aggregation and weak-point ranking.
+- **Offline, zero hot-path** (ADR-0043). Pure model walk; no LLM, no graph, no corpus required
+  for the structural tiers. Lives in the data/governance plane.
+- **Blocking caps the grade.** A hygiene *error* sets `blocking=True` and caps the letter grade
+  at `D` regardless of the numeric score — a quantitatively pretty ontology that fails the
+  linter must not read as shippable.
+- **Abstract superclasses are exempt from identity and CQ-coverage.** A class that is a
+  `broader` parent of another class *and* declares no properties of its own is treated as
+  abstract (never directly instantiated, per OWL/OntoClean), so it is not penalised for lacking
+  an identity key or for not being named by a competency question. This refinement came
+  directly out of the validation experiment below.
+
+Not exported from `seocho.__init__` — follows the existing offline-governance convention
+(`ontology_governance` is imported directly), keeping it off the hot SDK surface.
+
+## Validation (measured, before/after)
+
+`scripts/benchmarks/ontology_scorecard_experiment.py` scores a realistic hand-written
+first-draft ontology (the "before" a user actually produces) and the governed rewrite that
+applies exactly the weak points the scorecard surfaced. Record:
+`docs/decisions/ADR-0114-scorecard-experiment.json`.
+
+| | overall | grade | weak points |
+|---|---|---|---|
+| **before** (first draft) | 0.554 | F | 13 |
+| **after** (governed) | 0.918 | A | 2 |
+| **Δ** | **+0.363** | F→A | **−11** |
+
+Per-dimension lift: taxonomy_health +0.51, definitional_completeness +0.63, constraint_richness
++0.61, structural_integrity +0.08, functional_coverage −0.03 (adding classes the existing CQs
+do not exercise — itself a true signal that the CQ set should grow with the schema).
+
+Two findings honestly remained in the "after" arm — `Deal` still disconnected (a modeling gap
+the author introduced and missed) and `Person` a single-child parent (an acceptable design
+choice). The scorecard surfacing a residual defect the author overlooked is the point: it is a
+guardrail, not a rubber stamp.
+
+Cross-check against a known-good schema: the shipped `examples/run/schema.yaml` quickstart
+scores **0.978 / A** with zero weak points, and an attempt to "improve" it by bolting on an
+identity-less abstract root *lowered* the score — which is what prompted the abstract-class
+exemption above. The tool refuses to reward gratuitous abstraction.
+
+## Consequences
+
+- A single, comparable number + actionable weak-point list to gate ontology edits and version
+  bumps, and to drive the (future) refinement loop and versioning-with-substance layers.
+- The taxonomy-health tier is intentionally conservative (flatness only flagged at ≥6 classes;
+  cardinality weighted lightly). Deeper taxonomy verification — OntoClean rigidity/identity
+  meta-property checks via owlready2, and LLM-assisted CQ generation — are deferred follow-ups
+  (tickets off `seocho-g2r`), to be added as their own scored tiers.
+- A `seocho ontology score` CLI subcommand is a natural follow-up (not in this change).

--- a/docs/decisions/ADR-0114-scorecard-experiment.json
+++ b/docs/decisions/ADR-0114-scorecard-experiment.json
@@ -1,0 +1,135 @@
+{
+  "experiment": "ontology-scorecard-before-after",
+  "domain": "company/person/product first-draft → governed",
+  "before": {
+    "overall_score": 0.5543,
+    "grade": "F",
+    "blocking": false,
+    "dimensions": {
+      "structural_integrity": 0.92,
+      "taxonomy_health": 0.3,
+      "definitional_completeness": 0.375,
+      "constraint_richness": 0.3,
+      "functional_coverage": 0.8333
+    },
+    "weak_point_count": 13,
+    "weak_points": [
+      {
+        "severity": "major",
+        "dimension": "definitional_completeness",
+        "target": "Company",
+        "message": "Class 'Company' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents."
+      },
+      {
+        "severity": "major",
+        "dimension": "definitional_completeness",
+        "target": "Deal",
+        "message": "Class 'Deal' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents."
+      },
+      {
+        "severity": "major",
+        "dimension": "definitional_completeness",
+        "target": "Founder",
+        "message": "Class 'Founder' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents."
+      },
+      {
+        "severity": "major",
+        "dimension": "definitional_completeness",
+        "target": "Metric",
+        "message": "Class 'Metric' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents."
+      },
+      {
+        "severity": "major",
+        "dimension": "definitional_completeness",
+        "target": "Person",
+        "message": "Class 'Person' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents."
+      },
+      {
+        "severity": "major",
+        "dimension": "definitional_completeness",
+        "target": "Product",
+        "message": "Class 'Product' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents."
+      },
+      {
+        "severity": "major",
+        "dimension": "taxonomy_health",
+        "target": "<ontology>",
+        "message": "6 classes but no 'broader' hierarchy — consider an is-a taxonomy to enable subsumption."
+      },
+      {
+        "severity": "major",
+        "dimension": "taxonomy_health",
+        "target": "Deal",
+        "message": "Class 'Deal' is disconnected — give it a 'broader' parent or a relationship, or remove it."
+      },
+      {
+        "severity": "major",
+        "dimension": "taxonomy_health",
+        "target": "Founder",
+        "message": "Class 'Founder' is disconnected — give it a 'broader' parent or a relationship, or remove it."
+      },
+      {
+        "severity": "major",
+        "dimension": "taxonomy_health",
+        "target": "Metric",
+        "message": "Class 'Metric' is disconnected — give it a 'broader' parent or a relationship, or remove it."
+      },
+      {
+        "severity": "minor",
+        "dimension": "constraint_richness",
+        "target": "CEO_OF",
+        "message": "Relationship 'CEO_OF' has an untyped endpoint (source/target = Any) — it constrains no traversal."
+      },
+      {
+        "severity": "minor",
+        "dimension": "structural_integrity",
+        "target": "CEO_OF",
+        "message": "Relationship 'CEO_OF' has no definition."
+      },
+      {
+        "severity": "minor",
+        "dimension": "structural_integrity",
+        "target": "Company",
+        "message": "Class 'Company' has no definition (ISO 704 / FIBO require label + definition)."
+      }
+    ]
+  },
+  "after": {
+    "overall_score": 0.9176,
+    "grade": "A",
+    "blocking": false,
+    "dimensions": {
+      "structural_integrity": 1.0,
+      "taxonomy_health": 0.8071,
+      "definitional_completeness": 1.0,
+      "constraint_richness": 0.9054,
+      "functional_coverage": 0.8
+    },
+    "weak_point_count": 2,
+    "weak_points": [
+      {
+        "severity": "major",
+        "dimension": "taxonomy_health",
+        "target": "Deal",
+        "message": "Class 'Deal' is disconnected — give it a 'broader' parent or a relationship, or remove it."
+      },
+      {
+        "severity": "minor",
+        "dimension": "taxonomy_health",
+        "target": "Person",
+        "message": "Class 'Person' has exactly one subclass — a single-child branch is usually under-modeled or redundant."
+      }
+    ]
+  },
+  "delta": {
+    "overall_score": 0.3633,
+    "weak_point_count": -11,
+    "by_dimension": {
+      "structural_integrity": 0.08,
+      "taxonomy_health": 0.5071,
+      "definitional_completeness": 0.625,
+      "constraint_richness": 0.6054,
+      "functional_coverage": -0.0333
+    }
+  }
+}

--- a/docs/decisions/ADR-0115-finder-guardrail-ablation.json
+++ b/docs/decisions/ADR-0115-finder-guardrail-ablation.json
@@ -1,0 +1,20231 @@
+{
+  "experiment": "finder-guardrail-ablation",
+  "corpus": "Linq-AI-Research/FinDER",
+  "sample": {
+    "per_category": 20,
+    "total_docs": 160,
+    "max_chars": 3000,
+    "categories": {
+      "Accounting": 20,
+      "Company overview": 20,
+      "Financials": 20,
+      "Footnotes": 20,
+      "Governance": 20,
+      "Legal": 20,
+      "Risk": 20,
+      "Shareholder return": 20
+    }
+  },
+  "models": [
+    "DeepSeek-V3.1",
+    "MiniMax-M2.5",
+    "MiniMax-M2.7",
+    "gpt-oss-120b"
+  ],
+  "arms": {
+    "A_sparse_fibo_minus": "examples/datasets/fibo_minus.jsonld",
+    "B_rich_fibo_plus": "examples/datasets/fibo_plus.jsonld"
+  },
+  "scorecards": {
+    "A_sparse_fibo_minus": {
+      "ontology_name": "fibo_minus",
+      "package_id": "fibo_minus",
+      "version": "1.0.0",
+      "overall_score": 0.8975,
+      "grade": "B",
+      "blocking": false,
+      "dimensions": [
+        {
+          "name": "structural_integrity",
+          "score": 1.0,
+          "weight": 0.3,
+          "findings": [
+            "Clean: no hygiene errors or warnings."
+          ],
+          "stats": {
+            "error_count": 0,
+            "warning_count": 0
+          }
+        },
+        {
+          "name": "taxonomy_health",
+          "score": 1.0,
+          "weight": 0.25,
+          "findings": [
+            "Connected taxonomy: depth 0, 0/2 classes placed under a parent."
+          ],
+          "stats": {
+            "class_count": 2,
+            "rooted_count": 0,
+            "orphan_count": 0,
+            "orphans": [],
+            "max_depth": 0,
+            "single_child_parents": [],
+            "ontoclean_violations": 0,
+            "ontoclean_hard_violations": 0
+          }
+        },
+        {
+          "name": "definitional_completeness",
+          "score": 0.85,
+          "weight": 0.2,
+          "findings": [
+            "3/5 propertie(s) are bare typed slots (no description, no constraint)."
+          ],
+          "stats": {
+            "class_definition_ratio": 1.0,
+            "relationship_definition_ratio": 1.0,
+            "identity_ratio": 1.0,
+            "property_specification_ratio": 0.4,
+            "classes_without_identity": [],
+            "abstract_classes": []
+          }
+        },
+        {
+          "name": "constraint_richness",
+          "score": 0.85,
+          "weight": 0.15,
+          "findings": [
+            "No relationship declares a tighter-than-MANY_TO_MANY cardinality."
+          ],
+          "stats": {
+            "typed_endpoint_ratio": 1.0,
+            "tight_cardinality_ratio": 0.0,
+            "class_constraint_ratio": 1.0
+          }
+        },
+        {
+          "name": "functional_coverage",
+          "score": 0.5,
+          "weight": 0.1,
+          "findings": [
+            "11/11 competency question(s) are structurally impossible."
+          ],
+          "stats": {
+            "expressible_ratio": 0.0,
+            "element_coverage_ratio": 1.0,
+            "question_count": 11
+          }
+        }
+      ],
+      "weak_points": [
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S1-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S1-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'OperatingIncome', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S2-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'NetIncome', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S2-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'NetIncome', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S3-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'BusinessSegment', 'HAS_SEGMENT', 'ProductOrService', 'PROVIDES']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S3-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'BusinessSegment', 'HAS_SEGMENT']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S4-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'ProductOrService', 'PROVIDES', 'BusinessSegment', 'HAS_SEGMENT']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S5-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'DebtInstrument', 'ISSUED_DEBT']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S5-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'AccountingPolicy', 'APPLIES_POLICY', 'GOVERNS']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S6-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S6-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'NetIncome', 'REPORTED_METRIC']."
+        }
+      ],
+      "stats": {
+        "node_count": 2,
+        "relationship_count": 1,
+        "schema_fingerprint": "2b36433bd9d88ded",
+        "competency_questions_supplied": true
+      }
+    },
+    "B_rich_fibo_plus": {
+      "ontology_name": "fibo_plus",
+      "package_id": "fibo_plus",
+      "version": "1.0.0",
+      "overall_score": 0.816,
+      "grade": "B",
+      "blocking": false,
+      "dimensions": [
+        {
+          "name": "structural_integrity",
+          "score": 1.0,
+          "weight": 0.3,
+          "findings": [
+            "Clean: no hygiene errors or warnings."
+          ],
+          "stats": {
+            "error_count": 0,
+            "warning_count": 0
+          }
+        },
+        {
+          "name": "taxonomy_health",
+          "score": 0.8,
+          "weight": 0.25,
+          "findings": [
+            "Flat: 9 classes with zero subclass (broader) edges — no taxonomy structure to reason over."
+          ],
+          "stats": {
+            "class_count": 9,
+            "rooted_count": 0,
+            "orphan_count": 0,
+            "orphans": [],
+            "max_depth": 0,
+            "single_child_parents": [],
+            "ontoclean_violations": 0,
+            "ontoclean_hard_violations": 0
+          }
+        },
+        {
+          "name": "definitional_completeness",
+          "score": 0.84,
+          "weight": 0.2,
+          "findings": [
+            "16/25 propertie(s) are bare typed slots (no description, no constraint)."
+          ],
+          "stats": {
+            "class_definition_ratio": 1.0,
+            "relationship_definition_ratio": 1.0,
+            "identity_ratio": 1.0,
+            "property_specification_ratio": 0.36,
+            "classes_without_identity": [],
+            "abstract_classes": []
+          }
+        },
+        {
+          "name": "constraint_richness",
+          "score": 0.8688,
+          "weight": 0.15,
+          "findings": [
+            "Well-constrained: typed endpoints and per-class constraints throughout."
+          ],
+          "stats": {
+            "typed_endpoint_ratio": 1.0,
+            "tight_cardinality_ratio": 0.125,
+            "class_constraint_ratio": 1.0
+          }
+        },
+        {
+          "name": "functional_coverage",
+          "score": 0.1765,
+          "weight": 0.1,
+          "findings": [
+            "11/11 competency question(s) are structurally impossible."
+          ],
+          "stats": {
+            "expressible_ratio": 0.0,
+            "element_coverage_ratio": 0.3529,
+            "question_count": 11
+          }
+        }
+      ],
+      "weak_points": [
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S1-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S1-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'OperatingIncome', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S2-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'NetIncome', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S2-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'NetIncome', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S3-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'BusinessSegment', 'HAS_SEGMENT', 'ProductOrService', 'PROVIDES']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S3-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'BusinessSegment', 'HAS_SEGMENT']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S4-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'ProductOrService', 'PROVIDES', 'BusinessSegment', 'HAS_SEGMENT']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S5-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'DebtInstrument', 'ISSUED_DEBT']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S5-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'APPLIES_POLICY', 'GOVERNS']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S6-CQ1",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'Revenue', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "functional_coverage",
+          "target": "S6-CQ2",
+          "message": "Competency question is structurally impossible — missing: ['LegalEntity', 'NetIncome', 'REPORTED_METRIC']."
+        },
+        {
+          "severity": "major",
+          "dimension": "taxonomy_health",
+          "target": "<ontology>",
+          "message": "9 classes but no 'broader' hierarchy — consider an is-a taxonomy to enable subsumption."
+        }
+      ],
+      "stats": {
+        "node_count": 9,
+        "relationship_count": 8,
+        "schema_fingerprint": "dc6875eae443f6b9",
+        "competency_questions_supplied": true
+      }
+    }
+  },
+  "results": {
+    "A_sparse_fibo_minus": {
+      "per_model": {
+        "DeepSeek-V3.1": {
+          "aggregate": {
+            "docs_ok": 160,
+            "mean_nodes": 3.938,
+            "mean_rels": 2.925,
+            "mean_label_conformance": 0.8313,
+            "mean_rel_conformance": 0.5805,
+            "mean_extraction_score": 0.8226,
+            "distinct_labels": 2,
+            "label_entropy_bits": 0.8412,
+            "top1_label_share": 0.7302
+          },
+          "per_doc": [
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 40,
+              "rels": 39,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.9231,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.969,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 6,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 14,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.954,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 31,
+              "rels": 21,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.9524,
+              "extraction_score": 0.93,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 20,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.978,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.949,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            }
+          ]
+        },
+        "MiniMax-M2.5": {
+          "aggregate": {
+            "docs_ok": 160,
+            "mean_nodes": 4.544,
+            "mean_rels": 3.019,
+            "mean_label_conformance": 0.7312,
+            "mean_rel_conformance": 0.475,
+            "mean_extraction_score": 0.7234,
+            "distinct_labels": 2,
+            "label_entropy_bits": 0.6865,
+            "top1_label_share": 0.8171
+          },
+          "per_doc": [
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 13,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 6,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 15,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 40,
+              "rels": 39,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 17,
+              "rels": 16,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 52,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.949,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 28,
+              "rels": 27,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.968,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 10,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.914,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 9,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.98,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.973,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            }
+          ]
+        },
+        "MiniMax-M2.7": {
+          "aggregate": {
+            "docs_ok": 129,
+            "mean_nodes": 3.667,
+            "mean_rels": 2.519,
+            "mean_label_conformance": 0.7519,
+            "mean_rel_conformance": 0.4884,
+            "mean_extraction_score": 0.7389,
+            "distinct_labels": 3,
+            "label_entropy_bits": 0.9187,
+            "top1_label_share": 0.7336
+          },
+          "per_doc": [
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Accounting"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.949,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.949,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.978,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 28,
+              "rels": 27,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 27,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.978,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 13,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.975,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            }
+          ]
+        },
+        "gpt-oss-120b": {
+          "aggregate": {
+            "docs_ok": 160,
+            "mean_nodes": 3.9,
+            "mean_rels": 2.663,
+            "mean_label_conformance": 0.6687,
+            "mean_rel_conformance": 0.3688,
+            "mean_extraction_score": 0.6503,
+            "distinct_labels": 2,
+            "label_entropy_bits": 0.8036,
+            "top1_label_share": 0.7548
+          },
+          "per_doc": [
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.944,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.949,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 10,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 13,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.975,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.978,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.944,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 28,
+              "rels": 27,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 26,
+              "rels": 25,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.95,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 18,
+              "rels": 17,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 35,
+              "rels": 34,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.945,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 20,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Governance"
+            },
+            {
+              "nodes": 5,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.982,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.988,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.951,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.973,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.975,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.975,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.974,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 17,
+              "rels": 16,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.952,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.956,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.948,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            }
+          ]
+        }
+      }
+    },
+    "B_rich_fibo_plus": {
+      "per_model": {
+        "DeepSeek-V3.1": {
+          "aggregate": {
+            "docs_ok": 160,
+            "mean_nodes": 7.825,
+            "mean_rels": 6.45,
+            "mean_label_conformance": 0.9812,
+            "mean_rel_conformance": 0.9291,
+            "mean_extraction_score": 0.9674,
+            "distinct_labels": 9,
+            "label_entropy_bits": 2.4829,
+            "top1_label_share": 0.4497
+          },
+          "per_doc": [
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.965,
+              "labels": [
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.98,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 18,
+              "rels": 17,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.996,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.983,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.989,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.982,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.987,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Regulation",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation",
+                "FinancialMetric",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 21,
+              "rels": 20,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Regulation"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.986,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.994,
+              "labels": [
+                "Company",
+                "Product",
+                "FinancialMetric",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.984,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 10,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 15,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.917,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 20,
+              "rels": 19,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 31,
+              "rels": 30,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.9333,
+              "extraction_score": 0.926,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.9583,
+              "extraction_score": 0.939,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.9444,
+              "extraction_score": 0.933,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.988,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 28,
+              "rels": 27,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.963,
+              "extraction_score": 0.941,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.965,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.986,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.922,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.958,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 26,
+              "rels": 25,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.92,
+              "extraction_score": 0.92,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "Person",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.9444,
+              "extraction_score": 0.933,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 23,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Company",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.988,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.997,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Regulation",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "LegalIssue",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "AccountingPolicy"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.987,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Product",
+                "Regulation",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Event",
+                "Event",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 10,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.993,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.989,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Person",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Regulation",
+                "Event",
+                "Event",
+                "Event",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Event",
+                "Person",
+                "Person"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Regulation",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Person",
+                "Person",
+                "Person",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Regulation",
+                "Person",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Regulation",
+                "AccountingPolicy"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.98,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Regulation"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.97,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 10,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Regulation"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.969,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Regulation"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.99,
+              "labels": [
+                "Company",
+                "Event",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 17,
+              "rels": 16,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.968,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            }
+          ]
+        },
+        "MiniMax-M2.5": {
+          "aggregate": {
+            "docs_ok": 160,
+            "mean_nodes": 9.656,
+            "mean_rels": 7.506,
+            "mean_label_conformance": 0.9675,
+            "mean_rel_conformance": 0.7662,
+            "mean_extraction_score": 0.9573,
+            "distinct_labels": 10,
+            "label_entropy_bits": 2.5388,
+            "top1_label_share": 0.4595
+          },
+          "per_doc": [
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 0.8,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Product",
+                "Service",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 18,
+              "rels": 17,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 21,
+              "rels": 20,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.6,
+              "extraction_score": 0.806,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Product",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.944,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 15,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Event",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 37,
+              "rels": 36,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 12,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 42,
+              "rels": 41,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 37,
+              "rels": 36,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Event"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 35,
+              "rels": 34,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 37,
+              "rels": 36,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.966,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 22,
+              "rels": 21,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.946,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.998,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.98,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 7,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.917,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 24,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.924,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 20,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.921,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "AccountingPolicy",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.969,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.958,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.969,
+              "labels": [
+                "Company",
+                "Person",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 27,
+              "rels": 26,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.968,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 13,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 9,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 15,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Event"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.988,
+              "labels": [
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.988,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "AccountingPolicy"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.987,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.989,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Event",
+                "Event",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.995,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 17,
+              "rels": 16,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.995,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 8,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.996,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Event",
+                "Event",
+                "Regulation",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 20,
+              "rels": 19,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.997,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Company",
+                "Company",
+                "Event",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 8,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "LegalIssue",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "LegalIssue",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Event",
+                "Event",
+                "Event",
+                "Person",
+                "Person",
+                "Person",
+                "Regulation",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 10,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "AccountingPolicy"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Event",
+                "Product",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Person",
+                "Event",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Regulation",
+                "LegalIssue",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 12,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Regulation",
+                "Person"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Risk",
+                "Company"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Person",
+                "Person",
+                "Person",
+                "Regulation",
+                "Person",
+                "Person"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.917,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "AccountingPolicy",
+                "Product",
+                "Event",
+                "FinancialMetric",
+                "Company"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 10,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.968,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "AccountingPolicy"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Regulation",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Product",
+                "Regulation",
+                "AccountingPolicy",
+                "Risk",
+                "LegalIssue"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 21,
+              "rels": 20,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event",
+                "Event",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.979,
+              "labels": [
+                "Event",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            }
+          ]
+        },
+        "MiniMax-M2.7": {
+          "aggregate": {
+            "docs_ok": 128,
+            "mean_nodes": 7.883,
+            "mean_rels": 6.836,
+            "mean_label_conformance": 0.7891,
+            "mean_rel_conformance": 0.7578,
+            "mean_extraction_score": 0.7802,
+            "distinct_labels": 10,
+            "label_entropy_bits": 2.822,
+            "top1_label_share": 0.3201
+          },
+          "per_doc": [
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.992,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 17,
+              "rels": 16,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.987,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Product",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.971,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 11,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Regulation",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 20,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 20,
+              "rels": 20,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 20,
+              "rels": 19,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk",
+                "FinancialMetric",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 19,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Risk",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 28,
+              "rels": 27,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Company overview"
+            },
+            {
+              "nodes": 13,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 20,
+              "rels": 19,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.983,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Risk",
+                "AccountingPolicy",
+                "Event",
+                "Risk"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Financials"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.987,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Event",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 23,
+              "rels": 22,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Product",
+                "Product",
+                "Product",
+                "Company"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 29,
+              "rels": 28,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.968,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "AccountingPolicy",
+                "Product"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 15,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "nodes": 13,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 12,
+              "rels": 20,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Event"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Event",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Product",
+                "Regulation",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Legal"
+            },
+            {
+              "nodes": 16,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 9,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Event",
+                "Product"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Company",
+                "LegalIssue",
+                "Risk",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Legal"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "Regulation",
+                "Risk",
+                "AccountingPolicy"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Regulation",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Company",
+                "Person",
+                "Person",
+                "Company",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 15,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Regulation",
+                "AccountingPolicy",
+                "AccountingPolicy",
+                "Event",
+                "Event",
+                "Product",
+                "Product",
+                "Person"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 9,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Risk",
+                "Regulation",
+                "Event",
+                "Risk",
+                "Event",
+                "Event",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.93,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 12,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Regulation",
+                "AccountingPolicy",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.909,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 14,
+              "rels": 16,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Event",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.983,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "Event",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 1,
+              "rels": 1,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [
+                "<Label>"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.974,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Event",
+                "Event",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "error": "AttributeError: 'list' object has no attribute 'get'",
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.982,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Shareholder return"
+            }
+          ]
+        },
+        "gpt-oss-120b": {
+          "aggregate": {
+            "docs_ok": 160,
+            "mean_nodes": 7.625,
+            "mean_rels": 5.681,
+            "mean_label_conformance": 0.9,
+            "mean_rel_conformance": 0.7438,
+            "mean_extraction_score": 0.8878,
+            "distinct_labels": 9,
+            "label_entropy_bits": 2.5926,
+            "top1_label_share": 0.3754
+          },
+          "per_doc": [
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 16,
+              "rels": 15,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.997,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.995,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.989,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.987,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 12,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.992,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.974,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product",
+                "AccountingPolicy",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 6,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation",
+                "FinancialMetric",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "AccountingPolicy"
+              ],
+              "category": "Accounting"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 3,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Risk",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 24,
+              "rels": 23,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Product",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 13,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 13,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Company overview"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.889,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 25,
+              "rels": 24,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 39,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.958,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 19,
+              "rels": 18,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.998,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Regulation",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 7,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Risk"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 15,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.983,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Financials"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Financials"
+            },
+            {
+              "nodes": 28,
+              "rels": 27,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.965,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "Company",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.947,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.968,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.917,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 26,
+              "rels": 25,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 31,
+              "rels": 30,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.981,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 10,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Company"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.98,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 12,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "Person",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 24,
+              "rels": 23,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 0,
+              "rels": 0,
+              "label_conformance": 0.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.0,
+              "labels": [],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 22,
+              "rels": 21,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "AccountingPolicy"
+              ],
+              "category": "Footnotes"
+            },
+            {
+              "nodes": 8,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.976,
+              "labels": [
+                "Company",
+                "Product",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 13,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 15,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 4,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 14,
+              "rels": 13,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Event"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Product",
+                "Product",
+                "Product",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Regulation"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 10,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person"
+              ],
+              "category": "Governance"
+            },
+            {
+              "nodes": 13,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.985,
+              "labels": [
+                "Company",
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "LegalIssue",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.993,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "LegalIssue",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "AccountingPolicy",
+                "Risk",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 10,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.993,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "LegalIssue",
+                "LegalIssue",
+                "Product",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.99,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "Regulation"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.986,
+              "labels": [
+                "Company",
+                "Regulation",
+                "LegalIssue",
+                "LegalIssue",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 1,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.994,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "FinancialMetric"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Regulation",
+                "Risk",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 21,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Event",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.993,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 15,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.998,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Event"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.994,
+              "labels": [
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 8,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Company",
+                "Company",
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 6,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue",
+                "LegalIssue",
+                "Risk",
+                "Risk",
+                "Product"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "LegalIssue"
+              ],
+              "category": "Legal"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Risk",
+                "Event",
+                "Event",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 7,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk",
+                "Product",
+                "Regulation",
+                "Event"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 2,
+              "rels": 1,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Product",
+                "Product",
+                "Product",
+                "Product",
+                "Product"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Regulation",
+                "Risk",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 1.0,
+              "labels": [
+                "Company",
+                "Person",
+                "Person",
+                "Risk"
+              ],
+              "category": "Risk"
+            },
+            {
+              "nodes": 6,
+              "rels": 5,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.985,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Product"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.98,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.917,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 4,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 8,
+              "rels": 7,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 6,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.972,
+              "labels": [
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 9,
+              "rels": 8,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 15,
+              "rels": 14,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 5,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.969,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 3,
+              "rels": 2,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.967,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 11,
+              "rels": 10,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Regulation"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 7,
+              "rels": 6,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.962,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 13,
+              "rels": 12,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.96,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 2,
+              "rels": 0,
+              "label_conformance": 1.0,
+              "rel_conformance": 0.0,
+              "extraction_score": 0.959,
+              "labels": [
+                "Event",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 10,
+              "rels": 9,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.961,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 4,
+              "rels": 3,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.964,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric"
+              ],
+              "category": "Shareholder return"
+            },
+            {
+              "nodes": 14,
+              "rels": 11,
+              "label_conformance": 1.0,
+              "rel_conformance": 1.0,
+              "extraction_score": 0.963,
+              "labels": [
+                "Company",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "FinancialMetric",
+                "Event",
+                "Event"
+              ],
+              "category": "Shareholder return"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "summary": {
+    "A_sparse_fibo_minus": {
+      "mean_nodes": 4.0122,
+      "mean_rels": 2.7815,
+      "mean_label_conformance": 0.7458,
+      "mean_rel_conformance": 0.4782,
+      "mean_extraction_score": 0.7338,
+      "distinct_labels": 2.25,
+      "label_entropy_bits": 0.8125,
+      "top1_label_share": 0.7589
+    },
+    "B_rich_fibo_plus": {
+      "mean_nodes": 8.2473,
+      "mean_rels": 6.6182,
+      "mean_label_conformance": 0.9094,
+      "mean_rel_conformance": 0.7992,
+      "mean_extraction_score": 0.8982,
+      "distinct_labels": 9.5,
+      "label_entropy_bits": 2.6091,
+      "top1_label_share": 0.4012
+    },
+    "delta_B_minus_A": {
+      "mean_nodes": 4.2351,
+      "mean_rels": 3.8367,
+      "mean_label_conformance": 0.1636,
+      "mean_rel_conformance": 0.321,
+      "mean_extraction_score": 0.1644,
+      "distinct_labels": 7.25,
+      "label_entropy_bits": 1.7966,
+      "top1_label_share": -0.3577
+    }
+  }
+}

--- a/docs/decisions/ADR-0115-guardrail-ablation.json
+++ b/docs/decisions/ADR-0115-guardrail-ablation.json
@@ -1,0 +1,898 @@
+{
+  "experiment": "ontology-guardrail-ablation",
+  "provider": "MARA (api.cloud.mara.com)",
+  "models": [
+    "DeepSeek-V3.1",
+    "MiniMax-M2.5",
+    "MiniMax-M2.7",
+    "gpt-oss-120b"
+  ],
+  "phase_a": {
+    "models_succeeded": [
+      "DeepSeek-V3.1",
+      "MiniMax-M2.5",
+      "gpt-oss-120b"
+    ],
+    "per_model_tags": {
+      "DeepSeek-V3.1": {
+        "Employee": {
+          "rigid": false,
+          "carries_identity": true,
+          "supplies_identity": false,
+          "unity": true,
+          "dependent": true,
+          "rationale": "Employee is a role that can be entered and left while the person continues to exist, and depends on a company for its existence."
+        },
+        "Person": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Person is a fundamental and permanent category with inherent identity and unity, not dependent on other entities."
+        },
+        "Company": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Company is a rigid, independent entity with its own identity and unity as an organization."
+        },
+        "Product": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Product is a concrete object with essential identity and unity, existing independently as a manufactured item."
+        }
+      },
+      "MiniMax-M2.5": {
+        "Employee": {
+          "rigid": false,
+          "carries_identity": false,
+          "supplies_identity": false,
+          "unity": false,
+          "dependent": true,
+          "rationale": "Employee is a role that is anti-rigid, does not carry or supply its own identity, is not a unified whole, and necessarily depends on a company."
+        },
+        "Person": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Person is a rigid, identity-carrying, identity-supplying, unified, independent entity."
+        },
+        "Company": {
+          "rigid": false,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Company is anti-rigid, carries and supplies its own identity, is a unified entity, and does not necessarily depend on another entity."
+        },
+        "Product": {
+          "rigid": false,
+          "carries_identity": true,
+          "supplies_identity": false,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Product is anti-rigid, carries identity but does not supply its own identity, is a unified physical object, and does not necessarily depend on another entity."
+        }
+      },
+      "gpt-oss-120b": {
+        "Employee": {
+          "rigid": false,
+          "carries_identity": true,
+          "supplies_identity": false,
+          "unity": true,
+          "dependent": true,
+          "rationale": "Employee is an anti‑rigid role (can be lost), inherits identity from the underlying person, does not introduce its own identity criterion, each employee is a whole person, and employment necessarily depends on a company."
+        },
+        "Person": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Person is a rigid, essential kind of entity with its own identity criterion, each person is a unified whole, and persons do not ontologically depend on other entities."
+        },
+        "Company": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": true,
+          "unity": true,
+          "dependent": false,
+          "rationale": "Company is a rigid organizational entity that supplies its own legal identity, is a unified whole, and exists independently of other entities."
+        },
+        "Product": {
+          "rigid": true,
+          "carries_identity": true,
+          "supplies_identity": false,
+          "unity": true,
+          "dependent": true,
+          "rationale": "Product is treated as a rigid artifact kind, inherits identity from its material/artifact nature, does not introduce a new identity criterion, each product is a whole object, and its existence depends on having been created by a producer."
+        }
+      }
+    },
+    "consensus_tags": {
+      "Employee": {
+        "rigid": false,
+        "carries_identity": true,
+        "supplies_identity": false,
+        "unity": true,
+        "dependent": true,
+        "rationale": ""
+      },
+      "Person": {
+        "rigid": true,
+        "carries_identity": true,
+        "supplies_identity": true,
+        "unity": true,
+        "dependent": false,
+        "rationale": ""
+      },
+      "Company": {
+        "rigid": true,
+        "carries_identity": true,
+        "supplies_identity": true,
+        "unity": true,
+        "dependent": false,
+        "rationale": ""
+      },
+      "Product": {
+        "rigid": true,
+        "carries_identity": true,
+        "supplies_identity": false,
+        "unity": true,
+        "dependent": false,
+        "rationale": ""
+      }
+    },
+    "inference_prompt": "For each class decide, using its label, definition and properties:\n\n- rigid: true if being an instance of this class is ESSENTIAL and PERMANENT (a thing\n  cannot stop being one while continuing to exist, e.g. Person, Organism). false if\n  ANTI-RIGID — an instance can stop being one yet keep existing (roles like Student,\n  Employee, CEO; phases like Child). null if unsure.\n- carries_identity: true if instances have an identity criterion (a way to tell two\n  apart and re-identify one over time). Most concrete object types are true; pure\n  qualities/amounts are often false. null if unsure.\n- supplies_identity: true if THIS class introduces its own identity criterion rather\n  than inheriting one from a parent. null if unsure.\n- unity: true if every instance is a single connected WHOLE under one unifying relation\n  (e.g. an Organism, a Machine). false (anti-unity) for amounts/collections that need\n  not be wholes. null if unsure.\n- dependent: true if every instance NECESSARILY depends on some other distinct entity\n  existing (Student needs a school; Spouse needs a partner; Subsidiary needs a parent\n  company). false for independent substances. null if unsure.\n\nAlso give a one-sentence \"rationale\".\n\n\nClasses:\n- Employee: A person employed by a company. | properties: (none) | broader: (none)\n- Person: (no definition) | properties: name | broader: Employee\n- Company: (no definition) | properties: name | broader: (none)\n- Product: A product. | properties: (none) | broader: (none)\n\nReturn JSON: {\"classes\": {\"<Label>\": {\"rigid\": <bool|null>, \"carries_identity\": <bool|null>, \"supplies_identity\": <bool|null>, \"unity\": <bool|null>, \"dependent\": <bool|null>, \"rationale\": \"<str>\"}}}",
+    "draft_ontoclean": {
+      "ok": false,
+      "edges_checked": 1,
+      "violation_count": 2,
+      "violations": [
+        {
+          "constraint": "rigidity",
+          "parent": "Employee",
+          "child": "Person",
+          "severity": "violation",
+          "message": "'Person' (rigid: being a Person is permanent) is placed under anti-rigid 'Employee' (an instance can stop being a Employee). An anti-rigid class cannot subsume a rigid one — re-parent 'Person' or model the 'Employee' aspect as a role/relationship, not a superclass."
+        },
+        {
+          "constraint": "dependence",
+          "parent": "Employee",
+          "child": "Person",
+          "severity": "violation",
+          "message": "'Employee' is externally dependent but its subclass 'Person' is independent. A dependent class cannot subsume an independent one — dependence is inherited downward."
+        }
+      ],
+      "untagged_classes": []
+    },
+    "refined_ontoclean": {
+      "ok": true,
+      "edges_checked": 1,
+      "violation_count": 0,
+      "violations": [],
+      "untagged_classes": []
+    },
+    "draft_score": {
+      "overall": 0.5965,
+      "grade": "F",
+      "taxonomy_health": 0.55
+    },
+    "refined_score": {
+      "overall": 0.9557,
+      "grade": "A",
+      "taxonomy_health": 0.95
+    },
+    "delta_overall": 0.3592,
+    "violations_cleared": 2
+  },
+  "phase_b": {
+    "documents": [
+      "Acme Corp announced that Jane Doe will become its new chief executive officer next month.",
+      "Globex Inc acquired its smaller rival Initech in a deal worth two billion dollars.",
+      "The startup Hooli launched a new cloud product called Nucleus aimed at enterprises.",
+      "John Smith, a senior engineer at Hooli, was promoted to vice president of product.",
+      "Initech reported quarterly revenue of 450 million dollars, up 12 percent year over year.",
+      "Stark Industries offers a flagship product, the Arc Reactor, to industrial customers."
+    ],
+    "reference_schema": "biz-refined",
+    "results": {
+      "A_draft_guardrail": {
+        "per_model": {
+          "DeepSeek-V3.1": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 0.963,
+              "total_distinct_labels": 3
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 0,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          },
+          "MiniMax-M2.5": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 0.9815,
+              "total_distinct_labels": 3
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 0,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          },
+          "MiniMax-M2.7": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 0.963,
+              "total_distinct_labels": 3
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 0,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          },
+          "gpt-oss-120b": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 0.963,
+              "total_distinct_labels": 3
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 0,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 0.889,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "B_refined_guardrail": {
+        "per_model": {
+          "DeepSeek-V3.1": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 1.0,
+              "total_distinct_labels": 4
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 3,
+                "rel_count": 0,
+                "distinct_labels": 3,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Employee",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          },
+          "MiniMax-M2.5": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 1.0,
+              "total_distinct_labels": 4
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 3,
+                "rel_count": 0,
+                "distinct_labels": 3,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company",
+                  "Employee"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          },
+          "MiniMax-M2.7": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 1.0,
+              "total_distinct_labels": 4
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 3,
+                "rel_count": 0,
+                "distinct_labels": 3,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Employee",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          },
+          "gpt-oss-120b": {
+            "aggregate": {
+              "docs_ok": 6,
+              "mean_label_conformance": 1.0,
+              "mean_rel_conformance": 0.6667,
+              "mean_extraction_score": 1.0,
+              "total_distinct_labels": 4
+            },
+            "per_doc": [
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              },
+              {
+                "node_count": 3,
+                "rel_count": 0,
+                "distinct_labels": 3,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Person",
+                  "Employee",
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 1,
+                "rel_count": 0,
+                "distinct_labels": 1,
+                "label_conformance": 1.0,
+                "rel_conformance": 0.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company"
+                ]
+              },
+              {
+                "node_count": 2,
+                "rel_count": 1,
+                "distinct_labels": 2,
+                "label_conformance": 1.0,
+                "rel_conformance": 1.0,
+                "extraction_score": 1.0,
+                "labels": [
+                  "Company",
+                  "Product"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    "summary": {
+      "A_draft_guardrail": {
+        "mean_label_conformance": 1.0,
+        "mean_rel_conformance": 0.6667,
+        "mean_extraction_score": 0.9676,
+        "total_distinct_labels": 3
+      },
+      "B_refined_guardrail": {
+        "mean_label_conformance": 1.0,
+        "mean_rel_conformance": 0.6667,
+        "mean_extraction_score": 1.0,
+        "total_distinct_labels": 4
+      },
+      "delta_B_minus_A": {
+        "mean_label_conformance": 0.0,
+        "mean_rel_conformance": 0.0,
+        "mean_extraction_score": 0.0324,
+        "total_distinct_labels": 1
+      }
+    }
+  }
+}

--- a/docs/decisions/ADR-0115-ontoclean-critic-and-guardrail-validation.md
+++ b/docs/decisions/ADR-0115-ontoclean-critic-and-guardrail-validation.md
@@ -1,0 +1,174 @@
+# ADR-0115: OntoClean Meta-Property Critic — Refined Ontology as an LLM Guardrail
+
+Date: 2026-06-13
+Status: Proposed
+
+## Context
+
+ADR-0114 gave SEOCHO a graded ontology **scorecard** (the measurement instrument). Its
+`taxonomy_health` tier detects *structural* smells (orphans, flatness, single-child branches)
+but cannot tell whether an is-a edge is **formally** correct. "Person is-a Student" is
+well-formed structurally yet ontologically wrong: being a Person is permanent, being a Student
+is a revocable role.
+
+OntoClean (Guarino & Welty, 2002) is the discipline's answer: tag each class with four formal
+meta-properties — **rigidity, identity, unity, dependence** — and check that every subsumption
+edge respects the constraints those tags impose. The expensive part of OntoClean is the manual
+tagging; an LLM (MARA, per the user's authorization) can propose the tags.
+
+The product purpose (user framing, 2026-06-13): the scorecard + OntoClean critic + versioning
+form an **ontology refinement pipeline**, and the *refined, versioned* ontology is then used as
+an **LLM guardrail** (the extraction/query enforcement layer, ADR enforcement modes
+strict/guided/open). The metric that ultimately matters is the **LLM before/after difference**
+when a refined-ontology guardrail is in force versus a draft/no guardrail — i.e. exp-001's
+ontology-on/off ablation, but with "on" supplied by the governed pipeline rather than an
+ad-hoc schema.
+
+## Decision
+
+Add `seocho.ontology_ontoclean` with two cleanly separated halves:
+
+1. **Pure constraint engine** — `check_ontoclean(ontology, tags) -> OntoCleanResult`. Encodes
+   the four OntoClean subsumption constraints, deterministic, no I/O, fully unit-tested. A
+   `None` (unknown) tag on either endpoint skips that constraint, so unknowns never produce a
+   false violation.
+   - **Rigidity (C1):** an anti-rigid class cannot subsume a rigid one (flagship check).
+   - **Identity (C2):** identity is inherited downward; a subclass cannot drop a carried
+     identity criterion, and incompatible own-identity keys along a chain are warned.
+   - **Unity (C3):** a +U class and a ~U class cannot stand in is-a.
+   - **Dependence (C4):** a dependent class cannot subsume an independent one.
+2. **Injectable inference** — `infer_metaproperties(ontology, *, backend)` uses an LLM backend
+   (`create_llm_backend(provider="mara")` by default) to *propose* the tags. The backend is
+   injected, never constructed inside the engine, so: (a) the engine and tests run offline; (b)
+   the **scorecard stays LLM-free** — it consumes precomputed tags via the new
+   `score_ontology(..., ontoclean_tags=...)` parameter and folds hard violations into
+   `taxonomy_health`. This honours the "explicit opt-in over magic" principle: nothing fires a
+   model implicitly.
+
+Tags are serialisable (`dump_/load_metaproperties`) so an inferred tag set is cached and
+recorded as part of the data trail (every MARA use must be recorded — user requirement).
+
+## Validation
+
+### 1. OntoClean critic — deterministic before/after (measured, offline)
+
+`docs/decisions/ADR-0115-ontoclean-experiment.json`. A 4-class role ontology where the draft
+mis-models `Person broader Student` (rigid under an anti-rigid, dependent role); the fix makes
+`Person` a root with `Student`/`Employee` as roles beneath it. Hand-authored tags (the tags an
+LLM would propose).
+
+| | OntoClean | overall | grade | taxonomy_health |
+|---|---|---|---|---|
+| **before** (Person<:Student) | 2 violations | 0.781 | C | 0.250 |
+| **after** (fixed hierarchy) | 0 | 0.919 | A | 0.750 |
+| **Δ** | −2 | **+0.139** | C→A | **+0.500** |
+
+The one wrong edge tripped **two** independent constraints (rigidity *and* dependence) — exactly
+the redundant, formally-grounded signal OntoClean is prized for. Tests:
+`tests/seocho/test_ontology_ontoclean.py` (10) + scorecard integration.
+
+### 2. Live MARA ensemble + guardrail ablation (measured 2026-06-13)
+
+`scripts/benchmarks/ontology_guardrail_ablation.py`, provider MARA
+(`api.cloud.mara.com`), all four models (DeepSeek-V3.1, MiniMax-M2.5, MiniMax-M2.7,
+gpt-oss-120b). Record: `docs/decisions/ADR-0115-guardrail-ablation.json`.
+
+**Phase A — ensemble OntoClean refinement.** A draft business ontology with a *planted* defect
+(`Person broader Employee` — rigid Person under the anti-rigid role Employee). Each model
+independently inferred meta-properties; majority vote = consensus. **All three models that
+returned parseable JSON agreed: Person rigid=True, Employee rigid=False, Employee dependent=True**
+(MiniMax-M2.7 emitted unparseable reasoning in Phase A and was outvoted-by-absence — the ensemble
+is robust to one model failing). The critic flagged the edge on **two** constraints (rigidity +
+dependence); fixing the hierarchy cleared both.
+
+| | OntoClean | overall | grade |
+|---|---|---|---|
+| draft guardrail | 2 violations | 0.597 | F |
+| refined guardrail | 0 | 0.956 | A |
+
+**Phase B — guardrail payoff.** The same 6 documents were extracted by each model twice: with the
+draft ontology as the injected guardrail (arm A) vs the refined ontology (arm B), scored against
+the refined target schema. Cross-model means (all 4 models, consistent direction):
+
+| arm | label conformance | extraction_score | distinct labels |
+|---|---|---|---|
+| A — draft guardrail | 1.000 | 0.968 | 3 |
+| B — refined guardrail | 1.000 | **1.000** | 4 |
+| **Δ (B−A)** | 0 | **+0.032** | +1 |
+
+Reading (honest): both guardrails hold the LLM inside the vocabulary (conformance saturates at
+1.0 on this small/clean corpus), so the *enforcement* effect is equal. The refined guardrail's
+gain is **structural completeness** — its identity keys / unique constraints / definitions make
+the model fill the properties that score the extraction perfectly (1.0 vs 0.968), and it surfaces
+the extra entity type (Employee) the draft had malformed. The effect is small but **consistent
+across all four models** and isolates exactly what the governance pipeline buys downstream: not
+"more in-vocabulary" but "more completely and identifiably structured". A larger/noisier corpus
+is expected to widen the conformance gap too (exp-001 follow-up).
+
+The deterministic hand-tagged variant (`ADR-0115-ontoclean-experiment.json`) corroborates the
+Phase A constraint logic without a model in the loop.
+
+### 3. Large-corpus guardrail ablation on FinDER (measured 2026-06-13)
+
+`scripts/benchmarks/finder_guardrail_ablation.py`, corpus `Linq-AI-Research/FinDER` (5,703
+SEC-filing cases), **160-doc category-stratified sample (20 × 8 categories)**, all four MARA
+models, references truncated to 3,000 chars, 16-thread pool (1,280 extractions). Arms are two
+shipped FIBO variants used as extraction guardrails: **A = fibo_minus (2 classes)** vs
+**B = fibo_plus (9 classes)**. Each extraction scored against its own guardrail. Record:
+`docs/decisions/ADR-0115-finder-guardrail-ablation.json`.
+
+Cross-model means:
+
+| arm | nodes/doc | label conformance | extraction_score | distinct labels |
+|---|---|---|---|---|
+| A — sparse (fibo_minus) | 4.01 | 0.746 | 0.734 | 2.25 |
+| B — rich (fibo_plus) | 8.25 | 0.909 | 0.898 | 9.5 |
+| **Δ (B−A)** | **+4.24** | **+0.164** | **+0.164** | +7.25 |
+
+**The result inverts the toy-corpus reading and is far stronger.** On real, heterogeneous
+financial text a *too-sparse* guardrail HURTS: with only `Company`/`FinancialMetric` to choose
+from, the model is forced to mislabel the people, regulations and risks the text contains, so
+~25 % of its labels fall out of vocabulary (conformance 0.746). The richer guardrail gives the
+model adequate labels → higher conformance, higher score, ~2× coverage. Holds for **all four
+models** (Δscore DeepSeek +0.145, MiniMax-M2.5 +0.234, gpt-oss-120b +0.238, MiniMax-M2.7 +0.041).
+
+Honest caveats:
+- **MiniMax-M2.7 emitted unparseable JSON on ~20 % of docs** (31–32 / 160 per arm); its numbers
+  are over the successful subset and are the noisiest. The other three models had 0 parse errors.
+- **The benefit is strongly category-conditional** (cross-model Δscore by category):
+
+  | category | Δ extraction_score | conformance A→B |
+  |---|---|---|
+  | Governance | **+0.476** | 0.50 → 0.97 |
+  | Risk | **+0.423** | 0.55 → 0.97 |
+  | Company overview | +0.197 | 0.75 → 0.95 |
+  | Legal | +0.138 | 0.77 → 0.91 |
+  | Accounting | +0.073 | 0.87 → 0.93 |
+  | Footnotes | +0.047 | 0.86 → 0.91 |
+  | Financials | +0.005 | 0.72 → 0.73 |
+  | Shareholder return | **−0.021** | 0.97 → 0.95 |
+
+  Entity-rich domains (Governance, Risk) gain enormously; metric-dominated domains (Financials,
+  Shareholder return) gain nothing or regress slightly because the sparse schema is already
+  adequate and the extra labels add noise. This mirrors exp-001's "ontology helps in enumerable
+  domains" and refines the product claim: **the value of a richer ontology guardrail is
+  conditional on whether the domain's entities exceed the minimal vocabulary.**
+
+**Implication for the scorecard (feedback into ADR-0114).** The scorecard rated fibo_minus
+(0.90, B) *above* fibo_plus (0.82, B) — penalising fibo_plus's flatness — yet fibo_plus is the
+better guardrail overall. Intrinsic structural grade and downstream guardrail value diverge: the
+"best" ontology is corpus/task-dependent. This argues for (a) corpus-aware weighting (a guardrail
+use case should weight `constraint_richness`/coverage over taxonomy depth) and (b) running the
+functional tier against real target documents, not CQs alone. Tracked as a follow-up on
+`seocho-g2r`.
+
+## Consequences
+
+- The scorecard now grades is-a edges for *formal* correctness, not just structure — the
+  rigorous core of "axiom adjustment / taxonomy design".
+- OntoClean tagging, historically the methodology's bottleneck, becomes a single recorded MARA
+  call; tags are cached and versioned with the ontology.
+- Ties the intrinsic quality pipeline (scorecard + OntoClean + versioning) to the extrinsic
+  payoff (LLM-guardrail before/after), closing the measure→refine→prove loop.
+- Follow-ups (off `seocho-g2r`): the live MARA-tagged guardrail ablation; persisting tags into
+  the version snapshot store; a `seocho ontology ontoclean` CLI subcommand.

--- a/docs/decisions/ADR-0115-ontoclean-experiment.json
+++ b/docs/decisions/ADR-0115-ontoclean-experiment.json
@@ -1,0 +1,71 @@
+{
+  "experiment": "ontoclean-rigidity-before-after",
+  "meta_properties": {
+    "Person": {
+      "rigid": true,
+      "carries_identity": true,
+      "supplies_identity": true,
+      "unity": true,
+      "dependent": false,
+      "rationale": "A human is permanently a human."
+    },
+    "Student": {
+      "rigid": false,
+      "carries_identity": true,
+      "supplies_identity": false,
+      "unity": true,
+      "dependent": true,
+      "rationale": "One can stop being a student; depends on a school."
+    },
+    "Employee": {
+      "rigid": false,
+      "carries_identity": true,
+      "supplies_identity": false,
+      "unity": true,
+      "dependent": true,
+      "rationale": "A role; depends on an employer."
+    },
+    "Company": {
+      "rigid": true,
+      "carries_identity": true,
+      "supplies_identity": true,
+      "unity": true,
+      "dependent": false,
+      "rationale": "An incorporated entity."
+    }
+  },
+  "before": {
+    "ontoclean_ok": false,
+    "violations": [
+      {
+        "constraint": "rigidity",
+        "parent": "Student",
+        "child": "Person",
+        "severity": "violation",
+        "message": "'Person' (rigid: being a Person is permanent) is placed under anti-rigid 'Student' (an instance can stop being a Student). An anti-rigid class cannot subsume a rigid one — re-parent 'Person' or model the 'Student' aspect as a role/relationship, not a superclass."
+      },
+      {
+        "constraint": "dependence",
+        "parent": "Student",
+        "child": "Person",
+        "severity": "violation",
+        "message": "'Student' is externally dependent but its subclass 'Person' is independent. A dependent class cannot subsume an independent one — dependence is inherited downward."
+      }
+    ],
+    "overall": 0.7806,
+    "grade": "C",
+    "taxonomy_health": 0.25
+  },
+  "after": {
+    "ontoclean_ok": true,
+    "violations": [],
+    "overall": 0.9194,
+    "grade": "A",
+    "taxonomy_health": 0.75
+  },
+  "delta": {
+    "overall": 0.1389,
+    "taxonomy_health": 0.5,
+    "violations_cleared": 2
+  }
+}

--- a/scripts/benchmarks/finder_guardrail_ablation.py
+++ b/scripts/benchmarks/finder_guardrail_ablation.py
@@ -1,0 +1,247 @@
+"""Large-corpus guardrail ablation on FinDER (Linq-AI-Research/FinDER, 5,703 cases).
+
+Extends the small guardrail ablation to real SEC financial text. Compares a
+SPARSE FIBO guardrail (fibo_minus, 2 classes) against a RICH/refined FIBO
+guardrail (fibo_plus, 9 classes) as the LLM extraction guardrail, over a
+category-stratified sample, across all MARA models. Reports, per arm:
+
+  - coverage (nodes/rels per doc), conformance to the arm's own guardrail,
+    extraction_score, and exp-001-style label consistency (distinct labels,
+    label entropy in bits, top-1 share).
+
+Plus a scorecard reading of each FIBO variant (so the quality ladder the
+scorecard assigns is shown next to the downstream effect).
+
+Key from .env (ontology_guardrail_mara_api_key). Deterministic stratified
+sampling (sorted by _id, first N per category — no RNG). Run:
+    PYTHONPATH=src python3 scripts/benchmarks/finder_guardrail_ablation.py \
+        --per-category 8 --max-chars 3000 --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Lock
+
+from seocho.ontology import Ontology
+from seocho.ontology_scorecard import score_ontology
+from seocho.store.llm import create_llm_backend
+
+MODELS = ["DeepSeek-V3.1", "MiniMax-M2.5", "MiniMax-M2.7", "gpt-oss-120b"]
+ARMS = {
+    "A_sparse_fibo_minus": "examples/datasets/fibo_minus.jsonld",
+    "B_rich_fibo_plus": "examples/datasets/fibo_plus.jsonld",
+}
+
+_EXTRACT_SYSTEM = (
+    "You extract a knowledge graph from financial text, STRICTLY conforming to the "
+    "provided ontology. Use ONLY the listed entity labels and relationship types. "
+    "Return ONLY a JSON object."
+)
+
+
+def load_finder(per_category: int, max_chars: int):
+    from huggingface_hub import hf_hub_download
+    import pandas as pd
+
+    p = hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset")
+    df = pd.read_parquet(p)
+    docs = []
+    for cat, group in df.sort_values("_id").groupby("category"):
+        taken = 0
+        for _, row in group.iterrows():
+            refs = row["references"]
+            text = " ".join(str(x) for x in refs) if hasattr(refs, "__iter__") and not isinstance(refs, str) else str(refs)
+            text = text.strip()
+            if len(text) < 80:
+                continue
+            docs.append({"id": str(row["_id"]), "category": str(cat), "text": text[:max_chars]})
+            taken += 1
+            if taken >= per_category:
+                break
+    return docs
+
+
+def extraction_prompt(onto: Ontology, doc: str) -> str:
+    ctx = onto.to_extraction_context()
+    return (
+        f"ENTITY TYPES (use only these labels):\n{ctx.get('entity_types','')}\n\n"
+        f"RELATIONSHIP TYPES (use only these):\n{ctx.get('relationship_types','')}\n\n"
+        f"CONSTRAINTS:\n{ctx.get('constraints_summary','')}\n\n"
+        f"FINANCIAL TEXT:\n{doc}\n\n"
+        'Return JSON: {"nodes":[{"id":"n1","label":"<Label>","properties":{"name":"..."}}],'
+        '"relationships":[{"source":"n1","target":"n2","type":"<TYPE>"}]}'
+    )
+
+
+def _parse_graph(text: str) -> dict:
+    s = text.strip()
+    if s.startswith("```"):
+        s = "\n".join(l for l in s.split("\n") if not l.strip().startswith("```"))
+    try:
+        return json.loads(s)
+    except Exception:
+        m = re.search(r"\{.*\}", s, re.DOTALL)
+        try:
+            return json.loads(m.group(0)) if m else {}
+        except Exception:
+            return {}
+
+
+def _entropy(labels) -> float:
+    if not labels:
+        return 0.0
+    c = Counter(labels)
+    total = sum(c.values())
+    return round(-sum((n / total) * math.log2(n / total) for n in c.values()), 4)
+
+
+def _doc_metrics(graph: dict, guardrail: Ontology) -> dict:
+    nodes = [n for n in graph.get("nodes", []) if isinstance(n, dict)]
+    rels = [r for r in graph.get("relationships", []) if isinstance(r, dict)]
+    labels = [str(n.get("label", "")) for n in nodes]
+    rtypes = [str(r.get("type", "")) for r in rels]
+    label_ok = sum(1 for l in labels if l in guardrail.nodes)
+    rtype_ok = sum(1 for t in rtypes if t in guardrail.relationships)
+    sc = guardrail.score_extraction({"nodes": nodes, "relationships": rels})
+    return {
+        "nodes": len(nodes), "rels": len(rels),
+        "label_conformance": round(label_ok / len(labels), 4) if labels else 0.0,
+        "rel_conformance": round(rtype_ok / len(rtypes), 4) if rtypes else 0.0,
+        "extraction_score": sc["overall"],
+        "labels": labels,
+    }
+
+
+def _aggregate(per_doc):
+    ok = [d for d in per_doc if "error" not in d]
+    if not ok:
+        return {"docs_ok": 0}
+    all_labels = [l for d in ok for l in d["labels"]]
+    top1 = 0.0
+    if all_labels:
+        top1 = round(Counter(all_labels).most_common(1)[0][1] / len(all_labels), 4)
+    return {
+        "docs_ok": len(ok),
+        "mean_nodes": round(statistics.mean([d["nodes"] for d in ok]), 3),
+        "mean_rels": round(statistics.mean([d["rels"] for d in ok]), 3),
+        "mean_label_conformance": round(statistics.mean([d["label_conformance"] for d in ok]), 4),
+        "mean_rel_conformance": round(statistics.mean([d["rel_conformance"] for d in ok]), 4),
+        "mean_extraction_score": round(statistics.mean([d["extraction_score"] for d in ok]), 4),
+        "distinct_labels": len(set(all_labels)),
+        "label_entropy_bits": _entropy(all_labels),
+        "top1_label_share": top1,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--per-category", type=int, default=8)
+    ap.add_argument("--max-chars", type=int, default=3000)
+    ap.add_argument("--workers", type=int, default=12)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"',
+                    Path(".env").read_text(encoding="utf-8")).group(1)
+
+    docs = load_finder(args.per_category, args.max_chars)
+    cats = Counter(d["category"] for d in docs)
+    print(f"sampled {len(docs)} docs across {len(cats)} categories: {dict(cats)}")
+
+    ontos = {arm: Ontology.load(path) for arm, path in ARMS.items()}
+    cq_path = Path("examples/finder/datasets/competency_questions.yaml")
+    cqs = None
+    if cq_path.exists():
+        import yaml
+        raw = yaml.safe_load(cq_path.read_text())
+        cqs = raw.get("competency_questions", raw) if isinstance(raw, dict) else raw
+    scorecards = {arm: score_ontology(o, competency_questions=cqs).to_dict() for arm, o in ontos.items()}
+    for arm, sc in scorecards.items():
+        print(f"scorecard {arm}: {sc['grade']} ({sc['overall_score']})")
+
+    # One backend per model, shared across threads (openai client is thread-safe
+    # for independent requests). Calls are network I/O bound, so a thread pool
+    # over the full (arm, model, doc) grid gives a large speedup.
+    backends = {m: create_llm_backend(provider="mara", model=m, api_key=key) for m in MODELS}
+    tasks = [(arm, m, di, doc) for arm in ontos for m in MODELS for di, doc in enumerate(docs)]
+
+    done = {"n": 0}
+    lock = Lock()
+
+    def run_task(t):
+        arm, m, di, doc = t
+        try:
+            r = backends[m].complete(
+                system=_EXTRACT_SYSTEM, user=extraction_prompt(ontos[arm], doc["text"]),
+                temperature=0.0, max_tokens=4096, response_format={"type": "json_object"})
+            md = _doc_metrics(_parse_graph(r.text), ontos[arm])
+        except Exception as e:
+            md = {"error": f"{type(e).__name__}: {str(e)[:80]}"}
+        md["category"] = doc["category"]
+        with lock:
+            done["n"] += 1
+            if done["n"] % 25 == 0 or done["n"] == len(tasks):
+                print(f"  ... {done['n']}/{len(tasks)} extractions done")
+        return arm, m, di, md
+
+    # collect, preserving per-(arm,model) doc order by index
+    buckets = {arm: {m: [None] * len(docs) for m in MODELS} for arm in ontos}
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        for arm, m, di, md in pool.map(run_task, tasks):
+            buckets[arm][m][di] = md
+
+    results = {}
+    for arm in ontos:
+        results[arm] = {"per_model": {}}
+        for m in MODELS:
+            per_doc = buckets[arm][m]
+            agg = _aggregate(per_doc)
+            results[arm]["per_model"][m] = {"aggregate": agg, "per_doc": per_doc}
+            print(f"[{arm} / {m}] nodes={agg.get('mean_nodes')} conf={agg.get('mean_label_conformance')} "
+                  f"score={agg.get('mean_extraction_score')} entropy={agg.get('label_entropy_bits')} "
+                  f"distinct={agg.get('distinct_labels')}")
+
+    # cross-model means per arm
+    summary = {}
+    keys = ("mean_nodes", "mean_rels", "mean_label_conformance", "mean_rel_conformance",
+            "mean_extraction_score", "distinct_labels", "label_entropy_bits", "top1_label_share")
+    for arm in ontos:
+        aggs = [results[arm]["per_model"][m]["aggregate"] for m in MODELS
+                if results[arm]["per_model"][m]["aggregate"].get("docs_ok")]
+        summary[arm] = {k: round(statistics.mean([a[k] for a in aggs]), 4) for k in keys} if aggs else {}
+    if all(summary.values()):
+        summary["delta_B_minus_A"] = {
+            k: round(summary["B_rich_fibo_plus"][k] - summary["A_sparse_fibo_minus"][k], 4) for k in keys
+        }
+
+    record = {
+        "experiment": "finder-guardrail-ablation",
+        "corpus": "Linq-AI-Research/FinDER",
+        "sample": {"per_category": args.per_category, "total_docs": len(docs),
+                   "max_chars": args.max_chars, "categories": dict(cats)},
+        "models": MODELS,
+        "arms": ARMS,
+        "scorecards": scorecards,
+        "results": results,
+        "summary": summary,
+    }
+    Path(args.out).write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\n[written] {args.out}")
+    if "delta_B_minus_A" in summary:
+        a, b, d = summary["A_sparse_fibo_minus"], summary["B_rich_fibo_plus"], summary["delta_B_minus_A"]
+        print(f"\nCROSS-MODEL MEANS:")
+        print(f"  A (sparse): nodes={a['mean_nodes']} conf={a['mean_label_conformance']} score={a['mean_extraction_score']} entropy={a['label_entropy_bits']} distinct={a['distinct_labels']}")
+        print(f"  B (rich)  : nodes={b['mean_nodes']} conf={b['mean_label_conformance']} score={b['mean_extraction_score']} entropy={b['label_entropy_bits']} distinct={b['distinct_labels']}")
+        print(f"  Δ(B-A)    : nodes={d['mean_nodes']:+} conf={d['mean_label_conformance']:+} score={d['mean_extraction_score']:+} entropy={d['label_entropy_bits']:+}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/ontology_guardrail_ablation.py
+++ b/scripts/benchmarks/ontology_guardrail_ablation.py
@@ -1,0 +1,302 @@
+"""Live MARA experiment: ontology refinement (OntoClean ensemble) + guardrail ablation.
+
+Two phases, both recorded:
+
+  Phase A — refine: a MARA *ensemble* (all available models, majority vote per
+    meta-property) infers OntoClean meta-properties for a draft ontology that
+    contains a planted formal is-a defect. The critic flags it; we fix the
+    hierarchy; the scorecard measures the before/after lift.
+
+  Phase B — guardrail payoff: the SAME documents are extracted by each MARA model
+    twice — once with the DRAFT ontology injected as the extraction guardrail
+    (arm A), once with the REFINED ontology (arm B). We measure how well each
+    arm's extraction conforms to the refined target schema (label-in-ontology
+    rate + score_extraction) and how consistent its labels are. Hypothesis:
+    refined-guardrail (B) >= draft-guardrail (A).
+
+Key is read from .env (var ontology_guardrail_mara_api_key). Records everything
+to --out. Run:
+    PYTHONPATH=src python3 scripts/benchmarks/ontology_guardrail_ablation.py --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+from collections import Counter
+from pathlib import Path
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.ontology_ontoclean import (
+    MetaProperties,
+    build_inference_prompt,
+    check_ontoclean,
+    dump_metaproperties,
+    infer_metaproperties,
+)
+from seocho.ontology_scorecard import score_ontology
+from seocho.store.llm import create_llm_backend
+
+MODELS = ["DeepSeek-V3.1", "MiniMax-M2.5", "MiniMax-M2.7", "gpt-oss-120b"]
+
+DOCS = [
+    "Acme Corp announced that Jane Doe will become its new chief executive officer next month.",
+    "Globex Inc acquired its smaller rival Initech in a deal worth two billion dollars.",
+    "The startup Hooli launched a new cloud product called Nucleus aimed at enterprises.",
+    "John Smith, a senior engineer at Hooli, was promoted to vice president of product.",
+    "Initech reported quarterly revenue of 450 million dollars, up 12 percent year over year.",
+    "Stark Industries offers a flagship product, the Arc Reactor, to industrial customers.",
+]
+
+CQS = [
+    {"id": "cq1", "question": "Who is the CEO of a company?", "requires": ["Person", "CEO_OF", "Company"]},
+    {"id": "cq2", "question": "What product does a company offer?", "requires": ["Company", "OFFERS", "Product"]},
+]
+
+
+def draft_ontology() -> Ontology:
+    """A user's hand-written first draft with a PLANTED OntoClean defect: Person
+    (rigid) is modelled as a subclass of Employee (an anti-rigid role). Also
+    messy: missing definitions/identity, an untyped relationship."""
+    return Ontology(
+        "biz-draft",
+        version="v1",
+        nodes={
+            "Employee": NodeDef(description="A person employed by a company."),  # role, no identity
+            "Person": NodeDef(broader=["Employee"], properties={"name": P(str)}),  # VIOLATION + no def/identity
+            "Company": NodeDef(properties={"name": P(str)}),  # no def, name not unique
+            "Product": NodeDef(description="A product."),  # no identity
+        },
+        relationships={
+            "CEO_OF": RelDef(source="Person", target="Any"),  # untyped
+            "OFFERS": RelDef(source="Company", target="Product", description="offers"),
+            "ACQUIRED": RelDef(source="Company", target="Company", description="acquired"),
+        },
+    )
+
+
+def refined_ontology() -> Ontology:
+    """The governed rewrite: is-a fixed (Employee under Person), definitions,
+    identity keys, typed endpoints, cardinality."""
+    return Ontology(
+        "biz-refined",
+        version="1.1.0",
+        nodes={
+            "Person": NodeDef(description="A human being.",
+                              properties={"name": P(str, unique=True, description="Full name.")},
+                              identity_keys=["name"]),
+            "Employee": NodeDef(description="A person employed by a company (a role).",
+                                broader=["Person"],
+                                properties={"name": P(str, unique=True), "title": P(str)},
+                                identity_keys=["name"]),
+            "Company": NodeDef(description="A business organization.",
+                               properties={"name": P(str, unique=True, description="Registered name.")},
+                               identity_keys=["name"]),
+            "Product": NodeDef(description="A product or service offered by a company.",
+                               properties={"name": P(str, unique=True)}, identity_keys=["name"]),
+        },
+        relationships={
+            "CEO_OF": RelDef(source="Person", target="Company", cardinality="MANY_TO_ONE",
+                             description="Person leads the company as chief executive."),
+            "OFFERS": RelDef(source="Company", target="Product", cardinality="ONE_TO_MANY",
+                             description="Company offers a product."),
+            "ACQUIRED": RelDef(source="Company", target="Company", cardinality="MANY_TO_MANY",
+                               description="Company acquired another company."),
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Phase A — ensemble OntoClean inference
+# --------------------------------------------------------------------------- #
+
+_META_KEYS = ["rigid", "carries_identity", "supplies_identity", "unity", "dependent"]
+
+
+def ensemble_consensus(per_model_tags: dict, labels) -> dict:
+    """Majority vote per (label, meta-property). Ties or all-unknown -> None."""
+    consensus = {}
+    for label in labels:
+        md = {}
+        for key in _META_KEYS:
+            votes = [getattr(per_model_tags[m].get(label, MetaProperties()), key)
+                     for m in per_model_tags if label in per_model_tags[m]]
+            votes = [v for v in votes if v is not None]
+            if not votes:
+                md[key] = None
+            else:
+                c = Counter(votes)
+                top, n = c.most_common(1)[0]
+                md[key] = top if n > len(votes) / 2 else None
+        consensus[label] = MetaProperties(**md)
+    return consensus
+
+
+def phase_a(key: str) -> dict:
+    draft = draft_ontology()
+    per_model = {}
+    for m in MODELS:
+        be = create_llm_backend(provider="mara", model=m, api_key=key)
+        try:
+            tags = infer_metaproperties(draft, backend=be)
+            per_model[m] = tags
+            print(f"[A] {m}: tagged {len(tags)} classes")
+        except Exception as e:
+            print(f"[A] {m}: FAILED {type(e).__name__}: {str(e)[:100]}")
+    consensus = ensemble_consensus(per_model, list(draft.nodes))
+
+    draft_oc = check_ontoclean(draft, consensus)
+    refined = refined_ontology()
+    refined_oc = check_ontoclean(refined, consensus)
+
+    b = score_ontology(draft, competency_questions=CQS, ontoclean_tags=consensus)
+    a = score_ontology(refined, competency_questions=CQS, ontoclean_tags=consensus)
+    return {
+        "models_succeeded": list(per_model),
+        "per_model_tags": {m: dump_metaproperties(t) for m, t in per_model.items()},
+        "consensus_tags": dump_metaproperties(consensus),
+        "inference_prompt": build_inference_prompt(draft),
+        "draft_ontoclean": draft_oc.to_dict(),
+        "refined_ontoclean": refined_oc.to_dict(),
+        "draft_score": {"overall": round(b.overall_score, 4), "grade": b.grade,
+                        "taxonomy_health": round(b.dimension("taxonomy_health").score, 4)},
+        "refined_score": {"overall": round(a.overall_score, 4), "grade": a.grade,
+                          "taxonomy_health": round(a.dimension("taxonomy_health").score, 4)},
+        "delta_overall": round(a.overall_score - b.overall_score, 4),
+        "violations_cleared": len(draft_oc.violations) - len(refined_oc.violations),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Phase B — guardrail extraction ablation
+# --------------------------------------------------------------------------- #
+
+_EXTRACT_SYSTEM = (
+    "You extract a knowledge graph from text, STRICTLY conforming to the provided "
+    "ontology. Use ONLY the listed entity labels and relationship types. Return ONLY JSON."
+)
+
+
+def extraction_prompt(onto: Ontology, doc: str) -> str:
+    ctx = onto.to_extraction_context()
+    return (
+        f"ENTITY TYPES (use only these labels):\n{ctx.get('entity_types','')}\n\n"
+        f"RELATIONSHIP TYPES (use only these):\n{ctx.get('relationship_types','')}\n\n"
+        f"CONSTRAINTS:\n{ctx.get('constraints_summary','')}\n\n"
+        f"TEXT:\n{doc}\n\n"
+        'Return JSON: {"nodes":[{"id":"n1","label":"<Label>","properties":{"name":"..."}}],'
+        '"relationships":[{"source":"n1","target":"n2","type":"<TYPE>"}]}'
+    )
+
+
+def _parse_graph(text: str) -> dict:
+    s = text.strip()
+    if s.startswith("```"):
+        s = "\n".join(l for l in s.split("\n") if not l.strip().startswith("```"))
+    try:
+        return json.loads(s)
+    except Exception:
+        m = re.search(r"\{.*\}", s, re.DOTALL)
+        return json.loads(m.group(0)) if m else {"nodes": [], "relationships": []}
+
+
+def _conformance(graph: dict, reference: Ontology) -> dict:
+    nodes = [n for n in graph.get("nodes", []) if isinstance(n, dict)]
+    rels = [r for r in graph.get("relationships", []) if isinstance(r, dict)]
+    labels = [str(n.get("label", "")) for n in nodes]
+    rtypes = [str(r.get("type", "")) for r in rels]
+    label_ok = sum(1 for l in labels if l in reference.nodes)
+    rtype_ok = sum(1 for t in rtypes if t in reference.relationships)
+    sc = reference.score_extraction({"nodes": nodes, "relationships": rels})
+    return {
+        "node_count": len(nodes),
+        "rel_count": len(rels),
+        "distinct_labels": len(set(labels)),
+        "label_conformance": round(label_ok / len(labels), 4) if labels else 0.0,
+        "rel_conformance": round(rtype_ok / len(rtypes), 4) if rtypes else 0.0,
+        "extraction_score": sc["overall"],
+        "labels": labels,
+    }
+
+
+def phase_b(key: str) -> dict:
+    reference = refined_ontology()  # common target schema for fair conformance scoring
+    arms = {"A_draft_guardrail": draft_ontology(), "B_refined_guardrail": refined_ontology()}
+    results = {arm: {"per_model": {}} for arm in arms}
+
+    for arm, onto in arms.items():
+        for m in MODELS:
+            be = create_llm_backend(provider="mara", model=m, api_key=key)
+            per_doc = []
+            for doc in DOCS:
+                try:
+                    r = be.complete(system=_EXTRACT_SYSTEM, user=extraction_prompt(onto, doc),
+                                    temperature=0.0, max_tokens=4096, response_format={"type": "json_object"})
+                    graph = _parse_graph(r.text)
+                    per_doc.append(_conformance(graph, reference))
+                except Exception as e:
+                    per_doc.append({"error": f"{type(e).__name__}: {str(e)[:80]}"})
+            ok = [d for d in per_doc if "error" not in d]
+            agg = {
+                "docs_ok": len(ok),
+                "mean_label_conformance": round(statistics.mean([d["label_conformance"] for d in ok]), 4) if ok else 0.0,
+                "mean_rel_conformance": round(statistics.mean([d["rel_conformance"] for d in ok]), 4) if ok else 0.0,
+                "mean_extraction_score": round(statistics.mean([d["extraction_score"] for d in ok]), 4) if ok else 0.0,
+                "total_distinct_labels": len(set(l for d in ok for l in d["labels"])),
+            }
+            results[arm]["per_model"][m] = {"aggregate": agg, "per_doc": per_doc}
+            print(f"[B] {arm} / {m}: label_conf={agg['mean_label_conformance']} "
+                  f"score={agg['mean_extraction_score']} distinct={agg['total_distinct_labels']}")
+
+    # cross-model aggregate per arm
+    summary = {}
+    for arm in arms:
+        ms = [results[arm]["per_model"][m]["aggregate"] for m in MODELS if m in results[arm]["per_model"]]
+        summary[arm] = {
+            k: round(statistics.mean([a[k] for a in ms]), 4)
+            for k in ("mean_label_conformance", "mean_rel_conformance", "mean_extraction_score", "total_distinct_labels")
+        }
+    summary["delta_B_minus_A"] = {
+        k: round(summary["B_refined_guardrail"][k] - summary["A_draft_guardrail"][k], 4)
+        for k in summary["A_draft_guardrail"]
+    }
+    return {"documents": DOCS, "reference_schema": reference.name, "results": results, "summary": summary}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--phase", choices=["a", "b", "both"], default="both")
+    args = ap.parse_args()
+
+    env = Path(".env").read_text(encoding="utf-8")
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env).group(1)
+
+    record = {"experiment": "ontology-guardrail-ablation", "models": MODELS}
+    if args.phase in ("a", "both"):
+        print("=== Phase A: ensemble OntoClean refinement ===")
+        record["phase_a"] = phase_a(key)
+    if args.phase in ("b", "both"):
+        print("=== Phase B: guardrail extraction ablation ===")
+        record["phase_b"] = phase_b(key)
+
+    Path(args.out).write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\n[written] {args.out}")
+    if "phase_a" in record:
+        pa = record["phase_a"]
+        print(f"\nPhase A: draft {pa['draft_score']['grade']} ({pa['draft_score']['overall']}) "
+              f"-> refined {pa['refined_score']['grade']} ({pa['refined_score']['overall']}), "
+              f"violations cleared {pa['violations_cleared']}")
+    if "phase_b" in record:
+        s = record["phase_b"]["summary"]
+        print(f"Phase B (cross-model mean): A label_conf={s['A_draft_guardrail']['mean_label_conformance']} "
+              f"score={s['A_draft_guardrail']['mean_extraction_score']} | "
+              f"B label_conf={s['B_refined_guardrail']['mean_label_conformance']} "
+              f"score={s['B_refined_guardrail']['mean_extraction_score']} | "
+              f"Δscore={s['delta_B_minus_A']['mean_extraction_score']:+}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/ontology_scorecard_experiment.py
+++ b/scripts/benchmarks/ontology_scorecard_experiment.py
@@ -1,0 +1,159 @@
+"""Before/after experiment for the ontology quality scorecard.
+
+Demonstrates that ``seocho.ontology_scorecard.score_ontology`` (a) detects
+concrete defects in a real example ontology and (b) measurably rewards the
+fixes it recommends. The "before" arm is the shipped quickstart schema; the
+"after" arm applies exactly the weak points the scorecard surfaced.
+
+Run:
+    PYTHONPATH=src python3 scripts/benchmarks/ontology_scorecard_experiment.py
+
+Writes a JSON record to ``--out`` (default: stdout only).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.ontology_scorecard import score_ontology
+
+CQS = [
+    {"id": "cq1", "question": "Who is the CEO of a company?", "requires": ["Person", "CEO_OF", "Company"]},
+    {"id": "cq2", "question": "What products does a company offer?", "requires": ["Company", "OFFERS", "Product"]},
+    {"id": "cq3", "question": "Which company acquired another?", "requires": ["Company", "ACQUIRED"]},
+]
+
+
+def messy_first_draft() -> Ontology:
+    """The 'before' arm — a realistic hand-written first-draft ontology, the kind
+    a user produces before any governance: missing definitions, no identity keys,
+    a flat structure, an orphan class, and an untyped relationship."""
+    return Ontology(
+        "quickstart-draft",
+        version="v1",  # invalid semver
+        nodes={
+            "Company": NodeDef(properties={"name": P(str)}),  # no description, name not unique → no identity
+            "Person": NodeDef(description="A person."),  # no identity
+            "Founder": NodeDef(description="A founder."),  # no identity, single child of nothing
+            "Product": NodeDef(description="A product."),  # no identity
+            "Deal": NodeDef(description="A transaction."),  # no identity
+            "Metric": NodeDef(description="A KPI."),  # orphan: no broader, no relationship
+        },
+        relationships={
+            "CEO_OF": RelDef(source="Person", target="Any"),  # untyped target, no description
+            "OFFERS": RelDef(source="Company", target="Product", description="offers"),
+            "ACQUIRED": RelDef(source="Company", target="Company", description="acquired"),
+        },
+    )
+
+
+def improved_ontology() -> Ontology:
+    """The 'after' arm — the quickstart schema with the scorecard's recommended
+    fixes applied: an is-a taxonomy root (Agent), declared cardinalities, and
+    explicit identity keys."""
+    return Ontology(
+        "quickstart",
+        version="1.1.0",
+        description="Minimal company/person/product schema (taxonomy + cardinality hardened).",
+        nodes={
+            "Agent": NodeDef(description="An entity that can participate in business activity."),
+            "Company": NodeDef(
+                description="A business organization.",
+                broader=["Agent"],
+                properties={"name": P(str, unique=True, description="Registered company name.")},
+                identity_keys=["name"],
+            ),
+            "Person": NodeDef(
+                description="A person such as an executive or founder.",
+                broader=["Agent"],
+                properties={"name": P(str, unique=True, description="Full name.")},
+                identity_keys=["name"],
+            ),
+            "Founder": NodeDef(
+                description="A person who founded a company.",
+                broader=["Person"],
+                properties={"name": P(str, unique=True, description="Full name.")},
+                identity_keys=["name"],
+            ),
+            "Product": NodeDef(
+                description="A product or service offered by a company.",
+                properties={"name": P(str, unique=True, description="Product name.")},
+                identity_keys=["name"],
+            ),
+            "Deal": NodeDef(
+                description="An acquisition or transaction between companies.",
+                properties={"label": P(str, unique=True, description="Deal identifier.")},
+                identity_keys=["label"],
+            ),
+            "Metric": NodeDef(
+                description="A key performance indicator reported by a company.",
+                properties={"name": P(str, unique=True, description="Metric name.")},
+                identity_keys=["name"],
+            ),
+        },
+        relationships={
+            "CEO_OF": RelDef(source="Person", target="Company", cardinality="MANY_TO_ONE",
+                             description="Person leads the company as chief executive."),
+            "ACQUIRED": RelDef(source="Company", target="Company", cardinality="MANY_TO_MANY",
+                               description="Company acquired another company."),
+            "OFFERS": RelDef(source="Company", target="Product", cardinality="ONE_TO_MANY",
+                             description="Company offers a product or service."),
+            "REPORTS": RelDef(source="Company", target="Metric", cardinality="ONE_TO_MANY",
+                              description="Company reports a performance metric."),
+        },
+    )
+
+
+def _summarise(card) -> dict:
+    return {
+        "overall_score": round(card.overall_score, 4),
+        "grade": card.grade,
+        "blocking": card.blocking,
+        "dimensions": {d.name: round(d.score, 4) for d in card.dimensions},
+        "weak_point_count": len(card.weak_points),
+        "weak_points": [wp.to_dict() for wp in card.weak_points],
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    before_onto = messy_first_draft()
+    after_onto = improved_ontology()
+
+    before = score_ontology(before_onto, competency_questions=CQS)
+    after = score_ontology(after_onto, competency_questions=CQS)
+
+    record = {
+        "experiment": "ontology-scorecard-before-after",
+        "domain": "company/person/product first-draft → governed",
+        "before": _summarise(before),
+        "after": _summarise(after),
+        "delta": {
+            "overall_score": round(after.overall_score - before.overall_score, 4),
+            "weak_point_count": after.weak_point_count if hasattr(after, "weak_point_count") else len(after.weak_points) - len(before.weak_points),
+            "by_dimension": {
+                d.name: round(
+                    d.score - (before.dimension(d.name).score if before.dimension(d.name) else 0.0), 4
+                )
+                for d in after.dimensions
+            },
+        },
+    }
+    # weak_point_count delta computed plainly
+    record["delta"]["weak_point_count"] = len(after.weak_points) - len(before.weak_points)
+
+    text = json.dumps(record, indent=2, ensure_ascii=False)
+    print(text)
+    if args.out:
+        Path(args.out).write_text(text + "\n", encoding="utf-8")
+        print(f"\n[written] {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/ontology_ontoclean.py
+++ b/src/seocho/ontology_ontoclean.py
@@ -1,0 +1,360 @@
+"""OntoClean meta-property critic for is-a (subclass) hierarchies.
+
+OntoClean (Guarino & Welty, 2002, *Evaluating ontological decisions with
+OntoClean*) validates a taxonomy by tagging each class with four formal
+meta-properties and then checking that every subsumption (``broader``) edge
+respects the constraints those meta-properties impose. It is the rigorous core
+of "axiom adjustment / taxonomy design": it catches is-a edges that are
+*formally* wrong, not merely stylistically off.
+
+This module has two cleanly separated halves:
+
+1. A **pure constraint engine** (:func:`check_ontoclean`) that, given
+   meta-property tags, deterministically reports violations. No LLM, no I/O —
+   fully unit-testable offline. This is the part that encodes the OntoClean
+   axioms.
+2. An **optional, injectable inference step** (:func:`infer_metaproperties`)
+   that uses an LLM backend (MARA by default) to *propose* the tags, since
+   manual OntoClean tagging is the expensive part of the methodology. The
+   backend is injected so the engine never depends on a live model, and so the
+   scorecard stays offline (it consumes precomputed tags, never calls an LLM).
+
+The four meta-properties (tri-state: ``True`` / ``False`` / ``None`` = unknown,
+which conservatively skips its constraint so unknowns never produce a false
+violation):
+
+- ``rigid`` — +R: being an X is essential to every X for its whole existence.
+  ~R (anti-rigid): an instance can stop being an X yet keep existing (roles like
+  *Student*, phases like *Child*).
+- ``carries_identity`` — +I: instances have an identity criterion (a way to tell
+  two apart and re-identify one over time).
+- ``supplies_identity`` — +O: the class itself *introduces* that identity
+  criterion rather than inheriting it.
+- ``unity`` — +U: every instance is a single whole under one unifying relation;
+  ~U is anti-unity.
+- ``dependent`` — +D: every instance necessarily depends on some other entity
+  (e.g. *Student* on a school, *Spouse* on a partner).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .ontology import Ontology
+
+
+@dataclass(slots=True)
+class MetaProperties:
+    """OntoClean meta-property tags for one class. Tri-state; ``None`` = unknown."""
+
+    rigid: Optional[bool] = None
+    carries_identity: Optional[bool] = None
+    supplies_identity: Optional[bool] = None
+    unity: Optional[bool] = None
+    dependent: Optional[bool] = None
+    rationale: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "rigid": self.rigid,
+            "carries_identity": self.carries_identity,
+            "supplies_identity": self.supplies_identity,
+            "unity": self.unity,
+            "dependent": self.dependent,
+            "rationale": self.rationale,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MetaProperties":
+        def _tri(v: Any) -> Optional[bool]:
+            if v is None:
+                return None
+            if isinstance(v, str):
+                t = v.strip().lower()
+                if t in ("true", "yes", "+", "rigid"):
+                    return True
+                if t in ("false", "no", "-", "~", "anti"):
+                    return False
+                return None
+            return bool(v)
+
+        return cls(
+            rigid=_tri(data.get("rigid")),
+            carries_identity=_tri(data.get("carries_identity")),
+            supplies_identity=_tri(data.get("supplies_identity")),
+            unity=_tri(data.get("unity")),
+            dependent=_tri(data.get("dependent")),
+            rationale=str(data.get("rationale", "") or ""),
+        )
+
+
+@dataclass(slots=True)
+class OntoCleanViolation:
+    """One violated OntoClean subsumption constraint on a ``child broader parent``
+    edge (i.e. *parent subsumes child*)."""
+
+    constraint: str          # "rigidity" | "identity" | "unity" | "dependence"
+    parent: str
+    child: str
+    severity: str            # "violation" | "warning"
+    message: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "constraint": self.constraint,
+            "parent": self.parent,
+            "child": self.child,
+            "severity": self.severity,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True)
+class OntoCleanResult:
+    ok: bool
+    edges_checked: int
+    violations: List[OntoCleanViolation] = field(default_factory=list)
+    untagged_classes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "edges_checked": self.edges_checked,
+            "violation_count": len(self.violations),
+            "violations": [v.to_dict() for v in self.violations],
+            "untagged_classes": list(self.untagged_classes),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pure constraint engine
+# ---------------------------------------------------------------------------
+
+
+def check_ontoclean(
+    ontology: Ontology,
+    tags: Dict[str, MetaProperties],
+) -> OntoCleanResult:
+    """Check every ``broader`` (is-a) edge against the OntoClean constraints.
+
+    Parameters
+    ----------
+    ontology:
+        The ontology whose ``broader`` hierarchy is validated.
+    tags:
+        Meta-property tags per class label. Classes missing a tag are reported
+        in ``untagged_classes``; their edges are still checked against whatever
+        tags ARE present on the other endpoint (a ``None`` on either side skips
+        the affected constraint).
+
+    Returns
+    -------
+    OntoCleanResult
+        ``ok`` is True iff no hard ``violation`` was found (``warning`` does not
+        flip it). Each violation names the constraint, the parent/child, and a
+        plain-language explanation of why the is-a edge is formally wrong.
+    """
+    node_labels = set(ontology.nodes)
+    violations: List[OntoCleanViolation] = []
+    edges = 0
+
+    for child, nd in ontology.nodes.items():
+        for parent in (getattr(nd, "broader", []) or []):
+            if parent not in node_labels:
+                continue  # dangling broader — lint_ontology owns that finding
+            edges += 1
+            p = tags.get(parent)
+            c = tags.get(child)
+            if p is None and c is None:
+                continue
+
+            p = p or MetaProperties()
+            c = c or MetaProperties()
+
+            # C1 — Rigidity: an anti-rigid class cannot subsume a rigid one.
+            # Classic: Student(~R) must not be a superclass of Person(+R).
+            if p.rigid is False and c.rigid is True:
+                violations.append(OntoCleanViolation(
+                    "rigidity", parent, child, "violation",
+                    f"'{child}' (rigid: being a {child} is permanent) is placed under anti-rigid '{parent}' "
+                    f"(an instance can stop being a {parent}). An anti-rigid class cannot subsume a rigid one — "
+                    f"re-parent '{child}' or model the '{parent}' aspect as a role/relationship, not a superclass.",
+                ))
+
+            # C2 — Identity: identity criteria are inherited downward. A class
+            # that carries identity must not be subsumed by one that lacks it,
+            # and a child must not drop an identity criterion the parent supplies.
+            if p.carries_identity is True and c.carries_identity is False:
+                violations.append(OntoCleanViolation(
+                    "identity", parent, child, "violation",
+                    f"'{parent}' carries an identity criterion but its subclass '{child}' is tagged as carrying "
+                    f"none. Identity is inherited downward — a subclass cannot drop it.",
+                ))
+            # Soft check: both endpoints supply their OWN identity with different
+            # keys → incompatible own-identity along one chain.
+            if p.supplies_identity is True and c.supplies_identity is True:
+                p_keys = set(ontology.nodes[parent].effective_identity_keys)
+                c_keys = set(ontology.nodes[child].effective_identity_keys)
+                if p_keys and c_keys and not (c_keys >= p_keys):
+                    violations.append(OntoCleanViolation(
+                        "identity", parent, child, "warning",
+                        f"'{parent}' and '{child}' each supply their own identity criterion with incompatible keys "
+                        f"({sorted(p_keys)} vs {sorted(c_keys)}). A subclass should extend, not replace, the "
+                        f"parent's identity criterion.",
+                    ))
+
+            # C3 — Unity: a class with a unity criterion (+U) cannot subsume one
+            # with anti-unity (~U), or vice versa.
+            if p.unity is not None and c.unity is not None and p.unity != c.unity:
+                violations.append(OntoCleanViolation(
+                    "unity", parent, child, "violation",
+                    f"Unity mismatch: '{parent}' (+U={p.unity}) cannot subsume '{child}' (+U={c.unity}). "
+                    f"A whole and a non-whole do not stand in an is-a relation.",
+                ))
+
+            # C4 — Dependence: dependence is inherited. A dependent class cannot
+            # subsume an independent one (parent +D, child -D).
+            if p.dependent is True and c.dependent is False:
+                violations.append(OntoCleanViolation(
+                    "dependence", parent, child, "violation",
+                    f"'{parent}' is externally dependent but its subclass '{child}' is independent. "
+                    f"A dependent class cannot subsume an independent one — dependence is inherited downward.",
+                ))
+
+    untagged = sorted(l for l in node_labels if l not in tags)
+    hard = [v for v in violations if v.severity == "violation"]
+    return OntoCleanResult(
+        ok=not hard,
+        edges_checked=edges,
+        violations=violations,
+        untagged_classes=untagged,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Optional LLM-assisted meta-property inference (MARA by default)
+# ---------------------------------------------------------------------------
+
+_INFER_SYSTEM = (
+    "You are an ontology engineer applying the OntoClean methodology (Guarino & "
+    "Welty). For each class you assign four formal meta-properties. Answer ONLY "
+    "with the JSON object requested — no prose outside it."
+)
+
+_INFER_GUIDE = """For each class decide, using its label, definition and properties:
+
+- rigid: true if being an instance of this class is ESSENTIAL and PERMANENT (a thing
+  cannot stop being one while continuing to exist, e.g. Person, Organism). false if
+  ANTI-RIGID — an instance can stop being one yet keep existing (roles like Student,
+  Employee, CEO; phases like Child). null if unsure.
+- carries_identity: true if instances have an identity criterion (a way to tell two
+  apart and re-identify one over time). Most concrete object types are true; pure
+  qualities/amounts are often false. null if unsure.
+- supplies_identity: true if THIS class introduces its own identity criterion rather
+  than inheriting one from a parent. null if unsure.
+- unity: true if every instance is a single connected WHOLE under one unifying relation
+  (e.g. an Organism, a Machine). false (anti-unity) for amounts/collections that need
+  not be wholes. null if unsure.
+- dependent: true if every instance NECESSARILY depends on some other distinct entity
+  existing (Student needs a school; Spouse needs a partner; Subsidiary needs a parent
+  company). false for independent substances. null if unsure.
+
+Also give a one-sentence "rationale".
+"""
+
+
+def build_inference_prompt(ontology: Ontology) -> str:
+    """The user-message body for meta-property inference (exposed for logging /
+    reproducibility)."""
+    lines = [_INFER_GUIDE, "", "Classes:"]
+    for label, nd in ontology.nodes.items():
+        desc = str(getattr(nd, "description", "") or "").strip() or "(no definition)"
+        props = ", ".join(nd.properties.keys()) or "(none)"
+        broader = ", ".join(getattr(nd, "broader", []) or []) or "(none)"
+        lines.append(f"- {label}: {desc} | properties: {props} | broader: {broader}")
+    lines.append("")
+    lines.append(
+        'Return JSON: {"classes": {"<Label>": {"rigid": <bool|null>, '
+        '"carries_identity": <bool|null>, "supplies_identity": <bool|null>, '
+        '"unity": <bool|null>, "dependent": <bool|null>, "rationale": "<str>"}}}'
+    )
+    return "\n".join(lines)
+
+
+def _extract_json_object(text: str) -> Dict[str, Any]:
+    """Parse a JSON object from a model response, tolerating reasoning-model
+    preambles and code fences (MiniMax / gpt-oss emit chain-of-thought before the
+    JSON). Falls back to the outermost balanced ``{...}`` block."""
+    s = text.strip()
+    if s.startswith("```"):
+        s = "\n".join(l for l in s.split("\n") if not l.strip().startswith("```"))
+    try:
+        return json.loads(s)
+    except Exception:
+        pass
+    start = s.find("{")
+    if start == -1:
+        raise ValueError("no JSON object found in response")
+    depth = 0
+    for i in range(start, len(s)):
+        if s[i] == "{":
+            depth += 1
+        elif s[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(s[start:i + 1])
+    raise ValueError("unbalanced JSON object in response")
+
+
+def infer_metaproperties(
+    ontology: Ontology,
+    *,
+    backend: Any,
+    temperature: float = 0.0,
+    max_tokens: int = 4096,
+) -> Dict[str, MetaProperties]:
+    """Propose OntoClean meta-property tags for every class via an LLM backend.
+
+    ``backend`` is any object exposing ``complete(system=, user=, temperature=,
+    response_format=)`` returning an object with ``.text`` / ``.json()`` (the
+    SEOCHO ``LLMBackend`` contract; construct a MARA one with
+    ``create_llm_backend(provider="mara")``). Injected, not constructed here, so
+    the critic never hard-depends on a live model and tests run offline.
+    ``max_tokens`` is generous by default because reasoning models spend tokens
+    on chain-of-thought before emitting the JSON.
+
+    Returns a ``{label: MetaProperties}`` map. Labels the model omits are simply
+    absent (treated as untagged by :func:`check_ontoclean`).
+    """
+    user = build_inference_prompt(ontology)
+    response = backend.complete(
+        system=_INFER_SYSTEM,
+        user=user,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        response_format={"type": "json_object"},
+        task_hint="json_extraction",
+    )
+    try:
+        payload = response.json()
+    except Exception:
+        payload = _extract_json_object(response.text)
+    classes = payload.get("classes", payload) if isinstance(payload, dict) else {}
+    tags: Dict[str, MetaProperties] = {}
+    for label in ontology.nodes:
+        if label in classes and isinstance(classes[label], dict):
+            tags[label] = MetaProperties.from_dict(classes[label])
+    return tags
+
+
+def load_metaproperties(data: Dict[str, Dict[str, Any]]) -> Dict[str, MetaProperties]:
+    """Build a tag map from a plain dict (e.g. a hand-authored or cached JSON
+    file): ``{label: {rigid: ..., ...}}``."""
+    return {label: MetaProperties.from_dict(md) for label, md in data.items()}
+
+
+def dump_metaproperties(tags: Dict[str, MetaProperties]) -> Dict[str, Dict[str, Any]]:
+    """Serialise a tag map for caching / recording (the data-trail requirement)."""
+    return {label: mp.to_dict() for label, mp in tags.items()}

--- a/src/seocho/ontology_scorecard.py
+++ b/src/seocho/ontology_scorecard.py
@@ -1,0 +1,702 @@
+"""Graded, multi-dimensional quality scorecard for an ontology artifact (TBox).
+
+This is the *measurement instrument* for ontology engineering, and it is
+deliberately distinct from the two adjacent surfaces:
+
+- :func:`seocho.ontology_governance.build_ontology_governance_report` is a
+  binary *promotion gate* ("is this ontology safe to ship?"). It bundles
+  check + context + artifact draft + SHACL + synthetic-sample validation.
+- :meth:`seocho.ontology.Ontology.score_extraction` scores an *extracted graph*
+  (ABox instances) against the ontology — instance-level quality, not the
+  schema's own quality.
+
+The scorecard answers a different question: **how good is this ontology, and
+where is it weak?** It produces a 0.0-1.0 score per dimension, a letter grade,
+and an explicit, sorted list of *weak points* (concrete targets to fix). That
+makes it the foundation for the iterative refinement loop (axiom adjustment,
+taxonomy design) and for deciding whether a new ontology version is actually an
+improvement.
+
+Pure model walk: offline, zero hot-path, no LLM, no corpus required for the
+structural tiers (ADR-0043 / ADR-0114). Existing governance functions
+(:func:`lint_ontology`, :func:`competency_question_report`) are *composed*, not
+duplicated; the genuinely new contribution is the taxonomy-health tier.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import mean
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .ontology import Ontology
+from .ontology_governance import (
+    competency_question_coverage,
+    competency_question_report,
+    lint_ontology,
+)
+
+# Default dimension weights. functional_coverage is only counted when
+# competency questions are supplied (see ``score_ontology``).
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "structural_integrity": 0.30,
+    "taxonomy_health": 0.25,
+    "definitional_completeness": 0.20,
+    "constraint_richness": 0.15,
+    "functional_coverage": 0.10,
+}
+
+
+@dataclass(slots=True)
+class DimensionScore:
+    """One scored dimension of an ontology's quality.
+
+    ``score`` is in [0.0, 1.0]. ``findings`` are human-readable, actionable
+    observations. ``stats`` carries the raw metrics the score was derived from
+    so callers can build their own thresholds or dashboards.
+    """
+
+    name: str
+    score: float
+    weight: float
+    findings: List[str] = field(default_factory=list)
+    stats: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "score": round(self.score, 4),
+            "weight": self.weight,
+            "findings": list(self.findings),
+            "stats": dict(self.stats),
+        }
+
+
+@dataclass(slots=True)
+class WeakPoint:
+    """A concrete, fixable defect surfaced by the scorecard.
+
+    ``severity`` is ``"blocking"`` (a structural error that should block
+    promotion), ``"major"`` or ``"minor"``. ``target`` names the schema element
+    (class label, relationship type, or ``"<ontology>"`` for global findings).
+    """
+
+    severity: str
+    dimension: str
+    target: str
+    message: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "severity": self.severity,
+            "dimension": self.dimension,
+            "target": self.target,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True)
+class OntologyScorecard:
+    ontology_name: str
+    package_id: str
+    version: str
+    overall_score: float
+    grade: str
+    blocking: bool
+    dimensions: List[DimensionScore]
+    weak_points: List[WeakPoint]
+    stats: Dict[str, Any]
+
+    def dimension(self, name: str) -> Optional[DimensionScore]:
+        for dim in self.dimensions:
+            if dim.name == name:
+                return dim
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ontology_name": self.ontology_name,
+            "package_id": self.package_id,
+            "version": self.version,
+            "overall_score": round(self.overall_score, 4),
+            "grade": self.grade,
+            "blocking": self.blocking,
+            "dimensions": [d.to_dict() for d in self.dimensions],
+            "weak_points": [w.to_dict() for w in self.weak_points],
+            "stats": dict(self.stats),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+
+def _letter_grade(score: float, *, blocking: bool) -> str:
+    """Map an overall score to a letter grade. A blocking structural error caps
+    the grade at ``D`` — a quantitatively pretty ontology that won't even pass
+    the hygiene linter must not read as shippable."""
+    if blocking:
+        return "D" if score >= 0.6 else "F"
+    if score >= 0.9:
+        return "A"
+    if score >= 0.8:
+        return "B"
+    if score >= 0.7:
+        return "C"
+    if score >= 0.6:
+        return "D"
+    return "F"
+
+
+# ---------------------------------------------------------------------------
+# Dimension scorers (each pure; each returns a DimensionScore + WeakPoints)
+# ---------------------------------------------------------------------------
+
+
+def _score_structural_integrity(
+    ontology: Ontology, weight: float
+) -> tuple[DimensionScore, List[WeakPoint]]:
+    """Reuse the FIBO/ISO-704 hygiene linter. ERRORS are blocking and dominate;
+    WARNINGS are soft quality deductions."""
+    lint = lint_ontology(ontology)
+    errors = lint["errors"]
+    warnings = lint["warnings"]
+
+    # Errors are structural defects: a single one should sink the dimension.
+    # Warnings erode it gently (0.04 each, capped).
+    score = 1.0
+    score -= min(1.0, 0.34 * len(errors))
+    score -= min(0.4, 0.04 * len(warnings))
+    score = max(0.0, score)
+
+    weak: List[WeakPoint] = []
+    for f in errors:
+        weak.append(
+            WeakPoint("blocking", "structural_integrity", f.get("target", "<ontology>"), f["message"])
+        )
+    for f in warnings:
+        weak.append(
+            WeakPoint("minor", "structural_integrity", f.get("target", "<ontology>"), f["message"])
+        )
+
+    findings: List[str] = []
+    if errors:
+        findings.append(f"{len(errors)} structural error(s) — blocks promotion until fixed.")
+    if warnings:
+        findings.append(f"{len(warnings)} hygiene warning(s) (naming, missing definitions, dangling endpoints).")
+    if not errors and not warnings:
+        findings.append("Clean: no hygiene errors or warnings.")
+
+    dim = DimensionScore(
+        name="structural_integrity",
+        score=score,
+        weight=weight,
+        findings=findings,
+        stats={"error_count": len(errors), "warning_count": len(warnings)},
+    )
+    return dim, weak
+
+
+def _broader_depths(ontology: Ontology) -> Dict[str, int]:
+    """Depth of each class in the ``broader`` (subClassOf) forest. Root = 0.
+    Cycle-safe (a node already on the current path contributes no further
+    depth); lint flags cycles separately."""
+    node_labels = set(ontology.nodes)
+    broader_map = {
+        label: [p for p in (getattr(nd, "broader", []) or []) if p in node_labels]
+        for label, nd in ontology.nodes.items()
+    }
+    memo: Dict[str, int] = {}
+
+    def depth(label: str, on_path: frozenset) -> int:
+        if label in memo:
+            return memo[label]
+        parents = broader_map.get(label, [])
+        safe_parents = [p for p in parents if p not in on_path]
+        if not safe_parents:
+            result = 0
+        else:
+            result = 1 + max(depth(p, on_path | {label}) for p in safe_parents)
+            memo[label] = result
+        return result
+
+    return {label: depth(label, frozenset()) for label in node_labels}
+
+
+def _abstract_classes(ontology: Ontology) -> set:
+    """Classes that are pure classificatory superclasses: they are the
+    ``broader`` parent of at least one other class AND declare no properties of
+    their own. Following OWL/OntoClean practice, such classes are never directly
+    instantiated, so they are legitimately exempt from the identity requirement
+    and from competency-question element coverage."""
+    node_labels = set(ontology.nodes)
+    is_parent: set = set()
+    for nd in ontology.nodes.values():
+        for parent in (getattr(nd, "broader", []) or []):
+            if parent in node_labels:
+                is_parent.add(parent)
+    return {
+        label for label in is_parent
+        if not ontology.nodes[label].properties
+    }
+
+
+def _relationship_endpoints(ontology: Ontology) -> set:
+    """All class labels that appear as a (non-``Any``) relationship endpoint."""
+    endpoints: set = set()
+    for rd in ontology.relationships.values():
+        for role in ("source", "target"):
+            value = str(getattr(rd, role, "Any") or "Any")
+            if value != "Any":
+                endpoints.add(value)
+    return endpoints
+
+
+def _score_taxonomy_health(
+    ontology: Ontology, weight: float, ontoclean_tags: Optional[Dict[str, Any]] = None
+) -> tuple[DimensionScore, List[WeakPoint]]:
+    """NEW tier: is the class structure a connected, navigable taxonomy, or a
+    flat bag of disconnected labels? Surfaces the modeling smells an ontology
+    engineer cares about — orphans, flatness, degenerate single-child chains.
+
+    When ``ontoclean_tags`` (precomputed OntoClean meta-properties) are supplied,
+    is-a edges are additionally checked against the OntoClean subsumption
+    constraints (rigidity, identity, unity, dependence) and any violation is a
+    major weak point that penalises the dimension. No LLM is ever called here —
+    tags must be computed upstream (see ``ontology_ontoclean.infer_metaproperties``)."""
+    node_labels = list(ontology.nodes)
+    n = len(node_labels)
+    weak: List[WeakPoint] = []
+    findings: List[str] = []
+
+    if n == 0:
+        dim = DimensionScore("taxonomy_health", 0.0, weight, ["Ontology defines no classes."], {"class_count": 0})
+        weak.append(WeakPoint("blocking", "taxonomy_health", "<ontology>", "Ontology defines no classes."))
+        return dim, weak
+
+    broader_map = {
+        label: [p for p in (getattr(nd, "broader", []) or []) if p in set(node_labels)]
+        for label, nd in ontology.nodes.items()
+    }
+    has_parent = {label for label, parents in broader_map.items() if parents}
+    is_parent = {p for parents in broader_map.values() for p in parents}
+    endpoints = _relationship_endpoints(ontology)
+
+    # An orphan is a class connected to NOTHING: no parent, no child, and not a
+    # relationship endpoint. It is a floating concept the rest of the model can
+    # never reach — the clearest taxonomy defect.
+    orphans = [
+        label
+        for label in node_labels
+        if label not in has_parent and label not in is_parent and label not in endpoints
+    ]
+    orphan_ratio = len(orphans) / n
+
+    depths = _broader_depths(ontology)
+    max_depth = max(depths.values()) if depths else 0
+
+    # Single-child parents: a parent class with exactly one declared child is a
+    # degenerate branch (usually an unfinished taxonomy or a needless layer).
+    child_counts: Dict[str, int] = {}
+    for parents in broader_map.values():
+        for p in parents:
+            child_counts[p] = child_counts.get(p, 0) + 1
+    single_child_parents = [p for p, c in child_counts.items() if c == 1]
+
+    score = 1.0
+    # Orphans dominate: a disconnected concept is the canonical taxonomy defect.
+    score -= orphan_ratio
+    if orphans:
+        findings.append(f"{len(orphans)}/{n} class(es) are disconnected (no parent, child, or relationship).")
+        for label in orphans:
+            weak.append(
+                WeakPoint(
+                    "major", "taxonomy_health", label,
+                    f"Class '{label}' is disconnected — give it a 'broader' parent or a relationship, or remove it.",
+                )
+            )
+
+    # Flatness: a sizable class set with no subclassing at all is a vocabulary,
+    # not a taxonomy. The user explicitly wants taxonomy design, so flag it.
+    if n >= 6 and not has_parent:
+        score -= 0.2
+        findings.append(f"Flat: {n} classes with zero subclass (broader) edges — no taxonomy structure to reason over.")
+        weak.append(
+            WeakPoint(
+                "major", "taxonomy_health", "<ontology>",
+                f"{n} classes but no 'broader' hierarchy — consider an is-a taxonomy to enable subsumption.",
+            )
+        )
+
+    if single_child_parents:
+        score -= min(0.15, 0.05 * len(single_child_parents))
+        findings.append(f"{len(single_child_parents)} parent class(es) have a single child (degenerate branch).")
+        for p in single_child_parents:
+            weak.append(
+                WeakPoint(
+                    "minor", "taxonomy_health", p,
+                    f"Class '{p}' has exactly one subclass — a single-child branch is usually under-modeled or redundant.",
+                )
+            )
+
+    # OntoClean subsumption constraints (only when meta-property tags are
+    # supplied upstream; this function never calls an LLM).
+    ontoclean_violations = 0
+    ontoclean_hard = 0
+    if ontoclean_tags:
+        from .ontology_ontoclean import check_ontoclean
+
+        oc = check_ontoclean(ontology, ontoclean_tags)
+        ontoclean_violations = len(oc.violations)
+        for v in oc.violations:
+            sev = "major" if v.severity == "violation" else "minor"
+            if v.severity == "violation":
+                ontoclean_hard += 1
+            weak.append(WeakPoint(sev, "taxonomy_health", f"{v.child}<:{v.parent}", v.message))
+        if ontoclean_hard:
+            # Each formally-wrong is-a edge is a hard taxonomy defect.
+            score -= min(0.5, 0.2 * ontoclean_hard)
+            findings.append(f"{ontoclean_hard} OntoClean subsumption violation(s) on is-a edges.")
+
+    score = max(0.0, score)
+    if not findings:
+        findings.append(f"Connected taxonomy: depth {max_depth}, {len(has_parent)}/{n} classes placed under a parent.")
+
+    dim = DimensionScore(
+        name="taxonomy_health",
+        score=score,
+        weight=weight,
+        findings=findings,
+        stats={
+            "class_count": n,
+            "rooted_count": len(has_parent),
+            "orphan_count": len(orphans),
+            "orphans": sorted(orphans),
+            "max_depth": max_depth,
+            "single_child_parents": sorted(single_child_parents),
+            "ontoclean_violations": ontoclean_violations,
+            "ontoclean_hard_violations": ontoclean_hard,
+        },
+    )
+    return dim, weak
+
+
+def _score_definitional_completeness(
+    ontology: Ontology, weight: float
+) -> tuple[DimensionScore, List[WeakPoint]]:
+    """The 'is anything under-specified?' tier — the signal the user described as
+    'unclear things'. Measures coverage of definitions, identities, and
+    constrained properties."""
+    weak: List[WeakPoint] = []
+    findings: List[str] = []
+
+    classes = ontology.nodes
+    rels = ontology.relationships
+    n_classes = len(classes)
+    abstract = _abstract_classes(ontology)
+    # Concrete (directly instantiable) classes are the denominator for identity:
+    # abstract superclasses are never instantiated, so identity does not apply.
+    concrete = [l for l in classes if l not in abstract]
+
+    # 1. classes with a definition
+    classes_with_def = [l for l, nd in classes.items() if str(getattr(nd, "description", "") or "").strip()]
+    # 2. relationships with a definition
+    rels_with_def = [r for r, rd in rels.items() if str(getattr(rd, "description", "") or "").strip()]
+    # 3. concrete classes with a resolvable identity (effective_identity_keys non-empty)
+    concrete_with_identity = [l for l in concrete if classes[l].effective_identity_keys]
+    # 4. properties that are not bare typed slots (have a description OR a constraint)
+    total_props = 0
+    specified_props = 0
+    for nd in classes.values():
+        for pname, p in nd.properties.items():
+            total_props += 1
+            if str(getattr(p, "description", "") or "").strip() or p.unique or p.required or p.index:
+                specified_props += 1
+
+    def_ratio = len(classes_with_def) / n_classes if n_classes else 1.0
+    rel_def_ratio = len(rels_with_def) / len(rels) if rels else 1.0
+    identity_ratio = len(concrete_with_identity) / len(concrete) if concrete else 1.0
+    prop_spec_ratio = specified_props / total_props if total_props else 1.0
+
+    score = mean([def_ratio, rel_def_ratio, identity_ratio, prop_spec_ratio])
+
+    classes_without_identity = [l for l in concrete if not classes[l].effective_identity_keys]
+    for label in classes_without_identity:
+        weak.append(
+            WeakPoint(
+                "major", "definitional_completeness", label,
+                f"Class '{label}' has no identity (no identity_keys and no unique property) — instances cannot be deduplicated across documents.",
+            )
+        )
+    if identity_ratio < 1.0:
+        findings.append(f"{len(classes_without_identity)}/{len(concrete)} concrete class(es) lack a resolvable identity key.")
+    if def_ratio < 1.0:
+        findings.append(f"{n_classes - len(classes_with_def)}/{n_classes} class(es) have no definition.")
+    if prop_spec_ratio < 1.0:
+        findings.append(f"{total_props - specified_props}/{total_props} propertie(s) are bare typed slots (no description, no constraint).")
+    if not findings:
+        findings.append("Fully specified: every class is defined, identified, and its properties are constrained or documented.")
+
+    dim = DimensionScore(
+        name="definitional_completeness",
+        score=score,
+        weight=weight,
+        findings=findings,
+        stats={
+            "class_definition_ratio": round(def_ratio, 4),
+            "relationship_definition_ratio": round(rel_def_ratio, 4),
+            "identity_ratio": round(identity_ratio, 4),
+            "property_specification_ratio": round(prop_spec_ratio, 4),
+            "classes_without_identity": sorted(classes_without_identity),
+            "abstract_classes": sorted(abstract),
+        },
+    )
+    return dim, weak
+
+
+def _score_constraint_richness(
+    ontology: Ontology, weight: float
+) -> tuple[DimensionScore, List[WeakPoint]]:
+    """Does the ontology actually *constrain* extraction, or is it a loose
+    vocabulary? Measures typed relationship endpoints, declared cardinality, and
+    per-class constraints. A schema that constrains nothing cannot be trusted to
+    guide extraction — directly relevant to 'does it actually work?'."""
+    weak: List[WeakPoint] = []
+    findings: List[str] = []
+
+    rels = ontology.relationships
+    classes = ontology.nodes
+
+    typed_endpoints = 0
+    tight_cardinality = 0
+    for rtype, rd in rels.items():
+        src = str(getattr(rd, "source", "Any") or "Any")
+        tgt = str(getattr(rd, "target", "Any") or "Any")
+        if src != "Any" and tgt != "Any":
+            typed_endpoints += 1
+        else:
+            weak.append(
+                WeakPoint(
+                    "minor", "constraint_richness", rtype,
+                    f"Relationship '{rtype}' has an untyped endpoint (source/target = Any) — it constrains no traversal.",
+                )
+            )
+        if str(getattr(rd, "cardinality", "MANY_TO_MANY")) != "MANY_TO_MANY":
+            tight_cardinality += 1
+
+    classes_with_constraint = [
+        l for l, nd in classes.items()
+        if nd.unique_properties or nd.required_properties or nd.identity_keys
+    ]
+
+    endpoint_ratio = typed_endpoints / len(rels) if rels else 1.0
+    cardinality_ratio = tight_cardinality / len(rels) if rels else 1.0
+    class_constraint_ratio = len(classes_with_constraint) / len(classes) if classes else 1.0
+
+    # Endpoints and per-class constraints matter most; cardinality is a bonus
+    # (MANY_TO_MANY is often legitimately correct, so it is weighted lightly).
+    score = 0.45 * endpoint_ratio + 0.4 * class_constraint_ratio + 0.15 * cardinality_ratio
+
+    if endpoint_ratio < 1.0:
+        findings.append(f"{len(rels) - typed_endpoints}/{len(rels)} relationship(s) have an untyped (Any) endpoint.")
+    if class_constraint_ratio < 1.0:
+        findings.append(f"{len(classes) - len(classes_with_constraint)}/{len(classes)} class(es) carry no constraint (unique/required/identity).")
+    if rels and cardinality_ratio == 0.0:
+        findings.append("No relationship declares a tighter-than-MANY_TO_MANY cardinality.")
+    if not findings:
+        findings.append("Well-constrained: typed endpoints and per-class constraints throughout.")
+
+    dim = DimensionScore(
+        name="constraint_richness",
+        score=score,
+        weight=weight,
+        findings=findings,
+        stats={
+            "typed_endpoint_ratio": round(endpoint_ratio, 4),
+            "tight_cardinality_ratio": round(cardinality_ratio, 4),
+            "class_constraint_ratio": round(class_constraint_ratio, 4),
+        },
+    )
+    return dim, weak
+
+
+def _score_functional_coverage(
+    ontology: Ontology,
+    competency_questions: Sequence[Any],
+    weight: float,
+) -> tuple[DimensionScore, List[WeakPoint]]:
+    """Functional tier (Grüninger & Fox / Kendall & McGuinness): can the
+    ontology's vocabulary actually express the questions it is meant to answer?
+    Composes :func:`competency_question_report` (dict CQs with ``requires``) or
+    :func:`competency_question_coverage` (plain-string CQs)."""
+    weak: List[WeakPoint] = []
+    findings: List[str] = []
+    abstract = _abstract_classes(ontology)
+
+    def _adjusted_coverage(coverage: Dict[str, Any]) -> tuple[float, List[str]]:
+        """Element-coverage ratio with abstract superclasses removed from both
+        the uncovered set and the denominator — they need not be named directly
+        by a competency question."""
+        uncovered = [e for e in coverage["uncovered_elements"] if e not in abstract]
+        total = coverage["total_elements"] - len([a for a in abstract])
+        if total <= 0:
+            return 1.0, uncovered
+        return (total - len(uncovered)) / total, uncovered
+
+    dict_cqs = [cq for cq in competency_questions if isinstance(cq, dict)]
+    if dict_cqs:
+        report = competency_question_report(ontology, dict_cqs)
+        expressible_ratio = report["expressible_ratio"]
+        coverage_ratio, _ = _adjusted_coverage(report["coverage"])
+        score = mean([expressible_ratio, coverage_ratio])
+        for cq in report["questions"]:
+            if not cq["expressible"]:
+                weak.append(
+                    WeakPoint(
+                        "major", "functional_coverage", str(cq.get("id") or cq.get("requires")),
+                        f"Competency question is structurally impossible — missing: {cq['missing_elements']}.",
+                    )
+                )
+        if report["schema_impossible_count"]:
+            findings.append(f"{report['schema_impossible_count']}/{report['question_count']} competency question(s) are structurally impossible.")
+        stats = {
+            "expressible_ratio": round(expressible_ratio, 4),
+            "element_coverage_ratio": round(coverage_ratio, 4),
+            "question_count": report["question_count"],
+        }
+    else:
+        texts = [str(cq) for cq in competency_questions]
+        coverage = competency_question_coverage(ontology, texts)
+        coverage_ratio, uncovered_concrete = _adjusted_coverage(coverage)
+        score = coverage_ratio
+        coverage = {**coverage, "uncovered_elements": uncovered_concrete}
+        for label in coverage["uncovered_elements"]:
+            weak.append(
+                WeakPoint(
+                    "minor", "functional_coverage", label,
+                    f"Schema element '{label}' is exercised by no competency question (candidate dead schema or missing CQ).",
+                )
+            )
+        stats = {
+            "element_coverage_ratio": round(coverage_ratio, 4),
+            "uncovered_elements": coverage["uncovered_elements"],
+            "question_count": coverage["question_count"],
+        }
+        if coverage["uncovered_elements"]:
+            findings.append(f"{len(coverage['uncovered_elements'])} schema element(s) exercised by no competency question.")
+
+    if not findings:
+        findings.append("Every competency question is expressible and every element is exercised.")
+
+    dim = DimensionScore("functional_coverage", score, weight, findings, stats)
+    return dim, weak
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def score_ontology(
+    ontology: Ontology,
+    *,
+    competency_questions: Optional[Sequence[Union[str, Dict[str, Any]]]] = None,
+    ontoclean_tags: Optional[Dict[str, Any]] = None,
+    weights: Optional[Dict[str, float]] = None,
+) -> OntologyScorecard:
+    """Compute a graded, multi-dimensional quality scorecard for an ontology.
+
+    Parameters
+    ----------
+    ontology:
+        The ontology (TBox) to evaluate.
+    competency_questions:
+        Optional competency questions. Each item may be a plain string (matched
+        against the coverage lint) or a dict with a ``requires`` list of element
+        labels (matched against per-CQ expressibility). When omitted, the
+        ``functional_coverage`` dimension is skipped (not penalised) and a weak
+        point notes that functional validation could not be performed.
+    ontoclean_tags:
+        Optional precomputed OntoClean meta-properties (``{label:
+        MetaProperties}``, e.g. from
+        ``ontology_ontoclean.infer_metaproperties``). When supplied, is-a edges
+        are checked against the OntoClean subsumption constraints and violations
+        fold into ``taxonomy_health``. No LLM is called here.
+    weights:
+        Optional override of :data:`DEFAULT_WEIGHTS`. Dimensions absent from the
+        run (e.g. functional_coverage with no CQs) are dropped and the remaining
+        weights are renormalised.
+
+    Returns
+    -------
+    OntologyScorecard
+        Overall score (weighted mean of present dimensions), letter grade, a
+        ``blocking`` flag (set when the hygiene linter reports a structural
+        error), per-dimension breakdowns, and a severity-sorted list of weak
+        points to drive the refinement loop.
+    """
+    w = dict(weights or DEFAULT_WEIGHTS)
+    dimensions: List[DimensionScore] = []
+    weak_points: List[WeakPoint] = []
+
+    structural, weak = _score_structural_integrity(ontology, w.get("structural_integrity", 0.0))
+    dimensions.append(structural)
+    weak_points.extend(weak)
+
+    taxonomy, weak = _score_taxonomy_health(ontology, w.get("taxonomy_health", 0.0), ontoclean_tags)
+    dimensions.append(taxonomy)
+    weak_points.extend(weak)
+
+    definitional, weak = _score_definitional_completeness(ontology, w.get("definitional_completeness", 0.0))
+    dimensions.append(definitional)
+    weak_points.extend(weak)
+
+    constraint, weak = _score_constraint_richness(ontology, w.get("constraint_richness", 0.0))
+    dimensions.append(constraint)
+    weak_points.extend(weak)
+
+    if competency_questions:
+        functional, weak = _score_functional_coverage(
+            ontology, competency_questions, w.get("functional_coverage", 0.0)
+        )
+        dimensions.append(functional)
+        weak_points.extend(weak)
+    else:
+        weak_points.append(
+            WeakPoint(
+                "minor", "functional_coverage", "<ontology>",
+                "No competency questions supplied — functional (task-fit) validation was skipped.",
+            )
+        )
+
+    # Blocking iff the hygiene linter found a structural error.
+    blocking = any(wp.severity == "blocking" for wp in weak_points)
+
+    total_weight = sum(d.weight for d in dimensions)
+    if total_weight > 0:
+        overall = sum(d.score * d.weight for d in dimensions) / total_weight
+    else:
+        overall = mean([d.score for d in dimensions]) if dimensions else 0.0
+
+    grade = _letter_grade(overall, blocking=blocking)
+
+    severity_rank = {"blocking": 0, "major": 1, "minor": 2}
+    weak_points.sort(key=lambda wp: (severity_rank.get(wp.severity, 3), wp.dimension, wp.target))
+
+    return OntologyScorecard(
+        ontology_name=ontology.name,
+        package_id=ontology.package_id,
+        version=ontology.version,
+        overall_score=overall,
+        grade=grade,
+        blocking=blocking,
+        dimensions=dimensions,
+        weak_points=weak_points,
+        stats={
+            "node_count": len(ontology.nodes),
+            "relationship_count": len(ontology.relationships),
+            "schema_fingerprint": ontology.schema_fingerprint(),
+            "competency_questions_supplied": bool(competency_questions),
+        },
+    )

--- a/tests/seocho/test_ontology_ontoclean.py
+++ b/tests/seocho/test_ontology_ontoclean.py
@@ -1,0 +1,165 @@
+"""Tests for the OntoClean meta-property critic (seocho.ontology_ontoclean).
+
+The constraint engine is pure and tested offline with hand-authored tags; the
+LLM inference path is tested with a fake backend (no live MARA call)."""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.ontology_ontoclean import (
+    MetaProperties,
+    check_ontoclean,
+    dump_metaproperties,
+    infer_metaproperties,
+    load_metaproperties,
+)
+from seocho.ontology_scorecard import score_ontology
+
+
+def _person_under_student() -> Ontology:
+    """The canonical OntoClean rigidity violation: Person (rigid) modelled as a
+    subclass of Student (an anti-rigid role)."""
+    return Ontology(
+        "roles",
+        nodes={
+            "Student": NodeDef(
+                description="A person enrolled at a school.",
+                properties={"id": P(str, unique=True)},
+            ),
+            "Person": NodeDef(
+                description="A human being.",
+                broader=["Student"],  # WRONG: rigid under anti-rigid
+                properties={"ssn": P(str, unique=True)},
+            ),
+        },
+    )
+
+
+def _person_over_student() -> Ontology:
+    """The fix: Student (role) is a subclass of Person (rigid)."""
+    return Ontology(
+        "roles",
+        nodes={
+            "Person": NodeDef(
+                description="A human being.",
+                properties={"ssn": P(str, unique=True)},
+            ),
+            "Student": NodeDef(
+                description="A person enrolled at a school.",
+                broader=["Person"],
+                properties={"ssn": P(str, unique=True), "school": P(str)},
+            ),
+        },
+    )
+
+
+TAGS = {
+    "Person": MetaProperties(rigid=True, carries_identity=True, supplies_identity=True),
+    "Student": MetaProperties(rigid=False, carries_identity=True, dependent=True),
+}
+
+
+def test_rigidity_violation_detected():
+    result = check_ontoclean(_person_under_student(), TAGS)
+    assert not result.ok
+    assert result.edges_checked == 1
+    rigidity = [v for v in result.violations if v.constraint == "rigidity"]
+    assert len(rigidity) == 1
+    assert rigidity[0].parent == "Student" and rigidity[0].child == "Person"
+    assert rigidity[0].severity == "violation"
+
+
+def test_rigidity_fix_is_clean():
+    result = check_ontoclean(_person_over_student(), TAGS)
+    assert result.ok
+    assert not [v for v in result.violations if v.severity == "violation"]
+
+
+def test_unknown_tags_skip_constraint_no_false_positive():
+    # both endpoints unknown rigidity → no rigidity violation
+    tags = {"Person": MetaProperties(), "Student": MetaProperties()}
+    result = check_ontoclean(_person_under_student(), tags)
+    assert result.ok
+    assert result.edges_checked == 1
+
+
+def test_untagged_classes_reported():
+    result = check_ontoclean(_person_under_student(), {"Person": MetaProperties(rigid=True)})
+    assert "Student" in result.untagged_classes
+
+
+def test_dependence_violation():
+    onto = Ontology(
+        "dep",
+        nodes={
+            "Spouse": NodeDef(description="A married person.", properties={"id": P(str, unique=True)}),
+            "Citizen": NodeDef(description="A citizen.", broader=["Spouse"], properties={"id": P(str, unique=True)}),
+        },
+    )
+    tags = {
+        "Spouse": MetaProperties(dependent=True),
+        "Citizen": MetaProperties(dependent=False),
+    }
+    result = check_ontoclean(onto, tags)
+    assert any(v.constraint == "dependence" and v.severity == "violation" for v in result.violations)
+
+
+def test_unity_mismatch_violation():
+    onto = Ontology(
+        "unity",
+        nodes={
+            "Water": NodeDef(description="An amount of water.", properties={"id": P(str, unique=True)}),
+            "Lake": NodeDef(description="A body of water.", broader=["Water"], properties={"id": P(str, unique=True)}),
+        },
+    )
+    tags = {"Water": MetaProperties(unity=False), "Lake": MetaProperties(unity=True)}
+    result = check_ontoclean(onto, tags)
+    assert any(v.constraint == "unity" and v.severity == "violation" for v in result.violations)
+
+
+def test_scorecard_folds_ontoclean_violations_into_taxonomy_health():
+    onto = _person_under_student()
+    clean = score_ontology(onto)  # no tags → no OntoClean penalty
+    flagged = score_ontology(onto, ontoclean_tags=TAGS)
+    tax_clean = clean.dimension("taxonomy_health")
+    tax_flagged = flagged.dimension("taxonomy_health")
+    assert tax_flagged.stats["ontoclean_hard_violations"] == 1
+    assert tax_flagged.score < tax_clean.score
+    assert any(wp.dimension == "taxonomy_health" and "rigid" in wp.message.lower()
+               for wp in flagged.weak_points)
+
+
+def test_metaproperties_round_trip():
+    tags = TAGS
+    dumped = dump_metaproperties(tags)
+    reloaded = load_metaproperties(dumped)
+    assert reloaded["Person"].rigid is True
+    assert reloaded["Student"].rigid is False
+
+
+def test_infer_metaproperties_with_fake_backend():
+    class _FakeResponse:
+        def json(self):
+            return {
+                "classes": {
+                    "Person": {"rigid": True, "carries_identity": True},
+                    "Student": {"rigid": False, "dependent": True},
+                }
+            }
+
+    class _FakeBackend:
+        def __init__(self):
+            self.calls = []
+
+        def complete(self, **kwargs):
+            self.calls.append(kwargs)
+            return _FakeResponse()
+
+    backend = _FakeBackend()
+    tags = infer_metaproperties(_person_under_student(), backend=backend)
+    assert tags["Person"].rigid is True
+    assert tags["Student"].rigid is False
+    # response_format requested for deterministic JSON
+    assert backend.calls[0]["response_format"] == {"type": "json_object"}
+    # and the critic flags the violation on the inferred tags
+    assert not check_ontoclean(_person_under_student(), tags).ok

--- a/tests/seocho/test_ontology_scorecard.py
+++ b/tests/seocho/test_ontology_scorecard.py
@@ -1,0 +1,162 @@
+"""Tests for the ontology quality scorecard (seocho.ontology_scorecard)."""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.ontology_scorecard import (
+    DEFAULT_WEIGHTS,
+    OntologyScorecard,
+    score_ontology,
+)
+
+
+def _well_formed_ontology() -> Ontology:
+    """A small, deliberately healthy ontology: defined, identified, constrained,
+    connected taxonomy."""
+    return Ontology(
+        "people-orgs",
+        version="1.0.0",
+        nodes={
+            "Agent": NodeDef(description="Anything that can act."),
+            "Person": NodeDef(
+                description="A human being.",
+                broader=["Agent"],
+                properties={"name": P(str, unique=True, description="Full name.")},
+            ),
+            "Organization": NodeDef(
+                description="A structured group of people.",
+                broader=["Agent"],
+                properties={"name": P(str, unique=True, description="Legal name.")},
+            ),
+        },
+        relationships={
+            "WORKS_AT": RelDef(
+                source="Person",
+                target="Organization",
+                cardinality="MANY_TO_ONE",
+                description="Employment relationship.",
+            ),
+        },
+    )
+
+
+def _defective_ontology() -> Ontology:
+    """A deliberately weak ontology: flat (no broader), an orphan class, classes
+    without identity or definition, an untyped relationship."""
+    return Ontology(
+        "messy",
+        version="bad-version",
+        nodes={
+            "Thing": NodeDef(),  # no description, no identity
+            "Widget": NodeDef(description="A widget."),  # no identity
+            "Gadget": NodeDef(description="A gadget.", properties={"sku": P(str, unique=True)}),
+            "Floater": NodeDef(description="Connected to nothing."),  # orphan
+            "Person": NodeDef(description="A person.", properties={"name": P(str, unique=True)}),
+            "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        },
+        relationships={
+            # untyped endpoint (target = Any) — constrains no traversal
+            "RELATES_TO": RelDef(source="Person", target="Any", description="Vague link."),
+        },
+    )
+
+
+def test_well_formed_ontology_scores_high_and_not_blocking():
+    card = score_ontology(_well_formed_ontology())
+    assert isinstance(card, OntologyScorecard)
+    assert not card.blocking
+    assert card.overall_score >= 0.8
+    assert card.grade in {"A", "B"}
+    # taxonomy is connected: no orphans
+    tax = card.dimension("taxonomy_health")
+    assert tax is not None
+    assert tax.stats["orphan_count"] == 0
+
+
+def test_defective_ontology_scores_low_and_surfaces_weak_points():
+    card = score_ontology(_defective_ontology())
+    assert card.overall_score < 0.8
+    # Floater is disconnected → reported as an orphan
+    tax = card.dimension("taxonomy_health")
+    assert "Floater" in tax.stats["orphans"]
+    # flatness flagged (6 classes, zero broader edges)
+    assert any("Flat" in f or "flat" in f for f in tax.findings)
+    # classes without identity are surfaced
+    defi = card.dimension("definitional_completeness")
+    assert "Thing" in defi.stats["classes_without_identity"]
+    assert "Widget" in defi.stats["classes_without_identity"]
+    # untyped relationship endpoint penalised
+    constraint = card.dimension("constraint_richness")
+    assert constraint.stats["typed_endpoint_ratio"] < 1.0
+    # weak points are present and sorted by severity
+    assert card.weak_points
+    severities = [wp.severity for wp in card.weak_points]
+    rank = {"blocking": 0, "major": 1, "minor": 2}
+    assert severities == sorted(severities, key=lambda s: rank.get(s, 3))
+
+
+def test_structural_error_is_blocking_and_caps_grade():
+    # duplicate label used as BOTH a class and a relationship → lint ERROR
+    onto = Ontology(
+        "dup",
+        nodes={"Foo": NodeDef(description="A foo.", properties={"id": P(str, unique=True)})},
+        relationships={"Foo": RelDef(source="Foo", target="Foo", description="self.")},
+    )
+    card = score_ontology(onto)
+    assert card.blocking
+    # blocking caps the grade at D even if other dimensions are fine
+    assert card.grade in {"D", "F"}
+    assert any(wp.severity == "blocking" for wp in card.weak_points)
+
+
+def test_functional_coverage_skipped_without_competency_questions():
+    card = score_ontology(_well_formed_ontology())
+    assert card.dimension("functional_coverage") is None
+    assert not card.stats["competency_questions_supplied"]
+    # a weak point notes the skipped functional validation
+    assert any("functional" in wp.message.lower() for wp in card.weak_points)
+
+
+def test_functional_coverage_with_dict_competency_questions():
+    onto = _well_formed_ontology()
+    cqs = [
+        {"id": "cq1", "question": "Where does a person work?", "requires": ["Person", "WORKS_AT", "Organization"]},
+        {"id": "cq2", "question": "What is the budget?", "requires": ["Budget"]},  # impossible
+    ]
+    card = score_ontology(onto, competency_questions=cqs)
+    fc = card.dimension("functional_coverage")
+    assert fc is not None
+    assert fc.stats["expressible_ratio"] == 0.5
+    assert any("impossible" in f for f in fc.findings)
+
+
+def test_functional_coverage_with_string_competency_questions():
+    onto = _well_formed_ontology()
+    card = score_ontology(onto, competency_questions=["Where does a Person work at an Organization?"])
+    fc = card.dimension("functional_coverage")
+    assert fc is not None
+    assert "element_coverage_ratio" in fc.stats
+
+
+def test_to_dict_round_trips_structure():
+    card = score_ontology(_well_formed_ontology())
+    payload = card.to_dict()
+    assert payload["ontology_name"] == "people-orgs"
+    assert "dimensions" in payload and payload["dimensions"]
+    assert "weak_points" in payload
+    assert set(payload.keys()) >= {
+        "overall_score", "grade", "blocking", "dimensions", "weak_points", "stats"
+    }
+
+
+def test_custom_weights_renormalise():
+    onto = _well_formed_ontology()
+    card = score_ontology(onto, weights={"structural_integrity": 1.0, "taxonomy_health": 0.0,
+                                         "definitional_completeness": 0.0, "constraint_richness": 0.0})
+    # with all weight on a clean structural dimension, overall ~ structural score
+    structural = card.dimension("structural_integrity")
+    assert abs(card.overall_score - structural.score) < 1e-9
+
+
+def test_default_weights_sum_to_one():
+    assert abs(sum(DEFAULT_WEIGHTS.values()) - 1.0) < 1e-9


### PR DESCRIPTION
## Summary

Adds the **measurement layer** for SEOCHO ontology management: a graded scorecard for an ontology artifact (TBox) and an OntoClean meta-property critic, validated end-to-end against the LLM-guardrail use case.

- **`seocho.ontology_scorecard.score_ontology()`** (ADR-0114) — 5 dimensions (structural_integrity, taxonomy_health [new], definitional_completeness, constraint_richness, functional_coverage), 0–1 each + letter grade + blocking flag + severity-sorted weak points. Composes `lint_ontology` + `competency_question_report` (no duplication). Offline, zero hot-path.
- **`seocho.ontology_ontoclean`** (ADR-0115) — pure OntoClean subsumption-constraint engine (rigidity/identity/unity/dependence over is-a edges) + injectable LLM meta-property inference (MARA). Scorecard folds violations into `taxonomy_health` via `score_ontology(ontoclean_tags=...)`; the scorecard itself never calls an LLM.

## Why

The ontology tooling's quality was never verified — you cannot improve what you cannot measure. This gives a single comparable number + actionable weak-point list to gate ontology edits and version bumps, and ties intrinsic quality to the downstream payoff: a **refined ontology used as an LLM extraction guardrail**.

## Validation (measured, recorded next to each ADR)

- Scorecard: messy draft **0.554/F (13 weak points) → governed 0.918/A (2 residual)**.
- OntoClean deterministic: `Person <: Employee` (rigid under anti-rigid role) flagged on 2 constraints → fixed **F → A**.
- Live MARA ensemble (4 models): all independently tagged Person rigid / Employee anti-rigid → caught the planted defect.
- **FinDER large-corpus** (160 docs × 8 categories × 4 models, 1,280 extractions, thread-pooled): rich guardrail vs sparse **+0.164 extraction_score / +0.164 conformance across all 4 models**; benefit strongly category-conditional (Governance +0.48, Risk +0.42; Financials ≈0, Shareholder return −0.02). Surfaces that intrinsic grade and downstream guardrail value can diverge → corpus-aware weighting follow-up (seocho-g2r).

## Tests / CI

`bash scripts/ci/run_basic_ci.sh` → **631 passed, 3 skipped**; all contract checks (runtime shell, module ownership, root hierarchy, docs) pass. New unit tests: `test_ontology_scorecard.py`, `test_ontology_ontoclean.py`.

## Notes

- Offline only (ADR-0043); not exported from `__init__` (offline-governance convention).
- Benchmark scripts read the MARA key from a gitignored `.env`; no secret is committed.
- Follow-ups on `seocho-g2r`: corpus-aware scorecard weighting, version-snapshot persistence of OntoClean tags, `seocho ontology score`/`ontoclean` CLI.