### PR TITLE
feat(cli): add ontology eval-answers subcommand (ADR-0125)

### DIFF
--- a/docs/decisions/ADR-0125-eval-answers-cli.md
+++ b/docs/decisions/ADR-0125-eval-answers-cli.md
@@ -1,0 +1,39 @@
+# ADR-0125: `seocho ontology eval-answers` CLI Front Door
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0124 added the answer-accuracy eval surface to `seocho.evaluation`
+(`AnswerCase`, `evaluate_answer_accuracy`, `compare_guardrails_by_answer`). It is
+Python-only: to measure whether an ontology guardrail produces correct answers
+over a gold QA set, a user has to write a script that loads the ontology, builds a
+backend, hand-rolls `AnswerCase` objects, and calls the function. The other
+offline ontology helpers (`check`, `report`, `datahub`, `select-guardrail`)
+already have a CLI front door under `seocho ontology`; answer-accuracy did not.
+
+## Decision
+
+Expose the existing surface as `seocho ontology eval-answers` — no new
+answer/eval logic, just a thin front door:
+
+- `load_answer_cases(path) -> List[AnswerCase]` in `seocho.evaluation`: pure,
+  offline JSON loader. Reads a list of `{question, gold_answer, context,
+  category, case_id}` objects; required `question`/`gold_answer`, optional fields
+  default to empty; rejects non-list / non-object payloads.
+- `ontology eval-answers` subparser in `seocho.cli`: `--schema` (ontology file),
+  `--cases` (gold JSON), `--provider` (default `mara`), `--model`, `--workers`
+  (default 6), `--json`. Handler loads the ontology and cases, builds a backend
+  via `create_llm_backend(provider=, model=)` (credentials come from env only —
+  no key files read), runs `evaluate_answer_accuracy`, and prints the overall +
+  per-category report (or `report.to_dict()` as JSON with `--json`).
+
+The CLI does not touch hot request paths and adds no new evaluation behavior.
+
+## Validation
+
+- `tests/seocho/test_cli_eval_answers.py` — `load_answer_cases` field mapping,
+  optional defaulting, non-list rejection, and loaded cases feeding
+  `evaluate_answer_accuracy` over a fake backend (offline; no live backend).
+- `bash scripts/ci/run_basic_ci.sh` — full gate (tests + contract checks).

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -368,6 +368,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ontology_select_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
+    ontology_eval_answers_parser = ontology_subparsers.add_parser(
+        "eval-answers",
+        help="Measure answer accuracy of an ontology guardrail over a gold QA set (ADR-0124/0125)",
+    )
+    ontology_eval_answers_parser.add_argument("--schema", required=True, help="Ontology file (JSON-LD, YAML, or TTL)")
+    ontology_eval_answers_parser.add_argument(
+        "--cases", required=True,
+        help="Gold QA cases JSON: list of {question, gold_answer, context, category, case_id}",
+    )
+    ontology_eval_answers_parser.add_argument("--provider", default="mara", help="LLM provider preset (default: mara)")
+    ontology_eval_answers_parser.add_argument("--model", default=None, help="Model override (default: provider default)")
+    ontology_eval_answers_parser.add_argument("--workers", type=int, default=6, help="Concurrent workers (default: 6)")
+    ontology_eval_answers_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
     serve_http_parser = subparsers.add_parser("serve-http", help="Serve a portable bundle behind a small FastAPI runtime")
     serve_http_parser.add_argument("--bundle", required=True, help="Path to portable bundle JSON file")
     serve_http_parser.add_argument("--host", default="0.0.0.0", help="Bind host")
@@ -1666,6 +1680,24 @@ def _cmd_ontology(args: argparse.Namespace) -> int:
             print(f"  {rec.rationale}")
             for a in rec.advisories:
                 print(f"  · {a}")
+        return 0
+
+    if args.ontology_command == "eval-answers":
+        from .ontology import Ontology
+        from .evaluation import evaluate_answer_accuracy, load_answer_cases
+        from .store.llm import create_llm_backend
+
+        ontology = Ontology.load(args.schema)
+        cases = load_answer_cases(args.cases)
+        backend = create_llm_backend(provider=args.provider, model=args.model)
+        report = evaluate_answer_accuracy(backend, ontology, cases, model=args.model, workers=args.workers)
+        if getattr(args, "output_json", False):
+            print(json.dumps(report.to_dict(), indent=2, ensure_ascii=False))
+        else:
+            print(f"answer accuracy: {report.accuracy}  (scored={report.n_scored}, errors={report.errors})")
+            for cat in sorted(report.by_category):
+                print(f"  {cat or '(uncategorized)'}: {report.by_category[cat]} "
+                      f"(n={report.by_category_n.get(cat, 0)})")
         return 0
 
     raise SeochoError(f"Unknown ontology command: {args.ontology_command}")

--- a/src/seocho/evaluation.py
+++ b/src/seocho/evaluation.py
@@ -360,6 +360,30 @@ class AnswerCase:
     case_id: str = ""
 
 
+def load_answer_cases(path: str) -> List[AnswerCase]:
+    """Load gold QA cases from a JSON file (a list of objects). Each object needs
+    ``question`` and ``gold_answer``; ``context``/``category``/``case_id`` are
+    optional and default to empty. Pure/offline — no backend involved."""
+    import json
+    from pathlib import Path
+
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"answer-cases file must be a JSON list, got {type(data).__name__}")
+    cases: List[AnswerCase] = []
+    for i, obj in enumerate(data):
+        if not isinstance(obj, dict):
+            raise ValueError(f"answer-case #{i} must be a JSON object, got {type(obj).__name__}")
+        cases.append(AnswerCase(
+            question=str(obj.get("question", "")),
+            gold_answer=str(obj.get("gold_answer", "")),
+            context=str(obj.get("context", "")),
+            category=str(obj.get("category", "")),
+            case_id=str(obj.get("case_id", "")),
+        ))
+    return cases
+
+
 @dataclass(slots=True)
 class AnswerAccuracyReport:
     n_scored: int

--- a/tests/seocho/test_cli_eval_answers.py
+++ b/tests/seocho/test_cli_eval_answers.py
@@ -1,0 +1,84 @@
+"""Tests for the ``ontology eval-answers`` CLI loader (ADR-0125).
+
+The loader is pure/offline; we also confirm loaded cases feed
+``evaluate_answer_accuracy`` over a fake backend (mirrors test_answer_eval.py).
+The live CLI handler needs a real backend, so it is not exercised here.
+"""
+
+from __future__ import annotations
+
+import json
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.evaluation import (
+    AnswerCase,
+    evaluate_answer_accuracy,
+    load_answer_cases,
+)
+
+
+def _onto(*labels) -> Ontology:
+    return Ontology("o", nodes={l: NodeDef(description=f"{l}.", properties={"name": P(str, unique=True)}) for l in labels})
+
+
+class _Resp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeBackend:
+    """Answer call → fixed facts+answer; judge call (system mentions 'grade') →
+    correct iff the gold answer is 'yes'."""
+    model = "DeepSeek-V3.1"
+
+    def complete(self, *, system, user, **kw):
+        if "grade" in system.lower():
+            correct = "gold: yes" in user.lower()
+            return _Resp(json.dumps({"correct": correct}))
+        return _Resp('{"facts":[{"label":"Person","name":"x"}],"answer":"a"}')
+
+
+def test_load_answer_cases_maps_fields(tmp_path):
+    path = tmp_path / "cases.json"
+    path.write_text(json.dumps([
+        {"question": "q1", "gold_answer": "yes", "context": "ctx1", "category": "A", "case_id": "c1"},
+    ]), encoding="utf-8")
+    cases = load_answer_cases(str(path))
+    assert len(cases) == 1
+    c = cases[0]
+    assert isinstance(c, AnswerCase)
+    assert c.question == "q1"
+    assert c.gold_answer == "yes"
+    assert c.context == "ctx1"
+    assert c.category == "A"
+    assert c.case_id == "c1"
+
+
+def test_load_answer_cases_defaults_optionals(tmp_path):
+    path = tmp_path / "cases.json"
+    path.write_text(json.dumps([{"question": "q", "gold_answer": "no"}]), encoding="utf-8")
+    (c,) = load_answer_cases(str(path))
+    assert c.question == "q" and c.gold_answer == "no"
+    assert c.context == "" and c.category == "" and c.case_id == ""
+
+
+def test_load_answer_cases_rejects_non_list(tmp_path):
+    path = tmp_path / "cases.json"
+    path.write_text(json.dumps({"question": "q"}), encoding="utf-8")
+    import pytest
+    with pytest.raises(ValueError):
+        load_answer_cases(str(path))
+
+
+def test_loaded_cases_evaluate_with_fake_backend(tmp_path):
+    path = tmp_path / "cases.json"
+    path.write_text(json.dumps([
+        {"question": "q1", "gold_answer": "yes", "context": "ctx", "category": "A", "case_id": "1"},
+        {"question": "q2", "gold_answer": "no", "context": "ctx", "category": "B", "case_id": "2"},
+    ]), encoding="utf-8")
+    cases = load_answer_cases(str(path))
+    rep = evaluate_answer_accuracy(_FakeBackend(), _onto("Person"), cases, workers=1)
+    assert rep.n_scored == 2
+    assert rep.accuracy == 0.5
+    assert rep.by_category == {"A": 1.0, "B": 0.0}
+    assert rep.errors == 0


### PR DESCRIPTION
## Summary

Exposes the existing answer-accuracy eval surface (ADR-0124) as a CLI front door: `seocho ontology eval-answers`. No new evaluation logic, no hot-path changes.

- `src/seocho/evaluation.py`: add `load_answer_cases(path) -> List[AnswerCase]` — a pure/offline JSON loader (list of `{question, gold_answer, context, category, case_id}`; required `question`/`gold_answer`, optional fields default to empty; rejects non-list/non-object payloads).
- `src/seocho/cli.py`: add `ontology eval-answers` subparser (`--schema`, `--cases`, `--provider` default `mara`, `--model`, `--workers` default 6, `--json`). Handler loads the ontology + gold cases, builds a backend via `create_llm_backend(provider=, model=)` (credentials from env only — no key files), runs `evaluate_answer_accuracy`, and prints overall + per-category accuracy (or `report.to_dict()` JSON with `--json`).
- `docs/decisions/ADR-0125-eval-answers-cli.md`: ADR.
- `tests/seocho/test_cli_eval_answers.py`: loader field-mapping/defaulting/non-list rejection + loaded cases feeding `evaluate_answer_accuracy` over a fake backend (offline).

## Validation

- `PYTHONPATH=src python3 -m pytest tests/seocho/test_cli_eval_answers.py tests/seocho/test_answer_eval.py -q` → 9 passed
- `bash scripts/ci/run_basic_ci.sh` → 631 passed, 3 skipped; runtime-shell / module-ownership / root-hierarchy / docs contract checks all pass
- `seocho ontology eval-answers --help` renders the subcommand
- `git diff --check` clean