### PR TITLE
feat(ontology): domain-adaptive guardrail selector (ADR-0123)

### DIFF
--- a/docs/decisions/ADR-0123-domain-adaptive-guardrail-selector.md
+++ b/docs/decisions/ADR-0123-domain-adaptive-guardrail-selector.md
@@ -1,0 +1,56 @@
+# ADR-0123: Domain-Adaptive Guardrail Selector
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0122 established there is **no single best guardrail**: a rich ontology
+improves answers in entity/qualitative domains (Governance +0.67, Legal/Company
++0.42, Risk +0.33) but is neutral-to-harmful in numeric ones (Financials −0.08,
+Shareholder return −0.17 even as conformance rose to 1.0). The team needs that
+rule operationalized, not left as a finding.
+
+## Decision
+
+Add `seocho.guardrail_selector.select_guardrail(candidates, corpus_profile)` —
+picks the best guardrail ontology for a corpus, domain-adaptively, offline:
+
+1. Score each candidate against the corpus with the corpus-aware scorecard
+   (`profile="guardrail"`, ADR-0116) → `corpus_coverage`.
+2. Estimate the corpus's **numeric intensity** (frequency-weighted fraction of
+   entity mentions that are metric/quantity-like).
+3. Select: **entity** corpus (`numeric_intensity` low) → highest-coverage
+   (richest adequate) candidate; **numeric** corpus → the **leanest** candidate
+   within ε of best coverage (avoid over-enrichment noise), plus an advisory to
+   apply numeric validation (P3/ADR-0119) instead of vocabulary enrichment.
+   `select_per_domain()` maps the rule over per-domain profiles.
+
+CLI: `seocho ontology select-guardrail --candidates lean=a.jsonld,rich=b.jsonld
+--corpus profile.json`. Pure/offline (consumes a precomputed corpus profile, no
+LLM, no hot path).
+
+## Validation
+
+`tests/seocho/test_guardrail_selector.py` (6): numeric_intensity discriminates
+numeric vs entity corpora; entity corpus → rich; numeric corpus → lean + a
+validation advisory; numeric corpus still picks rich when lean's coverage is far
+worse (selector doesn't blindly force lean); per-domain mapping; profile loaders.
+
+Real-data demo: on the FinDER open-extraction corpus profile (268 types,
+`numeric_intensity` 0.33 → "entity") the selector picks **fibo_plus**
+(coverage 0.35 < 0.49 < 0.63 for minus/base/plus), matching ADR-0118's overall
+guardrail benefit. A Financials-only profile would push `numeric_intensity` up
+and flip the choice to lean.
+
+## Consequences
+
+- The ADR-0122 finding is now an automatic, testable decision an operator (or a
+  `seocho run`) can call to choose a guardrail per corpus/domain — rich where it
+  helps, lean where enrichment hurts, with numeric domains routed to P3 validation.
+- The numeric-intensity classifier is heuristic (keyword-based on the corpus's
+  observed labels); refine with the answer-accuracy signal (ADR-0122) as that
+  metric joins the eval surface.
+- Follow-ups: wire selection into the e2e run-spec (per-domain guardrail); add
+  answer-accuracy to the scorecard; learn the numeric-intensity threshold from
+  measured per-domain deltas rather than a fixed 0.5.

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -354,6 +354,20 @@ def build_parser() -> argparse.ArgumentParser:
     ontology_datahub_parser.add_argument("--emit", action="store_true", help="Actually emit to --gms (default: dry-run)")
     ontology_datahub_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
+    ontology_select_parser = ontology_subparsers.add_parser(
+        "select-guardrail",
+        help="Domain-adaptively pick the best guardrail ontology for a corpus (ADR-0122)",
+    )
+    ontology_select_parser.add_argument(
+        "--candidates", required=True,
+        help="Comma-separated name=path pairs, e.g. lean=fibo_minus.jsonld,rich=fibo_plus.jsonld",
+    )
+    ontology_select_parser.add_argument(
+        "--corpus", required=True,
+        help="Corpus profile JSON (label->freq, a CorpusProfile dict, or an experiment record)",
+    )
+    ontology_select_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
     serve_http_parser = subparsers.add_parser("serve-http", help="Serve a portable bundle behind a small FastAPI runtime")
     serve_http_parser.add_argument("--bundle", required=True, help="Path to portable bundle JSON file")
     serve_http_parser.add_argument("--host", default="0.0.0.0", help="Bind host")
@@ -1628,6 +1642,30 @@ def _cmd_ontology(args: argparse.Namespace) -> int:
                   f"({s['glossary_terms']} terms, {s['glossary_nodes']} nodes, {s['is_a_edges']} is-a edges)")
         else:
             print(text)
+        return 0
+
+    if args.ontology_command == "select-guardrail":
+        from .ontology import Ontology
+        from .guardrail_selector import load_corpus_profile, select_guardrail
+
+        candidates = {}
+        for pair in str(args.candidates).split(","):
+            pair = pair.strip()
+            if not pair:
+                continue
+            name, _, path = pair.partition("=")
+            if not path:
+                name, path = Path(name).stem, name
+            candidates[name.strip()] = Ontology.load(path.strip())
+        rec = select_guardrail(candidates, load_corpus_profile(args.corpus))
+        if getattr(args, "output_json", False):
+            print(json.dumps(rec.to_dict(), indent=2, ensure_ascii=False))
+        else:
+            print(f"chosen: {rec.chosen}  (domain={rec.domain_kind}, numeric_intensity={rec.numeric_intensity})")
+            print(f"  coverage: " + ", ".join(f"{n}={s['corpus_coverage']}" for n, s in rec.candidate_scores.items()))
+            print(f"  {rec.rationale}")
+            for a in rec.advisories:
+                print(f"  · {a}")
         return 0
 
     raise SeochoError(f"Unknown ontology command: {args.ontology_command}")

--- a/src/seocho/guardrail_selector.py
+++ b/src/seocho/guardrail_selector.py
@@ -1,0 +1,171 @@
+"""Domain-adaptive guardrail selector (ADR-0122 follow-up).
+
+ADR-0122 measured, across all FinDER case types, that a rich ontology guardrail
+*helps answers in entity/qualitative domains* (Governance +0.67, Legal/Company
++0.42, Risk +0.33) but is *neutral-to-harmful in numeric domains* (Financials
+−0.08, Shareholder return −0.17 — even as conformance rose to 1.0). So there is no
+single best guardrail: it is domain-conditional. This module encodes that learned
+rule as an automatic selector.
+
+Given candidate ontologies + a target-corpus profile (from an OPEN extraction,
+ADR-0116 `build_corpus_profile`), it:
+
+1. scores each candidate against the corpus with the corpus-aware scorecard
+   (`profile="guardrail"`), getting `corpus_coverage`;
+2. estimates the corpus's **numeric intensity** (how much of the entity mass is
+   metric/quantity-like);
+3. selects: for an **entity** corpus → the candidate with the best coverage
+   (richest adequate); for a **numeric** corpus → the **leanest** candidate whose
+   coverage is within ε of the best (avoid over-enrichment noise), and advises
+   applying numeric validation (P3/ADR-0119) rather than vocabulary enrichment.
+
+Pure and offline — consumes a precomputed corpus profile; no LLM, no hot path.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from .ontology import Ontology
+from .ontology_scorecard import CorpusProfile, score_ontology
+
+# Labels denoting a quantity/metric (the domains where vocabulary enrichment did
+# not help answering — ADR-0122). Matched against the label and its spaced form.
+_NUMERIC_LABEL_RE = re.compile(
+    r"metric|value|amount|ratio|price|rate|revenue|income|ebitda|margin|return|yield|"
+    r"monetary|measure|kpi|share\s*price|earnings|cash\s*flow|expense|cost|tax|debt|"
+    r"asset|liabilit|equity|dividend|percentage|number|count|quantity",
+    re.I,
+)
+
+
+def numeric_intensity(corpus_profile: CorpusProfile) -> float:
+    """Frequency-weighted fraction of the corpus's entity mentions whose type is
+    metric/quantity-like. ~0 = purely entity/qualitative corpus, ~1 = numeric."""
+    freqs = corpus_profile.label_frequencies
+    total = sum(freqs.values())
+    if total == 0:
+        return 0.0
+    numeric_mass = 0
+    for label, count in freqs.items():
+        spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", label).replace("_", " ")
+        if _NUMERIC_LABEL_RE.search(label) or _NUMERIC_LABEL_RE.search(spaced):
+            numeric_mass += count
+    return round(numeric_mass / total, 4)
+
+
+@dataclass(slots=True)
+class GuardrailRecommendation:
+    chosen: str
+    domain_kind: str                 # "entity" | "numeric" | "mixed"
+    numeric_intensity: float
+    rationale: str
+    advisories: List[str] = field(default_factory=list)
+    candidate_scores: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "chosen": self.chosen, "domain_kind": self.domain_kind,
+            "numeric_intensity": self.numeric_intensity, "rationale": self.rationale,
+            "advisories": list(self.advisories), "candidate_scores": dict(self.candidate_scores),
+        }
+
+
+def select_guardrail(
+    candidates: Dict[str, Ontology],
+    corpus_profile: CorpusProfile,
+    *,
+    competency_questions: Optional[Sequence[Union[str, Dict[str, Any]]]] = None,
+    numeric_threshold: float = 0.5,
+    coverage_epsilon: float = 0.05,
+) -> GuardrailRecommendation:
+    """Pick the best guardrail ontology for a corpus, domain-adaptively.
+
+    Parameters
+    ----------
+    candidates: name -> Ontology (e.g. {"lean": fibo_minus, "rich": fibo_plus}).
+    corpus_profile: target-corpus profile from an open extraction.
+    numeric_threshold: numeric_intensity at/above which the corpus is "numeric".
+    coverage_epsilon: for numeric corpora, candidates within this of the best
+        coverage are considered equivalent, so the leanest is chosen.
+    """
+    if not candidates:
+        raise ValueError("no candidate ontologies provided")
+
+    scores: Dict[str, Dict[str, Any]] = {}
+    for name, onto in candidates.items():
+        card = score_ontology(onto, corpus_profile=corpus_profile,
+                              competency_questions=competency_questions, profile="guardrail")
+        cc = card.dimension("corpus_coverage")
+        scores[name] = {
+            "corpus_coverage": round(cc.score, 4) if cc else 0.0,
+            "overall": round(card.overall_score, 4),
+            "grade": card.grade,
+            "n_classes": len(onto.nodes),
+        }
+
+    ni = numeric_intensity(corpus_profile)
+    best_cov = max(s["corpus_coverage"] for s in scores.values())
+    advisories: List[str] = []
+
+    if ni >= numeric_threshold:
+        domain_kind = "numeric"
+        # leanest candidate within ε of the best coverage — avoid over-enrichment noise
+        eligible = {n: s for n, s in scores.items() if s["corpus_coverage"] >= best_cov - coverage_epsilon}
+        chosen = min(eligible, key=lambda n: (eligible[n]["n_classes"], -eligible[n]["corpus_coverage"]))
+        rationale = (f"numeric-intensive corpus (numeric_intensity={ni}); per ADR-0122 vocabulary "
+                     f"enrichment does not improve numeric answers, so chose the leanest adequate "
+                     f"guardrail '{chosen}' ({scores[chosen]['n_classes']} classes, "
+                     f"coverage {scores[chosen]['corpus_coverage']}).")
+        advisories.append("Apply numeric-fact VALIDATION (P3/ADR-0119): reconciliation, unit/scale, "
+                          "fiscal-period checks — the lever for numeric domains, not more entity types.")
+        advisories.append("Do NOT over-enrich the guardrail here; conformance gains did not translate "
+                          "to answer accuracy in numeric domains (ADR-0122).")
+    else:
+        domain_kind = "entity" if ni <= (1.0 - numeric_threshold) else "mixed"
+        # richest adequate: maximize coverage (ties → richer/more classes)
+        chosen = max(scores, key=lambda n: (scores[n]["corpus_coverage"], scores[n]["n_classes"]))
+        rationale = (f"entity/qualitative corpus (numeric_intensity={ni}); per ADR-0122 a richer "
+                     f"guardrail materially improves answers here, so chose the highest-coverage "
+                     f"guardrail '{chosen}' (coverage {scores[chosen]['corpus_coverage']}, "
+                     f"{scores[chosen]['n_classes']} classes).")
+        if domain_kind == "mixed":
+            advisories.append("Mixed numeric/entity corpus — consider splitting by sub-domain and "
+                              "selecting a guardrail per split.")
+
+    return GuardrailRecommendation(
+        chosen=chosen, domain_kind=domain_kind, numeric_intensity=ni,
+        rationale=rationale, advisories=advisories, candidate_scores=scores,
+    )
+
+
+def select_per_domain(
+    domain_profiles: Dict[str, CorpusProfile],
+    candidates: Dict[str, Ontology],
+    **kwargs: Any,
+) -> Dict[str, GuardrailRecommendation]:
+    """Run :func:`select_guardrail` for each domain's corpus profile — the
+    operational form of ADR-0122's per-category finding."""
+    return {domain: select_guardrail(candidates, profile, **kwargs)
+            for domain, profile in domain_profiles.items()}
+
+
+def load_corpus_profile(data: Union[str, Dict[str, Any]]) -> CorpusProfile:
+    """Build a CorpusProfile from a label->frequency dict, a CorpusProfile dict
+    (``label_frequencies``), or an experiment record carrying ``corpus_profile``."""
+    import json
+    from pathlib import Path
+
+    if isinstance(data, str):
+        data = json.loads(Path(data).read_text(encoding="utf-8"))
+    if "corpus_profile" in data and isinstance(data["corpus_profile"], dict):
+        data = data["corpus_profile"]
+    if "label_frequencies" in data:
+        return CorpusProfile(
+            label_frequencies={str(k): int(v) for k, v in data["label_frequencies"].items()},
+            doc_count=int(data.get("doc_count", 0)), source=str(data.get("source", "")),
+        )
+    # assume a bare {label: freq} mapping
+    return CorpusProfile(label_frequencies={str(k): int(v) for k, v in data.items()})

--- a/tests/seocho/test_guardrail_selector.py
+++ b/tests/seocho/test_guardrail_selector.py
@@ -1,0 +1,89 @@
+"""Tests for the domain-adaptive guardrail selector (ADR-0122 follow-up)."""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology_scorecard import CorpusProfile, build_corpus_profile
+from seocho.guardrail_selector import (
+    load_corpus_profile,
+    numeric_intensity,
+    select_guardrail,
+    select_per_domain,
+)
+
+
+def _lean() -> Ontology:
+    return Ontology("lean", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+    })
+
+
+def _rich() -> Ontology:
+    return Ontology("rich", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+        "Person": NodeDef(description="A person.", properties={"name": P(str, unique=True)}),
+        "Regulation": NodeDef(description="A rule.", properties={"name": P(str, unique=True)}),
+        "Risk": NodeDef(description="A risk.", properties={"name": P(str, unique=True)}),
+        "LegalIssue": NodeDef(description="A legal issue.", properties={"name": P(str, unique=True)}),
+    })
+
+
+CANDIDATES = {"lean": _lean(), "rich": _rich()}
+
+# entity-heavy corpus: people, regulations, risks, legal issues
+_ENTITY_CORPUS = build_corpus_profile([
+    {"nodes": [{"label": "Person"}, {"label": "Regulation"}, {"label": "Governance"}]},
+    {"nodes": [{"label": "Risk"}, {"label": "LegalIssue"}, {"label": "Person"}]},
+    {"nodes": [{"label": "Committee"}, {"label": "Regulation"}]},
+])
+
+# numeric-heavy corpus: metrics/amounts dominate
+_NUMERIC_CORPUS = build_corpus_profile([
+    {"nodes": [{"label": "FinancialMetric"}, {"label": "Revenue"}, {"label": "EBITDA"}]},
+    {"nodes": [{"label": "FinancialMetric"}, {"label": "NetIncome"}, {"label": "Margin"}]},
+    {"nodes": [{"label": "Company"}, {"label": "FinancialMetric"}]},
+])
+
+
+def test_numeric_intensity_discriminates():
+    assert numeric_intensity(_NUMERIC_CORPUS) > 0.6
+    assert numeric_intensity(_ENTITY_CORPUS) < 0.2
+
+
+def test_entity_corpus_selects_rich():
+    rec = select_guardrail(CANDIDATES, _ENTITY_CORPUS)
+    assert rec.chosen == "rich"
+    assert rec.domain_kind == "entity"
+    assert rec.candidate_scores["rich"]["corpus_coverage"] >= rec.candidate_scores["lean"]["corpus_coverage"]
+
+
+def test_numeric_corpus_selects_lean_and_advises_validation():
+    rec = select_guardrail(CANDIDATES, _NUMERIC_CORPUS)
+    assert rec.domain_kind == "numeric"
+    # lean is within epsilon of best coverage on a numeric corpus → chosen
+    assert rec.chosen == "lean"
+    assert any("VALIDATION" in a or "validation" in a for a in rec.advisories)
+
+
+def test_numeric_corpus_picks_richer_only_if_coverage_much_better():
+    # if lean cannot cover the numeric corpus well, the selector must not force lean
+    onlymetric_lean = Ontology("om", nodes={"Company": NodeDef(description="c", properties={"name": P(str, unique=True)})})
+    cands = {"tiny": onlymetric_lean, "rich": _rich()}
+    rec = select_guardrail(cands, _NUMERIC_CORPUS, coverage_epsilon=0.05)
+    # tiny has near-zero coverage; rich covers FinancialMetric/Company → rich wins despite numeric
+    assert rec.chosen == "rich"
+
+
+def test_select_per_domain_maps_each():
+    recs = select_per_domain({"gov": _ENTITY_CORPUS, "fin": _NUMERIC_CORPUS}, CANDIDATES)
+    assert recs["gov"].chosen == "rich"
+    assert recs["fin"].chosen == "lean"
+
+
+def test_load_corpus_profile_shapes():
+    a = load_corpus_profile({"Person": 3, "Company": 1})
+    assert a.label_frequencies["Person"] == 3
+    b = load_corpus_profile({"corpus_profile": {"label_frequencies": {"Risk": 2}, "doc_count": 1}})
+    assert b.label_frequencies["Risk"] == 2 and b.doc_count == 1


### PR DESCRIPTION
Operationalizes ADR-0122. select_guardrail(candidates, corpus_profile): entity domain → richest adequate; numeric domain → leanest within ε of best coverage + advisory to use P3 numeric validation. numeric_intensity() classifies the corpus; select_per_domain() maps it. CLI 'seocho ontology select-guardrail'. Offline. 6 tests + run_basic_ci 631 passed; real FinDER profile (ni=0.33) → fibo_plus.