### PR TITLE
docs(eval): P3 v2 — numeric validation precision/recall measured; recall needs source grounding (ADR-0130)

### DIFF
--- a/docs/decisions/ADR-0127-p3v2-validator-precision.json
+++ b/docs/decisions/ADR-0127-p3v2-validator-precision.json
@@ -1,0 +1,615 @@
+{
+  "experiment": "P3v2-validator-precision",
+  "model": "DeepSeek-V3.1",
+  "summary": {
+    "n_scored": 80,
+    "n_correct": 44,
+    "n_structural_wrong": 28,
+    "OLD": {
+      "recall_on_structural": 0.9286,
+      "false_positive_on_correct": 0.9091
+    },
+    "NEW": {
+      "recall_on_structural": 0.0,
+      "false_positive_on_correct": 0.0455
+    }
+  },
+  "results": [
+    {
+      "id": "0019de4b",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "008beea7",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "00b0e3cd",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0191b4af",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0264fa95",
+      "type": "Compositional",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "027b67ae",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "03bb2a85",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "03f83848",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "04867d1f",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0542261a",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "05d9f1d9",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "06a2f739",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "06c09d44",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "06cbd247",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "070a12e3",
+      "type": "Compositional",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0748ea37",
+      "type": "Compositional",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "02b691db",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "080ee40b",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "08117364",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0ae7ad85",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "1023e5b0",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "1127cdbe",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "116f7dd0",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "1248cfe0",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "128144b8",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "1447cf8d",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "14d30823",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "15b5a805",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "17504a14",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "17d90aad",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "182f0809",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "18da327f",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "09e02aa0",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0aa82f46",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0b916241",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0b9424ce",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0e73082a",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "1212a36a",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "13e75b54",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "17e2ebe3",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "17f2bd61",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "1c44a557",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "1dc1afeb",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "200b60b0",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "21b12275",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "23e48bf5",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "24132b64",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "2448d34a",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "0098df3b",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "00b622f5",
+      "type": "Subtract",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "01d03a27",
+      "type": "Subtract",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "04617585",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "062e1065",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "08f24d41",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0ab8560c",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0f41b58e",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "114821a1",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "17c1ab79",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "1cd23310",
+      "type": "Subtract",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "2043c063",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "21e0225d",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "227a8b74",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "232e9758",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "24b36dea",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0016fe33",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "03d190de",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "08ba441b",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "09aaa84a",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0a89f264",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0dbaf98d",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0e7dfbe5",
+      "type": "Addition",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "187d825c",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "18a79c92",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "217c0933",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "22bb7b97",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "2a614102",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "2af21ee3",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "2bac5828",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "303b76f5",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "3a06278d",
+      "type": "Addition",
+      "old_flagged": false,
+      "new_flagged": false,
+      "correct": true
+    }
+  ]
+}

--- a/docs/decisions/ADR-0130-numeric-validation-cannot-catch-wrong-number-pulled.md
+++ b/docs/decisions/ADR-0130-numeric-validation-cannot-catch-wrong-number-pulled.md
@@ -1,0 +1,70 @@
+# ADR-0130: Measured — Isolated-Fact Numeric Validation Cannot Catch "Wrong Number Pulled"; Recall Needs Source-Grounded Reconciliation
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0127 redesigned numeric validation to be precision-first (soft findings,
+unit/scale normalization, relaxed presence, reconciliation) to fix ADR-0119's
+measured precision failure (old validator: recall 0.94 on structural-wrong cases,
+but **91% false-positive on correct answers** — it flagged almost everything). We
+re-measured (P3 v2) to confirm the new validator keeps recall while fixing
+precision.
+
+## Experiment
+
+`scripts/benchmarks/p3v2_validator_precision.py`, MARA DeepSeek-V3.1 (ub5 layer),
+**80 FinDER numeric-reasoning cases**, workers=6 + 429-retry. Extract facts +
+answer → judge correctness + error type → apply BOTH validators to each case's
+facts. Record: `docs/decisions/ADR-0127-p3v2-validator-precision.json`.
+
+## Findings (measured)
+
+| validator | recall on structural-wrong | false-positive on correct |
+|---|---|---|
+| OLD (ADR-0119: SHACL + rigid enums + required period) | **0.93** | **0.91** |
+| NEW (ADR-0127: soft + normalized + reconciliation) | **0.00** | **0.045** |
+
+(80 scored: 44 correct, 28 structural-wrong, 8 arithmetic/other.)
+
+## Interpretation — an honest negative result
+
+1. **The new validator achieved precision (FP 0.91 → 0.045) but recall collapsed
+   to 0.0.** By relaxing missing-period/unknown-unit to `info` and only `warn`-ing
+   on non-numeric value / implausible sign / failed reconciliation, it warns on
+   almost nothing — including the structural errors.
+2. **The old validator's 0.93 recall was an artifact of flagging *everything***
+   (91% of correct answers too). A detector that fires on ~all inputs has no real
+   recall. So neither extreme is a usable guardrail.
+3. **The dominant structural error is "wrong number pulled"** — a *plausible*
+   value that happens to be wrong (correct type, unit, period; just not the right
+   figure). **No isolated-fact rule can detect this**, because nothing in the
+   extracted fact alone reveals it is wrong. Reconciliation is the right idea, but
+   FinDER extractions rarely yield clean part/total groups, so it almost never
+   fires here.
+
+## Decision
+
+- **Keep `numeric_validation` as a precision-first SOFT signal** for the genuinely
+  catchable subset (non-numeric value, implausible sign, and reconciliation *when
+  groups exist*) and as a repair-trigger — but **do not claim it detects
+  wrong-number-pulled.** ADR-0127's "high recall" expectation is corrected here.
+- **Recall on the dominant error requires source-grounding**, not richer
+  isolated-fact rules: (a) compare each extracted value against the numbers
+  actually present in the source span (the extractor should emit the supporting
+  span/evidence), and/or (b) reconstruct reconciliation groups from the source
+  table. This is the real next feature for numeric correctness.
+
+## Consequences
+
+- Honest scoping: SEOCHO's numeric guarantee is **validation of the catchable +
+  source-grounded reconciliation**, not blanket numeric error detection. This
+  sharpens ADR-0118/0119's "scope numerics to validation" with what validation
+  can and cannot do.
+- Follow-up: an evidence-grounded numeric check (extracted value ⊂ source-span
+  numbers; table reconciliation) — measure its recall/precision before claiming
+  numeric-error detection.
+- Negative results are recorded deliberately: a validator that flags everything
+  (old) or nothing (new) both fail; the path forward is grounding, not tuning
+  isolated-fact thresholds.

--- a/scripts/benchmarks/p3v2_validator_precision.py
+++ b/scripts/benchmarks/p3v2_validator_precision.py
@@ -1,0 +1,192 @@
+"""P3 v2: does the new precision-first numeric validator (ADR-0127) keep recall
+while fixing the precision problem ADR-0119 measured (recall 0.94 / FP 0.91)?
+
+Same protocol as P3 (ADR-0119): FinDER numeric-reasoning cases, extract facts +
+answer (MARA via the ub5 structured layer), judge correctness + error type. Then
+apply BOTH validators to each case's facts and compare:
+  - OLD = validate_with_shacl (required value/period) + rigid unit/scale enum rules
+  - NEW = seocho.numeric_validation.validate_numeric_facts (soft, normalized,
+          reconciliation; a `warn` finding = flagged)
+Headline metrics for each: recall on structural-wrong cases + false-positive rate
+on correct cases.
+
+Key from .env. Run:
+  PYTHONPATH=src python3 scripts/benchmarks/p3v2_validator_precision.py \
+     --per-type 16 --max-chars 3500 --workers 6 --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Lock
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.llm_structured import StructuredOutputError, structured_complete
+from seocho.numeric_validation import validate_numeric_facts
+from seocho.store.llm import create_llm_backend
+
+NUMERIC_TYPES = ["Compositional", "Division", "Multiplication", "Subtract", "Addition"]
+# OLD validator's rigid enums (the ADR-0119 design that over-flagged)
+_OLD_UNITS = {"usd", "$", "dollars", "percent", "%", "shares", "ratio", "x", "eur", "gbp", "jpy", ""}
+_OLD_SCALES = {"", "ones", "thousand", "thousands", "million", "millions", "billion", "billions"}
+_PERIOD_RE = re.compile(r"(19|20)\d{2}|q[1-4]|fy|h[12]|first|second|third|fourth|quarter|annual", re.I)
+
+
+def _fin_numeric_ontology() -> Ontology:
+    return Ontology("fin-numeric", version="1.0.0", nodes={
+        "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True, required=True)}),
+        "FinancialMetric": NodeDef(description="A reported metric.", properties={
+            "name": P(str, required=True), "value": P(float, required=True),
+            "unit": P(str), "scale": P(str), "period": P(str, required=True), "company": P(str)}),
+    }, relationships={"REPORTED": RelDef(source="Company", target="FinancialMetric", cardinality="ONE_TO_MANY")})
+
+
+_OLD_ONTO = _fin_numeric_ontology()
+
+
+def old_validator_flags(facts) -> bool:
+    """Replicates the ADR-0119 validator: validate_with_shacl + rigid enum/period
+    rules. Returns True if it flags anything."""
+    nodes = [{"id": f"m{i}", "label": "FinancialMetric", "properties": f} for i, f in enumerate(facts) if isinstance(f, dict)]
+    try:
+        shacl = _OLD_ONTO.validate_with_shacl({"nodes": nodes, "relationships": []})
+    except Exception:
+        shacl = ["err"]
+    if shacl:
+        return True
+    for f in facts:
+        if not isinstance(f, dict):
+            return True
+        v = f.get("value")
+        try:
+            float(str(v).replace(",", "").replace("$", "").replace("%", "")) if v not in (None, "") else None
+        except Exception:
+            return True
+        if str(f.get("unit", "")).strip().lower() and str(f.get("unit", "")).strip().lower() not in _OLD_UNITS:
+            return True
+        if str(f.get("scale", "")).strip().lower() and str(f.get("scale", "")).strip().lower() not in _OLD_SCALES:
+            return True
+        period = str(f.get("period", "")).strip()
+        if not period or not _PERIOD_RE.search(period):
+            return True
+    return False
+
+
+def new_validator_flags(facts) -> bool:
+    """The ADR-0127 validator: a `warn` finding = flagged (info does not count)."""
+    return bool(validate_numeric_facts(facts).warnings)
+
+
+_EXTRACT_SYS = "You are a financial analyst. Extract numeric facts, then answer with a number. Return ONLY JSON."
+_EXTRACT_USER = ("FINANCIAL TEXT:\n{refs}\n\nQUESTION: {q}\n\n"
+                 'Return JSON: {{"facts":[{{"name":"...","value":<number>,"unit":"...","scale":"...",'
+                 '"period":"...","company":"..."}}],"answer":"..."}}')
+_JUDGE_SYS = "You grade financial answers. Return ONLY JSON."
+_CORRECT_USER = 'QUESTION: {q}\nGOLD: {gold}\nMODEL: {ans}\nIs MODEL numerically correct vs GOLD? JSON {{"correct":true|false}}'
+_CLASSIFY_USER = ('QUESTION: {q}\nGOLD: {gold}\nMODEL: {ans}\nFACTS: {facts}\nThe answer is WRONG. '
+                  'Is the error "structural" (wrong/missing/mis-typed extracted fact) or "arithmetic" '
+                  '(facts ok, math wrong)? JSON {{"error_type":"structural"|"arithmetic"}}')
+
+
+def _retry(fn, attempts=5, base=2.0):
+    last = None
+    for i in range(attempts):
+        try:
+            return fn()
+        except Exception as e:
+            last = e
+            if any(s in str(e).lower() for s in ("429", "rate limit", "timeout", "temporarily")):
+                time.sleep(base * (2 ** i)); continue
+            raise
+    raise last
+
+
+def load_cases(per_type, max_chars):
+    from huggingface_hub import hf_hub_download
+    import pandas as pd
+    df = pd.read_parquet(hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset"))
+    cases = []
+    for t in NUMERIC_TYPES:
+        taken = 0
+        for _, row in df[df["type"] == t].sort_values("_id").iterrows():
+            refs = row["references"]
+            text = " ".join(map(str, refs)) if hasattr(refs, "__iter__") and not isinstance(refs, str) else str(refs)
+            if len(text.strip()) < 80:
+                continue
+            cases.append({"id": str(row["_id"]), "type": t, "refs": text.strip()[:max_chars],
+                          "q": str(row["text"]), "gold": str(row["answer"])})
+            taken += 1
+            if taken >= per_type:
+                break
+    return cases
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--per-type", type=int, default=16)
+    ap.add_argument("--max-chars", type=int, default=3500)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--model", default="DeepSeek-V3.1")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    be = create_llm_backend(provider="mara", model=args.model, api_key=key)
+    cases = load_cases(args.per_type, args.max_chars)
+    print(f"{len(cases)} numeric cases")
+    done = {"n": 0}; lock = Lock()
+
+    def run(case):
+        out = {"id": case["id"], "type": case["type"]}
+        try:
+            ex = _retry(lambda: structured_complete(be, system=_EXTRACT_SYS,
+                user=_EXTRACT_USER.format(refs=case["refs"], q=case["q"]), model=args.model, task_hint="json_extraction"))
+            facts = ex.get("facts", []) if isinstance(ex, dict) else []
+            ans = str(ex.get("answer", ""))
+            out["old_flagged"] = old_validator_flags(facts)
+            out["new_flagged"] = new_validator_flags(facts)
+            jc = _retry(lambda: structured_complete(be, system=_JUDGE_SYS,
+                user=_CORRECT_USER.format(q=case["q"], gold=case["gold"], ans=ans), model=args.model))
+            out["correct"] = bool(jc.get("correct"))
+            if not out["correct"]:
+                jt = _retry(lambda: structured_complete(be, system=_JUDGE_SYS,
+                    user=_CLASSIFY_USER.format(q=case["q"], gold=case["gold"], ans=ans, facts=json.dumps(facts)[:1500]),
+                    model=args.model))
+                out["error_type"] = jt.get("error_type")
+        except Exception as e:
+            out["error"] = f"{type(e).__name__}: {str(e)[:80]}"
+        with lock:
+            done["n"] += 1
+            if done["n"] % 20 == 0 or done["n"] == len(cases):
+                print(f"  ... {done['n']}/{len(cases)}")
+        return out
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        results = list(pool.map(run, cases))
+
+    scored = [r for r in results if "correct" in r]
+    correct = [r for r in scored if r["correct"]]
+    structural = [r for r in scored if not r["correct"] and r.get("error_type") == "structural"]
+
+    def rate(subset, key):
+        return round(sum(1 for r in subset if r.get(key)) / len(subset), 4) if subset else None
+
+    summary = {
+        "n_scored": len(scored), "n_correct": len(correct), "n_structural_wrong": len(structural),
+        "OLD": {"recall_on_structural": rate(structural, "old_flagged"), "false_positive_on_correct": rate(correct, "old_flagged")},
+        "NEW": {"recall_on_structural": rate(structural, "new_flagged"), "false_positive_on_correct": rate(correct, "new_flagged")},
+    }
+    rec = {"experiment": "P3v2-validator-precision", "model": args.model, "summary": summary, "results": results}
+    Path(args.out).write_text(json.dumps(rec, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\n[written] {args.out}\n")
+    print(f"scored={len(scored)} correct={len(correct)} structural_wrong={len(structural)}")
+    print(f"OLD: recall={summary['OLD']['recall_on_structural']} FP_on_correct={summary['OLD']['false_positive_on_correct']}")
+    print(f"NEW: recall={summary['NEW']['recall_on_structural']} FP_on_correct={summary['NEW']['false_positive_on_correct']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Re-measured OLD vs NEW numeric validators on 80 FinDER cases (MARA). OLD recall 0.93/FP 0.91; NEW recall 0.00/FP 0.045. Honest negative result: isolated-fact rules can't catch 'wrong number pulled' (the dominant structural error); OLD's recall was a flag-everything artifact. Keep numeric_validation as a precision-first soft signal; recall needs source-grounding (extracted value ⊂ source-span numbers / table reconciliation) — the real next feature. Harness + data committed.