### PR TITLE
feat(ontology): purpose-weighted + corpus-aware scorecard (ADR-0116)

### DIFF
--- a/docs/decisions/ADR-0116-corpus-aware-scorecard.json
+++ b/docs/decisions/ADR-0116-corpus-aware-scorecard.json
@@ -1,0 +1,224 @@
+{
+  "experiment": "corpus-aware-scorecard-predicts-guardrail-value",
+  "model": "DeepSeek-V3.1",
+  "corpus_profile": {
+    "label_frequencies": {
+      "FinancialMetric": 230,
+      "Regulation": 28,
+      "BusinessProcess": 2,
+      "Product": 40,
+      "FinancialTerm": 10,
+      "Company": 43,
+      "BusinessUnit": 8,
+      "Service": 4,
+      "MonetaryValue": 13,
+      "Date": 27,
+      "Account": 1,
+      "Year": 12,
+      "FinancialConcept": 6,
+      "FinancialDocument": 1,
+      "BusinessStructure": 1,
+      "AssetType": 1,
+      "LegalTerm": 2,
+      "Industry": 15,
+      "Technology": 1,
+      "Risk": 33,
+      "PersonnelCount": 4,
+      "Country": 4,
+      "LegalIssue": 31,
+      "Organization": 10,
+      "Person": 60,
+      "BusinessSegment": 4,
+      "Concept": 37,
+      "Market": 1,
+      "CompetitorType": 1,
+      "ClientType": 1,
+      "PlatformType": 2,
+      "Competitor": 1,
+      "CompetitiveFactor": 10,
+      "Workflow": 1,
+      "ProductFeature": 1,
+      "MarketType": 1,
+      "FinancialInstrument": 4,
+      "ProductCategory": 2,
+      "Region": 5,
+      "OrganizationalUnit": 5,
+      "TimePeriod": 2,
+      "Document": 3,
+      "CurrencyAmount": 3,
+      "BusinessConcept": 5,
+      "FinancialActivity": 6,
+      "GovernmentAgency": 6,
+      "MonetaryThreshold": 1,
+      "Location": 9,
+      "LegalAction": 3,
+      "Entity": 7,
+      "Event": 1,
+      "Program": 13,
+      "Role": 3,
+      "Team": 2,
+      "Framework": 5,
+      "Plan": 2,
+      "Activity": 3,
+      "Training": 1,
+      "Facility": 1,
+      "Platform": 1,
+      "Committee": 5,
+      "Provider": 1,
+      "Process": 6,
+      "Impact": 3,
+      "RiskManagement": 1,
+      "System": 1,
+      "Infrastructure": 2,
+      "Data": 2,
+      "Certification": 1,
+      "Network": 1,
+      "Insurance": 1,
+      "Assessment": 1,
+      "Test": 1,
+      "Incident": 1,
+      "FinancialProgram": 5,
+      "StockExchange": 1,
+      "LegalDocument": 1,
+      "FinancialRole": 1,
+      "FinancialAction": 2,
+      "CorporateBody": 1,
+      "FinancialStatement": 1,
+      "Note": 1,
+      "AnnualReport": 1,
+      "Month": 1,
+      "Quantity": 1
+    },
+    "doc_count": 48,
+    "source": "FinDER open-extract N=48 DeepSeek-V3.1"
+  },
+  "downstream_guardrail_score": {
+    "fibo_minus": 0.734,
+    "fibo_plus": 0.898
+  },
+  "downstream_ranking": [
+    "fibo_plus",
+    "fibo_minus"
+  ],
+  "before_balanced": {
+    "fibo_minus": 0.8975,
+    "fibo_base": 0.8787,
+    "fibo_plus": 0.816
+  },
+  "before_ranking": [
+    "fibo_minus",
+    "fibo_base",
+    "fibo_plus"
+  ],
+  "after_guardrail_corpus": {
+    "fibo_minus": 0.7447,
+    "fibo_base": 0.7732,
+    "fibo_plus": 0.7728
+  },
+  "after_ranking": [
+    "fibo_base",
+    "fibo_plus",
+    "fibo_minus"
+  ],
+  "detail": {
+    "fibo_minus": {
+      "before_balanced": {
+        "overall": 0.8975,
+        "grade": "B"
+      },
+      "after_guardrail_corpus": {
+        "overall": 0.7447,
+        "grade": "C",
+        "corpus_coverage": 0.3487
+      },
+      "top_uncovered": [
+        {
+          "label": "Person",
+          "count": 60
+        },
+        {
+          "label": "Product",
+          "count": 40
+        },
+        {
+          "label": "Concept",
+          "count": 37
+        },
+        {
+          "label": "Risk",
+          "count": 33
+        },
+        {
+          "label": "LegalIssue",
+          "count": 31
+        }
+      ]
+    },
+    "fibo_base": {
+      "before_balanced": {
+        "overall": 0.8787,
+        "grade": "B"
+      },
+      "after_guardrail_corpus": {
+        "overall": 0.7732,
+        "grade": "C",
+        "corpus_coverage": 0.461
+      },
+      "top_uncovered": [
+        {
+          "label": "Product",
+          "count": 40
+        },
+        {
+          "label": "Concept",
+          "count": 37
+        },
+        {
+          "label": "Risk",
+          "count": 33
+        },
+        {
+          "label": "LegalIssue",
+          "count": 31
+        },
+        {
+          "label": "Date",
+          "count": 27
+        }
+      ]
+    },
+    "fibo_plus": {
+      "before_balanced": {
+        "overall": 0.816,
+        "grade": "B"
+      },
+      "after_guardrail_corpus": {
+        "overall": 0.7728,
+        "grade": "C",
+        "corpus_coverage": 0.5951
+      },
+      "top_uncovered": [
+        {
+          "label": "Concept",
+          "count": 37
+        },
+        {
+          "label": "Date",
+          "count": 27
+        },
+        {
+          "label": "Industry",
+          "count": 15
+        },
+        {
+          "label": "MonetaryValue",
+          "count": 13
+        },
+        {
+          "label": "Program",
+          "count": 13
+        }
+      ]
+    }
+  }
+}

--- a/docs/decisions/ADR-0116-purpose-weighted-corpus-aware-scorecard.md
+++ b/docs/decisions/ADR-0116-purpose-weighted-corpus-aware-scorecard.md
@@ -1,0 +1,90 @@
+# ADR-0116: Purpose-Weighted, Corpus-Aware Ontology Scorecard
+
+Date: 2026-06-13
+Status: Proposed
+
+## Context
+
+ADR-0115's FinDER guardrail ablation exposed a real defect in the ADR-0114
+scorecard: **the intrinsic grade diverged from — was in fact anti-correlated
+with — downstream guardrail value.** On FinDER the scorecard ranked the *sparse*
+`fibo_minus` (2 classes) ABOVE the *rich* `fibo_plus` (9 classes), penalising
+fibo_plus's flatness — yet fibo_plus was clearly the better extraction guardrail
+(extraction_score 0.898 vs 0.734). A measurement instrument that rewards the
+worse guardrail is misleading.
+
+Two root causes:
+1. **One-size weights.** taxonomy_health (which penalises flat schemas) carried
+   the same weight regardless of how the ontology would be used. For an
+   extraction guardrail, taxonomy *shape* matters far less than whether the
+   vocabulary can represent the corpus.
+2. **No corpus signal.** The scorecard judged the ontology in a vacuum. The
+   thing that actually determines guardrail value — *does the vocabulary cover
+   the entity types the target documents contain?* — was never measured.
+
+## Decision
+
+Two additions to `seocho.ontology_scorecard`, both preserving the offline,
+LLM-free contract (inputs are precomputed upstream):
+
+1. **Purpose-specific weight profiles** (`WEIGHT_PROFILES`, `score_ontology(...,
+   profile=)`):
+   - `balanced` (default) — the ADR-0114 weights.
+   - `guardrail` — weights `constraint_richness` + `corpus_coverage` (0.25 each)
+     and de-emphasises `taxonomy_health` (0.10); for extraction-guardrail use.
+   - `taxonomy` — weights `taxonomy_health` (0.35) for reasoning/subsumption use.
+   An explicit `weights=` still overrides.
+
+2. **Corpus-aware tier** (`CorpusProfile`, `build_corpus_profile`,
+   `score_ontology(..., corpus_profile=)`): a new `corpus_coverage` dimension =
+   the frequency-weighted fraction of the entity types a target corpus actually
+   needs that the ontology declares (label/alias, case-insensitive). The profile
+   is built upstream from an **OPEN, ontology-free extraction** over the corpus
+   (so it reflects the corpus's needs, not any candidate's vocabulary). The
+   largest uncovered labels become weak points — the precise classes to add.
+
+## Validation (measured 2026-06-13)
+
+`scripts/benchmarks/corpus_aware_scorecard_experiment.py`. Open-extracted 48
+FinDER docs (6 × 8 categories) with MARA DeepSeek-V3.1 → corpus profile of 85
+distinct types (top: FinancialMetric 230, Person 60, Company 43, Product 40,
+Risk 33, LegalIssue 31, Regulation 28). Scored the three FIBO variants. Record:
+`docs/decisions/ADR-0116-corpus-aware-scorecard.json`.
+
+**Ground truth (downstream guardrail extraction_score, ADR-0115):**
+`fibo_plus (0.898) > fibo_minus (0.734)`.
+
+| variant | BEFORE balanced (intrinsic) | AFTER guardrail+corpus | corpus_coverage |
+|---|---|---|---|
+| fibo_minus | **0.898 (rank 1)** | 0.745 (**rank 3**) | 0.349 |
+| fibo_base | 0.879 (rank 2) | 0.773 (rank 1) | 0.461 |
+| fibo_plus | 0.816 (rank 3) | 0.773 (rank 2) | 0.595 |
+
+- **The anti-correlation is fixed.** The sparse `fibo_minus` — the *worst*
+  guardrail — moves from rank 1 (intrinsic) to rank 3 (corpus-aware), matching
+  downstream reality.
+- **The `corpus_coverage` dimension is perfectly monotone with richness and
+  downstream value** (0.349 < 0.461 < 0.595 = minus < base < plus). It directly
+  measures guardrail adequacy.
+- The AFTER overall has fibo_base ≈ fibo_plus (0.7732 vs 0.7728): base covers the
+  highest-mass types (Company/Person/Metric/Regulation) while plus adds rarer
+  ones and still carries a flatness penalty. This is honest — it says fibo_plus's
+  marginal classes don't pay for themselves *on this corpus*, and that plus
+  should also grow a taxonomy.
+- **Actionable output:** even fibo_plus's corpus_coverage is only 0.60; its top
+  uncovered types are `Concept, Date, Industry, MonetaryValue, Program` — the
+  precise classes to add for FinDER. The scorecard now emits a refinement
+  to-do list grounded in the corpus.
+
+## Consequences
+
+- The scorecard now **predicts** guardrail value instead of contradicting it,
+  when used with `profile="guardrail"` + a corpus profile. This is the metric to
+  gate guardrail/version decisions.
+- `corpus_coverage` requires an upstream open extraction (one MARA pass over a
+  sample); it stays out of the scorecard core (offline contract preserved).
+- The corpus profile is the natural bridge to the refinement loop (Layer 2): its
+  top-uncovered labels are exactly the OOV-driven class proposals.
+- Follow-ups (`seocho-g2r`): persist corpus profiles + chosen profile alongside
+  ontology versions (Layer 3); a `seocho ontology score --profile --corpus` CLI;
+  alias/synonym normalisation so granular open labels (CEO→Person) map better.

--- a/scripts/benchmarks/corpus_aware_scorecard_experiment.py
+++ b/scripts/benchmarks/corpus_aware_scorecard_experiment.py
@@ -1,0 +1,168 @@
+"""Does the corpus-aware / guardrail-weighted scorecard predict downstream
+guardrail value, where the intrinsic 'balanced' grade did not?
+
+ADR-0115's FinDER ablation found the intrinsic scorecard ranked fibo_minus
+(sparse) ABOVE fibo_plus (rich) — yet fibo_plus was the better extraction
+guardrail (extraction_score 0.898 vs 0.734). This experiment closes that gap:
+
+  1. OPEN-extract a FinDER sample with MARA (no ontology constraint) -> the
+     entity types the corpus actually needs -> a CorpusProfile.
+  2. Score fibo_minus / base / plus two ways:
+       before: profile='balanced', no corpus  (the intrinsic ranking)
+       after:  profile='guardrail', + corpus  (the corpus-aware ranking)
+  3. Compare both rankings to the measured downstream guardrail extraction_score
+     (fibo_plus > fibo_base > fibo_minus). The 'after' ranking should match it;
+     the 'before' ranking does not.
+
+Key from .env. Run:
+    PYTHONPATH=src python3 scripts/benchmarks/corpus_aware_scorecard_experiment.py \
+        --per-category 5 --max-chars 2500 --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from seocho.ontology import Ontology
+from seocho.ontology_scorecard import build_corpus_profile, score_ontology
+from seocho.store.llm import create_llm_backend
+
+# Downstream guardrail extraction_score measured in ADR-0115 (cross-model means),
+# the ground truth the scorecard should track.
+DOWNSTREAM_GUARDRAIL_SCORE = {"fibo_minus": 0.734, "fibo_plus": 0.898}
+
+VARIANTS = {
+    "fibo_minus": "examples/datasets/fibo_minus.jsonld",
+    "fibo_base": "examples/datasets/fibo_base.jsonld",
+    "fibo_plus": "examples/datasets/fibo_plus.jsonld",
+}
+
+_OPEN_SYSTEM = (
+    "You extract entities from financial text. For each entity give a short, "
+    "GENERAL type label (e.g. Company, Person, FinancialMetric, Regulation, Risk, "
+    "Product, LegalIssue). Do NOT use a fixed schema — choose the type that fits. "
+    "Return ONLY JSON."
+)
+_OPEN_USER = (
+    'TEXT:\n{doc}\n\nReturn JSON: {{"nodes":[{{"label":"<GeneralType>","name":"..."}}]}}'
+)
+
+
+def load_finder(per_category: int, max_chars: int):
+    from huggingface_hub import hf_hub_download
+    import pandas as pd
+
+    p = hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset")
+    df = pd.read_parquet(p)
+    docs = []
+    for cat, group in df.sort_values("_id").groupby("category"):
+        taken = 0
+        for _, row in group.iterrows():
+            refs = row["references"]
+            text = " ".join(str(x) for x in refs) if hasattr(refs, "__iter__") and not isinstance(refs, str) else str(refs)
+            text = text.strip()
+            if len(text) < 80:
+                continue
+            docs.append({"category": str(cat), "text": text[:max_chars]})
+            taken += 1
+            if taken >= per_category:
+                break
+    return docs
+
+
+def _parse(text: str) -> dict:
+    s = text.strip()
+    if s.startswith("```"):
+        s = "\n".join(l for l in s.split("\n") if not l.strip().startswith("```"))
+    try:
+        return json.loads(s)
+    except Exception:
+        m = re.search(r"\{.*\}", s, re.DOTALL)
+        try:
+            return json.loads(m.group(0)) if m else {}
+        except Exception:
+            return {}
+
+
+def _ranking(scores: dict) -> list:
+    return [k for k, _ in sorted(scores.items(), key=lambda kv: -kv[1])]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--per-category", type=int, default=5)
+    ap.add_argument("--max-chars", type=int, default=2500)
+    ap.add_argument("--workers", type=int, default=16)
+    ap.add_argument("--model", default="DeepSeek-V3.1")  # reliable, 0 parse errors in ADR-0115
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"',
+                    Path(".env").read_text(encoding="utf-8")).group(1)
+
+    docs = load_finder(args.per_category, args.max_chars)
+    print(f"open-extracting {len(docs)} FinDER docs with {args.model} ...")
+    be = create_llm_backend(provider="mara", model=args.model, api_key=key)
+
+    def extract(doc):
+        try:
+            r = be.complete(system=_OPEN_SYSTEM, user=_OPEN_USER.format(doc=doc["text"]),
+                            temperature=0.0, max_tokens=4096, response_format={"type": "json_object"})
+            return _parse(r.text)
+        except Exception:
+            return {}
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        graphs = list(pool.map(extract, docs))
+    profile = build_corpus_profile(graphs, source=f"FinDER open-extract N={len(docs)} {args.model}")
+    top = sorted(profile.label_frequencies.items(), key=lambda kv: -kv[1])[:15]
+    print(f"corpus profile: {len(profile.label_frequencies)} distinct types; top: {top[:8]}")
+
+    cq_path = Path("examples/finder/datasets/competency_questions.yaml")
+    cqs = None
+    if cq_path.exists():
+        import yaml
+        raw = yaml.safe_load(cq_path.read_text())
+        cqs = raw.get("competency_questions", raw) if isinstance(raw, dict) else raw
+
+    before, after = {}, {}
+    detail = {}
+    for name, path in VARIANTS.items():
+        o = Ontology.load(path)
+        b = score_ontology(o, competency_questions=cqs, profile="balanced")
+        a = score_ontology(o, competency_questions=cqs, corpus_profile=profile, profile="guardrail")
+        before[name] = round(b.overall_score, 4)
+        after[name] = round(a.overall_score, 4)
+        cc = a.dimension("corpus_coverage")
+        detail[name] = {
+            "before_balanced": {"overall": before[name], "grade": b.grade},
+            "after_guardrail_corpus": {"overall": after[name], "grade": a.grade,
+                                       "corpus_coverage": round(cc.score, 4) if cc else None},
+            "top_uncovered": cc.stats.get("top_uncovered", [])[:5] if cc else [],
+        }
+
+    record = {
+        "experiment": "corpus-aware-scorecard-predicts-guardrail-value",
+        "model": args.model,
+        "corpus_profile": profile.to_dict(),
+        "downstream_guardrail_score": DOWNSTREAM_GUARDRAIL_SCORE,
+        "downstream_ranking": _ranking(DOWNSTREAM_GUARDRAIL_SCORE),
+        "before_balanced": before,
+        "before_ranking": _ranking(before),
+        "after_guardrail_corpus": after,
+        "after_ranking": _ranking(after),
+        "detail": detail,
+    }
+    Path(args.out).write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\n[written] {args.out}")
+    print(f"\nDownstream guardrail value (ground truth): {_ranking(DOWNSTREAM_GUARDRAIL_SCORE)}  {DOWNSTREAM_GUARDRAIL_SCORE}")
+    print(f"BEFORE (balanced, intrinsic):            {_ranking(before)}  {before}")
+    print(f"AFTER  (guardrail + corpus-aware):       {_ranking(after)}  {after}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/ontology_scorecard.py
+++ b/src/seocho/ontology_scorecard.py
@@ -25,6 +25,7 @@ duplicated; the genuinely new contribution is the taxonomy-health tier.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from statistics import mean
 from typing import Any, Dict, List, Optional, Sequence, Union
@@ -36,15 +37,78 @@ from .ontology_governance import (
     lint_ontology,
 )
 
-# Default dimension weights. functional_coverage is only counted when
-# competency questions are supplied (see ``score_ontology``).
+# Default dimension weights. functional_coverage / corpus_coverage are only
+# counted when their inputs are supplied (see ``score_ontology``); absent
+# dimensions are dropped and the remaining weights renormalised.
 DEFAULT_WEIGHTS: Dict[str, float] = {
     "structural_integrity": 0.30,
     "taxonomy_health": 0.25,
     "definitional_completeness": 0.20,
     "constraint_richness": 0.15,
     "functional_coverage": 0.10,
+    "corpus_coverage": 0.0,
 }
+
+# Purpose-specific weight profiles. The FinDER guardrail ablation (ADR-0115)
+# showed the intrinsic ``balanced`` grade can DIVERGE from downstream guardrail
+# value: a flat-but-rich ontology graded below a sparse one yet was the better
+# extraction guardrail. The fix is to weight by intended use. ``guardrail``
+# de-emphasises taxonomy shape and leans on constraint richness + how well the
+# ontology covers what the target corpus actually needs (corpus_coverage);
+# ``taxonomy`` (reasoning/subsumption use) does the opposite.
+WEIGHT_PROFILES: Dict[str, Dict[str, float]] = {
+    "balanced": dict(DEFAULT_WEIGHTS),
+    "guardrail": {
+        "structural_integrity": 0.15,
+        "taxonomy_health": 0.10,
+        "definitional_completeness": 0.20,
+        "constraint_richness": 0.25,
+        "functional_coverage": 0.05,
+        "corpus_coverage": 0.25,
+    },
+    "taxonomy": {
+        "structural_integrity": 0.25,
+        "taxonomy_health": 0.35,
+        "definitional_completeness": 0.20,
+        "constraint_richness": 0.10,
+        "functional_coverage": 0.10,
+        "corpus_coverage": 0.0,
+    },
+}
+
+
+@dataclass(slots=True)
+class CorpusProfile:
+    """A summary of the entity types a target corpus actually needs, computed
+    upstream (so the scorecard stays offline). The canonical way to build one is
+    an OPEN, ontology-free extraction over the corpus (``build_corpus_profile``):
+    the resulting label frequencies are *independent of any candidate ontology*
+    and represent what that corpus demands. Scoring a candidate ontology's
+    coverage of this profile is what the FinDER ablation showed actually
+    predicts downstream guardrail value."""
+
+    label_frequencies: Dict[str, int] = field(default_factory=dict)
+    doc_count: int = 0
+    source: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"label_frequencies": dict(self.label_frequencies),
+                "doc_count": self.doc_count, "source": self.source}
+
+
+def build_corpus_profile(graphs: Sequence[Dict[str, Any]], *, source: str = "") -> CorpusProfile:
+    """Build a :class:`CorpusProfile` from extracted graphs. Pass graphs from an
+    OPEN (ontology-free) extraction so the label set reflects the corpus's needs,
+    not a guardrail's vocabulary. Each graph is ``{"nodes": [{"label": ...}]}``."""
+    freqs: Dict[str, int] = {}
+    for g in graphs:
+        for node in (g or {}).get("nodes", []):
+            if not isinstance(node, dict):
+                continue
+            label = str(node.get("label", "")).strip()
+            if label:
+                freqs[label] = freqs.get(label, 0) + 1
+    return CorpusProfile(label_frequencies=freqs, doc_count=len(graphs), source=source)
 
 
 @dataclass(slots=True)
@@ -593,6 +657,72 @@ def _score_functional_coverage(
     return dim, weak
 
 
+def _score_corpus_coverage(
+    ontology: Ontology, profile: CorpusProfile, weight: float
+) -> tuple[DimensionScore, List[WeakPoint]]:
+    """Corpus-aware tier: does the ontology's vocabulary cover the entity types
+    the TARGET CORPUS actually needs? Score = frequency-weighted fraction of the
+    corpus's observed labels that the ontology declares (as a label or alias,
+    case-insensitively). This is the metric the FinDER ablation showed predicts
+    downstream guardrail value, where intrinsic structure did not: a sparse
+    ontology scores LOW here because the corpus mentions entities it cannot
+    represent. The biggest uncovered labels become weak points — the precise
+    classes to add."""
+    weak: List[WeakPoint] = []
+
+    # membership set: labels + aliases, casefolded (also a spaced form)
+    members = set()
+    for label, nd in ontology.nodes.items():
+        members.add(label.casefold())
+        members.add(re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", label).replace("_", " ").casefold())
+        for alias in (getattr(nd, "aliases", []) or []):
+            members.add(str(alias).strip().casefold())
+
+    freqs = profile.label_frequencies
+    total = sum(freqs.values())
+    if total == 0:
+        dim = DimensionScore("corpus_coverage", 1.0, weight,
+                             ["Empty corpus profile — corpus coverage not assessed."],
+                             {"covered_mass": 0, "total_mass": 0})
+        return dim, weak
+
+    covered_mass = 0
+    uncovered: List[tuple] = []
+    for label, count in freqs.items():
+        forms = {label.casefold(),
+                 re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", label).replace("_", " ").casefold()}
+        if forms & members:
+            covered_mass += count
+        else:
+            uncovered.append((label, count))
+
+    score = covered_mass / total
+    uncovered.sort(key=lambda kv: -kv[1])
+    for label, count in uncovered[:10]:
+        share = count / total
+        sev = "major" if share >= 0.05 else "minor"
+        weak.append(WeakPoint(
+            sev, "corpus_coverage", label,
+            f"Corpus mentions '{label}' {count}× ({share:.0%} of entities) but the ontology has no "
+            f"matching class — add it (or an alias) so the guardrail can represent it.",
+        ))
+
+    findings = [f"Covers {score:.0%} of corpus entity mentions "
+                f"({len(freqs) - len(uncovered)}/{len(freqs)} distinct labels)."]
+    if uncovered:
+        findings.append(f"Top uncovered: {', '.join(l for l, _ in uncovered[:5])}.")
+
+    dim = DimensionScore(
+        "corpus_coverage", score, weight, findings,
+        {"covered_mass": covered_mass, "total_mass": total,
+         "distinct_labels_covered": len(freqs) - len(uncovered),
+         "distinct_labels_total": len(freqs),
+         "top_uncovered": [{"label": l, "count": c} for l, c in uncovered[:10]],
+         "corpus_doc_count": profile.doc_count},
+    )
+    return dim, weak
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -603,6 +733,8 @@ def score_ontology(
     *,
     competency_questions: Optional[Sequence[Union[str, Dict[str, Any]]]] = None,
     ontoclean_tags: Optional[Dict[str, Any]] = None,
+    corpus_profile: Optional[CorpusProfile] = None,
+    profile: str = "balanced",
     weights: Optional[Dict[str, float]] = None,
 ) -> OntologyScorecard:
     """Compute a graded, multi-dimensional quality scorecard for an ontology.
@@ -623,10 +755,21 @@ def score_ontology(
         ``ontology_ontoclean.infer_metaproperties``). When supplied, is-a edges
         are checked against the OntoClean subsumption constraints and violations
         fold into ``taxonomy_health``. No LLM is called here.
+    corpus_profile:
+        Optional :class:`CorpusProfile` (from :func:`build_corpus_profile` over
+        an OPEN extraction of the target corpus). When supplied, adds the
+        ``corpus_coverage`` dimension — how well the ontology's vocabulary covers
+        the entity types the corpus actually needs. This is what predicts
+        downstream guardrail value (ADR-0115/0116).
+    profile:
+        Named weight profile — ``"balanced"`` (default), ``"guardrail"`` (weights
+        constraint_richness + corpus_coverage for extraction-guardrail use), or
+        ``"taxonomy"`` (weights taxonomy_health for reasoning use). See
+        :data:`WEIGHT_PROFILES`. Ignored when ``weights`` is given.
     weights:
-        Optional override of :data:`DEFAULT_WEIGHTS`. Dimensions absent from the
-        run (e.g. functional_coverage with no CQs) are dropped and the remaining
-        weights are renormalised.
+        Explicit override of the resolved profile weights. Dimensions absent from
+        the run (e.g. functional_coverage with no CQs, corpus_coverage with no
+        corpus) are dropped and the remaining weights renormalised.
 
     Returns
     -------
@@ -636,7 +779,10 @@ def score_ontology(
         error), per-dimension breakdowns, and a severity-sorted list of weak
         points to drive the refinement loop.
     """
-    w = dict(weights or DEFAULT_WEIGHTS)
+    if weights is not None:
+        w = dict(weights)
+    else:
+        w = dict(WEIGHT_PROFILES.get(profile, DEFAULT_WEIGHTS))
     dimensions: List[DimensionScore] = []
     weak_points: List[WeakPoint] = []
 
@@ -670,6 +816,19 @@ def score_ontology(
             )
         )
 
+    if corpus_profile is not None:
+        corpus, weak = _score_corpus_coverage(ontology, corpus_profile, w.get("corpus_coverage", 0.0))
+        dimensions.append(corpus)
+        weak_points.extend(weak)
+    else:
+        weak_points.append(
+            WeakPoint(
+                "minor", "corpus_coverage", "<ontology>",
+                "No corpus profile supplied — corpus-coverage (does the vocabulary fit the target "
+                "documents?) was skipped. This is the signal that predicts guardrail value.",
+            )
+        )
+
     # Blocking iff the hygiene linter found a structural error.
     blocking = any(wp.severity == "blocking" for wp in weak_points)
 
@@ -698,5 +857,7 @@ def score_ontology(
             "relationship_count": len(ontology.relationships),
             "schema_fingerprint": ontology.schema_fingerprint(),
             "competency_questions_supplied": bool(competency_questions),
+            "corpus_profile_supplied": corpus_profile is not None,
+            "weight_profile": "custom" if weights is not None else profile,
         },
     )

--- a/tests/seocho/test_ontology_scorecard.py
+++ b/tests/seocho/test_ontology_scorecard.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from seocho.ontology import NodeDef, Ontology, P, RelDef
 from seocho.ontology_scorecard import (
     DEFAULT_WEIGHTS,
+    WEIGHT_PROFILES,
+    CorpusProfile,
     OntologyScorecard,
+    build_corpus_profile,
     score_ontology,
 )
 
@@ -160,3 +163,75 @@ def test_custom_weights_renormalise():
 
 def test_default_weights_sum_to_one():
     assert abs(sum(DEFAULT_WEIGHTS.values()) - 1.0) < 1e-9
+
+
+def test_all_weight_profiles_sum_to_one():
+    for name, w in WEIGHT_PROFILES.items():
+        assert abs(sum(w.values()) - 1.0) < 1e-9, name
+
+
+def _sparse_onto() -> Ontology:
+    return Ontology("sparse", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+    })
+
+
+def _rich_onto() -> Ontology:
+    return Ontology("rich", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+        "Person": NodeDef(description="A person.", properties={"name": P(str, unique=True)}),
+        "Regulation": NodeDef(description="A rule.", aliases=["Rule"], properties={"name": P(str, unique=True)}),
+        "Risk": NodeDef(description="A risk.", properties={"name": P(str, unique=True)}),
+    })
+
+
+# corpus that needs people, regulations, risks — not just companies/metrics
+_CORPUS = build_corpus_profile([
+    {"nodes": [{"label": "Company"}, {"label": "Person"}, {"label": "Regulation"}]},
+    {"nodes": [{"label": "Risk"}, {"label": "Person"}, {"label": "FinancialMetric"}]},
+    {"nodes": [{"label": "Regulation"}, {"label": "Risk"}]},
+], source="test")
+
+
+def test_build_corpus_profile_counts_labels():
+    assert _CORPUS.label_frequencies["Person"] == 2
+    assert _CORPUS.label_frequencies["Regulation"] == 2
+    assert _CORPUS.doc_count == 3
+
+
+def test_corpus_coverage_sparse_low_rich_high():
+    sparse = score_ontology(_sparse_onto(), corpus_profile=_CORPUS)
+    rich = score_ontology(_rich_onto(), corpus_profile=_CORPUS)
+    cs = sparse.dimension("corpus_coverage")
+    cr = rich.dimension("corpus_coverage")
+    assert cs is not None and cr is not None
+    assert cr.score > cs.score  # rich covers more of what the corpus needs
+    # sparse surfaces the missing classes as weak points
+    missing = {wp.target for wp in sparse.weak_points if wp.dimension == "corpus_coverage"}
+    assert {"Person", "Regulation", "Risk"} & missing
+
+
+def test_corpus_coverage_skipped_without_profile():
+    card = score_ontology(_rich_onto())
+    assert card.dimension("corpus_coverage") is None
+    assert any(wp.dimension == "corpus_coverage" for wp in card.weak_points)
+
+
+def test_guardrail_profile_ranks_rich_above_sparse_on_corpus():
+    # the divergence fix: with the guardrail profile + corpus, the rich (flat but
+    # corpus-adequate) ontology should outrank the sparse one overall.
+    sparse = score_ontology(_sparse_onto(), corpus_profile=_CORPUS, profile="guardrail")
+    rich = score_ontology(_rich_onto(), corpus_profile=_CORPUS, profile="guardrail")
+    assert rich.overall_score > sparse.overall_score
+    assert rich.stats["weight_profile"] == "guardrail"
+
+
+def test_profile_changes_weighting():
+    onto = _rich_onto()
+    guard = score_ontology(onto, corpus_profile=_CORPUS, profile="guardrail")
+    tax = score_ontology(onto, corpus_profile=_CORPUS, profile="taxonomy")
+    # taxonomy dimension carries more weight under the taxonomy profile
+    assert guard.dimension("taxonomy_health").weight < tax.dimension("taxonomy_health").weight
+    assert guard.dimension("corpus_coverage").weight > tax.dimension("corpus_coverage").weight


### PR DESCRIPTION
**Stacked on #304** (base = `feat/ontology-scorecard`; retarget to `main` once #304 merges).

## Summary
Fixes the divergence #304's FinDER ablation (ADR-0115) surfaced: the intrinsic scorecard ranked sparse `fibo_minus` **above** rich `fibo_plus`, yet fibo_plus was the better extraction guardrail. Two offline additions:

- **`WEIGHT_PROFILES` + `score_ontology(profile=)`** — `balanced` / `guardrail` (weights constraint_richness + corpus_coverage) / `taxonomy`.
- **`corpus_coverage` dimension** (`CorpusProfile`, `build_corpus_profile`, `score_ontology(corpus_profile=)`) — frequency-weighted fraction of the entity types the target corpus actually needs that the ontology declares; top uncovered labels become weak points (the exact classes to add).

## Validation (FinDER, MARA open-extraction)
Ground truth downstream guardrail: `fibo_plus (0.898) > fibo_minus (0.734)`.

| variant | balanced (intrinsic) | guardrail+corpus | corpus_coverage |
|---|---|---|---|
| fibo_minus | 0.898 (rank 1) | 0.745 (**rank 3**) | 0.349 |
| fibo_base | 0.879 | 0.773 (rank 1) | 0.461 |
| fibo_plus | 0.816 (rank 3) | 0.773 | 0.595 |

`corpus_coverage` is monotone with downstream value; the sparse ontology moves from best→worst. Even fibo_plus's top uncovered types (Concept, Date, Industry, MonetaryValue) are emitted as an actionable add-list.

## Tests / CI
`run_basic_ci.sh` + `check-doc-contracts.sh` pass; new unit tests for profiles + corpus_coverage. Corpus profile built from one upstream open extraction — scorecard core stays offline/LLM-free.