### PR TITLE
feat(eval): answer-accuracy on the evaluation surface (ADR-0124)

### DIFF
--- a/docs/decisions/ADR-0124-answer-accuracy-eval-surface.md
+++ b/docs/decisions/ADR-0124-answer-accuracy-eval-surface.md
@@ -1,0 +1,51 @@
+# ADR-0124: Answer-Accuracy on the Evaluation Surface
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0122 showed that **extraction conformance is not a safe proxy for answer
+quality** — they can move in opposite directions (Shareholder return: conformance
+0.96→1.0 yet answer accuracy 0.58→0.42). The scorecard (offline, structural) and
+the corpus-aware/selector layers reason about conformance/coverage; the evaluation
+surface needs a first-class, reusable way to measure the thing users actually want
+— **correct answers** — with an ontology in force as the extraction guardrail.
+
+## Decision
+
+Add answer-accuracy primitives to `seocho.evaluation` (the eval surface):
+
+- `AnswerCase` — a gold QA case (question, gold_answer, context, category, id).
+- `evaluate_answer_accuracy(backend, ontology, cases, *, judge_backend=, model=,
+  workers=)` — per case: extract facts + answer with the ontology as guardrail
+  (via the provider-aware structured layer, ADR-0120), then LLM-judge the answer
+  vs gold; returns overall + per-category accuracy, label_conformance, and raw
+  per-case results. Bounded concurrency with 429-retry (ADR-0122 lesson).
+- `compare_guardrails_by_answer(backend, ontologies, cases)` — answer accuracy per
+  candidate guardrail; the reusable form of the FinDER answer matrix. **Pairs with
+  the offline `guardrail_selector` (ADR-0123): the selector picks offline, this
+  validates the pick against gold answers.**
+
+Backends are injected (SEOCHO `LLMBackend` contract) so the surface is testable
+with fakes; offline core, online only when a live backend is passed.
+
+## Validation
+
+`tests/seocho/test_answer_eval.py` (5): overall + per-category accuracy, label
+conformance, error exclusion, multi-guardrail compare, dict shape — all with a
+fake backend (no network).
+
+Live (MARA DeepSeek-V3.1, 15 FinDER cases × 3 categories, 0 errors), record
+`ADR-0124-answer-eval-live.json`: sparse guardrail **0.467** → rich **0.667**;
+by category Governance 0.4→0.8, Company overview 0.6→0.8 (entity-rich gain),
+Financials 0.4→0.4 (numeric, flat) — reproducing ADR-0122 through the new API.
+
+## Consequences
+
+- The eval surface now reports answer accuracy, not just conformance — the safe
+  metric for gating guardrail/version decisions and for the
+  measure→select→validate loop (scorecard → selector → answer-accuracy).
+- Follow-ups: feed answer-accuracy back to learn the selector's numeric-intensity
+  threshold (ADR-0123); a second judge / wider N before external claims; a
+  `seocho ontology eval-answers` CLI over a gold-cases file.

--- a/docs/decisions/ADR-0124-answer-eval-live.json
+++ b/docs/decisions/ADR-0124-answer-eval-live.json
@@ -1,0 +1,22 @@
+{
+  "experiment": "answer-eval-surface-live",
+  "n_cases": 15,
+  "sparse": {
+    "accuracy": 0.4667,
+    "by_category": {
+      "Governance": 0.4,
+      "Financials": 0.4,
+      "Company overview": 0.6
+    },
+    "errors": 0
+  },
+  "rich": {
+    "accuracy": 0.6667,
+    "by_category": {
+      "Governance": 0.8,
+      "Financials": 0.4,
+      "Company overview": 0.8
+    },
+    "errors": 0
+  }
+}

--- a/src/seocho/evaluation.py
+++ b/src/seocho/evaluation.py
@@ -334,3 +334,155 @@ def _flatten_values(value: Any) -> List[str]:
 def _normalize_token(value: Any) -> str:
     text = str(value or "").strip().lower()
     return " ".join(text.split())
+
+
+# ---------------------------------------------------------------------------
+# Answer-accuracy evaluation (ADR-0122/0123): conformance is NOT a safe proxy
+# for answer quality — they can move in opposite directions — so the eval
+# surface must measure actual answer correctness over a gold QA set, with an
+# ontology injected as the extraction guardrail.
+# ---------------------------------------------------------------------------
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
+
+
+@dataclass(slots=True)
+class AnswerCase:
+    """One gold QA case: a question + expected answer, with the source context to
+    extract/answer from and an optional category for per-segment breakdown."""
+
+    question: str
+    gold_answer: str
+    context: str = ""
+    category: str = ""
+    case_id: str = ""
+
+
+@dataclass(slots=True)
+class AnswerAccuracyReport:
+    n_scored: int
+    accuracy: float
+    by_category: Dict[str, float] = field(default_factory=dict)
+    by_category_n: Dict[str, int] = field(default_factory=dict)
+    errors: int = 0
+    results: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "n_scored": self.n_scored, "accuracy": self.accuracy,
+            "by_category": dict(self.by_category), "by_category_n": dict(self.by_category_n),
+            "errors": self.errors, "results": list(self.results),
+        }
+
+
+_ANS_SYS = ("You are a financial analyst. Use ONLY the entity/relationship types in the provided "
+            "ontology to extract the relevant facts, then answer the question. Return ONLY JSON.")
+_JUDGE_SYS = "You grade answers. Return ONLY JSON."
+_JUDGE_USER = ('QUESTION: {q}\nGOLD: {gold}\nMODEL ANSWER: {ans}\n'
+               'Is the model answer correct vs gold (same entity/number/fact, allowing phrasing/'
+               'rounding)? Return JSON {{"correct": true|false}}')
+
+
+def _ans_user(ontology: "Ontology", context: str, question: str) -> str:
+    ctx = ontology.to_extraction_context()
+    return (f"ONTOLOGY ENTITY TYPES:\n{ctx.get('entity_types','')}\n\n"
+            f"ONTOLOGY RELATIONSHIP TYPES:\n{ctx.get('relationship_types','')}\n\n"
+            f"CONTEXT:\n{context}\n\nQUESTION: {question}\n\n"
+            'Return JSON: {"facts":[{"label":"...","name":"...","value":"..."}],"answer":"..."}')
+
+
+def _eval_retry(fn, *, attempts: int = 5, base: float = 2.0):
+    last = None
+    for i in range(attempts):
+        try:
+            return fn()
+        except Exception as e:  # noqa: BLE001
+            last = e
+            msg = str(e).lower()
+            if "429" in msg or "rate limit" in msg or "timeout" in msg or "temporarily" in msg:
+                time.sleep(base * (2 ** i))
+                continue
+            raise
+    raise last
+
+
+def evaluate_answer_accuracy(
+    backend: Any,
+    ontology: "Ontology",
+    cases: Sequence[AnswerCase],
+    *,
+    judge_backend: Optional[Any] = None,
+    model: Optional[str] = None,
+    max_chars: int = 3500,
+    workers: int = 6,
+) -> AnswerAccuracyReport:
+    """Measure answer accuracy over a gold QA set with ``ontology`` as the
+    extraction guardrail. For each case: extract facts + answer (robustly, via the
+    provider-aware structured layer), then LLM-judge the answer vs gold. Returns
+    overall + per-category accuracy. ``backend``/``judge_backend`` follow the
+    SEOCHO ``LLMBackend`` contract; injected, so this is testable with fakes.
+
+    Concurrency is bounded by ``workers`` with 429-retry (MARA rate-limits at high
+    concurrency — see ADR-0122)."""
+    from .llm_structured import StructuredOutputError, structured_complete
+
+    judge = judge_backend or backend
+    mdl = model or getattr(backend, "model", "")
+    done = {"n": 0}
+    lock = Lock()
+
+    def run(case: AnswerCase) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"case_id": case.case_id, "category": case.category}
+        try:
+            ex = _eval_retry(lambda: structured_complete(
+                backend, system=_ANS_SYS, user=_ans_user(ontology, case.context[:max_chars], case.question),
+                model=mdl, task_hint="json_extraction"))
+            ans = str(ex.get("answer", "")) if isinstance(ex, dict) else ""
+            facts = ex.get("facts", []) if isinstance(ex, dict) else []
+            labels = [str(f.get("label", "")) for f in facts if isinstance(f, dict)]
+            out["label_conformance"] = (
+                round(sum(1 for l in labels if l in ontology.nodes) / len(labels), 4) if labels else 0.0)
+            jc = _eval_retry(lambda: structured_complete(
+                judge, system=_JUDGE_SYS,
+                user=_JUDGE_USER.format(q=case.question, gold=case.gold_answer, ans=ans), model=mdl))
+            out["correct"] = bool(jc.get("correct")) if isinstance(jc, dict) else False
+        except Exception as e:  # noqa: BLE001
+            out["error"] = f"{type(e).__name__}: {str(e)[:80]}"
+        with lock:
+            done["n"] += 1
+        return out
+
+    if workers > 1 and len(cases) > 1:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            results = list(pool.map(run, cases))
+    else:
+        results = [run(c) for c in cases]
+
+    scored = [r for r in results if "correct" in r]
+    errors = sum(1 for r in results if "error" in r)
+    by_cat: Dict[str, List[int]] = {}
+    for r in scored:
+        by_cat.setdefault(r.get("category", ""), []).append(1 if r["correct"] else 0)
+    return AnswerAccuracyReport(
+        n_scored=len(scored),
+        accuracy=round(mean([1 if r["correct"] else 0 for r in scored]), 4) if scored else 0.0,
+        by_category={c: round(mean(v), 4) for c, v in by_cat.items() if v},
+        by_category_n={c: len(v) for c, v in by_cat.items()},
+        errors=errors, results=results,
+    )
+
+
+def compare_guardrails_by_answer(
+    backend: Any,
+    ontologies: Dict[str, "Ontology"],
+    cases: Sequence[AnswerCase],
+    **kwargs: Any,
+) -> Dict[str, AnswerAccuracyReport]:
+    """Answer-accuracy per candidate guardrail — the reusable form of the FinDER
+    answer matrix (ADR-0122). Pairs with the offline guardrail selector
+    (``seocho.guardrail_selector``): the selector picks offline, this validates the
+    pick against gold answers."""
+    return {name: evaluate_answer_accuracy(backend, onto, cases, **kwargs)
+            for name, onto in ontologies.items()}

--- a/tests/seocho/test_answer_eval.py
+++ b/tests/seocho/test_answer_eval.py
@@ -1,0 +1,77 @@
+"""Tests for the answer-accuracy evaluation surface (ADR-0122/0123)."""
+
+from __future__ import annotations
+
+import json
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.evaluation import (
+    AnswerCase,
+    compare_guardrails_by_answer,
+    evaluate_answer_accuracy,
+)
+
+
+def _onto(*labels) -> Ontology:
+    return Ontology("o", nodes={l: NodeDef(description=f"{l}.", properties={"name": P(str, unique=True)}) for l in labels})
+
+
+class _Resp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeBackend:
+    """Answer call → fixed facts+answer; judge call (system mentions 'grade') →
+    correct iff the gold answer is 'yes'."""
+    model = "DeepSeek-V3.1"
+
+    def complete(self, *, system, user, **kw):
+        if "grade" in system.lower():
+            correct = "gold: yes" in user.lower()
+            return _Resp(json.dumps({"correct": correct}))
+        return _Resp('{"facts":[{"label":"Person","name":"x"},{"label":"OOV","name":"y"}],"answer":"a"}')
+
+
+def _cases():
+    return [
+        AnswerCase(question="q1", gold_answer="yes", context="ctx", category="A", case_id="1"),
+        AnswerCase(question="q2", gold_answer="no", context="ctx", category="B", case_id="2"),
+    ]
+
+
+def test_answer_accuracy_overall_and_by_category():
+    rep = evaluate_answer_accuracy(_FakeBackend(), _onto("Person"), _cases(), workers=1)
+    assert rep.n_scored == 2
+    assert rep.accuracy == 0.5
+    assert rep.by_category == {"A": 1.0, "B": 0.0}
+    assert rep.by_category_n == {"A": 1, "B": 1}
+    assert rep.errors == 0
+
+
+def test_label_conformance_recorded():
+    rep = evaluate_answer_accuracy(_FakeBackend(), _onto("Person"), _cases(), workers=1)
+    # facts were Person (in ontology) + OOV (not) → conformance 0.5
+    assert all(r["label_conformance"] == 0.5 for r in rep.results if "label_conformance" in r)
+
+
+def test_errors_excluded_from_scoring():
+    class _Boom:
+        model = "x"
+        def complete(self, **kw):
+            raise RuntimeError("boom")  # non-retryable
+    rep = evaluate_answer_accuracy(_Boom(), _onto("Person"), _cases(), workers=1)
+    assert rep.errors == 2 and rep.n_scored == 0 and rep.accuracy == 0.0
+
+
+def test_compare_guardrails_by_answer():
+    reps = compare_guardrails_by_answer(
+        _FakeBackend(), {"lean": _onto("Person"), "rich": _onto("Person", "Company")}, _cases(), workers=1)
+    assert set(reps) == {"lean", "rich"}
+    assert reps["lean"].accuracy == 0.5 and reps["rich"].accuracy == 0.5
+
+
+def test_to_dict_shape():
+    rep = evaluate_answer_accuracy(_FakeBackend(), _onto("Person"), _cases(), workers=1)
+    d = rep.to_dict()
+    assert set(d) >= {"n_scored", "accuracy", "by_category", "by_category_n", "errors", "results"}


### PR DESCRIPTION
Conformance ≠ answer quality (ADR-0122). Adds AnswerCase, evaluate_answer_accuracy(), compare_guardrails_by_answer() to seocho.evaluation — extract+answer with ontology guardrail via ub5 layer, LLM-judge vs gold, overall+per-category, 429-retry. Pairs with offline guardrail_selector (select offline, validate here). Fake-testable. 5 tests; live MARA: sparse 0.467→rich 0.667 reproducing ADR-0122. run_basic_ci 631 passed.