### PR TITLE
feat(ontology): ambiguity-review proposal engine — Phase 2 (ADR-0128)

### DIFF
--- a/docs/decisions/ADR-0128-ambiguity-proposal-engine.md
+++ b/docs/decisions/ADR-0128-ambiguity-proposal-engine.md
@@ -1,0 +1,49 @@
+# ADR-0128: Ambiguity-Review Proposal Engine (Phase 2)
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+The ambiguity-review loop (seocho-2mg) Phase 1 (PR #309) quarantines OOV mentions,
+clusters them, and applies a declarative mapping-spec to the taxonomy. Its
+proposals were heuristic (`starter_mapping_spec`). Phase 2 generates *LLM*
+proposals, ranked by their measured effect, so the human reviews a
+consequence-annotated list rather than guessing.
+
+## Decision
+
+Add to `seocho.ontology_ambiguity`:
+
+- `MappingProposal` (surface, action, target, parent, description, confidence,
+  predicted_coverage_delta, rationale) with `to_spec_entry()` / `to_dict()`.
+- `propose_mappings(clusters, ontology, *, backend, model=None, top_k=20)` — asks
+  the LLM (injected `backend`, via the provider-aware structured layer ADR-0120)
+  to choose `alias` / `new_class` (+parent, +definition) / `ignore` for each top
+  cluster. Each non-ignore proposal is then **scored offline**: apply it with
+  `apply_mapping_spec`, re-score `corpus_coverage` against a profile built from
+  the clusters, and record `predicted_coverage_delta`. Proposals are ranked by
+  predicted lift then confidence.
+- `proposals_to_mapping_spec(proposals, *, min_confidence)` — converts accepted
+  proposals into a mapping-spec consumable by `apply_mapping_spec`.
+
+The LLM call is injected → fake-testable; scoring/conversion is pure/offline.
+
+## Validation
+
+`tests/seocho/test_ambiguity_proposals.py` (3, fake backend): proposals parse and
+a `new_class` for a high-frequency cluster gets a positive predicted coverage
+delta and ranks first; `proposals_to_mapping_spec` filters by confidence, drops
+`ignore`, and round-trips through `apply_mapping_spec` (adds the class under its
+parent); empty clusters → empty. `run_basic_ci` green.
+
+## Consequences
+
+- The review queue now shows, per ambiguous surface, the recommended action +
+  confidence + the measured coverage lift of accepting it — the
+  consequence-preview the design called for, headless and reproducible.
+- Pairs with Phase 1 (quarantine/apply) and the DataHub surface (seocho-qxj) which
+  will render these proposals for human approval.
+- Follow-ups: OntoClean pre-validation of proposed is-a placements; batch live
+  run over the FinDER quarantine; confidence calibration against accepted/rejected
+  outcomes.

--- a/src/seocho/ontology_ambiguity.py
+++ b/src/seocho/ontology_ambiguity.py
@@ -265,3 +265,145 @@ def _bump_minor(version: str) -> str:
 def load_mapping_spec(path: str | Path) -> Dict[str, Any]:
     import yaml
     return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — LLM proposal engine (ADR-0128, seocho-2mg). Phase 1 gives a
+# heuristic ``starter_mapping_spec``; this generates proposals with an LLM (via
+# the provider-aware structured layer) and scores each by its predicted
+# corpus-coverage lift, so the human reviews a ranked, consequence-annotated list.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class MappingProposal:
+    surface: str
+    action: str                       # alias | new_class | same_as | ignore
+    target: str = ""
+    parent: str = ""
+    description: str = ""
+    confidence: float = 0.0
+    predicted_coverage_delta: Optional[float] = None
+    rationale: str = ""
+
+    def to_spec_entry(self) -> Dict[str, Any]:
+        entry: Dict[str, Any] = {"surface": self.surface, "action": self.action}
+        if self.action in ("alias", "same_as", "new_class") and self.target:
+            entry["target"] = self.target
+        if self.action == "new_class":
+            if self.parent:
+                entry["parent"] = self.parent
+            if self.description:
+                entry["description"] = self.description
+        return entry
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "surface": self.surface, "action": self.action, "target": self.target,
+            "parent": self.parent, "description": self.description,
+            "confidence": self.confidence, "predicted_coverage_delta": self.predicted_coverage_delta,
+            "rationale": self.rationale,
+        }
+
+
+_PROPOSE_SYS = (
+    "You are an ontology engineer triaging out-of-ontology entity mentions. For each surface form, "
+    "choose how to map it into the ontology. Return ONLY JSON."
+)
+
+
+def _propose_prompt(clusters: List[Dict[str, Any]], ontology: Ontology) -> str:
+    labels = ", ".join(ontology.nodes.keys()) or "(none)"
+    lines = [f"EXISTING ONTOLOGY CLASSES: {labels}", "", "AMBIGUOUS SURFACE FORMS (with frequency / example context):"]
+    for c in clusters:
+        ex = (c.get("examples") or [""])[0][:160]
+        lines.append(f"- '{c['surface']}' (x{c.get('frequency', 1)}; candidates={c.get('candidate_labels', [])}) e.g. {ex!r}")
+    lines.append("")
+    lines.append(
+        'For each, choose an action: "alias" (a synonym of an existing class -> set "target" to that class), '
+        '"new_class" (a genuinely new type -> set "target" to a PascalCase label, "parent" to an existing class '
+        'or "", and a short "description"), or "ignore" (noise). '
+        'Return JSON: {"proposals":[{"surface","action","target","parent","description","confidence","rationale"}]} '
+        "with confidence in [0,1]."
+    )
+    return "\n".join(lines)
+
+
+def propose_mappings(
+    clusters: List[Dict[str, Any]],
+    ontology: Ontology,
+    *,
+    backend: Any,
+    model: Optional[str] = None,
+    top_k: int = 20,
+) -> List[MappingProposal]:
+    """Generate ranked mapping proposals for the top clusters via an LLM
+    (injected ``backend``; routed through the provider-aware structured layer,
+    ADR-0120). Each proposal is annotated with its predicted corpus-coverage lift
+    (computed offline by applying it and re-scoring). Fake-testable."""
+    from .llm_structured import StructuredOutputError, structured_complete
+
+    top = list(clusters)[:top_k]
+    if not top:
+        return []
+    try:
+        payload = structured_complete(
+            backend, system=_PROPOSE_SYS, user=_propose_prompt(top, ontology),
+            model=model, task_hint="json_extraction",
+        )
+    except StructuredOutputError:
+        return []
+    raw = payload.get("proposals", []) if isinstance(payload, dict) else []
+
+    # corpus profile from the clusters → measure each proposal's coverage lift
+    from .ontology_scorecard import CorpusProfile, score_ontology
+
+    profile = CorpusProfile(
+        label_frequencies={str(c["surface"]): int(c.get("frequency", 1)) for c in top},
+        source="ambiguity-clusters",
+    )
+
+    def _coverage(o: Ontology) -> float:
+        dim = score_ontology(o, corpus_profile=profile, profile="guardrail").dimension("corpus_coverage")
+        return dim.score if dim else 0.0
+
+    base_cov = _coverage(ontology)
+    proposals: List[MappingProposal] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        action = str(item.get("action", "")).strip()
+        if action not in _VALID_ACTIONS:
+            continue
+        prop = MappingProposal(
+            surface=str(item.get("surface", "")).strip(),
+            action=action,
+            target=str(item.get("target", "")).strip(),
+            parent=str(item.get("parent", "")).strip(),
+            description=str(item.get("description", "")).strip(),
+            confidence=float(item.get("confidence", 0.0) or 0.0),
+            rationale=str(item.get("rationale", "")).strip(),
+        )
+        if action != "ignore":
+            try:
+                candidate = apply_mapping_spec(ontology, {"mappings": [prop.to_spec_entry()]})
+                prop.predicted_coverage_delta = round(_coverage(candidate) - base_cov, 4)
+            except Exception:
+                prop.predicted_coverage_delta = None
+        proposals.append(prop)
+    # rank: biggest predicted lift first, then confidence
+    proposals.sort(key=lambda p: (-(p.predicted_coverage_delta or 0.0), -p.confidence))
+    return proposals
+
+
+def proposals_to_mapping_spec(
+    proposals: List[MappingProposal],
+    *,
+    min_confidence: float = 0.0,
+    ontology_name: str = "",
+) -> Dict[str, Any]:
+    """Convert accepted proposals (confidence >= threshold, non-ignore) into a
+    mapping-spec consumable by :func:`apply_mapping_spec`."""
+    mappings = [p.to_spec_entry() for p in proposals
+                if p.action != "ignore" and p.confidence >= min_confidence]
+    return {"ontology": ontology_name, "mappings": mappings}

--- a/tests/seocho/test_ambiguity_proposals.py
+++ b/tests/seocho/test_ambiguity_proposals.py
@@ -1,0 +1,72 @@
+"""Tests for the ambiguity proposal engine — Phase 2 (ADR-0128)."""
+
+from __future__ import annotations
+
+import json
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology_ambiguity import (
+    apply_mapping_spec,
+    propose_mappings,
+    proposals_to_mapping_spec,
+)
+
+
+def _onto() -> Ontology:
+    return Ontology("biz", version="1.0.0", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+        "Concept": NodeDef(description="A concept."),
+    })
+
+
+_CLUSTERS = [
+    {"surface": "Regulation", "frequency": 12, "signals": {"oov": 12}, "candidate_labels": [], "examples": ["Basel III..."]},
+    {"surface": "Adj. EBITDA", "frequency": 7, "signals": {"oov": 7}, "candidate_labels": [], "examples": []},
+    {"surface": "junk", "frequency": 1, "signals": {"oov": 1}, "candidate_labels": [], "examples": []},
+]
+
+
+class _Resp:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeBackend:
+    model = "DeepSeek-V3.1"
+
+    def complete(self, *, system, user, **kw):
+        return _Resp(json.dumps({"proposals": [
+            {"surface": "Regulation", "action": "new_class", "target": "Regulation",
+             "parent": "Concept", "description": "A regulatory rule.", "confidence": 0.9, "rationale": "recurring"},
+            {"surface": "Adj. EBITDA", "action": "alias", "target": "Company",
+             "confidence": 0.4, "rationale": "metric alias (toy)"},
+            {"surface": "junk", "action": "ignore", "confidence": 0.8, "rationale": "noise"},
+        ]}))
+
+
+def test_propose_mappings_parses_and_scores():
+    props = propose_mappings(_CLUSTERS, _onto(), backend=_FakeBackend())
+    by_surface = {p.surface: p for p in props}
+    assert by_surface["Regulation"].action == "new_class"
+    # new_class for a high-frequency surface in the cluster corpus → positive coverage lift
+    assert by_surface["Regulation"].predicted_coverage_delta is not None
+    assert by_surface["Regulation"].predicted_coverage_delta > 0
+    # ranked: the biggest predicted lift comes first
+    assert props[0].surface == "Regulation"
+
+
+def test_proposals_to_spec_filters_and_round_trips():
+    props = propose_mappings(_CLUSTERS, _onto(), backend=_FakeBackend())
+    spec = proposals_to_mapping_spec(props, min_confidence=0.5)
+    surfaces = {m["surface"] for m in spec["mappings"]}
+    assert "Regulation" in surfaces           # conf 0.9 kept
+    assert "Adj. EBITDA" not in surfaces      # conf 0.4 filtered
+    assert "junk" not in surfaces             # ignore dropped
+    # the spec applies cleanly and adds the new class
+    new_onto = apply_mapping_spec(_onto(), spec)
+    assert "Regulation" in new_onto.nodes
+    assert new_onto.nodes["Regulation"].broader == ["Concept"]
+
+
+def test_empty_clusters_returns_empty():
+    assert propose_mappings([], _onto(), backend=_FakeBackend()) == []


### PR DESCRIPTION
propose_mappings(clusters, ontology, backend) → LLM proposals (alias/new_class/ignore) via the provider-aware structured layer, each scored offline by predicted corpus_coverage lift and ranked. proposals_to_mapping_spec() filters + round-trips through apply_mapping_spec. Injected backend → fake-testable. 3 tests + run_basic_ci 631 passed.