### PR TITLE
feat(integrations): DataHub connector PoC — ontology → Business Glossary (ADR-0121, seocho-qxj)

### DIFF
--- a/docs/decisions/ADR-0121-datahub-glossary-connector.md
+++ b/docs/decisions/ADR-0121-datahub-glossary-connector.md
@@ -1,0 +1,55 @@
+# ADR-0121: DataHub Connector (PoC) — Ontology → Business Glossary
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+The ambiguity-review mapping surface and the broader distribution play target
+**DataHub**, not a bespoke Streamlit app (user decision, 2026-06-14): couple to an
+existing metadata ecosystem the user already operates. SEOCHO remains the
+authoring/quality engine (scorecard + OntoClean — which DataHub lacks); DataHub
+provides the glossary tree, search, lineage, and approval workflow we ride rather
+than rebuild.
+
+## Decision
+
+Add `seocho.datahub_export` (PoC, Phase A): a **pure, offline** mapping from an
+Ontology to DataHub Business-Glossary Metadata Change Proposals (MCPs), plus an
+optional, import-guarded live emitter.
+
+- `ontology_to_glossary_mcps(ontology)` → list of MCP dicts (the shape the
+  `datahub` SDK's `MetadataChangeProposalWrapper` serializes to). Mapping:
+  package → `glossaryNode`; class → `glossaryTerm` (definition, parentNode,
+  customProperties: aliases / same_as / identity_keys / version); `broader` →
+  `glossaryRelatedTerms.isRelatedTerms` (DataHub "Is A"); relationship types →
+  terms under a `<package> Relationships` node with source/target/cardinality.
+- Deterministic URNs (`urn:li:glossaryTerm:<package_id>.<label>`) → re-export is
+  an idempotent UPSERT.
+- `emit_to_datahub(mcps, gms_server=, token=, dry_run=)` — emits via
+  `DatahubRestEmitter` when the `datahub` SDK + a server are available; otherwise
+  returns the dry-run payload (never crashes). CLI: `seocho ontology datahub
+  --schema X [--output mcps.json] [--gms URL --token T --emit]`.
+
+Offline/data-plane; the connector core has no `datahub` dependency (testable
+without it). Exact aspect field names follow DataHub's documented model and must
+be verified against the target `datahub` version when wiring live emit.
+
+## Validation
+
+`tests/seocho/test_datahub_export.py` (7): package node + terms count, deterministic/
+idempotent URNs, customProperties carry SEOCHO metadata, is-a edge aspect,
+relationship endpoints, dry-run + no-server safety. CLI demo: `fibo_plus.jsonld`
+→ 19 MCPs (17 terms, 2 nodes). `run_basic_ci` green.
+
+## Consequences
+
+- SEOCHO's governed ontology becomes visible/actionable in DataHub without
+  rebuilding a UI; the glossary is the natural home for the ambiguity-review
+  mapping decisions (seocho-2mg Phase 3) and for surfacing scorecard/OntoClean
+  governance.
+- Follow-ups (seocho-qxj): Phase B — emit ambiguity clusters as glossary-term
+  proposals + round-trip the mapping-spec; Phase C — scorecard/OntoClean verdicts
+  as Structured Properties and numeric-validation (P3) results as Assertions /
+  Data Contracts; verify aspect shapes against a live DataHub; add `datahub` as an
+  optional extra (`seocho[datahub]`).

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -343,6 +343,17 @@ def build_parser() -> argparse.ArgumentParser:
     ontology_review_parser.add_argument("--workspace", default="", help="workspace_id to stamp on quarantined items")
     ontology_review_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
+    ontology_datahub_parser = ontology_subparsers.add_parser(
+        "datahub",
+        help="Export an ontology to a DataHub Business Glossary (MCP payloads; optional live emit)",
+    )
+    ontology_datahub_parser.add_argument("--schema", required=True, help="Ontology file (JSON-LD, YAML, or TTL)")
+    ontology_datahub_parser.add_argument("--output", default=None, help="Write MCP JSON to this path (dry-run)")
+    ontology_datahub_parser.add_argument("--gms", default=None, help="DataHub GMS server URL (for live emit)")
+    ontology_datahub_parser.add_argument("--token", default=None, help="DataHub access token (for live emit)")
+    ontology_datahub_parser.add_argument("--emit", action="store_true", help="Actually emit to --gms (default: dry-run)")
+    ontology_datahub_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
     serve_http_parser = subparsers.add_parser("serve-http", help="Serve a portable bundle behind a small FastAPI runtime")
     serve_http_parser.add_argument("--bundle", required=True, help="Path to portable bundle JSON file")
     serve_http_parser.add_argument("--host", default="0.0.0.0", help="Bind host")
@@ -1593,6 +1604,31 @@ def _cmd_ontology(args: argparse.Namespace) -> int:
             return 0
 
         raise SeochoError(f"Unknown review action: {args.review_action}")
+
+    if args.ontology_command == "datahub":
+        from .ontology import Ontology
+        from .datahub_export import emit_to_datahub, glossary_mcps_to_json, ontology_to_glossary_mcps
+
+        ontology = Ontology.load(args.schema)
+        mcps = ontology_to_glossary_mcps(ontology)
+        if args.emit:
+            result = emit_to_datahub(mcps, gms_server=args.gms, token=args.token, dry_run=False)
+            if getattr(args, "output_json", False):
+                print(json.dumps({k: v for k, v in result.items() if k != "mcps"}, indent=2, ensure_ascii=False))
+            else:
+                print(f"datahub emit: mode={result['mode']} "
+                      + (f"sent={result.get('sent')}" if result.get("emitted") else f"({result.get('error','dry-run')})"))
+            return 0 if result.get("emitted") or result["mode"] == "dry_run" else 1
+        text = glossary_mcps_to_json(mcps)
+        if args.output:
+            Path(args.output).write_text(text + "\n", encoding="utf-8")
+            from .datahub_export import export_summary
+            s = export_summary(mcps)
+            print(f"wrote {s['mcp_count']} MCP(s) → {args.output} "
+                  f"({s['glossary_terms']} terms, {s['glossary_nodes']} nodes, {s['is_a_edges']} is-a edges)")
+        else:
+            print(text)
+        return 0
 
     raise SeochoError(f"Unknown ontology command: {args.ontology_command}")
 

--- a/src/seocho/datahub_export.py
+++ b/src/seocho/datahub_export.py
@@ -1,0 +1,165 @@
+"""DataHub connector (PoC, seocho-qxj Phase A): export a SEOCHO Ontology to a
+DataHub Business Glossary.
+
+Decision (user, 2026-06-14): the ambiguity-mapping surface / distribution target
+is DataHub, not a bespoke Streamlit app — couple to an existing metadata
+ecosystem. SEOCHO stays the authoring/quality engine (scorecard + OntoClean,
+which DataHub lacks); DataHub provides the glossary tree, search, and approval
+workflow we ride instead of rebuilding.
+
+This module is **pure and offline**: it maps an Ontology to a list of DataHub
+Metadata Change Proposals (MCPs) as plain dicts (the same shape the
+``datahub`` SDK's ``MetadataChangeProposalWrapper`` serializes to). Emission to a
+live GMS is optional and guarded behind an import, so the connector is fully
+testable without DataHub installed or a server running. URNs are deterministic
+(``<package_id>.<label>``) so re-export is an idempotent UPSERT.
+
+Mapping:
+- one ``glossaryNode`` per ontology package (the container);
+- one ``glossaryTerm`` per class, with definition, parentNode = the package node,
+  and customProperties carrying aliases / same_as / identity_keys / version;
+- ``glossaryRelatedTerms.isRelatedTerms`` for each ``broader`` (is-a) edge
+  (DataHub's "Is A" relationship);
+- relationship types as terms under a ``<package> Relationships`` child node,
+  with source/target/cardinality in customProperties.
+
+NOTE: exact aspect field names follow DataHub's documented model; verify against
+the target ``datahub`` version when wiring live emit (Phase C).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from .ontology import Ontology
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", str(s).strip())
+
+
+def _node_urn(node_id: str) -> str:
+    return f"urn:li:glossaryNode:{_slug(node_id)}"
+
+
+def _term_urn(term_id: str) -> str:
+    return f"urn:li:glossaryTerm:{_slug(term_id)}"
+
+
+def _mcp(entity_type: str, urn: str, aspect_name: str, aspect: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "entityType": entity_type,
+        "entityUrn": urn,
+        "changeType": "UPSERT",
+        "aspectName": aspect_name,
+        "aspect": aspect,
+    }
+
+
+def ontology_to_glossary_mcps(ontology: Ontology) -> List[Dict[str, Any]]:
+    """Map an Ontology to DataHub glossary MCPs (pure; deterministic URNs)."""
+    pkg = ontology.package_id or ontology.name
+    pkg_node_id = pkg
+    rel_node_id = f"{pkg}.Relationships"
+    mcps: List[Dict[str, Any]] = []
+
+    # package container node
+    mcps.append(_mcp("glossaryNode", _node_urn(pkg_node_id), "glossaryNodeInfo", {
+        "name": ontology.name,
+        "definition": (ontology.description or f"SEOCHO ontology '{ontology.name}'").strip(),
+        "id": _slug(pkg_node_id),
+    }))
+
+    # classes → terms
+    for label, nd in ontology.nodes.items():
+        term_id = f"{pkg}.{label}"
+        custom: Dict[str, str] = {"seocho_class": label, "ontology_version": str(ontology.version)}
+        aliases = [str(a) for a in (getattr(nd, "aliases", []) or [])]
+        if aliases:
+            custom["aliases"] = ", ".join(aliases)
+        if getattr(nd, "same_as", None):
+            custom["same_as"] = str(nd.same_as)
+        ik = nd.effective_identity_keys
+        if ik:
+            custom["identity_keys"] = ", ".join(ik)
+        mcps.append(_mcp("glossaryTerm", _term_urn(term_id), "glossaryTermInfo", {
+            "name": label,
+            "definition": (str(getattr(nd, "description", "") or "").strip() or f"{label} (no definition)"),
+            "termSource": "INTERNAL",
+            "parentNode": _node_urn(pkg_node_id),
+            "customProperties": custom,
+        }))
+        # broader (is-a) → glossaryRelatedTerms.isRelatedTerms
+        parents = [p for p in (getattr(nd, "broader", []) or []) if p in ontology.nodes]
+        if parents:
+            mcps.append(_mcp("glossaryTerm", _term_urn(term_id), "glossaryRelatedTerms", {
+                "isRelatedTerms": [_term_urn(f"{pkg}.{p}") for p in parents],
+            }))
+
+    # relationships → terms under a Relationships sub-node
+    if ontology.relationships:
+        mcps.append(_mcp("glossaryNode", _node_urn(rel_node_id), "glossaryNodeInfo", {
+            "name": f"{ontology.name} Relationships",
+            "definition": "Relationship types declared by this ontology.",
+            "id": _slug(rel_node_id),
+            "parentNode": _node_urn(pkg_node_id),
+        }))
+        for rtype, rd in ontology.relationships.items():
+            rterm_id = f"{pkg}.rel.{rtype}"
+            mcps.append(_mcp("glossaryTerm", _term_urn(rterm_id), "glossaryTermInfo", {
+                "name": rtype,
+                "definition": (str(getattr(rd, "description", "") or "").strip() or f"{rtype} relationship"),
+                "termSource": "INTERNAL",
+                "parentNode": _node_urn(rel_node_id),
+                "customProperties": {
+                    "source": str(getattr(rd, "source", "Any")),
+                    "target": str(getattr(rd, "target", "Any")),
+                    "cardinality": str(getattr(rd, "cardinality", "MANY_TO_MANY")),
+                },
+            }))
+    return mcps
+
+
+def export_summary(mcps: List[Dict[str, Any]]) -> Dict[str, int]:
+    return {
+        "mcp_count": len(mcps),
+        "glossary_nodes": sum(1 for m in mcps if m["entityType"] == "glossaryNode"),
+        "glossary_terms": len({m["entityUrn"] for m in mcps if m["entityType"] == "glossaryTerm"}),
+        "is_a_edges": sum(len(m["aspect"].get("isRelatedTerms", [])) for m in mcps
+                          if m["aspectName"] == "glossaryRelatedTerms"),
+    }
+
+
+def emit_to_datahub(
+    mcps: List[Dict[str, Any]],
+    *,
+    gms_server: Optional[str] = None,
+    token: Optional[str] = None,
+    dry_run: bool = True,
+) -> Dict[str, Any]:
+    """Emit MCPs to a DataHub GMS if the ``datahub`` SDK and a server are
+    available; otherwise return the dry-run payload. Idempotent (UPSERT by URN)."""
+    if dry_run or not gms_server:
+        return {"emitted": False, "mode": "dry_run", "summary": export_summary(mcps), "mcps": mcps}
+    try:
+        from datahub.emitter.mce_builder import make_glossary_term_urn  # noqa: F401
+        from datahub.emitter.mcp import MetadataChangeProposalWrapper  # noqa: F401
+        from datahub.emitter.rest_emitter import DatahubRestEmitter
+    except Exception as exc:  # datahub not installed
+        return {"emitted": False, "mode": "unavailable", "error": f"datahub SDK not available: {exc}",
+                "summary": export_summary(mcps), "mcps": mcps}
+    emitter = DatahubRestEmitter(gms_server=gms_server, token=token)
+    sent = 0
+    for m in mcps:
+        emitter.emit_mcp(MetadataChangeProposalWrapper(
+            entityUrn=m["entityUrn"], aspectName=m["aspectName"], aspect=m["aspect"],
+        ))
+        sent += 1
+    return {"emitted": True, "mode": "live", "sent": sent, "gms_server": gms_server,
+            "summary": export_summary(mcps)}
+
+
+def glossary_mcps_to_json(mcps: List[Dict[str, Any]]) -> str:
+    return json.dumps(mcps, indent=2, ensure_ascii=False)

--- a/tests/seocho/test_datahub_export.py
+++ b/tests/seocho/test_datahub_export.py
@@ -1,0 +1,77 @@
+"""Tests for the DataHub glossary connector (PoC, seocho-qxj)."""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.datahub_export import (
+    emit_to_datahub,
+    export_summary,
+    ontology_to_glossary_mcps,
+)
+
+
+def _onto() -> Ontology:
+    return Ontology("people-orgs", package_id="po", version="1.2.0", description="People and orgs.", nodes={
+        "Agent": NodeDef(description="Anything that acts."),
+        "Person": NodeDef(description="A human.", broader=["Agent"], aliases=["Individual"],
+                          properties={"name": P(str, unique=True)}, same_as="schema:Person"),
+        "Company": NodeDef(description="A firm.", broader=["Agent"], properties={"name": P(str, unique=True)}),
+    }, relationships={
+        "WORKS_AT": RelDef(source="Person", target="Company", cardinality="MANY_TO_ONE", description="employment"),
+    })
+
+
+def test_mcps_have_package_node_and_terms():
+    mcps = ontology_to_glossary_mcps(_onto())
+    s = export_summary(mcps)
+    assert s["glossary_terms"] == 3 + 1  # 3 classes + 1 relationship term
+    assert s["glossary_nodes"] == 2      # package node + Relationships node
+    assert s["is_a_edges"] == 2          # Person->Agent, Company->Agent
+
+
+def test_term_urns_deterministic_and_idempotent():
+    a = ontology_to_glossary_mcps(_onto())
+    b = ontology_to_glossary_mcps(_onto())
+    assert a == b  # deterministic → idempotent UPSERT
+    person = next(m for m in a if m["aspectName"] == "glossaryTermInfo" and m["aspect"]["name"] == "Person")
+    assert person["entityUrn"] == "urn:li:glossaryTerm:po.Person"
+    assert person["aspect"]["parentNode"] == "urn:li:glossaryNode:po"
+    assert person["changeType"] == "UPSERT"
+
+
+def test_custom_properties_carry_seocho_metadata():
+    mcps = ontology_to_glossary_mcps(_onto())
+    person = next(m for m in mcps if m["aspectName"] == "glossaryTermInfo" and m["aspect"]["name"] == "Person")
+    cp = person["aspect"]["customProperties"]
+    assert cp["aliases"] == "Individual"
+    assert cp["same_as"] == "schema:Person"
+    assert cp["identity_keys"] == "name"
+    assert cp["ontology_version"] == "1.2.0"
+
+
+def test_is_a_edge_aspect():
+    mcps = ontology_to_glossary_mcps(_onto())
+    rel = [m for m in mcps if m["aspectName"] == "glossaryRelatedTerms"]
+    person_rel = next(m for m in rel if m["entityUrn"] == "urn:li:glossaryTerm:po.Person")
+    assert person_rel["aspect"]["isRelatedTerms"] == ["urn:li:glossaryTerm:po.Agent"]
+
+
+def test_relationship_term_has_endpoints():
+    mcps = ontology_to_glossary_mcps(_onto())
+    rel_term = next(m for m in mcps if m["aspectName"] == "glossaryTermInfo" and m["aspect"]["name"] == "WORKS_AT")
+    cp = rel_term["aspect"]["customProperties"]
+    assert cp["source"] == "Person" and cp["target"] == "Company" and cp["cardinality"] == "MANY_TO_ONE"
+
+
+def test_emit_dry_run_default():
+    mcps = ontology_to_glossary_mcps(_onto())
+    result = emit_to_datahub(mcps, dry_run=True)
+    assert result["emitted"] is False
+    assert result["mode"] == "dry_run"
+    assert result["summary"]["mcp_count"] == len(mcps)
+
+
+def test_emit_without_server_is_dry_run():
+    mcps = ontology_to_glossary_mcps(_onto())
+    result = emit_to_datahub(mcps, gms_server=None, dry_run=False)
+    assert result["emitted"] is False  # no server → dry-run, never crashes


### PR DESCRIPTION
Pure offline Ontology → DataHub glossary MCP mapping + optional import-guarded live emit. package→glossaryNode, class→glossaryTerm (definition/parentNode/customProperties), broader→isRelatedTerms (Is-A), relationships→terms. Deterministic URNs → idempotent UPSERT. CLI `seocho ontology datahub`. No datahub dependency in core (testable offline). Decision: DataHub is the mapping/distribution surface, not Streamlit. 7 tests + run_basic_ci 631 passed; fibo_plus→19 MCPs.