### PR TITLE
feat(ontology): OntoClean pre-validation of new_class proposals (ADR-0128 follow-up)

### DIFF
--- a/src/seocho/ontology_ambiguity.py
+++ b/src/seocho/ontology_ambiguity.py
@@ -285,6 +285,9 @@ class MappingProposal:
     confidence: float = 0.0
     predicted_coverage_delta: Optional[float] = None
     rationale: str = ""
+    # OntoClean pre-validation of the proposed is-a edge (new_class under parent):
+    # None = not checked (no tags), "ok" = passes, else a violation message.
+    ontoclean: Optional[str] = None
 
     def to_spec_entry(self) -> Dict[str, Any]:
         entry: Dict[str, Any] = {"surface": self.surface, "action": self.action}
@@ -302,7 +305,7 @@ class MappingProposal:
             "surface": self.surface, "action": self.action, "target": self.target,
             "parent": self.parent, "description": self.description,
             "confidence": self.confidence, "predicted_coverage_delta": self.predicted_coverage_delta,
-            "rationale": self.rationale,
+            "rationale": self.rationale, "ontoclean": self.ontoclean,
         }
 
 
@@ -329,6 +332,23 @@ def _propose_prompt(clusters: List[Dict[str, Any]], ontology: Ontology) -> str:
     return "\n".join(lines)
 
 
+def _ontoclean_precheck(candidate: Ontology, prop: "MappingProposal", tags: Dict[str, Any]) -> Optional[str]:
+    """Run the OntoClean subsumption check on the candidate ontology (which now
+    contains the proposed ``new_class`` under its parent) and report the verdict
+    for that edge. Returns None when the proposed class is untagged (can't check)."""
+    from .ontology_ontoclean import check_ontoclean
+
+    child_label = prop.target or prop.surface
+    if child_label not in tags:
+        return None  # no meta-properties for the proposed class → cannot judge
+    result = check_ontoclean(candidate, tags)
+    hits = [v for v in result.violations
+            if v.severity == "violation" and v.child == child_label and v.parent == prop.parent]
+    if hits:
+        return f"violation: {hits[0].message}"
+    return "ok"
+
+
 def propose_mappings(
     clusters: List[Dict[str, Any]],
     ontology: Ontology,
@@ -336,11 +356,15 @@ def propose_mappings(
     backend: Any,
     model: Optional[str] = None,
     top_k: int = 20,
+    ontoclean_tags: Optional[Dict[str, Any]] = None,
 ) -> List[MappingProposal]:
     """Generate ranked mapping proposals for the top clusters via an LLM
     (injected ``backend``; routed through the provider-aware structured layer,
     ADR-0120). Each proposal is annotated with its predicted corpus-coverage lift
-    (computed offline by applying it and re-scoring). Fake-testable."""
+    (computed offline by applying it and re-scoring). When ``ontoclean_tags``
+    (``{label: MetaProperties}``) are supplied, a ``new_class`` proposal's
+    is-a placement under its parent is OntoClean-prechecked and the verdict is
+    recorded on ``proposal.ontoclean``. Fake-testable."""
     from .llm_structured import StructuredOutputError, structured_complete
 
     top = list(clusters)[:top_k]
@@ -388,6 +412,8 @@ def propose_mappings(
             try:
                 candidate = apply_mapping_spec(ontology, {"mappings": [prop.to_spec_entry()]})
                 prop.predicted_coverage_delta = round(_coverage(candidate) - base_cov, 4)
+                if action == "new_class" and prop.parent and ontoclean_tags:
+                    prop.ontoclean = _ontoclean_precheck(candidate, prop, ontoclean_tags)
             except Exception:
                 prop.predicted_coverage_delta = None
         proposals.append(prop)

--- a/tests/seocho/test_ambiguity_proposals.py
+++ b/tests/seocho/test_ambiguity_proposals.py
@@ -70,3 +70,45 @@ def test_proposals_to_spec_filters_and_round_trips():
 
 def test_empty_clusters_returns_empty():
     assert propose_mappings([], _onto(), backend=_FakeBackend()) == []
+
+
+def test_ontoclean_precheck_flags_rigid_under_role():
+    from seocho.ontology_ontoclean import MetaProperties
+
+    onto = Ontology("roles", version="1.0.0", nodes={
+        "Employee": NodeDef(description="A role.", properties={"id": P(str, unique=True)}),
+    })
+    clusters = [{"surface": "Person", "frequency": 9, "signals": {"oov": 9}, "candidate_labels": [], "examples": []}]
+
+    class _Fake:
+        model = "DeepSeek-V3.1"
+        def complete(self, *, system, user, **kw):
+            return _Resp(json.dumps({"proposals": [
+                {"surface": "Person", "action": "new_class", "target": "Person",
+                 "parent": "Employee", "description": "A human.", "confidence": 0.9, "rationale": "x"}]}))
+
+    tags = {"Person": MetaProperties(rigid=True), "Employee": MetaProperties(rigid=False)}
+    props = propose_mappings(clusters, onto, backend=_Fake(), ontoclean_tags=tags)
+    p = props[0]
+    assert p.action == "new_class" and p.parent == "Employee"
+    assert p.ontoclean and p.ontoclean.startswith("violation")  # rigid Person under anti-rigid Employee
+
+
+def test_ontoclean_precheck_ok_and_skipped():
+    from seocho.ontology_ontoclean import MetaProperties
+
+    onto = Ontology("biz2", version="1.0.0", nodes={"Concept": NodeDef(description="c.")})
+    clusters = [{"surface": "Regulation", "frequency": 9, "signals": {"oov": 9}, "candidate_labels": [], "examples": []}]
+
+    class _Fake:
+        model = "DeepSeek-V3.1"
+        def complete(self, *, system, user, **kw):
+            return _Resp(json.dumps({"proposals": [
+                {"surface": "Regulation", "action": "new_class", "target": "Regulation",
+                 "parent": "Concept", "description": "A rule.", "confidence": 0.9, "rationale": "x"}]}))
+
+    # both tagged rigid → ok
+    tags = {"Regulation": MetaProperties(rigid=True), "Concept": MetaProperties(rigid=True)}
+    assert propose_mappings(clusters, onto, backend=_Fake(), ontoclean_tags=tags)[0].ontoclean == "ok"
+    # no tags supplied → not checked (None)
+    assert propose_mappings(clusters, onto, backend=_Fake())[0].ontoclean is None


### PR DESCRIPTION
propose_mappings(ontoclean_tags=) prechecks each new_class proposal's is-a placement via check_ontoclean; records 'ok'/'violation: ...'/None on proposal.ontoclean. Catches rigid-under-role etc. Offline/fake-testable. 2 tests + run_basic_ci 631 passed.