### PR TITLE
docs(ontology): ADR-0118 — scale-validated guardrail is structural-not-numeric; scope numerics to SHACL validation

### DIFF
--- a/docs/decisions/ADR-0118-finance-guardrail-scope-numeric-to-validation.md
+++ b/docs/decisions/ADR-0118-finance-guardrail-scope-numeric-to-validation.md
@@ -1,0 +1,89 @@
+# ADR-0118: Scale-Validated Guardrail Value Is Structural-Not-Numeric → Scope Numeric Guarantees to SHACL Validation
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0115/0116 established, on a 160-doc FinDER sample, that a richer ontology guardrail improves
+LLM extraction and that corpus-aware scoring predicts that value. Before committing the product
+thesis ("ontology-governed graph memory makes financial LLM/RAG safer and more correct") we needed
+(a) a larger-sample replication and (b) an external evidence base for *which* correctness the
+ontology actually buys — because the FinDER data already hinted that numeric categories barely
+benefited.
+
+Two inputs informed this ADR:
+
+1. **Scale replication (measured).** FinDER guardrail ablation at **N=320** (40 × 8 categories,
+   all 4 MARA models, 2,560 thread-pooled extractions) + corpus-aware scorecard over a 268-type
+   open-extraction profile. Data: `ADR-0118-scale-validation-summary.json` (full per-doc records
+   retained out-of-repo).
+2. **Problem-definition survey (deep-research, 23 verified / 2 refuted claims from authoritative
+   sources).** Full writeup in the Obsidian vault (`wiki/finance-ontology-problem-definition.md`).
+
+## Findings
+
+### Scale replication confirms and sharpens ADR-0115
+
+| arm | extraction_score | conformance | nodes/doc |
+|---|---|---|---|
+| sparse (fibo_minus, 2 classes) | 0.733 | 0.745 | 4.29 |
+| rich (fibo_plus, 9 classes) | **0.891** | **0.902** | 8.56 |
+| Δ | **+0.158** | +0.158 | +4.27 |
+
+Replicates the N=160 result (+0.164) almost exactly; positive for **all four models** (DeepSeek
++0.134, MiniMax-M2.5 +0.241, gpt-oss-120b +0.237, MiniMax-M2.7 +0.020). Corpus-aware scoring again
+moved the sparse ontology from rank-1 (intrinsic) to rank-3 (guardrail+corpus), matching downstream.
+
+**The benefit is category-conditional, now decisively:**
+
+| entity-rich (large gain) | Δscore | | numeric-heavy (≈0 / negative) | Δscore |
+|---|---|---|---|---|
+| Governance | **+0.546** | | Footnotes | +0.019 |
+| Risk | **+0.324** | | Financials | **+0.002** |
+| Legal | +0.163 | | Shareholder return | **−0.029** |
+| Accounting / Company overview | +0.138 / +0.130 | | | |
+
+### Survey establishes the problem and the same tension
+
+- Integration is real and costly: managing financial data without common standards "runs into the
+  **billions of dollars**" (OFR); FIBO (OWL 2 DL) + LEI are the canonical ontology + identity
+  remedies — though the LEI alone does **not** solve entity resolution (~99% of global entities
+  unregistered).
+- Numbers are where LLMs fail: FinQA best **61%** vs **91%** human; ConvFinQA **<70%** vs 89%;
+  FinanceQA **~60%** task failure; GPT-4-turbo **9%** closed-book. Regulators (FSB, BoE, GAO) name
+  model risk / data quality / hallucination as material-to-systemic.
+- **The honest tension (independently surfaced by the survey):** ontology/KG grounding fixes entity
+  identity, closed-vocabulary extraction, typed links, provenance, and disambiguation — **but it
+  does not perform arithmetic.**
+
+### Convergence
+
+The survey's tension and our N=320 measurement agree: the guardrail soars on entity-rich domains
+(Governance +0.55) and is flat/negative on numeric-heavy ones (Financials +0.002, Shareholder
+return −0.03). Two independent methods — external literature and in-house measurement — converge on
+**guardrail value is structural, not arithmetic.**
+
+## Decision
+
+1. **Scope the product's numeric correctness claim to validation, not computation.** SEOCHO must
+   NOT claim "the ontology produces correct numbers." It should target **numeric-fact validation**
+   via SHACL/constraint checks over extracted facts (unit/scale, fiscal period, reconciliation,
+   materiality, cross-entity consistency) — catching wrong numbers, not computing them. This is
+   the **P3** workstream and the next experiment (does SHACL catch LLM numeric errors, and what
+   fraction are structurally catchable vs inherently arithmetic?).
+2. **Keep the structural claim, which is measured and strong:** identity, closed-vocabulary
+   extraction, typed relationships, provenance, disambiguation-before-retrieval. Use corpus-aware
+   `profile="guardrail"` scoring (ADR-0116) to choose/justify a guardrail per corpus.
+3. **Prioritize `seocho-ub5` (provider-aware meta-prompt).** MiniMax-M2.7 failed ~16% of
+   extractions on JSON parsing (vs 0% for the other three) — a concrete reliability gap that costs
+   ensemble coverage.
+
+## Consequences
+
+- Product framing is now evidence-backed and honest about the numeric boundary.
+- P3 (SHACL numeric validation) becomes the headline next experiment — it addresses the exact gap
+  the survey flagged ("no source measured a KG-grounding intervention's effect on numeric
+  benchmarks") and the exact category (numeric) our guardrail did not help.
+- Tickets: `seocho-g2r` (eval), `seocho-ub5` (provider meta-prompt), plus a new P3 numeric-validation
+  ticket. Identity long-tail (FIBO+LEI bridging) tracked under `seocho-uxs`.

--- a/docs/decisions/ADR-0118-scale-validation-summary.json
+++ b/docs/decisions/ADR-0118-scale-validation-summary.json
@@ -1,0 +1,151 @@
+{
+  "experiment": "ADR-0118 scale validation N=320",
+  "sample": {
+    "per_category": 40,
+    "total_docs": 320,
+    "max_chars": 3000,
+    "categories": {
+      "Accounting": 40,
+      "Company overview": 40,
+      "Financials": 40,
+      "Footnotes": 40,
+      "Governance": 40,
+      "Legal": 40,
+      "Risk": 40,
+      "Shareholder return": 40
+    }
+  },
+  "models": [
+    "DeepSeek-V3.1",
+    "MiniMax-M2.5",
+    "MiniMax-M2.7",
+    "gpt-oss-120b"
+  ],
+  "guardrail_ablation_cross_model": {
+    "A_sparse_fibo_minus": {
+      "mean_nodes": 4.2862,
+      "mean_rels": 3.076,
+      "mean_label_conformance": 0.7447,
+      "mean_rel_conformance": 0.4732,
+      "mean_extraction_score": 0.7332,
+      "distinct_labels": 2.25,
+      "label_entropy_bits": 0.8086,
+      "top1_label_share": 0.7606
+    },
+    "B_rich_fibo_plus": {
+      "mean_nodes": 8.5565,
+      "mean_rels": 6.9852,
+      "mean_label_conformance": 0.9022,
+      "mean_rel_conformance": 0.7953,
+      "mean_extraction_score": 0.8912,
+      "distinct_labels": 9.75,
+      "label_entropy_bits": 2.5894,
+      "top1_label_share": 0.4173
+    },
+    "delta_B_minus_A": {
+      "mean_nodes": 4.2703,
+      "mean_rels": 3.9092,
+      "mean_label_conformance": 0.1575,
+      "mean_rel_conformance": 0.3221,
+      "mean_extraction_score": 0.158,
+      "distinct_labels": 7.5,
+      "label_entropy_bits": 1.7808,
+      "top1_label_share": -0.3433
+    }
+  },
+  "per_model_extraction_score": {
+    "DeepSeek-V3.1": {
+      "A": 0.8364,
+      "B": 0.9707,
+      "errors_A": 0,
+      "errors_B": 0
+    },
+    "MiniMax-M2.5": {
+      "A": 0.7091,
+      "B": 0.9499,
+      "errors_A": 0,
+      "errors_B": 2
+    },
+    "MiniMax-M2.7": {
+      "A": 0.7562,
+      "B": 0.776,
+      "errors_A": 51,
+      "errors_B": 53
+    },
+    "gpt-oss-120b": {
+      "A": 0.6312,
+      "B": 0.8684,
+      "errors_A": 0,
+      "errors_B": 0
+    }
+  },
+  "per_category_delta": {
+    "Accounting": {
+      "delta_score": 0.1377,
+      "conf_A": 0.786,
+      "conf_B": 0.918
+    },
+    "Company overview": {
+      "delta_score": 0.1304,
+      "conf_A": 0.787,
+      "conf_B": 0.916
+    },
+    "Financials": {
+      "delta_score": 0.0024,
+      "conf_A": 0.738,
+      "conf_B": 0.747
+    },
+    "Footnotes": {
+      "delta_score": 0.019,
+      "conf_A": 0.867,
+      "conf_B": 0.887
+    },
+    "Governance": {
+      "delta_score": 0.5458,
+      "conf_A": 0.417,
+      "conf_B": 0.96
+    },
+    "Legal": {
+      "delta_score": 0.1631,
+      "conf_A": 0.752,
+      "conf_B": 0.914
+    },
+    "Risk": {
+      "delta_score": 0.3242,
+      "conf_A": 0.65,
+      "conf_B": 0.974
+    },
+    "Shareholder return": {
+      "delta_score": -0.0288,
+      "conf_A": 0.973,
+      "conf_B": 0.941
+    }
+  },
+  "corpus_aware": {
+    "before_balanced": {
+      "fibo_minus": 0.8975,
+      "fibo_base": 0.8787,
+      "fibo_plus": 0.816
+    },
+    "before_ranking": [
+      "fibo_minus",
+      "fibo_base",
+      "fibo_plus"
+    ],
+    "after_guardrail_corpus": {
+      "fibo_minus": 0.7551,
+      "fibo_base": 0.7814,
+      "fibo_plus": 0.7813
+    },
+    "after_ranking": [
+      "fibo_base",
+      "fibo_plus",
+      "fibo_minus"
+    ],
+    "downstream_ranking": [
+      "fibo_plus",
+      "fibo_minus"
+    ],
+    "corpus_distinct_types": 268
+  }
+}


### PR DESCRIPTION
N=320 FinDER replication (4 models, 2560 extractions) confirms ADR-0115 (+0.158 extraction_score, all models positive), decisively category-conditional (Governance +0.55 / Risk +0.32 vs Financials +0.002 / Shareholder return -0.03). A deep-research survey (23 verified claims, FIBO/LEI/OFR/FSB/BoE/GAO + FinQA/ConvFinQA/FinanceQA/FinDER) independently surfaces the same tension. Decision: scope numeric correctness to SHACL VALIDATION, not computation. Compact summary committed (full per-doc out-of-repo).