### PR TITLE
feat(eval): comprehensive FinDER guardrail answer-accuracy matrix (ADR-0122)

### DIFF
--- a/docs/decisions/ADR-0122-finder-answer-matrix.json
+++ b/docs/decisions/ADR-0122-finder-answer-matrix.json
@@ -1,0 +1,1623 @@
+{
+  "experiment": "finder-guardrail-answer-matrix",
+  "model": "DeepSeek-V3.1",
+  "n_cases": 96,
+  "overall": {
+    "acc_sparse": 0.4583,
+    "acc_rich": 0.6667
+  },
+  "by_kind": {
+    "lookup": {
+      "acc_sparse": 0.4643,
+      "acc_rich": 0.6667
+    },
+    "reasoning": {
+      "acc_sparse": 0.4167,
+      "acc_rich": 0.6667
+    }
+  },
+  "per_category": {
+    "Accounting": {
+      "acc_sparse": 0.4167,
+      "acc_rich": 0.4167,
+      "acc_delta": 0.0,
+      "conf_sparse": 0.6945,
+      "conf_rich": 0.9643,
+      "n": 12
+    },
+    "Company overview": {
+      "acc_sparse": 0.4167,
+      "acc_rich": 0.8333,
+      "acc_delta": 0.4166,
+      "conf_sparse": 0.55,
+      "conf_rich": 0.881,
+      "n": 12
+    },
+    "Financials": {
+      "acc_sparse": 0.6667,
+      "acc_rich": 0.5833,
+      "acc_delta": -0.0834,
+      "conf_sparse": 0.8588,
+      "conf_rich": 0.75,
+      "n": 12
+    },
+    "Footnotes": {
+      "acc_sparse": 0.6667,
+      "acc_rich": 0.75,
+      "acc_delta": 0.0833,
+      "conf_sparse": 0.8056,
+      "conf_rich": 1.0,
+      "n": 12
+    },
+    "Governance": {
+      "acc_sparse": 0.25,
+      "acc_rich": 0.9167,
+      "acc_delta": 0.6667,
+      "conf_sparse": 0.0833,
+      "conf_rich": 0.8333,
+      "n": 12
+    },
+    "Legal": {
+      "acc_sparse": 0.4167,
+      "acc_rich": 0.8333,
+      "acc_delta": 0.4166,
+      "conf_sparse": 0.5833,
+      "conf_rich": 0.9833,
+      "n": 12
+    },
+    "Risk": {
+      "acc_sparse": 0.25,
+      "acc_rich": 0.5833,
+      "acc_delta": 0.3333,
+      "conf_sparse": 0.4167,
+      "conf_rich": 0.9722,
+      "n": 12
+    },
+    "Shareholder return": {
+      "acc_sparse": 0.5833,
+      "acc_rich": 0.4167,
+      "acc_delta": -0.1666,
+      "conf_sparse": 0.963,
+      "conf_rich": 1.0,
+      "n": 12
+    }
+  },
+  "results": [
+    {
+      "arm": "A_sparse",
+      "id": "0012cd67",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "002451b2",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "018ff1c9",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02b54a46",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03b929e0",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 0.6667,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0496b898",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "04e40770",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0506434f",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "058f8cb2",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0692fb7d",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "06ea40c6",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "08924154",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 0.6667,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "013b2cfe",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0191b4af",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 0.6,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01bb4fc0",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02b691db",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03bb2a85",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03f83848",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "010633b6",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01364ca9",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01ee8a21",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02354203",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02632d80",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02e67f32",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0016fe33",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0019de4b",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "008beea7",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0098df3b",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00b0e3cd",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 0.75,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00b622f5",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00e57882",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00f4fdce",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 0.5556,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "011e2750",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "021cafe5",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "037b46e9",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03ae4ea2",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "001b53d3",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0035be65",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0065ac90",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "006a120d",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00aa16a5",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00baaedf",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01142856",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "019039a6",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02204e09",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0223f23b",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02dc0ea1",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "04389fb2",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 0.6667,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00058289",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "001536af",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00f6b423",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01207279",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0139e066",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02037b95",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0207e3fc",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02651161",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "029fdcea",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02df4a77",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "038a64ad",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03e4e09c",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "002d8b2b",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "00af2af1",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01e84425",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "033627fb",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "064dbe0e",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "068a1239",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "06cb1da2",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0a6b86d1",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0a6d7405",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0b050b73",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0b7b9455",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0cf13966",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0144bfd6",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "021d681e",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "031701a5",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "032ab4b7",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0366e15b",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0373c9f4",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03b6872f",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03c84735",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03f6e507",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03fa63cb",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "0458dc8a",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "04a8b1c4",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "003a51f0",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "008c8617",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 0.5556,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "009d2b5a",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "01350b8a",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "013def13",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "02a615b1",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03754f32",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "038ce6e8",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "03d51e63",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "A_sparse",
+      "id": "042651a2",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "04931eea",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "A_sparse",
+      "id": "04db4dff",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0012cd67",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "002451b2",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "018ff1c9",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02b54a46",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "03b929e0",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0496b898",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "04e40770",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0506434f",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 0.5714,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "058f8cb2",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0692fb7d",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "06ea40c6",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "08924154",
+      "category": "Accounting",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "013b2cfe",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 0.5714,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0191b4af",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "01bb4fc0",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02b691db",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03bb2a85",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "03f83848",
+      "category": "Company overview",
+      "kind": "reasoning",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "010633b6",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "01364ca9",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "01ee8a21",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02354203",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02632d80",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02e67f32",
+      "category": "Company overview",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0016fe33",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0019de4b",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "008beea7",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 0.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0098df3b",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00b0e3cd",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "00b622f5",
+      "category": "Financials",
+      "kind": "reasoning",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00e57882",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00f4fdce",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "011e2750",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "021cafe5",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "037b46e9",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03ae4ea2",
+      "category": "Financials",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "001b53d3",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0035be65",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0065ac90",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "006a120d",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "00aa16a5",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00baaedf",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "01142856",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "019039a6",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "02204e09",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0223f23b",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02dc0ea1",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "04389fb2",
+      "category": "Footnotes",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00058289",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "001536af",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00f6b423",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "01207279",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0139e066",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02037b95",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0207e3fc",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02651161",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "029fdcea",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02df4a77",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 0.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "038a64ad",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03e4e09c",
+      "category": "Governance",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "002d8b2b",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "00af2af1",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "01e84425",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "033627fb",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "064dbe0e",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "068a1239",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "06cb1da2",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 0.8,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0a6b86d1",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0a6d7405",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0b050b73",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0b7b9455",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0cf13966",
+      "category": "Legal",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0144bfd6",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "021d681e",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 0.6667,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "031701a5",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "032ab4b7",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0366e15b",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "0373c9f4",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03b6872f",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03c84735",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "03f6e507",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03fa63cb",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "0458dc8a",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "04a8b1c4",
+      "category": "Risk",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "003a51f0",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "008c8617",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "009d2b5a",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "01350b8a",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "013def13",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "02a615b1",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "03754f32",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "038ce6e8",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "03d51e63",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "042651a2",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": true
+    },
+    {
+      "arm": "B_rich",
+      "id": "04931eea",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    },
+    {
+      "arm": "B_rich",
+      "id": "04db4dff",
+      "category": "Shareholder return",
+      "kind": "lookup",
+      "label_conformance": 1.0,
+      "correct": false
+    }
+  ]
+}

--- a/docs/decisions/ADR-0122-guardrail-helps-entity-categories-hurts-numeric-answering.md
+++ b/docs/decisions/ADR-0122-guardrail-helps-entity-categories-hurts-numeric-answering.md
@@ -1,0 +1,81 @@
+# ADR-0122: Across All FinDER Case Types, the Guardrail Helps *Entity* Categories' Answers and Is Neutral-to-Harmful for *Numeric* Ones → Domain-Adaptive Guardrail Selection
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+Prior runs measured extraction *conformance* (ADR-0115/0118) and numeric-fact
+*validation* (ADR-0119). The open question for "check all the cases": does the
+ontology guardrail improve the thing users want — **correct answers** — across the
+full FinDER case space (8 categories; reasoning lives only in Company overview +
+Financials)? This run builds the complete category × arm **answer-accuracy**
+matrix.
+
+## Experiment
+
+`scripts/benchmarks/finder_guardrail_answer_matrix.py`, MARA DeepSeek-V3.1 via the
+ub5 structured-output layer (ADR-0120). **96 cases (12 × 8 categories)**, each
+answered twice — sparse `fibo_minus` vs rich `fibo_plus` injected as the guardrail
+— then LLM-judged for correctness vs FinDER gold. Re-run at 6 workers with
+429-retry after a first run was contaminated by MARA rate-limits (honest fix).
+**0 errors, n=12 every category.** Record:
+`docs/decisions/ADR-0122-finder-answer-matrix.json`.
+
+## Findings (measured)
+
+Overall answer accuracy: **sparse 0.458 → rich 0.667 (+0.21).**
+By kind: lookup 0.464→0.667 (+0.20); reasoning 0.417→0.667 (+0.25).
+
+| category | acc sparse | acc rich | Δ acc | conformance A→B |
+|---|---|---|---|---|
+| **Governance** | 0.25 | **0.92** | **+0.67** | 0.08→0.83 |
+| **Company overview** | 0.42 | **0.83** | **+0.42** | 0.55→0.88 |
+| **Legal** | 0.42 | **0.83** | **+0.42** | 0.58→0.98 |
+| **Risk** | 0.25 | **0.58** | **+0.33** | 0.42→0.97 |
+| Footnotes | 0.67 | 0.75 | +0.08 | 0.81→1.0 |
+| Accounting | 0.42 | 0.42 | **0.00** | 0.69→0.96 |
+| Financials | 0.67 | 0.58 | **−0.08** | 0.86→0.75 |
+| Shareholder return | 0.58 | 0.42 | **−0.17** | 0.96→1.0 |
+
+## Interpretation
+
+1. **The guardrail's answer-accuracy value is real and large for entity/qualitative
+   categories** — Governance +0.67, Company overview +0.42, Legal +0.42, Risk
+   +0.33. Here the rich vocabulary lets the model represent the people, committees,
+   regulations, and risks the questions are about, so it answers them.
+2. **For numeric/metric-heavy categories the guardrail is neutral-to-harmful** —
+   Accounting 0.00, Financials −0.08, **Shareholder return −0.17**. The sharpest
+   case: Shareholder return conformance rose 0.96→1.0 yet answer accuracy *fell*
+   0.58→0.42. **More conformant extraction did not produce better answers — the
+   richer ontology's extra entity types are a distraction when the task is
+   arithmetic over a few metrics.** This is the same structural-not-arithmetic
+   boundary as ADR-0118/0119, now visible at the answer level across all cases.
+3. So the guardrail is not universally good: it is a **domain-conditional** tool.
+   Blanket enrichment hurts the numeric tail.
+
+## Decision (develop accordingly)
+
+- **Domain-adaptive guardrail selection.** Do not ship one ontology for all
+  categories. Choose the guardrail per domain/corpus using the corpus-aware
+  scorecard (ADR-0116, `profile="guardrail"`): rich for entity-heavy domains,
+  lean for numeric domains. This is a concrete feature: a per-domain guardrail
+  resolver keyed by corpus_coverage + the measured answer-accuracy deltas here.
+- **For numeric domains, lean on numeric VALIDATION (P3/ADR-0119), not vocabulary
+  enrichment.** Reconciliation / unit / period checks, not more entity types.
+- **Add answer-accuracy (not just conformance) to the evaluation surface** — this
+  run shows conformance and answer accuracy can move in *opposite* directions
+  (Shareholder return), so conformance alone is an unsafe proxy.
+
+## Consequences
+
+- The product claim is now precise and honest across the full case space: "an
+  ontology guardrail materially improves answers in entity/qualitative financial
+  domains (Governance/Legal/Company/Risk: +0.3 to +0.7) and should be applied
+  selectively — for numeric domains, structural validation, not vocabulary, is the
+  lever."
+- Feeds: domain-adaptive guardrail selection (new follow-up on seocho-g2r);
+  answer-accuracy metric in the scorecard/eval; P3 precision work (ADR-0119).
+- Caveat: single model (DeepSeek-V3.1), n=12/category, LLM-judge correctness;
+  directional and consistent with three prior runs, but widen N + add a second
+  judge before headline external claims.

--- a/scripts/benchmarks/finder_guardrail_answer_matrix.py
+++ b/scripts/benchmarks/finder_guardrail_answer_matrix.py
@@ -1,0 +1,186 @@
+"""Comprehensive FinDER guardrail verification: does the ontology guardrail improve
+downstream ANSWER correctness across ALL case types (8 categories × lookup/reasoning)?
+
+Prior runs measured extraction CONFORMANCE (ADR-0115/0118) and numeric-fact
+VALIDATION (P3/ADR-0119). The open gap: whether the guardrail improves the thing
+users actually want — correct ANSWERS — across the full case space. FinDER's
+reasoning cases live only in Company overview + Financials; the other 6 categories
+are lookup. This builds the full category × arm matrix.
+
+Per case × arm (sparse fibo_minus vs rich fibo_plus, injected as guardrail):
+  extract facts + answer (one robust structured call via ub5) → LLM-judge answer
+  correctness vs FinDER gold. Reports per-category answer accuracy under each arm
+  + delta, so we see WHERE the guardrail helps answering and develop accordingly.
+
+Key from .env. Run:
+  PYTHONPATH=src python3 scripts/benchmarks/finder_guardrail_answer_matrix.py \
+     --per-category 12 --max-chars 3500 --workers 16 --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Lock
+
+
+def _with_retry(fn, *, attempts: int = 5, base: float = 2.0):
+    """Retry on rate-limit / transient errors with exponential backoff."""
+    last = None
+    for i in range(attempts):
+        try:
+            return fn()
+        except Exception as e:  # noqa: BLE001
+            last = e
+            msg = str(e).lower()
+            if "429" in msg or "rate limit" in msg or "timeout" in msg or "temporarily" in msg:
+                time.sleep(base * (2 ** i))
+                continue
+            raise
+    raise last
+
+from seocho.ontology import Ontology
+from seocho.llm_structured import StructuredOutputError, structured_complete
+from seocho.store.llm import create_llm_backend
+
+ARMS = {"A_sparse": "examples/datasets/fibo_minus.jsonld", "B_rich": "examples/datasets/fibo_plus.jsonld"}
+
+_ANS_SYS = ("You are a financial analyst. Use ONLY the entity/relationship types in the provided "
+            "ontology to extract the relevant facts, then answer the question. Return ONLY JSON.")
+
+
+def _ans_user(onto: Ontology, refs: str, q: str) -> str:
+    ctx = onto.to_extraction_context()
+    return (f"ONTOLOGY ENTITY TYPES:\n{ctx.get('entity_types','')}\n\n"
+            f"ONTOLOGY RELATIONSHIP TYPES:\n{ctx.get('relationship_types','')}\n\n"
+            f"FINANCIAL TEXT:\n{refs}\n\nQUESTION: {q}\n\n"
+            'Return JSON: {"facts":[{"label":"...","name":"...","value":"..."}],"answer":"..."}')
+
+
+_JUDGE_SYS = "You grade financial answers. Return ONLY JSON."
+_JUDGE_USER = ('QUESTION: {q}\nGOLD: {gold}\nMODEL ANSWER: {ans}\n'
+               'Is the model answer correct vs gold (same entity/number/fact, allowing phrasing/rounding)? '
+               'Return JSON {{"correct": true|false}}')
+
+
+def load_matrix(per_category: int, max_chars: int):
+    from huggingface_hub import hf_hub_download
+    import pandas as pd
+    df = pd.read_parquet(hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset"))
+    df["reasoning_bool"] = df["reasoning"].astype(str).isin(["True", "true"])
+    cases = []
+    for cat, g in df.sort_values("_id").groupby("category"):
+        # balance lookup/reasoning when both exist
+        kinds = [True, False] if g["reasoning_bool"].nunique() > 1 else [g["reasoning_bool"].iloc[0]]
+        per_kind = max(1, per_category // len(kinds))
+        for kind in kinds:
+            sub = g[g["reasoning_bool"] == kind]
+            taken = 0
+            for _, row in sub.iterrows():
+                refs = row["references"]
+                text = " ".join(map(str, refs)) if hasattr(refs, "__iter__") and not isinstance(refs, str) else str(refs)
+                if len(text.strip()) < 80:
+                    continue
+                cases.append({"id": str(row["_id"]), "category": str(cat),
+                              "kind": "reasoning" if kind else "lookup",
+                              "refs": text.strip()[:max_chars], "q": str(row["text"]), "gold": str(row["answer"])})
+                taken += 1
+                if taken >= per_kind:
+                    break
+    return cases
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--per-category", type=int, default=12)
+    ap.add_argument("--max-chars", type=int, default=3500)
+    ap.add_argument("--workers", type=int, default=16)
+    ap.add_argument("--model", default="DeepSeek-V3.1")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    ontos = {arm: Ontology.load(p) for arm, p in ARMS.items()}
+    be = create_llm_backend(provider="mara", model=args.model, api_key=key)
+    cases = load_matrix(args.per_category, args.max_chars)
+    print(f"{len(cases)} cases; running {len(cases)*len(ARMS)} answer+judge pairs")
+
+    done = {"n": 0}; lock = Lock()
+    tasks = [(arm, ci) for arm in ontos for ci in range(len(cases))]
+
+    def run(t):
+        arm, ci = t
+        case = cases[ci]
+        out = {"arm": arm, "id": case["id"], "category": case["category"], "kind": case["kind"]}
+        try:
+            ex = _with_retry(lambda: structured_complete(
+                be, system=_ANS_SYS, user=_ans_user(ontos[arm], case["refs"], case["q"]),
+                model=args.model, task_hint="json_extraction"))
+            ans = str(ex.get("answer", ""))
+            facts = ex.get("facts", []) if isinstance(ex, dict) else []
+            labels = [str(f.get("label", "")) for f in facts if isinstance(f, dict)]
+            out["label_conformance"] = round(sum(1 for l in labels if l in ontos[arm].nodes) / len(labels), 4) if labels else 0.0
+            jc = _with_retry(lambda: structured_complete(
+                be, system=_JUDGE_SYS, user=_JUDGE_USER.format(q=case["q"], gold=case["gold"], ans=ans),
+                model=args.model))
+            out["correct"] = bool(jc.get("correct"))
+        except StructuredOutputError as e:
+            out["error"] = str(e)[:80]
+        except Exception as e:
+            out["error"] = f"{type(e).__name__}: {str(e)[:80]}"
+        with lock:
+            done["n"] += 1
+            if done["n"] % 40 == 0 or done["n"] == len(tasks):
+                print(f"  ... {done['n']}/{len(tasks)}")
+        return out
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        results = list(pool.map(run, tasks))
+
+    # aggregate per category × arm
+    acc = defaultdict(lambda: defaultdict(list))   # category -> arm -> [0/1]
+    conf = defaultdict(lambda: defaultdict(list))
+    kindacc = defaultdict(lambda: defaultdict(list))  # kind -> arm -> [0/1]
+    for r in results:
+        if "correct" not in r:
+            continue
+        acc[r["category"]][r["arm"]].append(1 if r["correct"] else 0)
+        kindacc[r["kind"]][r["arm"]].append(1 if r["correct"] else 0)
+        if "label_conformance" in r:
+            conf[r["category"]][r["arm"]].append(r["label_conformance"])
+
+    def _mean(xs): return round(statistics.mean(xs), 4) if xs else None
+
+    per_category = {}
+    for cat in sorted(acc):
+        a, b = _mean(acc[cat]["A_sparse"]), _mean(acc[cat]["B_rich"])
+        per_category[cat] = {"acc_sparse": a, "acc_rich": b,
+                             "acc_delta": round((b or 0) - (a or 0), 4),
+                             "conf_sparse": _mean(conf[cat]["A_sparse"]), "conf_rich": _mean(conf[cat]["B_rich"]),
+                             "n": len(acc[cat]["A_sparse"])}
+    by_kind = {k: {"acc_sparse": _mean(kindacc[k]["A_sparse"]), "acc_rich": _mean(kindacc[k]["B_rich"])}
+               for k in kindacc}
+    overall = {"acc_sparse": _mean([v for c in acc.values() for v in c["A_sparse"]]),
+               "acc_rich": _mean([v for c in acc.values() for v in c["B_rich"]])}
+
+    record = {"experiment": "finder-guardrail-answer-matrix", "model": args.model,
+              "n_cases": len(cases), "overall": overall, "by_kind": by_kind,
+              "per_category": per_category, "results": results}
+    Path(args.out).write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\n[written] {args.out}\n")
+    print(f"OVERALL answer accuracy: sparse {overall['acc_sparse']}  rich {overall['acc_rich']}")
+    print(f"by kind: {by_kind}")
+    print(f"{'category':20s} {'sparse':>7s} {'rich':>7s} {'Δacc':>7s}  {'conf A→B':>14s}")
+    for cat, m in per_category.items():
+        print(f"{cat:20s} {str(m['acc_sparse']):>7s} {str(m['acc_rich']):>7s} {m['acc_delta']:>+7.3f}  "
+              f"{str(m['conf_sparse'])}→{str(m['conf_rich'])}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Full category × arm ANSWER-accuracy matrix across all 8 FinDER categories (96 cases, DeepSeek-V3.1 via ub5, 0 errors). Rich vs sparse guardrail: overall 0.458→0.667. Entity/qualitative categories gain big (Governance +0.67, Company overview/Legal +0.42, Risk +0.33); numeric neutral/harmful (Financials −0.08, Shareholder return −0.17 despite conformance 0.96→1.0). Conformance ≠ answer accuracy. Decision: domain-adaptive guardrail selection; numeric domains use P3 validation not vocabulary; add answer-accuracy to eval. 429-retry harness (honest re-run after rate-limit contamination).