### PR TITLE
docs(first-touch): runnable first snippet, single provider, unified onboarding

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -18,6 +18,15 @@ uv pip install "seocho[local]"
 embedded LadybugDB graph path. You do not need to run a server for this first
 example.
 
+Set your provider key. SEOCHO recommends MARA:
+
+```bash
+export MARA_API_KEY=...
+```
+
+Prefer OpenAI/DeepSeek/Kimi? Export that provider's key and swap the `llm=`
+string below (`"openai/gpt-4o"`, `"deepseek/deepseek-chat"`, `"kimi/kimi-k2.5"`).
+
 ## 2. Run The Smallest Example
 
 ```python
@@ -34,7 +43,7 @@ ontology = Ontology(
     },
 )
 
-client = Seocho.local(ontology)
+client = Seocho.local(ontology, llm="mara/MiniMax-M2.5")
 client.add("Marie Curie worked at the University of Paris.")
 
 print(client.ask("Where did Marie Curie work?"))
@@ -51,8 +60,8 @@ What happened:
 The finance-compliance example is the fastest complete project-shaped path:
 
 ```bash
-export OPENAI_API_KEY=...
-python examples/finance-compliance/quickstart.py
+export MARA_API_KEY=...
+uv run python examples/finance-compliance/quickstart.py --llm mara/MiniMax-M2.5
 ```
 
 It ships:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ evidence.
 In one sentence: SEOCHO turns your ontology into the operating contract for
 graph memory, retrieval, and agent answers.
 
-The durable product layer is the ontology control plane: indexing and query
-runs emit ontology signals, SEOCHO compiles those signals into reviewable
-profiles, and agents select the best profile before routing, text-to-Cypher,
-debate, reasoning, or answer synthesis.
+Under the hood, indexing and query runs emit ontology signals that SEOCHO
+compiles into reviewable profiles, so an agent picks the right profile before
+routing, text-to-Cypher, reasoning, or answer synthesis.
 
 ```mermaid
 flowchart LR
@@ -63,11 +62,15 @@ ontology = Ontology(
     },
 )
 
-client = Seocho.local(ontology)
+client = Seocho.local(ontology, llm="mara/MiniMax-M2.5")
 client.add("Marie Curie worked at the University of Paris.")
 
 print(client.ask("Where did Marie Curie work?"))
 ```
+
+> Export your provider key first — SEOCHO recommends MARA: `export MARA_API_KEY=...`.
+> Prefer another provider? Pass `llm="openai/gpt-4o"` (or `deepseek/…`, `kimi/…`)
+> and export that provider's key instead.
 
 That example creates a local ontology-aware graph memory. The same public
 facade can later point at a running SEOCHO runtime:
@@ -90,8 +93,8 @@ uv pip install "seocho[local]"
 Run a complete example:
 
 ```bash
-export OPENAI_API_KEY=...
-uv run python examples/finance-compliance/quickstart.py
+export MARA_API_KEY=...
+uv run python examples/finance-compliance/quickstart.py --llm mara/MiniMax-M2.5
 ```
 
 The finance-compliance example ingests six short mock filings into an embedded
@@ -222,15 +225,18 @@ For contributor placement rules, read
 
 ## Learn More
 
+Same order as the [docs onboarding path](docs/README.md), top to bottom:
+
 | Need | Start here |
 |---|---|
+| Why SEOCHO exists | [docs/WHY_SEOCHO.md](docs/WHY_SEOCHO.md) |
 | First run | [QUICKSTART.md](QUICKSTART.md) |
 | Beginner walkthrough | [docs/BEGINNER_GUIDE.md](docs/BEGINNER_GUIDE.md) |
-| Bring your own data | [docs/APPLY_YOUR_DATA.md](docs/APPLY_YOUR_DATA.md) |
 | Python SDK details | [docs/PYTHON_INTERFACE_QUICKSTART.md](docs/PYTHON_INTERFACE_QUICKSTART.md) |
+| Bring your own data | [docs/APPLY_YOUR_DATA.md](docs/APPLY_YOUR_DATA.md) |
+| File/artifact locations | [docs/FILES_AND_ARTIFACTS.md](docs/FILES_AND_ARTIFACTS.md) |
 | Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
 | Runtime deployment | [docs/RUNTIME_DEPLOYMENT.md](docs/RUNTIME_DEPLOYMENT.md) |
-| File/artifact locations | [docs/FILES_AND_ARTIFACTS.md](docs/FILES_AND_ARTIFACTS.md) |
 | Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Maintainer workflow | [docs/WORKFLOW.md](docs/WORKFLOW.md) |
 | Issue and task system | [docs/ISSUE_TASK_SYSTEM.md](docs/ISSUE_TASK_SYSTEM.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,9 @@ now?
 
 | If you need to... | Start here |
 |---|---|
+| understand why SEOCHO exists | [WHY_SEOCHO.md](WHY_SEOCHO.md) |
 | get a first local success path | [../QUICKSTART.md](../QUICKSTART.md) |
-| understand local `ask()` vs runtime `semantic/react/debate` | [../README.md#execution-surfaces](../README.md#execution-surfaces) |
+| understand local `ask()` vs runtime `semantic/react/debate` | [../README.md#choose-a-mode](../README.md#choose-a-mode) |
 | bring up the full local runtime stack | [RUNTIME_DEPLOYMENT.md](RUNTIME_DEPLOYMENT.md) |
 | follow a runnable notebook walkthrough | [../examples/quickstart.ipynb](../examples/quickstart.ipynb) |
 | understand SEOCHO with architecture snippets | [BEGINNER_GUIDE.md](BEGINNER_GUIDE.md) |
@@ -23,7 +24,6 @@ now?
 | inspect files, artifacts, and traces | [FILES_AND_ARTIFACTS.md](FILES_AND_ARTIFACTS.md) |
 | understand the system design | [ARCHITECTURE.md](ARCHITECTURE.md) |
 | understand the top-level repository layout | [REPOSITORY_LAYOUT.md](REPOSITORY_LAYOUT.md) |
-| review repository hierarchy cleanup priorities | [REPOSITORY_HIERARCHY_REVIEW.md](REPOSITORY_HIERARCHY_REVIEW.md) |
 | understand GitHub automation | [GITHUB_AUTOMATION.md](GITHUB_AUTOMATION.md) |
 | present SEOCHO to a technical audience | [presentations/SEOCHO_OVERVIEW_DEEP_DIVE.md](presentations/SEOCHO_OVERVIEW_DEEP_DIVE.md) |
 | measure behavior with FinDER and benchmark tracks | [BENCHMARKS.md](BENCHMARKS.md) |
@@ -104,6 +104,24 @@ Recommended onboarding order:
 - [decisions/DECISION_LOG.md](decisions/DECISION_LOG.md): architecture decision
   history
 - [../CONTRIBUTING.md](../CONTRIBUTING.md): contribution flow and PR rules
+
+## Internal & Maintainer Docs
+
+These are working documents (planning, reviews, migrations, known issues). They
+are not part of the getting-started path — skip them on a first read.
+
+- [AGENT_SERVER_REFACTOR_PLAN.md](AGENT_SERVER_REFACTOR_PLAN.md)
+- [RUNTIME_PACKAGE_MIGRATION.md](RUNTIME_PACKAGE_MIGRATION.md)
+- [ARCHITECTURE_HEALTH.md](ARCHITECTURE_HEALTH.md)
+- [REPOSITORY_HIERARCHY_REVIEW.md](REPOSITORY_HIERARCHY_REVIEW.md)
+- [PHILOSOPHY_FEASIBILITY_REVIEW.md](PHILOSOPHY_FEASIBILITY_REVIEW.md)
+- [PROMPT_ASSEMBLY_DISCUSSION_MEMO.md](PROMPT_ASSEMBLY_DISCUSSION_MEMO.md)
+- [BASELINE_INSTRUCTIONS.md](BASELINE_INSTRUCTIONS.md)
+- [KNOWN_ISSUE.md](KNOWN_ISSUE.md)
+
+> Follow-up: physically relocating these under `docs/internal/` is tracked
+> separately because the `website/` doc generator and several cross-links
+> reference their current paths.
 
 ## Docs Sync Integration
 


### PR DESCRIPTION
## Why

First-touch review (README → docs index → first run) surfaced several defects that erode trust in the first 5 minutes:

1. **First snippet failed without a key.** `Seocho.local(ontology)` defaults to `openai/gpt-4o` (`client.py:336`), so the very first copy-pasted code died with no `OPENAI_API_KEY` and no mention of one until QUICKSTART §3.
2. **Provider story split three ways** — `openai/gpt-4o` default, `OPENAI_API_KEY` in the finance example, `MARA_API_KEY` in the YAML example — with no single recommended provider.
3. **Dead anchor** on the docs index first table: `docs/README.md` → `../README.md#execution-surfaces` (no such section).
4. **Two divergent onboarding orders** between README "Learn More" and `docs/README.md`, and `WHY_SEOCHO.md` wasn't linked from the README at all.
5. **Internal working docs mixed into the user "Start Here" path.**

## What changed (docs-only)

- First snippet is runnable as shown: explicit `llm="mara/MiniMax-M2.5"` + documented `MARA_API_KEY`, with OpenAI/DeepSeek/Kimi as the documented swap. README + QUICKSTART + finance example all aligned on **MARA recommended**.
- Fixed the dead anchor (`#execution-surfaces` → `#choose-a-mode`).
- Unified onboarding: README "Learn More" now leads with `WHY_SEOCHO` and matches the `docs/README.md` order top-to-bottom.
- Demoted internal/maintainer docs out of "Start Here" into a labeled **Internal & Maintainer Docs** section.
- Tightened the dense control-plane restatement in the README intro.

## Deferred

Physically relocating internal docs under `docs/internal/` is tracked in **seocho-mw6** — `website/scripts/generate-docs.mjs` and several cross-links reference current paths (e.g. `RUNTIME_PACKAGE_MIGRATION`: 9 refs), so the move needs its own link-rewrite pass.

## Validation

- `bash scripts/ci/check-doc-contracts.sh` → passed
- `git diff --check` → clean
- Docs-only; no runtime/SDK behavior change.