### PR TITLE
feat(ontology): precision-first soft numeric-fact validation + reconciliation (ADR-0127)

### DIFF
--- a/docs/decisions/ADR-0127-numeric-validation-soft-precision-first.md
+++ b/docs/decisions/ADR-0127-numeric-validation-soft-precision-first.md
@@ -1,0 +1,49 @@
+# ADR-0127: Precision-First, Soft Numeric-Fact Validation (Reconciliation)
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0119's P3 experiment: financial numeric errors are ~91% *structural*, and a
+constraint validator caught ~94% of them (recall) but flagged ~91% of *correct*
+answers too (precision) — because rigid unit/scale enums mis-fire (the model puts
+"millions" in `unit`) and a required `period` is too strict. ADR-0119's decision
+was to engineer for precision: validate softly, normalize unit/scale, relax
+presence, and prioritize reconciliation.
+
+## Decision
+
+New pure/offline module `seocho.numeric_validation`:
+
+- `NumericFact.from_dict` — tolerant parse; **a scale word found in the `unit`
+  field (e.g. "millions") is recognised as a scale and relocated**, not flagged
+  (the dominant false-positive source in ADR-0119).
+- Findings are **soft only** (`info` / `warn`, never a hard reject). Missing
+  period → `info` (relaxed); unknown unit after normalization → not a warn;
+  non-numeric value, implausible sign, and failed reconciliation → `warn`.
+- `validate_numeric_facts(facts)` → findings + a `confidence` (drops only on
+  `warn`) + `repairs` (soft re-ask suggestions).
+- `reconcile(parts, total, rel_tol)` and a heuristic `find_reconciliation_groups`
+  — sum-of-parts ≈ total catches a wrong number pulled without recomputing.
+
+The intent vs ADR-0119: clean facts are **not** flagged (high precision), while
+the structural errors that matter (bad number, broken reconciliation) still warn.
+
+## Validation
+
+`tests/seocho/test_numeric_validation.py` (7): a well-formed fact set →
+confidence 1.0, zero warnings (the precision fix — contrast ADR-0119's 91% FP);
+`unit="millions"` normalized to scale, not flagged; non-numeric value warns;
+missing period is `info` (confidence stays 1.0); negative revenue warns;
+reconciliation passes on 3+4=7 and warns on 3+4≠10 (unit + end-to-end). `run_basic_ci` green.
+
+## Consequences
+
+- A usable numeric guardrail for the numeric domains where vocabulary enrichment
+  does not help (ADR-0122): soft signals + reconciliation + a confidence the
+  query lane can use as a repair trigger, rather than a hard reject that flags
+  everything.
+- Follow-ups: re-run the P3 measurement (FinDER numeric cases) with this validator
+  to quantify the new precision/recall; wire `confidence` into the query/repair
+  loop; pass explicit reconciliation groups when the extractor knows them.

--- a/src/seocho/numeric_validation.py
+++ b/src/seocho/numeric_validation.py
@@ -1,0 +1,172 @@
+"""Numeric-fact validation as SOFT, precision-first signals (ADR-0127).
+
+ADR-0119's P3 experiment found financial numeric errors are ~91% *structural*
+(wrong/missing/mis-typed extracted fact) and that constraint checks catch ~94% of
+them (high recall) — but a naive validator flagged ~91% of *correct* answers too
+(terrible precision), largely because rigid unit/scale enums mis-fire (the model
+puts "millions" in the ``unit`` field) and a required ``period`` is too strict.
+
+This module is the precision-first redesign: every finding is SOFT (``info`` /
+``warn`` — never a hard reject), unit/scale are NORMALIZED before any check, a
+missing period is ``info`` not ``warn``, and the highest-value check is
+RECONCILIATION (sum-of-parts ≈ total) which catches a wrong number pulled without
+recomputing the answer. Pure/offline; the result is a confidence + repair
+suggestions a caller can use as a soft re-ask trigger.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+_SCALE_TOKENS = {
+    "thousand": "thousand", "thousands": "thousand", "k": "thousand",
+    "million": "million", "millions": "million", "mm": "million", "mn": "million", "m": "million",
+    "billion": "billion", "billions": "billion", "bn": "billion", "b": "billion",
+    "ones": "", "absolute": "", "units": "",
+}
+_UNIT_TOKENS = {
+    "$": "usd", "usd": "usd", "dollar": "usd", "dollars": "usd",
+    "€": "eur", "eur": "eur", "£": "gbp", "gbp": "gbp", "jpy": "jpy", "¥": "jpy",
+    "%": "percent", "percent": "percent", "pct": "percent",
+    "shares": "shares", "share": "shares", "x": "ratio", "ratio": "ratio", "bps": "bps",
+}
+_NEGATIVE_IMPLAUSIBLE = re.compile(r"revenue|assets?|shares?|cash|capitalization|market\s*cap", re.I)
+_PERIOD_RE = re.compile(r"(19|20)\d{2}|q[1-4]|fy|h[12]|first|second|third|fourth|quarter|annual", re.I)
+
+
+def normalize_scale(s: str) -> str:
+    return _SCALE_TOKENS.get(str(s or "").strip().lower(), str(s or "").strip().lower())
+
+
+def normalize_unit(s: str) -> str:
+    return _UNIT_TOKENS.get(str(s or "").strip().lower(), str(s or "").strip().lower())
+
+
+@dataclass(slots=True)
+class NumericFact:
+    name: str = ""
+    value: Optional[float] = None
+    unit: str = ""
+    scale: str = ""
+    period: str = ""
+    company: str = ""
+    raw_value: Any = None
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "NumericFact":
+        """Tolerant parse. CRITICAL precision fix (ADR-0119): a scale word that the
+        model placed in ``unit`` (e.g. "millions") is recognised as a SCALE and
+        moved, rather than flagged as an off-vocabulary unit."""
+        raw = d.get("value")
+        try:
+            value = float(str(raw).replace(",", "").replace("$", "").replace("%", "").strip()) if raw not in (None, "") else None
+        except Exception:
+            value = None
+        unit = str(d.get("unit", "")).strip()
+        scale = str(d.get("scale", "")).strip()
+        # if the "unit" is actually a scale word, relocate it
+        if not scale and unit.lower() in _SCALE_TOKENS:
+            scale, unit = unit, ""
+        return cls(
+            name=str(d.get("name", "")), value=value,
+            unit=normalize_unit(unit), scale=normalize_scale(scale),
+            period=str(d.get("period", "")).strip(), company=str(d.get("company", "")).strip(),
+            raw_value=raw,
+        )
+
+
+@dataclass(slots=True)
+class NumericFinding:
+    severity: str          # "info" | "warn"  — never a hard reject
+    code: str
+    fact: str
+    message: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"severity": self.severity, "code": self.code, "fact": self.fact, "message": self.message}
+
+
+@dataclass(slots=True)
+class NumericValidationResult:
+    findings: List[NumericFinding] = field(default_factory=list)
+    confidence: float = 1.0
+    repairs: List[str] = field(default_factory=list)
+
+    @property
+    def warnings(self) -> List[NumericFinding]:
+        return [f for f in self.findings if f.severity == "warn"]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "findings": [f.to_dict() for f in self.findings],
+            "confidence": round(self.confidence, 4),
+            "repairs": list(self.repairs),
+        }
+
+
+def validate_numeric_facts(facts: List[Dict[str, Any]]) -> NumericValidationResult:
+    """Soft, precision-first validation. Confidence drops only on ``warn`` findings;
+    ``info`` (relaxed signals like a missing period or unknown unit) does not."""
+    findings: List[NumericFinding] = []
+    repairs: List[str] = []
+    parsed = [NumericFact.from_dict(f) for f in facts if isinstance(f, dict)]
+
+    for fct in parsed:
+        nm = fct.name or "(unnamed)"
+        if fct.raw_value not in (None, "") and fct.value is None:
+            findings.append(NumericFinding("warn", "value_not_numeric", nm,
+                                           f"value {fct.raw_value!r} does not parse as a number"))
+            repairs.append(f"re-extract a numeric value for '{nm}'")
+        if not fct.period:
+            findings.append(NumericFinding("info", "missing_period", nm,
+                                           "no fiscal period — relaxed (info), supply if known"))
+        elif not _PERIOD_RE.search(fct.period):
+            findings.append(NumericFinding("info", "period_unrecognized", nm,
+                                           f"period '{fct.period}' not a recognizable fiscal period"))
+        if fct.value is not None and fct.value < 0 and _NEGATIVE_IMPLAUSIBLE.search(nm):
+            findings.append(NumericFinding("warn", "implausible_sign", nm,
+                                           f"negative value {fct.value} is implausible for '{nm}'"))
+            repairs.append(f"check the sign of '{nm}'")
+
+    # reconciliation across grouped facts
+    for group in find_reconciliation_groups(parsed):
+        finding = reconcile(group["parts"], group["total"])
+        if finding is not None:
+            findings.append(finding)
+            repairs.append(f"reconcile components of '{group['total'].name}'")
+
+    n_warn = sum(1 for f in findings if f.severity == "warn")
+    confidence = max(0.0, 1.0 - 0.34 * n_warn)
+    return NumericValidationResult(findings=findings, confidence=confidence, repairs=repairs)
+
+
+def reconcile(parts: List[NumericFact], total: NumericFact, *, rel_tol: float = 0.01) -> Optional[NumericFinding]:
+    """Warn when the parts do not sum to the stated total (beyond ``rel_tol``).
+    Catches a wrong number pulled WITHOUT recomputing the answer."""
+    vals = [p.value for p in parts if p.value is not None]
+    if not vals or total.value is None:
+        return None
+    s = sum(vals)
+    denom = abs(total.value) if total.value else 1.0
+    if abs(s - total.value) / denom > rel_tol:
+        return NumericFinding("warn", "reconciliation", total.name or "(total)",
+                              f"sum of parts {s} != stated total {total.value} "
+                              f"(parts: {[p.name for p in parts]})")
+    return None
+
+
+def find_reconciliation_groups(facts: List[NumericFact]) -> List[Dict[str, Any]]:
+    """Heuristic grouping: a fact whose name contains 'total'/'net'/'sum' is a
+    candidate total; the remaining facts sharing a token stem with it are its
+    parts. Deliberately simple — explicit groups should be passed to
+    :func:`reconcile` directly when available."""
+    groups: List[Dict[str, Any]] = []
+    totals = [f for f in facts if re.search(r"\btotal\b|\bnet\b|\bsum\b", f.name, re.I)]
+    for total in totals:
+        stem = re.sub(r"\b(total|net|sum)\b", "", total.name, flags=re.I).strip().lower()
+        parts = [f for f in facts if f is not total and stem and stem in f.name.lower()]
+        if len(parts) >= 2:
+            groups.append({"total": total, "parts": parts})
+    return groups

--- a/tests/seocho/test_numeric_validation.py
+++ b/tests/seocho/test_numeric_validation.py
@@ -1,0 +1,62 @@
+"""Tests for soft, precision-first numeric validation (ADR-0127)."""
+
+from __future__ import annotations
+
+from seocho.numeric_validation import (
+    NumericFact,
+    reconcile,
+    validate_numeric_facts,
+)
+
+
+def test_clean_facts_not_flagged():
+    # the ADR-0119 precision fix: a well-formed fact must NOT be flagged
+    res = validate_numeric_facts([
+        {"name": "total revenue", "value": "1,234.5", "unit": "$", "scale": "millions", "period": "FY2023"},
+    ])
+    assert res.confidence == 1.0
+    assert res.warnings == []
+
+
+def test_scale_word_in_unit_is_normalized_not_flagged():
+    res = validate_numeric_facts([{"name": "ebitda", "value": 50, "unit": "millions", "period": "FY2022"}])
+    assert res.warnings == []  # "millions" relocated to scale, no warn
+    fct = NumericFact.from_dict({"name": "x", "value": 1, "unit": "millions"})
+    assert fct.scale == "million" and fct.unit == ""
+
+
+def test_non_numeric_value_warns():
+    res = validate_numeric_facts([{"name": "revenue", "value": "about a lot", "period": "FY2023"}])
+    assert any(f.code == "value_not_numeric" and f.severity == "warn" for f in res.findings)
+    assert res.confidence < 1.0
+
+
+def test_missing_period_is_info_not_warn():
+    res = validate_numeric_facts([{"name": "revenue", "value": 100, "unit": "$"}])
+    assert any(f.code == "missing_period" and f.severity == "info" for f in res.findings)
+    assert res.warnings == []  # relaxed → confidence stays 1.0
+    assert res.confidence == 1.0
+
+
+def test_negative_revenue_warns():
+    res = validate_numeric_facts([{"name": "total revenue", "value": -5, "period": "FY2023"}])
+    assert any(f.code == "implausible_sign" and f.severity == "warn" for f in res.findings)
+
+
+def test_reconcile_pass_and_fail():
+    p1 = NumericFact.from_dict({"name": "segment A revenue", "value": 3})
+    p2 = NumericFact.from_dict({"name": "segment B revenue", "value": 4})
+    ok_total = NumericFact.from_dict({"name": "total revenue", "value": 7})
+    bad_total = NumericFact.from_dict({"name": "total revenue", "value": 10})
+    assert reconcile([p1, p2], ok_total) is None
+    f = reconcile([p1, p2], bad_total)
+    assert f is not None and f.code == "reconciliation" and f.severity == "warn"
+
+
+def test_reconciliation_group_detected_end_to_end():
+    res = validate_numeric_facts([
+        {"name": "segment A revenue", "value": 3},
+        {"name": "segment B revenue", "value": 4},
+        {"name": "total revenue", "value": 10},  # 3+4 != 10
+    ])
+    assert any(f.code == "reconciliation" for f in res.findings)


### PR DESCRIPTION
Redesigns numeric validation per ADR-0119's precision lesson. Soft findings (info/warn, no hard reject); unit/scale normalization (scale word in unit field relocated, not flagged); missing period is info; reconciliation (sum-of-parts != total). Clean facts not flagged. Pure/offline. 7 tests + run_basic_ci 631 passed.