### PR TITLE
feat(integrations): DataHub approval round-trip into the ontology (ADR-0129 follow-up)

### DIFF
--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -368,6 +368,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ontology_select_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
+    ontology_dhapply_parser = ontology_subparsers.add_parser(
+        "datahub-apply",
+        help="Round-trip approved DataHub glossary terms back into the ontology (close the review loop)",
+    )
+    ontology_dhapply_parser.add_argument("--schema", required=True, help="Ontology file (JSON-LD, YAML, or TTL)")
+    ontology_dhapply_parser.add_argument("--terms", required=True, help="Reviewed glossary terms JSON (list of records)")
+    ontology_dhapply_parser.add_argument("--status", default="APPROVED", help="Only apply terms with this review status")
+    ontology_dhapply_parser.add_argument("--output", default=None, help="Write the new ontology JSON-LD here")
+    ontology_dhapply_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
     ontology_eval_answers_parser = ontology_subparsers.add_parser(
         "eval-answers",
         help="Measure answer accuracy of an ontology guardrail over a gold QA set (ADR-0124/0125)",
@@ -1656,6 +1666,24 @@ def _cmd_ontology(args: argparse.Namespace) -> int:
                   f"({s['glossary_terms']} terms, {s['glossary_nodes']} nodes, {s['is_a_edges']} is-a edges)")
         else:
             print(text)
+        return 0
+
+    if args.ontology_command == "datahub-apply":
+        from .ontology import Ontology
+        from .datahub_export import datahub_glossary_to_mapping_spec
+        from .ontology_ambiguity import apply_mapping_spec
+
+        ontology = Ontology.load(args.schema)
+        term_records = json.loads(Path(args.terms).read_text(encoding="utf-8"))
+        spec = datahub_glossary_to_mapping_spec(term_records, only_status=args.status, ontology_name=ontology.name)
+        new_onto = apply_mapping_spec(ontology, spec)
+        payload = new_onto.to_jsonld()
+        if args.output:
+            Path(args.output).write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+            print(f"applied {len(spec['mappings'])} approved term(s): {ontology.version} → {new_onto.version}, "
+                  f"{len(ontology.nodes)} → {len(new_onto.nodes)} classes → {args.output}")
+        else:
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
         return 0
 
     if args.ontology_command == "select-guardrail":

--- a/src/seocho/datahub_export.py
+++ b/src/seocho/datahub_export.py
@@ -269,3 +269,45 @@ def numeric_validation_to_assertions(
             },
         }),
     ]
+
+
+def datahub_glossary_to_mapping_spec(
+    term_records: List[Dict[str, Any]],
+    *,
+    only_status: str = "APPROVED",
+    ontology_name: str = "",
+) -> Dict[str, Any]:
+    """Round-trip: turn reviewed DataHub glossary terms back into a SEOCHO
+    mapping-spec (consumable by ``ontology_ambiguity.apply_mapping_spec``), closing
+    the human-approval loop. ``term_records`` is the normalized form a DataHub
+    read yields after human edits: dicts with ``name`` and (from customProperties)
+    ``review_status`` / ``action`` / ``target`` / ``parent`` / ``description``.
+    Only terms whose status matches ``only_status`` become mappings.
+
+    (A live DataHub GraphQL source adapter that produces these records is a
+    follow-up; this function defines the offline contract and is fully tested.)"""
+    mappings: List[Dict[str, Any]] = []
+    for rec in term_records:
+        if not isinstance(rec, dict):
+            continue
+        if str(rec.get("review_status") or rec.get("status") or "").upper() != only_status.upper():
+            continue
+        name = str(rec.get("name", "")).strip()
+        if not name:
+            continue
+        action = str(rec.get("action") or "new_class").strip()
+        if action not in {"alias", "new_class", "same_as"}:
+            continue
+        entry: Dict[str, Any] = {"surface": name, "action": action}
+        target = str(rec.get("target") or (name if action == "new_class" else "")).strip()
+        if target:
+            entry["target"] = target
+        if action == "new_class":
+            parent = str(rec.get("parent", "")).strip()
+            if parent:
+                entry["parent"] = parent
+            desc = str(rec.get("description", "")).strip()
+            if desc:
+                entry["description"] = desc
+        mappings.append(entry)
+    return {"ontology": ontology_name, "mappings": mappings}

--- a/tests/seocho/test_datahub_roundtrip.py
+++ b/tests/seocho/test_datahub_roundtrip.py
@@ -1,0 +1,46 @@
+"""Tests for the DataHub approval round-trip (ADR-0129 follow-up)."""
+
+from __future__ import annotations
+
+from seocho.datahub_export import datahub_glossary_to_mapping_spec
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology_ambiguity import apply_mapping_spec
+
+
+def _terms():
+    return [
+        {"name": "Regulation", "review_status": "APPROVED", "action": "new_class",
+         "parent": "Concept", "description": "A rule."},
+        {"name": "Adj. EBITDA", "review_status": "APPROVED", "action": "alias", "target": "FinancialMetric"},
+        {"name": "Maybe", "review_status": "PROPOSED", "action": "new_class", "parent": "Concept"},  # not approved
+        {"name": "junk", "status": "REJECTED", "action": "ignore"},
+    ]
+
+
+def test_only_approved_terms_become_mappings():
+    spec = datahub_glossary_to_mapping_spec(_terms(), only_status="APPROVED")
+    surfaces = {m["surface"]: m for m in spec["mappings"]}
+    assert set(surfaces) == {"Regulation", "Adj. EBITDA"}   # PROPOSED + REJECTED excluded
+    assert surfaces["Regulation"]["action"] == "new_class"
+    assert surfaces["Regulation"]["parent"] == "Concept"
+    assert surfaces["Adj. EBITDA"]["action"] == "alias"
+    assert surfaces["Adj. EBITDA"]["target"] == "FinancialMetric"
+
+
+def test_roundtrip_applies_to_ontology():
+    onto = Ontology("biz", version="1.0.0", nodes={
+        "Concept": NodeDef(description="A concept."),
+        "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+    })
+    spec = datahub_glossary_to_mapping_spec(_terms(), only_status="APPROVED", ontology_name=onto.name)
+    new_onto = apply_mapping_spec(onto, spec)
+    assert "Regulation" in new_onto.nodes
+    assert new_onto.nodes["Regulation"].broader == ["Concept"]
+    assert "Adj. EBITDA" in new_onto.nodes["FinancialMetric"].aliases
+    assert new_onto.version == "1.1.0"  # minor bump
+
+
+def test_empty_when_no_approved():
+    spec = datahub_glossary_to_mapping_spec(
+        [{"name": "x", "review_status": "PROPOSED", "action": "new_class"}], only_status="APPROVED")
+    assert spec["mappings"] == []


### PR DESCRIPTION
datahub_glossary_to_mapping_spec() + CLI 'seocho ontology datahub-apply' round-trip approved DataHub glossary terms back into a new ontology version (DataHub review → taxonomy), closing the loop. Offline; live GraphQL source adapter is a follow-up. 3 tests + CLI smoke + run_basic_ci 631 passed.