### PR TITLE
feat(ontology): versioned snapshot store (ADR-0117, Layer 3)

### DIFF
--- a/docs/decisions/ADR-0117-ontology-snapshot-store.md
+++ b/docs/decisions/ADR-0117-ontology-snapshot-store.md
@@ -1,0 +1,70 @@
+# ADR-0117: Versioned Ontology Snapshot Store (Layer 3)
+
+Date: 2026-06-13
+Status: Proposed
+
+## Context
+
+The ontology-management roadmap had its measure/refine layers — scorecard
+(ADR-0114), OntoClean critic (ADR-0115), purpose-weighted corpus-aware tier
+(ADR-0116) — but no *persistence*. `ontology_versioning` could compute a
+fingerprint and an upgrade plan between two in-memory ontologies, but there was
+no store of versions, no history, and no way to answer "is v2 actually a better
+guardrail than v1?" with the evidence that justified the bump. Without that,
+version acceptance stays subjective and a downstream consumer cannot pull a
+known-good, evidence-backed ontology by version.
+
+## Decision
+
+Add `seocho.ontology_snapshot_store.OntologySnapshotStore` — a filesystem-backed,
+JSON, offline store of **immutable, evidence-carrying** ontology versions.
+
+- **Content-addressed + immutable.** A snapshot is keyed by `(package_id,
+  version)` and stamped with `schema_fingerprint`. Re-saving identical content is
+  idempotent; re-saving a version with *different* content raises
+  `SnapshotConflict` — you cannot silently mutate a published version, which
+  forces a real semver bump.
+- **Carries the evidence.** Each snapshot optionally stores the
+  `OntologyScorecard`, the OntoClean consensus tags (`dump_metaproperties`), the
+  `CorpusProfile` it was judged against, and the weight profile used.
+- **Operations:** `save`, `get`, `list`/`latest` (semver-ordered), `history`
+  (compact lineage timeline), and `compare(from, to)` — which reuses
+  `build_ontology_upgrade_plan` + `diff_ontologies` for the schema delta and adds
+  a **measured guardrail verdict**: it prefers the `corpus_coverage` delta (the
+  downstream-predictive signal from ADR-0116), falling back to overall score.
+- **Offline.** No DB, no LLM; it persists what the upstream evaluation produced.
+
+This closes the measure → refine → **persist & prove** loop: a version is
+accepted because its stored evidence shows it is better, and the comparison is
+reproducible.
+
+## Validation (measured 2026-06-13)
+
+`scripts/benchmarks/ontology_versioning_demo.py` — deterministic, reuses the
+FinDER corpus profile recorded by ADR-0116 (no new LLM calls). Stores the two
+FinDER guardrail arms as one package's two versions and compares them. Record:
+`docs/decisions/ADR-0117-versioning-snapshot-demo.json`.
+
+| version | grade | overall (guardrail) | corpus_coverage | fingerprint |
+|---|---|---|---|---|
+| fibo_finder 1.0.0 (sparse) | C | 0.758 | 0.349 | 053fa00f |
+| fibo_finder 2.0.0 (rich) | B | 0.804 | 0.595 | c6c9959f |
+
+`compare(1.0.0 → 2.0.0)`: `schema_changed=True`, `recommended_bump=major`, added
+`{Person, Regulation, Risk, Product, LegalIssue, Event, AccountingPolicy}`,
+**guardrail verdict = "better"** (basis `corpus_coverage`, delta **+0.2464**).
+The store reproduces, with persisted evidence, the conclusion the live FinDER
+ablation reached — now as an objective, queryable version record.
+
+## Consequences
+
+- Version acceptance becomes objective and auditable; a downstream consumer can
+  `get(package_id, version)` an evidence-backed ontology to use as an extraction
+  guardrail, or `compare` two versions before upgrading.
+- The store is the home for the refinement loop's outputs (OntoClean tags,
+  corpus profiles) and the natural integration point for a future `seocho
+  ontology version` CLI and a migration-script generator.
+- Tests: `tests/seocho/test_ontology_snapshot_store.py` (immutability, ordering,
+  history, compare verdict).
+- Follow-ups (`seocho-g2r`): ABox migration-Cypher generation on bump; a
+  retention/GC policy; remote/object-store backend behind the same interface.

--- a/docs/decisions/ADR-0117-versioning-snapshot-demo.json
+++ b/docs/decisions/ADR-0117-versioning-snapshot-demo.json
@@ -1,0 +1,88 @@
+{
+  "experiment": "ontology-versioning-snapshot-demo",
+  "store_dir": "/tmp/seocho_snap_b86i_077",
+  "corpus_source": "FinDER open-extract N=48 DeepSeek-V3.1",
+  "history": [
+    {
+      "version": "1.0.0",
+      "created_at": "2026-06-14T05:29:41.198360+00:00",
+      "schema_fingerprint": "053fa00f",
+      "grade": "C",
+      "overall_score": 0.7575,
+      "corpus_coverage": 0.3487,
+      "notes": "sparse FIBO (2 classes) — initial guardrail"
+    },
+    {
+      "version": "2.0.0",
+      "created_at": "2026-06-14T05:29:41.199197+00:00",
+      "schema_fingerprint": "c6c9959f",
+      "grade": "B",
+      "overall_score": 0.8042,
+      "corpus_coverage": 0.5951,
+      "notes": "rich FIBO (9 classes) — refined guardrail"
+    }
+  ],
+  "comparison": {
+    "package_id": "fibo_finder",
+    "from_version": "1.0.0",
+    "to_version": "2.0.0",
+    "schema_changed": true,
+    "recommended_bump": "major",
+    "requires_migration": true,
+    "changes": {
+      "metadata": {
+        "changed": [
+          "graph_type",
+          "version",
+          "description"
+        ]
+      },
+      "nodes": {
+        "added": [
+          "AccountingPolicy",
+          "Event",
+          "LegalIssue",
+          "Person",
+          "Product",
+          "Regulation",
+          "Risk"
+        ],
+        "removed": [],
+        "changed": [
+          "Company",
+          "FinancialMetric"
+        ]
+      },
+      "relationships": {
+        "added": [
+          "APPLIES",
+          "ATTENDED",
+          "EMPLOYS",
+          "FACES",
+          "FOLLOWS",
+          "INVOLVED_IN",
+          "PRODUCES"
+        ],
+        "removed": [],
+        "changed": [
+          "REPORTED"
+        ]
+      }
+    },
+    "scorecard_delta": {
+      "overall": 0.0467,
+      "by_dimension": {
+        "constraint_richness": 0.0188,
+        "corpus_coverage": 0.2464,
+        "definitional_completeness": -0.01,
+        "structural_integrity": 0.0,
+        "taxonomy_health": -0.2
+      }
+    },
+    "guardrail_verdict": {
+      "verdict": "better",
+      "basis": "corpus_coverage",
+      "delta": 0.2464
+    }
+  }
+}

--- a/scripts/benchmarks/ontology_versioning_demo.py
+++ b/scripts/benchmarks/ontology_versioning_demo.py
@@ -1,0 +1,77 @@
+"""Demo: versioned snapshot store with evidence-backed version-to-version
+guardrail comparison. Deterministic — reuses the FinDER corpus profile recorded
+by the ADR-0116 experiment (no new LLM calls).
+
+Stores fibo_minus as v1.0.0 and fibo_plus as v2.0.0 (each with a guardrail+corpus
+scorecard), then compares them: schema diff + recommended bump + measured
+guardrail-value delta. Run:
+    PYTHONPATH=src python3 scripts/benchmarks/ontology_versioning_demo.py --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+from seocho.ontology import Ontology
+from seocho.ontology_scorecard import CorpusProfile, score_ontology
+from seocho.ontology_snapshot_store import OntologySnapshotStore
+
+CORPUS_SRC = "docs/decisions/ADR-0116-corpus-aware-scorecard.json"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--store", default=None, help="store dir (default: temp)")
+    args = ap.parse_args()
+
+    corpus_data = json.loads(Path(CORPUS_SRC).read_text(encoding="utf-8"))["corpus_profile"]
+    corpus = CorpusProfile(
+        label_frequencies=corpus_data["label_frequencies"],
+        doc_count=corpus_data.get("doc_count", 0),
+        source=corpus_data.get("source", ""),
+    )
+
+    # Same package, two versions: a sparse v1 and a richer v2 (the FinDER guardrails).
+    v1 = Ontology.load("examples/datasets/fibo_minus.jsonld")
+    v1.package_id, v1.version = "fibo_finder", "1.0.0"
+    v2 = Ontology.load("examples/datasets/fibo_plus.jsonld")
+    v2.package_id, v2.version = "fibo_finder", "2.0.0"
+
+    store_dir = args.store or tempfile.mkdtemp(prefix="seocho_snap_")
+    store = OntologySnapshotStore(store_dir)
+    store.save(v1, scorecard=score_ontology(v1, corpus_profile=corpus, profile="guardrail"),
+               corpus_profile=corpus, weight_profile="guardrail",
+               notes="sparse FIBO (2 classes) — initial guardrail")
+    store.save(v2, scorecard=score_ontology(v2, corpus_profile=corpus, profile="guardrail"),
+               corpus_profile=corpus, weight_profile="guardrail",
+               notes="rich FIBO (9 classes) — refined guardrail")
+
+    history = store.history("fibo_finder")
+    comparison = store.compare("fibo_finder", "1.0.0", "2.0.0")
+
+    record = {
+        "experiment": "ontology-versioning-snapshot-demo",
+        "store_dir": store_dir,
+        "corpus_source": corpus.source,
+        "history": history,
+        "comparison": comparison,
+    }
+    Path(args.out).write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"[written] {args.out}\n")
+    print("HISTORY (fibo_finder):")
+    for h in history:
+        print(f"  v{h['version']:6s} grade={h['grade']} overall={h['overall_score']} "
+              f"corpus_coverage={h['corpus_coverage']}  fp={h['schema_fingerprint']}  — {h['notes']}")
+    gv = comparison["guardrail_verdict"]
+    print(f"\nCOMPARE 1.0.0 -> 2.0.0: schema_changed={comparison['schema_changed']} "
+          f"bump={comparison['recommended_bump']}")
+    print(f"  added nodes: {comparison['changes'].get('nodes', {}).get('added')}")
+    print(f"  GUARDRAIL VERDICT: v2 is '{gv['verdict']}' (basis={gv['basis']}, delta={gv['delta']:+})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/ontology_snapshot_store.py
+++ b/src/seocho/ontology_snapshot_store.py
@@ -1,0 +1,270 @@
+"""Versioned ontology snapshot store — Layer 3 of the ontology-management roadmap.
+
+The scorecard (ADR-0114), OntoClean critic (ADR-0115) and corpus-aware tier
+(ADR-0116) measure and refine an ontology. This module gives those refinements a
+*home*: an immutable, content-addressed snapshot store that persists each
+ontology version **together with the evaluation evidence that justified it** —
+its scorecard, its OntoClean consensus tags, the corpus profile it was judged
+against, and the weight profile used. That makes version acceptance objective
+("is v2 actually a better guardrail than v1?") and lets a downstream consumer
+pull a known-good, evidence-backed ontology by version.
+
+Design:
+
+- **Filesystem-backed, JSON, offline.** No DB, no LLM. One file per snapshot
+  under ``<root>/<package_id>/<version>__<fp8>.json``.
+- **Immutable + content-addressed.** A snapshot is keyed by ``(package_id,
+  version)`` and stamped with the schema fingerprint. Re-saving the same version
+  with the *same* fingerprint is idempotent; with a *different* fingerprint it
+  raises — you cannot silently mutate a published version (forces a real bump).
+- **Carries evidence.** Optional scorecard / OntoClean tags / corpus profile /
+  weight-profile travel with the ontology, so ``compare`` can report not just a
+  schema diff but a measured guardrail-value delta.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .ontology import Ontology
+from .ontology_versioning import build_ontology_upgrade_plan, parse_semver
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe(name: str) -> str:
+    return "".join(c if (c.isalnum() or c in "-._") else "_" for c in str(name))
+
+
+@dataclass(slots=True)
+class OntologySnapshot:
+    """One immutable, evidence-carrying ontology version."""
+
+    package_id: str
+    version: str
+    schema_fingerprint: str
+    created_at: str
+    ontology: Dict[str, Any]                      # Ontology.to_dict()
+    scorecard: Optional[Dict[str, Any]] = None    # OntologyScorecard.to_dict()
+    ontoclean_tags: Optional[Dict[str, Any]] = None
+    corpus_profile: Optional[Dict[str, Any]] = None
+    weight_profile: str = "balanced"
+    notes: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "package_id": self.package_id,
+            "version": self.version,
+            "schema_fingerprint": self.schema_fingerprint,
+            "created_at": self.created_at,
+            "ontology": self.ontology,
+            "scorecard": self.scorecard,
+            "ontoclean_tags": self.ontoclean_tags,
+            "corpus_profile": self.corpus_profile,
+            "weight_profile": self.weight_profile,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OntologySnapshot":
+        return cls(
+            package_id=data["package_id"],
+            version=data["version"],
+            schema_fingerprint=data["schema_fingerprint"],
+            created_at=data.get("created_at", ""),
+            ontology=data.get("ontology", {}),
+            scorecard=data.get("scorecard"),
+            ontoclean_tags=data.get("ontoclean_tags"),
+            corpus_profile=data.get("corpus_profile"),
+            weight_profile=data.get("weight_profile", "balanced"),
+            notes=data.get("notes", ""),
+        )
+
+    def load_ontology(self) -> Ontology:
+        return Ontology.from_dict(self.ontology)
+
+    def overall_score(self) -> Optional[float]:
+        return (self.scorecard or {}).get("overall_score")
+
+    def dimension_score(self, name: str) -> Optional[float]:
+        for d in (self.scorecard or {}).get("dimensions", []):
+            if d.get("name") == name:
+                return d.get("score")
+        return None
+
+
+class SnapshotConflict(Exception):
+    """Raised when a version is re-saved with different content (a silent
+    mutation of a published version)."""
+
+
+class OntologySnapshotStore:
+    """Filesystem-backed store of immutable, evidence-carrying ontology versions."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    # ---- paths -----------------------------------------------------------
+    def _pkg_dir(self, package_id: str) -> Path:
+        d = self.root / _safe(package_id)
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _path(self, package_id: str, version: str, fingerprint: str) -> Path:
+        return self._pkg_dir(package_id) / f"{_safe(version)}__{fingerprint[:8]}.json"
+
+    # ---- write -----------------------------------------------------------
+    def save(
+        self,
+        ontology: Ontology,
+        *,
+        scorecard: Optional[Any] = None,
+        ontoclean_tags: Optional[Dict[str, Any]] = None,
+        corpus_profile: Optional[Any] = None,
+        weight_profile: str = "balanced",
+        notes: str = "",
+        created_at: Optional[str] = None,
+    ) -> OntologySnapshot:
+        """Persist ``ontology`` as a snapshot of ``(package_id, version)``.
+
+        ``scorecard`` may be an ``OntologyScorecard`` or its dict; ``corpus_profile``
+        a ``CorpusProfile`` or its dict; ``ontoclean_tags`` the dict form from
+        ``dump_metaproperties``. Idempotent for identical content; raises
+        :class:`SnapshotConflict` if the version already exists with different
+        content."""
+        fp = ontology.schema_fingerprint()
+        snap = OntologySnapshot(
+            package_id=ontology.package_id,
+            version=ontology.version,
+            schema_fingerprint=fp,
+            created_at=created_at or _now_iso(),
+            ontology=ontology.to_dict(),
+            scorecard=scorecard.to_dict() if hasattr(scorecard, "to_dict") else scorecard,
+            ontoclean_tags=ontoclean_tags,
+            corpus_profile=corpus_profile.to_dict() if hasattr(corpus_profile, "to_dict") else corpus_profile,
+            weight_profile=weight_profile,
+            notes=notes,
+        )
+
+        # immutability guard: same version + different fingerprint = conflict
+        for existing in self._versions(ontology.package_id):
+            if existing.version == ontology.version and existing.schema_fingerprint != fp:
+                raise SnapshotConflict(
+                    f"version '{ontology.version}' of '{ontology.package_id}' already exists with a "
+                    f"different schema (fingerprint {existing.schema_fingerprint[:8]} != {fp[:8]}). "
+                    f"Bump the version before saving changed content."
+                )
+
+        path = self._path(ontology.package_id, ontology.version, fp)
+        path.write_text(json.dumps(snap.to_dict(), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        return snap
+
+    # ---- read ------------------------------------------------------------
+    def _versions(self, package_id: str) -> List[OntologySnapshot]:
+        d = self.root / _safe(package_id)
+        if not d.exists():
+            return []
+        out = []
+        for f in d.glob("*.json"):
+            try:
+                out.append(OntologySnapshot.from_dict(json.loads(f.read_text(encoding="utf-8"))))
+            except Exception:
+                continue
+        return out
+
+    @staticmethod
+    def _sort_key(s: OntologySnapshot):
+        sv = parse_semver(s.version)
+        # valid semver sorts by tuple first; invalid versions fall back to created_at
+        return (0, sv, s.created_at) if sv else (1, (0, 0, 0), s.created_at)
+
+    def list(self, package_id: Optional[str] = None) -> List[OntologySnapshot]:
+        """All snapshots (optionally for one package), oldest→newest by semver
+        then creation time."""
+        if package_id is not None:
+            snaps = self._versions(package_id)
+        else:
+            snaps = [s for d in self.root.iterdir() if d.is_dir() for s in self._versions(d.name)]
+        return sorted(snaps, key=self._sort_key)
+
+    def get(self, package_id: str, version: str) -> Optional[OntologySnapshot]:
+        for s in self._versions(package_id):
+            if s.version == version:
+                return s
+        return None
+
+    def latest(self, package_id: str) -> Optional[OntologySnapshot]:
+        snaps = self.list(package_id)
+        return snaps[-1] if snaps else None
+
+    def history(self, package_id: str) -> List[Dict[str, Any]]:
+        """A compact lineage timeline for display."""
+        return [
+            {
+                "version": s.version,
+                "created_at": s.created_at,
+                "schema_fingerprint": s.schema_fingerprint[:8],
+                "grade": (s.scorecard or {}).get("grade"),
+                "overall_score": s.overall_score(),
+                "corpus_coverage": s.dimension_score("corpus_coverage"),
+                "notes": s.notes,
+            }
+            for s in self.list(package_id)
+        ]
+
+    # ---- compare ---------------------------------------------------------
+    def compare(self, package_id: str, from_version: str, to_version: str) -> Dict[str, Any]:
+        """Compare two stored versions: schema diff + recommended bump + measured
+        scorecard / guardrail-value delta + a verdict on whether ``to_version`` is
+        a better guardrail."""
+        a = self.get(package_id, from_version)
+        b = self.get(package_id, to_version)
+        if a is None or b is None:
+            missing = from_version if a is None else to_version
+            raise KeyError(f"snapshot '{package_id}' v'{missing}' not found")
+
+        plan = build_ontology_upgrade_plan(a.load_ontology(), b.load_ontology())
+
+        # scorecard deltas
+        score_delta: Dict[str, Any] = {}
+        if a.scorecard and b.scorecard:
+            if a.overall_score() is not None and b.overall_score() is not None:
+                score_delta["overall"] = round(b.overall_score() - a.overall_score(), 4)
+            dims = {d["name"] for d in a.scorecard.get("dimensions", [])} | {
+                d["name"] for d in b.scorecard.get("dimensions", [])
+            }
+            score_delta["by_dimension"] = {
+                name: round((b.dimension_score(name) or 0.0) - (a.dimension_score(name) or 0.0), 4)
+                for name in sorted(dims)
+                if a.dimension_score(name) is not None and b.dimension_score(name) is not None
+            }
+
+        # guardrail verdict: prefer corpus_coverage (the downstream-predictive
+        # signal, ADR-0116); fall back to overall.
+        cc_a, cc_b = a.dimension_score("corpus_coverage"), b.dimension_score("corpus_coverage")
+        verdict, basis, delta = "unknown", None, None
+        if cc_a is not None and cc_b is not None:
+            basis, delta = "corpus_coverage", round(cc_b - cc_a, 4)
+        elif score_delta.get("overall") is not None:
+            basis, delta = "overall_score", score_delta["overall"]
+        if delta is not None:
+            verdict = "better" if delta > 0.001 else ("worse" if delta < -0.001 else "equal")
+
+        return {
+            "package_id": package_id,
+            "from_version": from_version,
+            "to_version": to_version,
+            "schema_changed": a.schema_fingerprint != b.schema_fingerprint,
+            "recommended_bump": plan.recommended_bump,
+            "requires_migration": plan.requires_migration,
+            "changes": plan.changes,
+            "scorecard_delta": score_delta,
+            "guardrail_verdict": {"verdict": verdict, "basis": basis, "delta": delta},
+        }

--- a/tests/seocho/test_ontology_snapshot_store.py
+++ b/tests/seocho/test_ontology_snapshot_store.py
@@ -1,0 +1,102 @@
+"""Tests for the versioned ontology snapshot store (Layer 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.ontology_scorecard import build_corpus_profile, score_ontology
+from seocho.ontology_snapshot_store import (
+    OntologySnapshotStore,
+    SnapshotConflict,
+)
+
+
+def _v1() -> Ontology:
+    return Ontology("acme", package_id="acme", version="1.0.0", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+    })
+
+
+def _v2() -> Ontology:
+    return Ontology("acme", package_id="acme", version="2.0.0", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+        "Person": NodeDef(description="A person.", properties={"name": P(str, unique=True)}),
+        "Regulation": NodeDef(description="A rule.", properties={"name": P(str, unique=True)}),
+    })
+
+
+_CORPUS = build_corpus_profile([
+    {"nodes": [{"label": "Company"}, {"label": "Person"}, {"label": "Regulation"}]},
+    {"nodes": [{"label": "Person"}, {"label": "FinancialMetric"}]},
+], source="test")
+
+
+def test_save_get_roundtrip(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    snap = store.save(_v1(), notes="initial")
+    assert snap.schema_fingerprint
+    got = store.get("acme", "1.0.0")
+    assert got is not None
+    assert got.notes == "initial"
+    o = got.load_ontology()
+    assert set(o.nodes) == {"Company", "FinancialMetric"}
+
+
+def test_idempotent_same_content(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    store.save(_v1())
+    store.save(_v1())  # same version + same fingerprint → no error
+    assert len([s for s in store.list("acme") if s.version == "1.0.0"]) == 1
+
+
+def test_immutability_conflict_on_changed_content(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    store.save(_v1())
+    mutated = _v1()
+    mutated.nodes["Extra"] = NodeDef(description="sneaky change", properties={"id": P(str, unique=True)})
+    with pytest.raises(SnapshotConflict):
+        store.save(mutated)  # same version 1.0.0, different schema
+
+
+def test_list_and_latest_ordering(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    store.save(_v2())
+    store.save(_v1())
+    versions = [s.version for s in store.list("acme")]
+    assert versions == ["1.0.0", "2.0.0"]  # semver order regardless of save order
+    assert store.latest("acme").version == "2.0.0"
+
+
+def test_history_carries_evidence(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    store.save(_v1(), scorecard=score_ontology(_v1(), corpus_profile=_CORPUS, profile="guardrail"),
+               corpus_profile=_CORPUS, weight_profile="guardrail")
+    hist = store.history("acme")
+    assert hist[0]["version"] == "1.0.0"
+    assert hist[0]["grade"] is not None
+    assert hist[0]["corpus_coverage"] is not None
+
+
+def test_compare_reports_diff_and_guardrail_verdict(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    store.save(_v1(), scorecard=score_ontology(_v1(), corpus_profile=_CORPUS, profile="guardrail"),
+               corpus_profile=_CORPUS, weight_profile="guardrail")
+    store.save(_v2(), scorecard=score_ontology(_v2(), corpus_profile=_CORPUS, profile="guardrail"),
+               corpus_profile=_CORPUS, weight_profile="guardrail")
+    cmp = store.compare("acme", "1.0.0", "2.0.0")
+    assert cmp["schema_changed"] is True
+    assert cmp["recommended_bump"] in {"major", "minor", "patch"}
+    # v2 adds Person+Regulation which the corpus needs → better guardrail
+    assert cmp["guardrail_verdict"]["basis"] == "corpus_coverage"
+    assert cmp["guardrail_verdict"]["verdict"] == "better"
+    assert cmp["guardrail_verdict"]["delta"] > 0
+
+
+def test_compare_missing_version_raises(tmp_path):
+    store = OntologySnapshotStore(tmp_path)
+    store.save(_v1())
+    with pytest.raises(KeyError):
+        store.compare("acme", "1.0.0", "9.9.9")


### PR DESCRIPTION
Stacked on #305. Immutable, content-addressed snapshot store persisting each ontology version with its evaluation evidence (scorecard, OntoClean tags, corpus profile, weight profile). save/get/list/latest/history + compare() with a measured guardrail verdict (corpus_coverage delta). Demo: fibo_finder v1.0.0 (sparse, cc 0.349) vs v2.0.0 (rich, cc 0.595) -> 'better' +0.2464. Tests + run_basic_ci pass.