### PR TITLE
feat(e2e): wire domain-adaptive guardrail selector into the run-spec (ADR-0123)

### DIFF
--- a/docs/RUN_SPECS.md
+++ b/docs/RUN_SPECS.md
@@ -136,7 +136,31 @@ data against the ontology vocabulary:
 | `guided` | Default — the tuned behavior the FinDER experiments validated. The ontology guides extraction prompts; relaxed retry and `Entity` fallback stay available; validation errors are reported but content is written. |
 | `open` | Admit everything: same write behavior as `guided`, plus every out-of-vocabulary node/relationship is stamped with `_out_of_ontology: "true"` — the triage signal for offline ontology-evolution governance. `validation_on_fail: reject` is rejected as incoherent. |
 
-The policy is compiled by `seocho.EnforcementPolicy` from
+## Domain-adaptive guardrail selection
+
+Instead of a fixed `ontology.path`, a run can declare `ontology.select` to let
+SEOCHO pick the best guardrail ontology for the target corpus (ADR-0123). The
+runner scores each candidate against the corpus profile with the corpus-aware
+scorecard and chooses — richest-adequate for entity/qualitative corpora, leanest
+for numeric corpora (where vocabulary enrichment does not improve answers,
+ADR-0122):
+
+```yaml
+ontology:
+  select:
+    candidates:
+      lean: ./fibo_minus.jsonld
+      rich: ./fibo_plus.jsonld
+    corpus_profile: ./corpus_profile.json   # {label: freq} or build_corpus_profile output
+  enforcement: guided
+```
+
+The corpus profile comes from an open (ontology-free) extraction over the corpus
+(`seocho.ontology_scorecard.build_corpus_profile`). At run time the chosen
+ontology is logged (`[guardrail] selected '<name>' …`) and recorded on the run.
+Provide either `ontology.path` (fixed) or `ontology.select` — not neither.
+
+The enforcement policy is compiled by `seocho.EnforcementPolicy` from
 `AgentConfig.ontology_enforcement`; agent design specs may declare
 `ontology.enforcement` too, and an explicit run-spec value overrides the
 design (the implicit `guided` default never does). These are admission

--- a/src/seocho/e2e.py
+++ b/src/seocho/e2e.py
@@ -186,10 +186,37 @@ def _build_vector_store(spec: RunSpec) -> Optional[Any]:
     )
 
 
+def resolve_guardrail(spec: RunSpec) -> RunSpec:
+    """Domain-adaptively pick the guardrail ontology when ``ontology.select`` was
+    declared (ADR-0123): score the candidates against the corpus profile and set
+    ``spec.ontology_path`` to the chosen candidate, recording the recommendation
+    on ``spec.selected_guardrail``. No-op when a fixed ``ontology.path`` is set."""
+    if spec.ontology_path or not spec.guardrail_candidates:
+        return spec
+    from .guardrail_selector import load_corpus_profile, select_guardrail
+    from .ontology import Ontology
+
+    candidates = {name: Ontology.load(_resolve(spec, path))
+                  for name, path in spec.guardrail_candidates.items()}
+    corpus_profile = load_corpus_profile(_resolve(spec, spec.guardrail_corpus_profile))
+    rec = select_guardrail(candidates, corpus_profile)
+    spec.ontology_path = spec.guardrail_candidates[rec.chosen]
+    spec.selected_guardrail = rec.to_dict()
+    return spec
+
+
 def build(spec: RunSpec) -> RunContext:
     """Assemble live SDK objects from a validated run spec."""
     from .client import Seocho
     from .ontology import Ontology
+
+    resolve_guardrail(spec)
+    if spec.selected_guardrail:
+        rec = spec.selected_guardrail
+        print(f"[guardrail] selected '{rec['chosen']}' ({spec.ontology_path}) for "
+              f"{rec['domain_kind']} corpus (numeric_intensity={rec['numeric_intensity']})")
+        for advisory in rec.get("advisories", []):
+            print(f"[guardrail] · {advisory}")
 
     ontology = Ontology.load(_resolve(spec, spec.ontology_path))
 

--- a/src/seocho/guardrail_selector.py
+++ b/src/seocho/guardrail_selector.py
@@ -158,7 +158,7 @@ def load_corpus_profile(data: Union[str, Dict[str, Any]]) -> CorpusProfile:
     import json
     from pathlib import Path
 
-    if isinstance(data, str):
+    if isinstance(data, (str, Path)):
         data = json.loads(Path(data).read_text(encoding="utf-8"))
     if "corpus_profile" in data and isinstance(data["corpus_profile"], dict):
         data = data["corpus_profile"]

--- a/src/seocho/run_spec.py
+++ b/src/seocho/run_spec.py
@@ -51,7 +51,7 @@ _TOP_LEVEL_KEYS = {
     "output",
 }
 _SECTION_KEYS: Dict[str, set] = {
-    "ontology": {"path", "enforcement"},
+    "ontology": {"path", "enforcement", "select"},
     "documents": {"path", "recursive"},
     "models": {"default", "indexing", "query"},
     "graph": {"kind", "uri", "path", "user", "password", "database"},
@@ -201,6 +201,14 @@ class RunSpec:
     questions: List[QuestionSpec] = field(default_factory=list)
     output_dir: str = "runs"
     source_path: str = ""
+    # Optional domain-adaptive guardrail selection (ADR-0123): when
+    # ``ontology.select`` is declared instead of a fixed ``ontology.path``, the
+    # runner scores the candidates against the corpus profile and picks one.
+    # ``ontology_path`` is then filled at resolve time and ``selected_guardrail``
+    # records the recommendation.
+    guardrail_candidates: Dict[str, str] = field(default_factory=dict)
+    guardrail_corpus_profile: str = ""
+    selected_guardrail: Optional[Dict[str, Any]] = None
 
     # -- model resolution ------------------------------------------------
 
@@ -312,6 +320,23 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
     ontology = _path_or_mapping(payload, "ontology", errors=errors)
     documents = _path_or_mapping(payload, "documents", errors=errors)
 
+    # Optional domain-adaptive guardrail selection (ADR-0123).
+    select = ontology.get("select")
+    guardrail_candidates: Dict[str, str] = {}
+    guardrail_corpus_profile = ""
+    if select is not None:
+        if not isinstance(select, Mapping):
+            errors.append("at ontology.select: must be a mapping with 'candidates' and 'corpus_profile'.")
+        else:
+            cands = select.get("candidates") or {}
+            if not isinstance(cands, Mapping) or not cands:
+                errors.append("at ontology.select.candidates: a non-empty mapping of name -> ontology path is required.")
+            else:
+                guardrail_candidates = {str(k): _string(v) for k, v in cands.items()}
+            guardrail_corpus_profile = _string(select.get("corpus_profile"))
+            if not guardrail_corpus_profile:
+                errors.append("at ontology.select.corpus_profile: a corpus-profile path is required.")
+
     models_value = payload.get("models")
     if isinstance(models_value, str):
         models: Dict[str, str] = {"default": models_value.strip()}
@@ -367,10 +392,13 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
         questions=_parse_questions(payload.get("questions"), errors=errors),
         output_dir=_string(output.get("dir")) or "runs",
         source_path=source_path,
+        guardrail_candidates=guardrail_candidates,
+        guardrail_corpus_profile=guardrail_corpus_profile,
     )
 
-    if not spec.ontology_path:
-        errors.append("at ontology: a run spec requires ontology (path or mapping with 'path').")
+    if not spec.ontology_path and not (spec.guardrail_candidates and spec.guardrail_corpus_profile):
+        errors.append("at ontology: a run spec requires ontology (path/mapping with 'path', "
+                      "or 'select' with candidates + corpus_profile).")
     if not spec.documents_path:
         errors.append("at documents: a run spec requires documents (path or mapping with 'path').")
     if spec.enforcement not in _ALLOWED_ENFORCEMENT_MODES:

--- a/tests/seocho/test_run_spec_guardrail_select.py
+++ b/tests/seocho/test_run_spec_guardrail_select.py
@@ -1,0 +1,79 @@
+"""Tests for domain-adaptive guardrail selection wired into the e2e run-spec (ADR-0123)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from seocho.e2e import resolve_guardrail
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.run_spec import RunSpecError, parse_run_spec
+
+
+def test_parse_select_block_populates_candidates():
+    spec = parse_run_spec({
+        "ontology": {"select": {
+            "candidates": {"lean": "fibo_minus.jsonld", "rich": "fibo_plus.jsonld"},
+            "corpus_profile": "profile.json",
+        }},
+        "documents": "./docs",
+        "questions": ["q1?"],
+    })
+    assert spec.ontology_path == ""
+    assert spec.guardrail_candidates == {"lean": "fibo_minus.jsonld", "rich": "fibo_plus.jsonld"}
+    assert spec.guardrail_corpus_profile == "profile.json"
+
+
+def test_parse_select_missing_corpus_profile_errors():
+    with pytest.raises(RunSpecError):
+        parse_run_spec({
+            "ontology": {"select": {"candidates": {"lean": "a.jsonld"}}},
+            "documents": "./docs", "questions": ["q?"],
+        })
+
+
+def test_parse_requires_path_or_select():
+    with pytest.raises(RunSpecError):
+        parse_run_spec({"ontology": {}, "documents": "./docs", "questions": ["q?"]})
+
+
+def test_fixed_path_still_works():
+    spec = parse_run_spec({"ontology": "./schema.yaml", "documents": "./docs", "questions": ["q?"]})
+    assert spec.ontology_path == "./schema.yaml"
+    assert not spec.guardrail_candidates
+
+
+def _write_onto(path, name, labels):
+    o = Ontology(name, nodes={l: NodeDef(description=f"{l}.", properties={"name": P(str, unique=True)}) for l in labels})
+    o.to_jsonld(path)
+
+
+def test_resolve_guardrail_picks_for_entity_corpus(tmp_path):
+    lean = tmp_path / "lean.jsonld"
+    rich = tmp_path / "rich.jsonld"
+    _write_onto(lean, "lean", ["Company", "FinancialMetric"])
+    _write_onto(rich, "rich", ["Company", "FinancialMetric", "Person", "Regulation", "Risk"])
+    profile = tmp_path / "profile.json"
+    # entity-heavy corpus (people, regulations, risks)
+    profile.write_text(json.dumps({"label_frequencies": {"Person": 8, "Regulation": 6, "Risk": 5, "Company": 2}}))
+    spec_yaml = tmp_path / "run.yaml"
+    spec_yaml.write_text("x")  # just to anchor source_path
+
+    spec = parse_run_spec({
+        "ontology": {"select": {"candidates": {"lean": "lean.jsonld", "rich": "rich.jsonld"},
+                                "corpus_profile": "profile.json"}},
+        "documents": "./docs", "questions": ["q?"],
+    }, source_path=str(spec_yaml))
+
+    resolve_guardrail(spec)
+    assert spec.ontology_path == "rich.jsonld"        # entity corpus → richer guardrail
+    assert spec.selected_guardrail["chosen"] == "rich"
+    assert spec.selected_guardrail["domain_kind"] == "entity"
+
+
+def test_resolve_guardrail_noop_when_path_fixed(tmp_path):
+    spec = parse_run_spec({"ontology": "./schema.yaml", "documents": "./docs", "questions": ["q?"]})
+    resolve_guardrail(spec)
+    assert spec.ontology_path == "./schema.yaml"
+    assert spec.selected_guardrail is None


### PR DESCRIPTION
A run can declare `ontology.select` (candidates + corpus_profile) instead of a fixed `ontology.path`. The e2e runner's `resolve_guardrail()` scores candidates against the corpus profile and picks one before indexing — richest-adequate for entity corpora, leanest for numeric (ADR-0122) — logging + recording the choice. Fixed path still works. RUN_SPECS.md documents the block. 6 new tests; e2e suite + run_basic_ci 631 + doc-contracts pass.