### PR TITLE
feat(ontology): calibrate guardrail numeric-intensity threshold from answer-accuracy (ADR-0126)

### DIFF
--- a/docs/decisions/ADR-0126-calibrate-numeric-intensity-threshold.md
+++ b/docs/decisions/ADR-0126-calibrate-numeric-intensity-threshold.md
@@ -1,0 +1,44 @@
+# ADR-0126: Calibrate the Guardrail Selector's Numeric-Intensity Threshold from Measured Answer-Accuracy
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0123's `select_guardrail` uses a fixed `numeric_threshold=0.5` to decide
+whether a corpus is "numeric" (→ lean guardrail) or "entity" (→ rich). ADR-0122/
+0124 produced the ground-truth signal that boundary should track: per-domain
+**answer-accuracy deltas** (rich minus sparse). The threshold should be learned
+from those deltas, not guessed.
+
+## Decision
+
+Add to `seocho.guardrail_selector` (pure/offline/deterministic):
+
+- `DomainObservation(domain, numeric_intensity, rich_minus_sparse_delta)` — a
+  measured per-domain point.
+- `calibrate_numeric_threshold(observations, *, default=0.5)` — finds the
+  threshold T best separating domains where the rich guardrail helped
+  (`delta>0` → entity, `ni<T`) from where it did not (`delta<=0` → numeric,
+  `ni>=T`). Scans candidate thresholds (midpoints of sorted unique intensities +
+  0/1 bounds), maximizes agreement with measured outcomes, ties broken toward
+  `default`. Returns `{threshold, accuracy, n, default}`.
+
+The calibrated T is passed to `select_guardrail(..., numeric_threshold=T)`.
+
+## Validation
+
+`tests/seocho/test_numeric_threshold_calibration.py` (4): cleanly separable
+observations → accuracy 1.0 and the boundary lands between the entity and numeric
+clusters; empty → default; noisy/overlapping → best-possible separator
+(accuracy ≥ 0.75); the calibrated threshold flips the selector's entity/numeric
+decision at the boundary. `run_basic_ci` green.
+
+## Consequences
+
+- The domain split is now data-driven: feed the ADR-0122/0124 per-category deltas
+  (Governance +0.67 … Shareholder return −0.17) and their corpus numeric
+  intensities to learn the operating threshold for a given corpus family.
+- Follow-up: as more answer-accuracy measurements accrue (more domains, more
+  judges), re-calibrate; consider a soft/probabilistic boundary instead of a hard
+  cut.

--- a/src/seocho/guardrail_selector.py
+++ b/src/seocho/guardrail_selector.py
@@ -169,3 +169,69 @@ def load_corpus_profile(data: Union[str, Dict[str, Any]]) -> CorpusProfile:
         )
     # assume a bare {label: freq} mapping
     return CorpusProfile(label_frequencies={str(k): int(v) for k, v in data.items()})
+
+
+# ---------------------------------------------------------------------------
+# Learning the numeric-intensity threshold from measured answer-accuracy deltas
+# (ADR-0126). ADR-0123 hard-coded 0.5; ADR-0122/0124 give per-domain deltas
+# (rich-minus-sparse answer accuracy) we can use to calibrate the boundary.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class DomainObservation:
+    """A measured per-domain point: how numeric the domain's corpus is, and
+    whether the richer guardrail actually helped its answers."""
+
+    domain: str
+    numeric_intensity: float
+    rich_minus_sparse_delta: float  # measured answer-accuracy delta; >0 = rich helped
+
+
+def calibrate_numeric_threshold(
+    observations: Sequence[DomainObservation],
+    *,
+    default: float = 0.5,
+) -> Dict[str, Any]:
+    """Find the numeric_intensity threshold T that best separates domains where
+    the rich guardrail helped (delta>0 → should be treated as entity, ni<T) from
+    those where it did not (delta<=0 → numeric, ni>=T).
+
+    Scans candidate thresholds (midpoints between sorted unique intensities, plus
+    the 0/1 bounds), scores each by agreement with the measured outcomes, and
+    returns the best (ties broken toward ``default``). Pure/deterministic."""
+    obs = list(observations)
+    if not obs:
+        return {"threshold": default, "accuracy": None, "n": 0, "default": default}
+
+    intensities = sorted({o.numeric_intensity for o in obs})
+    candidates = [0.0]
+    for a, b in zip(intensities, intensities[1:]):
+        candidates.append((a + b) / 2.0)
+    candidates.append(1.0)
+    # also allow thresholds just above each observed intensity so a point can be
+    # classified numeric (ni >= T) exactly at a boundary
+    candidates = sorted(set(candidates))
+
+    def agreement(t: float) -> int:
+        correct = 0
+        for o in obs:
+            predict_rich_helps = o.numeric_intensity < t
+            actual_rich_helps = o.rich_minus_sparse_delta > 0
+            if predict_rich_helps == actual_rich_helps:
+                correct += 1
+        return correct
+
+    best_t = default
+    best_score = -1
+    for t in candidates:
+        s = agreement(t)
+        if s > best_score or (s == best_score and abs(t - default) < abs(best_t - default)):
+            best_score, best_t = s, t
+
+    return {
+        "threshold": round(best_t, 4),
+        "accuracy": round(best_score / len(obs), 4),
+        "n": len(obs),
+        "default": default,
+    }

--- a/tests/seocho/test_numeric_threshold_calibration.py
+++ b/tests/seocho/test_numeric_threshold_calibration.py
@@ -1,0 +1,68 @@
+"""Tests for learning the numeric-intensity threshold (ADR-0126)."""
+
+from __future__ import annotations
+
+from seocho.ontology_scorecard import build_corpus_profile
+from seocho.guardrail_selector import (
+    DomainObservation,
+    calibrate_numeric_threshold,
+    select_guardrail,
+)
+from seocho.ontology import NodeDef, Ontology, P
+
+
+def test_separable_observations_give_perfect_threshold():
+    # entity domains (low ni, rich helped) vs numeric domains (high ni, rich hurt)
+    obs = [
+        DomainObservation("Governance", 0.05, +0.67),
+        DomainObservation("Legal", 0.15, +0.42),
+        DomainObservation("Financials", 0.80, -0.08),
+        DomainObservation("Shareholder return", 0.90, -0.17),
+    ]
+    out = calibrate_numeric_threshold(obs)
+    assert out["accuracy"] == 1.0
+    assert 0.15 < out["threshold"] < 0.80  # boundary lands between the clusters
+    assert out["n"] == 4
+
+
+def test_empty_returns_default():
+    out = calibrate_numeric_threshold([], default=0.42)
+    assert out["threshold"] == 0.42 and out["accuracy"] is None and out["n"] == 0
+
+
+def test_noisy_picks_best_possible():
+    obs = [
+        DomainObservation("a", 0.2, +0.3),
+        DomainObservation("b", 0.4, -0.1),   # overlaps — entity-ish ni but hurt
+        DomainObservation("c", 0.6, +0.2),   # overlaps — numeric-ish ni but helped
+        DomainObservation("d", 0.8, -0.2),
+    ]
+    out = calibrate_numeric_threshold(obs)
+    assert 0.0 <= out["accuracy"] <= 1.0
+    assert out["accuracy"] >= 0.75  # best separator still classifies >= 3/4
+
+
+def _lean():
+    return Ontology("lean", nodes={"Company": NodeDef(description="c", properties={"name": P(str, unique=True)})})
+
+
+def _rich():
+    return Ontology("rich", nodes={
+        "Company": NodeDef(description="c", properties={"name": P(str, unique=True)}),
+        "Person": NodeDef(description="p", properties={"name": P(str, unique=True)}),
+        "FinancialMetric": NodeDef(description="m", properties={"name": P(str, unique=True)}),
+    })
+
+
+def test_calibrated_threshold_flips_decision_at_boundary():
+    # a corpus with numeric_intensity ~0.5 (one metric, one entity mention)
+    corpus = build_corpus_profile([{"nodes": [{"label": "FinancialMetric"}, {"label": "Person"}]}])
+    cands = {"lean": _lean(), "rich": _rich()}
+    ni = select_guardrail(cands, corpus).numeric_intensity
+    # threshold just above ni → corpus treated as entity → rich
+    hi = select_guardrail(cands, corpus, numeric_threshold=ni + 0.01)
+    # threshold just below ni → corpus treated as numeric → lean preferred when coverage close
+    lo = select_guardrail(cands, corpus, numeric_threshold=max(0.0, ni - 0.01))
+    # threshold above ni → not classified numeric (rich-leaning); below → numeric (lean-leaning)
+    assert hi.domain_kind != "numeric"
+    assert lo.domain_kind == "numeric"


### PR DESCRIPTION
Learns the entity-vs-numeric boundary from per-domain rich-minus-sparse answer-accuracy deltas (ADR-0122/0124) instead of hard-coded 0.5. DomainObservation + calibrate_numeric_threshold(). Pure/offline. 4 tests + run_basic_ci 631 passed.