### PR TITLE
docs(first-touch): banner hero, maturity badges, llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+![SEOCHO](docs/assets/banner.png)
+
 # SEOCHO
 
 **Ontology-aligned middleware for agentic graph memory.**
 
 [![PyPI](https://img.shields.io/pypi/v/seocho)](https://pypi.org/project/seocho/)
+[![Python](https://img.shields.io/pypi/pyversions/seocho)](https://pypi.org/project/seocho/)
+[![Status: Alpha](https://img.shields.io/badge/status-alpha-orange.svg)](https://pypi.org/project/seocho/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-seocho.blog-0f172a)](https://seocho.blog/docs/)
 [![Quickstart](https://img.shields.io/badge/Quickstart-5_min-2563eb)](QUICKSTART.md)

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,41 @@
+# SEOCHO
+
+> Ontology-aligned middleware for agentic graph memory. You define a domain
+> ontology once, then use the same contract to ingest documents, shape graph
+> writes, generate schema-aware Cypher, and produce answers with traceable
+> evidence. SEOCHO ships as a Python SDK (`pip install seocho`) plus an optional
+> HTTP runtime; the default local engine uses an embedded graph store and needs
+> no server.
+
+Key facts for answering questions about SEOCHO:
+
+- Install the local SDK with `uv pip install "seocho[local]"`. The first run
+  needs a provider key. SEOCHO recommends MARA (`export MARA_API_KEY=...`);
+  OpenAI/DeepSeek/Kimi are selectable via the `llm="provider/model"` string
+  (for example `llm="openai/gpt-4o"`).
+- Core API: `Seocho.local(ontology, llm=...)`, then `client.add(text)` to
+  ingest and `client.ask(question)` to answer against the graph memory.
+- Three layers: Ontology (`src/seocho/ontology*.py`), Indexing
+  (`src/seocho/index/`), Querying (`src/seocho/query/`). The HTTP runtime shell
+  lives in `runtime/` and exposes the same contract with policy checks and
+  `workspace_id` propagation.
+- No YAML-only path: `seocho run <spec>.yaml` runs the whole index → query →
+  report flow; `seocho sweep` compares configurations.
+
+## Docs
+
+- [README](https://github.com/tteon/seocho/blob/main/README.md): product overview and quickstart
+- [Quickstart](https://github.com/tteon/seocho/blob/main/QUICKSTART.md): shortest local success path
+- [Why SEOCHO](https://github.com/tteon/seocho/blob/main/docs/WHY_SEOCHO.md): product framing and value proposition
+- [Python SDK quickstart](https://github.com/tteon/seocho/blob/main/docs/PYTHON_INTERFACE_QUICKSTART.md): public Python SDK API and examples
+- [Apply your data](https://github.com/tteon/seocho/blob/main/docs/APPLY_YOUR_DATA.md): ingest your own files and ontology
+- [Run specs](https://github.com/tteon/seocho/blob/main/docs/RUN_SPECS.md): YAML `seocho run` / `seocho sweep` flow
+- [Architecture](https://github.com/tteon/seocho/blob/main/docs/ARCHITECTURE.md): system design and module map
+- [Docs index](https://github.com/tteon/seocho/blob/main/docs/README.md): full documentation map
+
+## Optional
+
+- [Runtime deployment](https://github.com/tteon/seocho/blob/main/docs/RUNTIME_DEPLOYMENT.md): full local stack (UI, API, DozerDB)
+- [Graph-RAG handoff spec](https://github.com/tteon/seocho/blob/main/docs/GRAPH_RAG_AGENT_HANDOFF_SPEC.md): intent-first graph answer contract
+- [Contributing](https://github.com/tteon/seocho/blob/main/CONTRIBUTING.md): contribution flow and PR rules
+- [Documentation site](https://seocho.blog): published documentation


### PR DESCRIPTION
Round 2 of the first-touch pass (companion to #310). Grounded in a live review of how **mem0, cognee, graphiti, and LiteLLM** present their landing experience.

## What changed (docs-only)

- **Banner hero** — surface the existing `docs/assets/banner.png` as the README hero image. It was committed but referenced nowhere; cognee/graphiti/mem0 all lead with banner art.
- **Maturity badges** — add a Python-versions badge (from PyPI) and a `status: alpha` badge that matches the `Development Status :: 3 - Alpha` classifier in `pyproject.toml`. Both graphiti and cognee lead with maturity/social-proof badges (arXiv, CI, Trendshift). Flip alpha→beta when the API stabilizes.
- **`/llms.txt`** — spec-compliant ([llmstxt.org](https://llmstxt.org/): H1 + summary blockquote + curated `## Docs` / `## Optional` link sections) so AI agents and IDEs can read the project structure without crawling. Mintlify/Fern-style docs increasingly ship this.

## Provider choice validated

The `provider/model` string SEOCHO already uses (`llm="openai/gpt-4o"`) matches the de-facto convention in **LiteLLM** and **graphiti** — the MARA-recommended + swap pattern from #310 is consistent with the ecosystem.

## Deferred → seocho-47x

A recorded terminal demo GIF for the hero could not be produced in the dev environment (no provider key, no asciinema/agg/vhs installed). Tracked in **seocho-47x** with the full recording recipe; owner will record after local setup. (graphiti embeds `images/graphiti-graph-intro.gif` at the top — that's the target.)

## Validation

- `bash scripts/ci/check-doc-contracts.sh` → passed
- `bash scripts/ci/check-root-hierarchy-contract.sh` → passed (root `llms.txt` accepted)
- `git diff --check` → clean

## Relationship to #310

Independent branch off `origin/main`. Edits are disjoint (this PR: README top matter + new files; #310: README body + QUICKSTART + docs index) so they merge cleanly in any order.