### PR TITLE
feat(integrations): DataHub Phase B/C — proposals + governance MCPs (ADR-0129)

### DIFF
--- a/docs/decisions/ADR-0129-datahub-phase-bc.md
+++ b/docs/decisions/ADR-0129-datahub-phase-bc.md
@@ -1,0 +1,48 @@
+# ADR-0129: DataHub Connector Phase B/C — Ambiguity Proposals + Governance as Structured Properties / Assertions
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0121 (Phase A) exports an ontology to a DataHub Business Glossary. The user
+chose DataHub as the ambiguity-mapping/distribution surface. Phase B/C surface the
+rest of the SEOCHO loop in DataHub: the ambiguity-review queue, and the governance
+signals (scorecard, numeric validation) DataHub itself can't compute.
+
+## Decision
+
+Extend `seocho.datahub_export` (pure dict-MCP construction, no live `datahub`):
+
+- **Phase B** — `ambiguity_clusters_to_glossary_proposals(clusters, *,
+  package_id, status="PROPOSED")`: each cluster becomes a PROPOSED `glossaryTerm`
+  under a `<package_id>.Proposed` node, customProperties carrying frequency,
+  signals, candidate_labels, review_status. The review queue, visible in DataHub.
+- **Phase C** — `scorecard_to_structured_properties(scorecard, *, target_urn)`:
+  overall_score / grade / blocking / each dimension score as `structuredProperties`
+  under `seocho.scorecard.*` on the package node. And
+  `numeric_validation_to_assertions(validation, *, dataset_urn,
+  confidence_threshold)`: an `assertionInfo` + `assertionRunEvent` (SUCCESS iff
+  confidence ≥ threshold and no warnings) — numeric validation (ADR-0127) as a
+  DataHub data-quality assertion.
+
+Deterministic URNs; no `datahub` dependency in these functions. Aspect field
+names follow DataHub's documented model and must be verified against the target
+`datahub` version before live emit.
+
+## Validation
+
+`tests/seocho/test_datahub_bc.py` (3): clusters → N PROPOSED terms + 1 Proposed
+node with deterministic URNs and review_status/frequency in customProperties;
+scorecard → structuredProperties MCP carrying overall/grade/blocking + each
+dimension; numeric validation → assertionInfo+assertionRunEvent with SUCCESS for a
+clean result and FAILURE for one with a warn finding. `run_basic_ci` green.
+
+## Consequences
+
+- The full SEOCHO loop is now expressible in DataHub: governed glossary (A),
+  review queue (B), and quality/quality-gate signals (C) — SEOCHO computes them,
+  DataHub renders/approves them.
+- Follow-ups (seocho-qxj): wire these into `emit_to_datahub` paths + a CLI; verify
+  exact aspect shapes against a live GMS; round-trip approvals (DataHub term
+  status → mapping-spec) to close the loop with `apply_mapping_spec`.

--- a/src/seocho/datahub_export.py
+++ b/src/seocho/datahub_export.py
@@ -163,3 +163,109 @@ def emit_to_datahub(
 
 def glossary_mcps_to_json(mcps: List[Dict[str, Any]]) -> str:
     return json.dumps(mcps, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Phase B/C (ADR-0129): surface the ambiguity-review queue + SEOCHO governance
+# (scorecard / numeric validation) in DataHub. Pure dict-MCP construction — no
+# live `datahub` calls. Aspect field names follow DataHub's documented model;
+# verify against the target datahub version before live emit.
+# ---------------------------------------------------------------------------
+
+
+def ambiguity_clusters_to_glossary_proposals(
+    clusters: List[Dict[str, Any]],
+    *,
+    package_id: str,
+    status: str = "PROPOSED",
+) -> List[Dict[str, Any]]:
+    """Render ambiguity-review clusters as PROPOSED glossary terms under a
+    ``<package_id>.Proposed`` node — the review queue, visible in DataHub."""
+    proposed_node_id = f"{package_id}.Proposed"
+    mcps: List[Dict[str, Any]] = [_mcp("glossaryNode", _node_urn(proposed_node_id), "glossaryNodeInfo", {
+        "name": f"{package_id} — Proposed (ambiguity review)",
+        "definition": "Out-of-ontology mentions awaiting human mapping (SEOCHO ambiguity review).",
+        "id": _slug(proposed_node_id),
+        "parentNode": _node_urn(package_id),
+    })]
+    for c in clusters:
+        surface = str(c.get("surface", ""))
+        if not surface:
+            continue
+        term_id = f"{package_id}.proposed.{surface}"
+        mcps.append(_mcp("glossaryTerm", _term_urn(term_id), "glossaryTermInfo", {
+            "name": surface,
+            "definition": ((c.get("examples") or [""])[0] or f"Proposed term '{surface}' (under review)")[:280],
+            "termSource": "INTERNAL",
+            "parentNode": _node_urn(proposed_node_id),
+            "customProperties": {
+                "review_status": status,
+                "frequency": str(c.get("frequency", 0)),
+                "signals": json.dumps(c.get("signals", {}), ensure_ascii=False),
+                "candidate_labels": ", ".join(c.get("candidate_labels", []) or []),
+            },
+        }))
+    return mcps
+
+
+def scorecard_to_structured_properties(
+    scorecard: Dict[str, Any],
+    *,
+    target_urn: str,
+) -> List[Dict[str, Any]]:
+    """Map an ``OntologyScorecard.to_dict()`` onto DataHub structuredProperties on
+    ``target_urn`` (e.g. the package glossaryNode): overall score, grade, blocking,
+    and each dimension score under ``seocho.scorecard.*`` keys."""
+    props: List[Dict[str, Any]] = [
+        {"propertyUrn": "urn:li:structuredProperty:seocho.scorecard.overall_score",
+         "values": [scorecard.get("overall_score")]},
+        {"propertyUrn": "urn:li:structuredProperty:seocho.scorecard.grade",
+         "values": [scorecard.get("grade")]},
+        {"propertyUrn": "urn:li:structuredProperty:seocho.scorecard.blocking",
+         "values": [bool(scorecard.get("blocking"))]},
+    ]
+    for dim in scorecard.get("dimensions", []):
+        name = dim.get("name")
+        if name:
+            props.append({
+                "propertyUrn": f"urn:li:structuredProperty:seocho.scorecard.{name}",
+                "values": [dim.get("score")],
+            })
+    entity_type = "glossaryNode" if ":glossaryNode:" in target_urn else "dataset"
+    return [_mcp(entity_type, target_urn, "structuredProperties", {"properties": props})]
+
+
+def numeric_validation_to_assertions(
+    validation: Dict[str, Any],
+    *,
+    dataset_urn: str,
+    confidence_threshold: float = 1.0,
+) -> List[Dict[str, Any]]:
+    """Map a ``NumericValidationResult.to_dict()`` onto DataHub assertion MCPs on
+    ``dataset_urn``: an assertionInfo (the rule) + an assertionRunEvent (the
+    result — SUCCESS iff confidence >= threshold and no warnings)."""
+    confidence = float(validation.get("confidence", 1.0) or 0.0)
+    warnings = [f for f in validation.get("findings", []) if f.get("severity") == "warn"]
+    passed = confidence >= confidence_threshold and not warnings
+    assertion_urn = f"urn:li:assertion:seocho.numeric_validation.{_slug(dataset_urn)}"
+    return [
+        _mcp("assertion", assertion_urn, "assertionInfo", {
+            "type": "DATASET",
+            "description": "SEOCHO numeric-fact validation (unit/scale/period/reconciliation; ADR-0127).",
+            "datasetAssertion": {"dataset": dataset_urn, "scope": "DATASET_ROWS",
+                                 "operator": "_NATIVE_", "nativeType": "seocho.numeric_validation"},
+        }),
+        _mcp("assertion", assertion_urn, "assertionRunEvent", {
+            "assertionUrn": assertion_urn,
+            "asserteeUrn": dataset_urn,
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS" if passed else "FAILURE",
+                "nativeResults": {
+                    "confidence": str(round(confidence, 4)),
+                    "warning_count": str(len(warnings)),
+                    "findings": json.dumps(validation.get("findings", []), ensure_ascii=False)[:900],
+                },
+            },
+        }),
+    ]

--- a/tests/seocho/test_datahub_bc.py
+++ b/tests/seocho/test_datahub_bc.py
@@ -1,0 +1,55 @@
+"""Tests for DataHub connector Phase B/C (ADR-0129)."""
+
+from __future__ import annotations
+
+import json
+
+from seocho.datahub_export import (
+    ambiguity_clusters_to_glossary_proposals,
+    numeric_validation_to_assertions,
+    scorecard_to_structured_properties,
+)
+
+_CLUSTERS = [
+    {"surface": "Regulation", "frequency": 12, "signals": {"oov": 12}, "candidate_labels": [], "examples": ["Basel III"]},
+    {"surface": "Adj. EBITDA", "frequency": 7, "signals": {"oov": 7}, "candidate_labels": ["FinancialMetric"], "examples": []},
+]
+
+
+def test_clusters_to_proposed_terms():
+    mcps = ambiguity_clusters_to_glossary_proposals(_CLUSTERS, package_id="fin")
+    terms = [m for m in mcps if m["entityType"] == "glossaryTerm"]
+    nodes = [m for m in mcps if m["entityType"] == "glossaryNode"]
+    assert len(terms) == 2 and len(nodes) == 1            # 2 proposed terms + 1 Proposed node
+    reg = next(m for m in terms if m["aspect"]["name"] == "Regulation")
+    assert reg["entityUrn"] == "urn:li:glossaryTerm:fin.proposed.Regulation"   # deterministic
+    cp = reg["aspect"]["customProperties"]
+    assert cp["review_status"] == "PROPOSED" and cp["frequency"] == "12"
+    assert nodes[0]["aspect"]["parentNode"] == "urn:li:glossaryNode:fin"
+
+
+def test_scorecard_to_structured_properties():
+    sc = {"overall_score": 0.92, "grade": "A", "blocking": False,
+          "dimensions": [{"name": "taxonomy_health", "score": 0.8}, {"name": "corpus_coverage", "score": 0.6}]}
+    mcps = scorecard_to_structured_properties(sc, target_urn="urn:li:glossaryNode:fin")
+    assert len(mcps) == 1 and mcps[0]["aspectName"] == "structuredProperties"
+    keys = {p["propertyUrn"] for p in mcps[0]["aspect"]["properties"]}
+    assert "urn:li:structuredProperty:seocho.scorecard.overall_score" in keys
+    assert "urn:li:structuredProperty:seocho.scorecard.taxonomy_health" in keys
+    assert "urn:li:structuredProperty:seocho.scorecard.corpus_coverage" in keys
+
+
+def test_numeric_validation_to_assertions_pass_and_fail():
+    clean = {"findings": [], "confidence": 1.0}
+    dirty = {"findings": [{"severity": "warn", "code": "reconciliation", "message": "sum != total"}], "confidence": 0.66}
+    ds = "urn:li:dataset:(urn:li:dataPlatform:seocho,fin_graph,PROD)"
+    ok = numeric_validation_to_assertions(clean, dataset_urn=ds)
+    bad = numeric_validation_to_assertions(dirty, dataset_urn=ds)
+    ok_run = next(m for m in ok if m["aspectName"] == "assertionRunEvent")
+    bad_run = next(m for m in bad if m["aspectName"] == "assertionRunEvent")
+    assert ok_run["aspect"]["result"]["type"] == "SUCCESS"
+    assert bad_run["aspect"]["result"]["type"] == "FAILURE"
+    info = next(m for m in ok if m["aspectName"] == "assertionInfo")
+    assert info["aspect"]["datasetAssertion"]["dataset"] == ds   # dataset urn embedded
+    # both emit assertionInfo + assertionRunEvent
+    assert {m["aspectName"] for m in ok} == {"assertionInfo", "assertionRunEvent"}


### PR DESCRIPTION
ambiguity_clusters_to_glossary_proposals (review queue as PROPOSED terms), scorecard_to_structured_properties, numeric_validation_to_assertions. Pure dict-MCP, no datahub dep in core. 3 tests + run_basic_ci 631 passed.