### PR TITLE
feat(ontology): ambiguity review loop Phase 1 — quarantine + detection + mapping-spec + CLI (seocho-2mg)

### DIFF
--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -325,6 +325,24 @@ def build_parser() -> argparse.ArgumentParser:
     ontology_inspect_parser.add_argument("--source", required=True, help="OWL file path or URI")
     ontology_inspect_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
+    ontology_review_parser = ontology_subparsers.add_parser(
+        "review",
+        help="Ambiguity review loop: quarantine OOV entities, cluster them, and map them back into the taxonomy",
+    )
+    ontology_review_parser.add_argument(
+        "review_action",
+        choices=["ingest", "clusters", "export-spec", "apply"],
+        help="ingest: detect+quarantine from an extracted-graph JSON; clusters: list ranked quarantine; "
+             "export-spec: write a starter mapping-spec YAML; apply: apply a mapping-spec to an ontology",
+    )
+    ontology_review_parser.add_argument("--quarantine", default=".seocho_quarantine.jsonl", help="Quarantine JSONL path")
+    ontology_review_parser.add_argument("--schema", default=None, help="Ontology file (for ingest/export-spec/apply)")
+    ontology_review_parser.add_argument("--graph", default=None, help="Extracted-graph JSON (for ingest)")
+    ontology_review_parser.add_argument("--spec", default=None, help="Mapping-spec YAML (for apply)")
+    ontology_review_parser.add_argument("--output", default=None, help="Output path (export-spec / apply)")
+    ontology_review_parser.add_argument("--workspace", default="", help="workspace_id to stamp on quarantined items")
+    ontology_review_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
     serve_http_parser = subparsers.add_parser("serve-http", help="Serve a portable bundle behind a small FastAPI runtime")
     serve_http_parser.add_argument("--bundle", required=True, help="Path to portable bundle JSON file")
     serve_http_parser.add_argument("--host", default="0.0.0.0", help="Bind host")
@@ -1506,6 +1524,75 @@ def _cmd_ontology(args: argparse.Namespace) -> int:
                 f"imports={inspection.stats.get('import_count', 0)}"
             )
         return 0 if inspection.available and inspection.error is None else 1
+
+    if args.ontology_command == "review":
+        from .ontology import Ontology
+        from .ontology_ambiguity import (
+            AmbiguityQuarantine,
+            apply_mapping_spec,
+            detect_ambiguities,
+            load_mapping_spec,
+            starter_mapping_spec,
+        )
+
+        q = AmbiguityQuarantine(args.quarantine)
+
+        if args.review_action == "ingest":
+            if not args.schema or not args.graph:
+                raise SeochoError("review ingest requires --schema and --graph")
+            ontology = Ontology.load(args.schema)
+            graph = json.loads(Path(args.graph).read_text(encoding="utf-8"))
+            found = detect_ambiguities(graph, ontology, source=args.graph, workspace_id=args.workspace)
+            n = q.add(found)
+            if getattr(args, "output_json", False):
+                print(json.dumps({"ingested": n, "items": [f.to_dict() for f in found]}, indent=2, ensure_ascii=False))
+            else:
+                print(f"quarantined {n} ambiguous mention(s) → {args.quarantine}")
+            return 0
+
+        if args.review_action == "clusters":
+            clusters = q.clusters()
+            if getattr(args, "output_json", False):
+                print(json.dumps(clusters, indent=2, ensure_ascii=False))
+            else:
+                if not clusters:
+                    print("quarantine empty")
+                for c in clusters:
+                    print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
+                          f"candidates={c['candidate_labels']}")
+            return 0
+
+        if args.review_action == "export-spec":
+            if not args.schema:
+                raise SeochoError("review export-spec requires --schema")
+            import yaml
+            ontology = Ontology.load(args.schema)
+            spec = starter_mapping_spec(q.clusters(), ontology)
+            text = yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)
+            if args.output:
+                Path(args.output).write_text(text, encoding="utf-8")
+                print(f"wrote starter mapping-spec → {args.output} ({len(spec['mappings'])} mappings)")
+            else:
+                print(text)
+            return 0
+
+        if args.review_action == "apply":
+            if not args.schema or not args.spec:
+                raise SeochoError("review apply requires --schema and --spec")
+            ontology = Ontology.load(args.schema)
+            spec = load_mapping_spec(args.spec)
+            new_onto = apply_mapping_spec(ontology, spec)
+            payload = new_onto.to_jsonld()
+            if args.output:
+                Path(args.output).write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+                print(f"applied {len(spec.get('mappings', []))} mapping(s): "
+                      f"{ontology.version} → {new_onto.version}, {len(ontology.nodes)} → {len(new_onto.nodes)} classes "
+                      f"→ {args.output}")
+            else:
+                print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return 0
+
+        raise SeochoError(f"Unknown review action: {args.review_action}")
 
     raise SeochoError(f"Unknown ontology command: {args.ontology_command}")
 

--- a/src/seocho/ontology_ambiguity.py
+++ b/src/seocho/ontology_ambiguity.py
@@ -1,0 +1,267 @@
+"""Ambiguity review loop — Phase 1: quarantine, detection, mapping-spec.
+
+The virtuous cycle (선순환): ambiguous / out-of-ontology entities surfaced during
+extraction are **quarantined** (never silently dropped or force-fit), aggregated
+into ranked clusters, mapped by the user via a declarative mapping-spec (the
+durable, git-friendly artifact a UI will later write), and the decisions are
+**applied back into the ontology taxonomy** — improving the next extraction.
+
+This module is offline and headless (no LLM, no hot path): detection is a pure
+walk over an already-extracted graph; the quarantine is a JSONL store; the
+mapping-spec is YAML. LLM-backed proposals and a Streamlit UI are later phases;
+this phase gives a testable spine and a CLI (`seocho ontology review`).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .ontology import NodeDef, Ontology
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+# Why a mention was quarantined.
+SIGNAL_OOV = "oov"                       # label not declared in the ontology
+SIGNAL_FALLBACK = "entity_fallback"      # admitted as bare Entity / heuristic fallback
+SIGNAL_OUT_OF_ONTOLOGY = "out_of_ontology"  # carries the open-mode _out_of_ontology stamp
+SIGNAL_ALIAS_COLLISION = "alias_collision"  # surface maps to >1 declared class
+
+
+@dataclass(slots=True)
+class AmbiguousEntity:
+    surface: str                          # the mention's display form (name or label)
+    label: str                            # the label extraction assigned (may be OOV/Entity)
+    signal: str                           # one of SIGNAL_*
+    candidate_labels: List[str] = field(default_factory=list)
+    context: str = ""
+    source: str = ""
+    workspace_id: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "surface": self.surface, "label": self.label, "signal": self.signal,
+            "candidate_labels": list(self.candidate_labels), "context": self.context,
+            "source": self.source, "workspace_id": self.workspace_id,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "AmbiguousEntity":
+        return cls(
+            surface=str(d.get("surface", "")), label=str(d.get("label", "")),
+            signal=str(d.get("signal", "")), candidate_labels=list(d.get("candidate_labels", []) or []),
+            context=str(d.get("context", "")), source=str(d.get("source", "")),
+            workspace_id=str(d.get("workspace_id", "")),
+        )
+
+
+def _norm(s: str) -> str:
+    return " ".join(str(s or "").strip().lower().split())
+
+
+# ---------------------------------------------------------------------------
+# Detection (pure, offline)
+# ---------------------------------------------------------------------------
+
+def detect_ambiguities(
+    data: Dict[str, Any],
+    ontology: Ontology,
+    *,
+    source: str = "",
+    workspace_id: str = "",
+) -> List[AmbiguousEntity]:
+    """Flag nodes in an *already-extracted* graph that are ambiguous w.r.t. the
+    ontology. Pure walk — no LLM, no hot path.
+
+    Signals: label not declared (OOV); admitted as bare ``Entity``; carries the
+    open-mode ``_out_of_ontology`` stamp; surface form that is an alias of more
+    than one declared class (alias collision)."""
+    declared = set(ontology.nodes)
+    # alias -> set of class labels (for collision detection)
+    alias_owners: Dict[str, set] = {}
+    for label, nd in ontology.nodes.items():
+        for alias in (getattr(nd, "aliases", []) or []):
+            alias_owners.setdefault(_norm(alias), set()).add(label)
+
+    out: List[AmbiguousEntity] = []
+    for node in data.get("nodes", []):
+        if not isinstance(node, dict):
+            continue
+        label = str(node.get("label", "")).strip()
+        props = node.get("properties", {}) or {}
+        surface = str(props.get("name") or node.get("id") or label).strip()
+        context = str(props.get("context") or props.get("description") or "")[:300]
+
+        signal = None
+        candidates: List[str] = []
+        if str(props.get("_out_of_ontology", "")).lower() == "true":
+            signal = SIGNAL_OUT_OF_ONTOLOGY
+        elif label == "Entity":
+            signal = SIGNAL_FALLBACK
+        elif label and label not in declared:
+            signal = SIGNAL_OOV
+        else:
+            owners = alias_owners.get(_norm(surface), set())
+            if len(owners) > 1:
+                signal = SIGNAL_ALIAS_COLLISION
+                candidates = sorted(owners)
+
+        if signal:
+            out.append(AmbiguousEntity(
+                surface=surface or label, label=label, signal=signal,
+                candidate_labels=candidates, context=context,
+                source=source, workspace_id=workspace_id,
+            ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Quarantine store (JSONL, append-only)
+# ---------------------------------------------------------------------------
+
+class AmbiguityQuarantine:
+    """Append-only JSONL store of quarantined mentions, kept separate from the
+    clean graph (the whole point: never silently force-fit)."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def add(self, items: List[AmbiguousEntity]) -> int:
+        with self.path.open("a", encoding="utf-8") as fh:
+            for it in items:
+                fh.write(json.dumps(it.to_dict(), ensure_ascii=False) + "\n")
+        return len(items)
+
+    def all(self) -> List[AmbiguousEntity]:
+        if not self.path.exists():
+            return []
+        out = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    out.append(AmbiguousEntity.from_dict(json.loads(line)))
+                except Exception:
+                    continue
+        return out
+
+    def clusters(self) -> List[Dict[str, Any]]:
+        """Group mentions by normalized surface; rank by frequency (the impact
+        proxy a UI/LLM phase will refine with corpus_coverage gain)."""
+        groups: Dict[str, Dict[str, Any]] = {}
+        for it in self.all():
+            key = _norm(it.surface)
+            g = groups.setdefault(key, {
+                "surface": it.surface, "frequency": 0, "signals": {},
+                "candidate_labels": set(), "labels": set(), "examples": [],
+            })
+            g["frequency"] += 1
+            g["signals"][it.signal] = g["signals"].get(it.signal, 0) + 1
+            g["candidate_labels"].update(it.candidate_labels)
+            g["labels"].add(it.label)
+            if it.context and len(g["examples"]) < 3:
+                g["examples"].append(it.context)
+        clusters = []
+        for g in groups.values():
+            clusters.append({
+                "surface": g["surface"], "frequency": g["frequency"],
+                "signals": g["signals"], "labels": sorted(g["labels"]),
+                "candidate_labels": sorted(g["candidate_labels"]), "examples": g["examples"],
+            })
+        clusters.sort(key=lambda c: -c["frequency"])
+        return clusters
+
+
+# ---------------------------------------------------------------------------
+# Mapping spec (the declarative, git-friendly artifact)
+# ---------------------------------------------------------------------------
+
+# action: "alias" (add surface as alias of target class), "new_class" (add a new
+# class `target` with broader `parent`), "same_as" (alias to an existing class),
+# "ignore" (noise — leave in quarantine, no ontology change).
+_VALID_ACTIONS = {"alias", "new_class", "same_as", "ignore"}
+
+
+def starter_mapping_spec(clusters: List[Dict[str, Any]], ontology: Ontology) -> Dict[str, Any]:
+    """A heuristic first-draft spec from quarantine clusters (no LLM): suggest
+    `alias` when the surface already collides with declared aliases, else
+    `new_class` for capitalized/typed-looking surfaces, else `ignore`. A human or
+    a later LLM phase edits this before applying."""
+    mappings = []
+    for c in clusters:
+        surface = c["surface"]
+        if c["candidate_labels"]:
+            action, entry = "alias", {"surface": surface, "action": "alias", "target": c["candidate_labels"][0]}
+        elif re.match(r"^[A-Z][A-Za-z0-9 ]+$", surface) and len(surface) <= 40:
+            label = re.sub(r"[^A-Za-z0-9]", "", surface.title())
+            entry = {"surface": surface, "action": "new_class", "target": label, "parent": "", "description": ""}
+        else:
+            entry = {"surface": surface, "action": "ignore"}
+        mappings.append(entry)
+    return {"ontology": ontology.name, "mappings": mappings}
+
+
+def apply_mapping_spec(ontology: Ontology, spec: Dict[str, Any]) -> Ontology:
+    """Apply a mapping spec to produce a NEW draft ontology (minor version bump).
+    Pure transform; the caller decides whether to snapshot/version it."""
+    data = ontology.to_dict()
+    nodes = data.setdefault("nodes", {})
+
+    def _resolve_class(name: str) -> Optional[str]:
+        if name in nodes:
+            return name
+        nl = _norm(name)
+        for label in nodes:
+            if _norm(label) == nl:
+                return label
+        return None
+
+    for m in (spec.get("mappings") or []):
+        action = str(m.get("action", "")).strip()
+        if action not in _VALID_ACTIONS:
+            raise ValueError(f"invalid mapping action: {m.get('action')!r}")
+        surface = str(m.get("surface", "")).strip()
+        if action == "ignore" or not surface:
+            continue
+        if action in ("alias", "same_as"):
+            target = _resolve_class(str(m.get("target", "")))
+            if not target:
+                raise ValueError(f"alias/same_as target class not found: {m.get('target')!r}")
+            aliases = nodes[target].setdefault("aliases", [])
+            if surface not in aliases:
+                aliases.append(surface)
+        elif action == "new_class":
+            label = str(m.get("target") or "").strip() or re.sub(r"[^A-Za-z0-9]", "", surface.title())
+            if label not in nodes:
+                nd: Dict[str, Any] = {"description": str(m.get("description", "") or ""), "properties": {}}
+                parent = str(m.get("parent", "") or "").strip()
+                if parent:
+                    presolved = _resolve_class(parent)
+                    if not presolved:
+                        raise ValueError(f"new_class parent not found: {parent!r}")
+                    nd["broader"] = [presolved]
+                if _norm(surface) != _norm(label):
+                    nd["aliases"] = [surface]
+                nodes[label] = nd
+
+    new_onto = Ontology.from_dict(data)
+    new_onto.version = _bump_minor(ontology.version)
+    return new_onto
+
+
+def _bump_minor(version: str) -> str:
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)$", str(version or "").strip())
+    if not m:
+        return version
+    return f"{m.group(1)}.{int(m.group(2)) + 1}.0"
+
+
+def load_mapping_spec(path: str | Path) -> Dict[str, Any]:
+    import yaml
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}

--- a/tests/seocho/test_ontology_ambiguity.py
+++ b/tests/seocho/test_ontology_ambiguity.py
@@ -1,0 +1,105 @@
+"""Tests for the ambiguity review loop — Phase 1 (quarantine, detect, mapping-spec)."""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology_ambiguity import (
+    AmbiguityQuarantine,
+    AmbiguousEntity,
+    apply_mapping_spec,
+    detect_ambiguities,
+    starter_mapping_spec,
+)
+
+
+def _onto() -> Ontology:
+    return Ontology("biz", version="1.0.0", nodes={
+        "Company": NodeDef(description="A company.", aliases=["Firm"], properties={"name": P(str, unique=True)}),
+        "Person": NodeDef(description="A person.", aliases=["Firm"], properties={"name": P(str, unique=True)}),
+        "Concept": NodeDef(description="A concept."),
+    })
+
+
+def _graph() -> dict:
+    return {"nodes": [
+        {"id": "c1", "label": "Company", "properties": {"name": "Acme"}},          # clean
+        {"id": "r1", "label": "Regulation", "properties": {"name": "Basel III"}},  # OOV
+        {"id": "e1", "label": "Entity", "properties": {"name": "mystery thing"}},  # fallback
+        {"id": "o1", "label": "Risk", "properties": {"name": "FX risk", "_out_of_ontology": "true"}},  # stamped
+        {"id": "f1", "label": "Company", "properties": {"name": "Firm"}},          # alias collision (Company+Person)
+    ], "relationships": []}
+
+
+def test_detect_signals():
+    found = detect_ambiguities(_graph(), _onto(), source="doc1", workspace_id="ws1")
+    by_signal = {f.signal for f in found}
+    assert "oov" in by_signal            # Regulation
+    assert "entity_fallback" in by_signal  # Entity
+    assert "out_of_ontology" in by_signal  # stamped Risk
+    assert "alias_collision" in by_signal  # Firm → Company+Person
+    # clean Company/Acme not flagged
+    assert all(f.surface != "Acme" for f in found)
+    assert all(f.workspace_id == "ws1" for f in found)
+
+
+def test_quarantine_roundtrip_and_clusters(tmp_path):
+    q = AmbiguityQuarantine(tmp_path / "q.jsonl")
+    found = detect_ambiguities(_graph(), _onto())
+    # add twice to build frequency
+    q.add(found); q.add(found)
+    clusters = q.clusters()
+    assert clusters[0]["frequency"] >= clusters[-1]["frequency"]  # sorted desc
+    reg = next(c for c in clusters if c["surface"] == "Basel III")
+    assert reg["frequency"] == 2
+    assert reg["signals"].get("oov") == 2
+
+
+def test_starter_spec_suggests_actions():
+    q_clusters = [
+        {"surface": "Basel III", "frequency": 5, "signals": {"oov": 5}, "labels": ["Regulation"], "candidate_labels": [], "examples": []},
+        {"surface": "Firm", "frequency": 3, "signals": {"alias_collision": 3}, "labels": ["Company"], "candidate_labels": ["Company", "Person"], "examples": []},
+        {"surface": "lower-case noise", "frequency": 1, "signals": {"oov": 1}, "labels": ["x"], "candidate_labels": [], "examples": []},
+    ]
+    spec = starter_mapping_spec(q_clusters, _onto())
+    actions = {m["surface"]: m["action"] for m in spec["mappings"]}
+    assert actions["Firm"] == "alias"            # has candidate labels
+    assert actions["Basel III"] == "new_class"   # capitalized, no candidate
+    assert actions["lower-case noise"] == "ignore"
+
+
+def test_apply_alias_and_new_class():
+    onto = _onto()
+    spec = {"mappings": [
+        {"surface": "Adj. EBITDA", "action": "alias", "target": "Company"},
+        {"surface": "Basel III", "action": "new_class", "target": "Regulation", "parent": "Concept",
+         "description": "A regulatory rule."},
+        {"surface": "noise", "action": "ignore"},
+    ]}
+    new_onto = apply_mapping_spec(onto, spec)
+    assert "Regulation" in new_onto.nodes
+    assert new_onto.nodes["Regulation"].broader == ["Concept"]
+    assert "Adj. EBITDA" in new_onto.nodes["Company"].aliases
+    assert new_onto.version == "1.1.0"   # minor bump
+    # original ontology unchanged
+    assert "Regulation" not in onto.nodes
+
+
+def test_apply_rejects_bad_parent_and_action():
+    import pytest
+    onto = _onto()
+    with pytest.raises(ValueError):
+        apply_mapping_spec(onto, {"mappings": [{"surface": "X", "action": "new_class", "target": "X", "parent": "Nonexistent"}]})
+    with pytest.raises(ValueError):
+        apply_mapping_spec(onto, {"mappings": [{"surface": "X", "action": "frobnicate"}]})
+
+
+def test_apply_then_score_improves_corpus_coverage():
+    # the loop's payoff: registering a needed class lifts corpus_coverage
+    from seocho.ontology_scorecard import build_corpus_profile, score_ontology
+    corpus = build_corpus_profile([{"nodes": [{"label": "Regulation"}, {"label": "Company"}]}])
+    onto = _onto()
+    before = score_ontology(onto, corpus_profile=corpus).dimension("corpus_coverage").score
+    new_onto = apply_mapping_spec(onto, {"mappings": [
+        {"surface": "Basel III", "action": "new_class", "target": "Regulation", "parent": "Concept"}]})
+    after = score_ontology(new_onto, corpus_profile=corpus).dimension("corpus_coverage").score
+    assert after > before


### PR DESCRIPTION
Phase 1 of the virtuous cycle (선순환). Ambiguous/OOV entities are quarantined (not dropped/force-fit), clustered+ranked, mapped via a declarative mapping-spec YAML, and applied back into the taxonomy.

- `detect_ambiguities()` — pure offline: OOV / Entity-fallback / open-mode `_out_of_ontology` stamp / alias collision.
- `AmbiguityQuarantine` — append-only JSONL; `clusters()` ranks by frequency.
- mapping-spec (alias/new_class/same_as/ignore) + `apply_mapping_spec()` → new draft ontology (minor bump).
- CLI `seocho ontology review {ingest,clusters,export-spec,apply}` — headless; the artifact a Streamlit UI (Phase 3) will write.

Offline, no hot path. Composes corpus_coverage/OntoClean/snapshot store as the loop's measure/validate/version steps. 10 new tests + run_basic_ci 631 passed. End-to-end verified via CLI (ingest→clusters→export-spec→apply → ontology 1.0.0→1.1.0 with new Regulation class).