### PR TITLE
feat(ontology): source-grounded numeric check — the recall lever (ADR-0131)

### DIFF
--- a/docs/decisions/ADR-0131-p3v3-grounded.json
+++ b/docs/decisions/ADR-0131-p3v3-grounded.json
@@ -1,0 +1,698 @@
+{
+  "experiment": "P3v3-grounded-validator",
+  "model": "DeepSeek-V3.1",
+  "summary": {
+    "n_scored": 80,
+    "n_correct": 45,
+    "n_structural_wrong": 18,
+    "OLD": {
+      "recall_on_structural": 0.9444,
+      "false_positive_on_correct": 0.9111
+    },
+    "NEW": {
+      "recall_on_structural": 0.0,
+      "false_positive_on_correct": 0.0
+    },
+    "GROUNDED": {
+      "recall_on_structural": 0.2222,
+      "false_positive_on_correct": 0.5111
+    }
+  },
+  "results": [
+    {
+      "id": "0019de4b",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "008beea7",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "00b0e3cd",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0191b4af",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "0264fa95",
+      "type": "Compositional",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "027b67ae",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "03bb2a85",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "03f83848",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "04867d1f",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "0542261a",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "05d9f1d9",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "06a2f739",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "06c09d44",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "06cbd247",
+      "type": "Compositional",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "070a12e3",
+      "type": "Compositional",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0748ea37",
+      "type": "Compositional",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "02b691db",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "080ee40b",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "08117364",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "0ae7ad85",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "1023e5b0",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "1127cdbe",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "116f7dd0",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "1248cfe0",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "128144b8",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "1447cf8d",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "14d30823",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "15b5a805",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "17504a14",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "17d90aad",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "182f0809",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "18da327f",
+      "type": "Division",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "09e02aa0",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0aa82f46",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "0b916241",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "0b9424ce",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0e73082a",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "1212a36a",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "13e75b54",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "17e2ebe3",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "17f2bd61",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "1c44a557",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "1dc1afeb",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "200b60b0",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "21b12275",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "23e48bf5",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "24132b64",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "2448d34a",
+      "type": "Multiplication",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "0098df3b",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "00b622f5",
+      "type": "Subtract",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "01d03a27",
+      "type": "Subtract",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "04617585",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "062e1065",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "08f24d41",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "0ab8560c",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0f41b58e",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "114821a1",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "17c1ab79",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "1cd23310",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "2043c063",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "21e0225d",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "227a8b74",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "232e9758",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "24b36dea",
+      "type": "Subtract",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0016fe33",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "03d190de",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "08ba441b",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "09aaa84a",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "0a89f264",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "0dbaf98d",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "0e7dfbe5",
+      "type": "Addition",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "187d825c",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "18a79c92",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "arithmetic"
+    },
+    {
+      "id": "217c0933",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "22bb7b97",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": false,
+      "error_type": "structural"
+    },
+    {
+      "id": "2a614102",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "2af21ee3",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "2bac5828",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    },
+    {
+      "id": "303b76f5",
+      "type": "Addition",
+      "old_flagged": true,
+      "new_flagged": false,
+      "grounded_flagged": true,
+      "correct": true
+    },
+    {
+      "id": "3a06278d",
+      "type": "Addition",
+      "old_flagged": false,
+      "new_flagged": false,
+      "grounded_flagged": false,
+      "correct": true
+    }
+  ]
+}

--- a/docs/decisions/ADR-0131-source-grounded-numeric-check.md
+++ b/docs/decisions/ADR-0131-source-grounded-numeric-check.md
@@ -1,0 +1,74 @@
+# ADR-0131: Source-Grounded Numeric Check — Recovers Real Recall, Precision Needs Derived-Fact Filtering
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0130 concluded that isolated-fact numeric rules cannot catch the dominant
+financial error ("wrong number pulled" — a plausible-but-wrong value), and that
+recall needs **source grounding**: check whether an extracted value actually
+appears in the source text. This ADR implements and measures that.
+
+## Decision
+
+Add source grounding to `seocho.numeric_validation`:
+
+- `extract_source_numbers(text)` — all numbers in the source (commas, `$`, `%`,
+  parenthesised negatives, and scale-expanded forms: `$539.2 million` → 539.2 and
+  539_200_000).
+- `ground_facts(facts, source_text, *, rel_tol)` — flags each extracted value with
+  no source match as `warn` (`ungrounded_value`), scale-aware.
+- `validate_numeric_facts(facts, *, source_text=None)` folds grounding in when a
+  source is supplied (precision preserved when it is not).
+
+## Validation (measured, P3 v3, MARA, 80 FinDER numeric cases)
+
+`scripts/benchmarks/p3v3_grounded_validator.py`, record
+`docs/decisions/ADR-0131-p3v3-grounded.json`. Same protocol as P3 v1/v2; three
+validators on the extracted facts.
+
+| validator | recall on structural-wrong | false-positive on correct |
+|---|---|---|
+| OLD (SHACL + rigid rules) | 0.94 | 0.91 |
+| NEW (isolated-fact soft) | 0.00 | 0.00 |
+| **GROUNDED (value ∈ source)** | **0.22** | **0.51** |
+
+(45 correct, 18 structural-wrong.)
+
+## Interpretation — directionally right, precision work remains
+
+1. **Grounding is the only approach that recovers non-trivial recall on a real
+   precision budget.** It catches ~22% of structural errors — the fabricated /
+   mis-computed values absent from the source — which both isolated-fact rules
+   (NEW: 0) and the flag-everything OLD (recall is an artifact of 0.91 FP) cannot
+   meaningfully detect.
+2. **But it over-flags correct answers (FP 0.51).** Root cause: it grounds *all*
+   extracted facts, including **derived / intermediate values** the model computes
+   (a ratio, a difference, the answer itself) that are legitimately absent from
+   the source — plus number-format mismatches the extractor/matcher misses.
+3. So grounding-as-is is a useful *signal* but not yet a usable gate. The honest
+   recall ceiling is also bounded: a wrong value that happens to equal a *different*
+   real source number (wrong-cell selection) is grounded and uncatchable here.
+
+## Decision / next
+
+- Ship `ground_facts` + `validate_numeric_facts(source_text=)` as a soft signal /
+  repair-trigger (it is the best numeric-error detector measured so far), but
+  **do not gate on it** at FP 0.51.
+- To make it a gate, the next steps (measured before claiming): (a) **distinguish
+  source-quoted facts from derived ones** — have the extractor mark whether each
+  fact is quoted vs computed, and ground only the quoted ones; (b) harden number
+  normalization/matching (currency words, ranges, units); (c) consider grounding
+  only the *answer-relevant input* facts.
+- Synthesis across ADR-0119/0130/0131: numeric correctness is genuinely hard;
+  flag-everything and flag-nothing both fail; grounding is the right lever and the
+  remaining work is derived-fact filtering, not more isolated-fact rules.
+
+## Consequences
+
+- SEOCHO now has a measured numeric-error *detector* (grounding) with known
+  recall/precision, recorded honestly rather than asserted.
+- This is the financial-numbers-matter throughline (the user's emphasis): the
+  product's numeric guarantee is source-grounded validation, scoped to what the
+  measurements show it can do.

--- a/scripts/benchmarks/p3v3_grounded_validator.py
+++ b/scripts/benchmarks/p3v3_grounded_validator.py
@@ -1,0 +1,165 @@
+"""P3 v3: does SOURCE-GROUNDED numeric validation (ADR-0131) recover recall on
+"wrong-number-pulled" without wrecking precision — where OLD over-flagged
+(recall 0.93 / FP 0.91) and NEW under-flagged (recall 0.00 / FP 0.045, ADR-0130)?
+
+Same FinDER numeric protocol; per case compute three validator verdicts on the
+extracted facts: OLD (SHACL+rigid rules), NEW (soft isolated-fact), GROUNDED
+(value present in the source references). Metrics: recall on structural-wrong +
+false-positive on correct.
+
+Run: PYTHONPATH=src python3 scripts/benchmarks/p3v3_grounded_validator.py \
+       --per-type 16 --workers 6 --out <file.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Lock
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.llm_structured import structured_complete
+from seocho.numeric_validation import ground_facts, validate_numeric_facts
+from seocho.store.llm import create_llm_backend
+
+NUMERIC_TYPES = ["Compositional", "Division", "Multiplication", "Subtract", "Addition"]
+_OLD_UNITS = {"usd", "$", "dollars", "percent", "%", "shares", "ratio", "x", "eur", "gbp", "jpy", ""}
+_OLD_SCALES = {"", "ones", "thousand", "thousands", "million", "millions", "billion", "billions"}
+_PERIOD_RE = re.compile(r"(19|20)\d{2}|q[1-4]|fy|h[12]|first|second|third|fourth|quarter|annual", re.I)
+_OLD_ONTO = Ontology("fin-numeric", version="1.0.0", nodes={
+    "Company": NodeDef(description="c", properties={"name": P(str, unique=True, required=True)}),
+    "FinancialMetric": NodeDef(description="m", properties={
+        "name": P(str, required=True), "value": P(float, required=True),
+        "unit": P(str), "scale": P(str), "period": P(str, required=True), "company": P(str)})},
+    relationships={"REPORTED": RelDef(source="Company", target="FinancialMetric", cardinality="ONE_TO_MANY")})
+
+
+def old_flags(facts) -> bool:
+    nodes = [{"id": f"m{i}", "label": "FinancialMetric", "properties": f} for i, f in enumerate(facts) if isinstance(f, dict)]
+    try:
+        if _OLD_ONTO.validate_with_shacl({"nodes": nodes, "relationships": []}):
+            return True
+    except Exception:
+        return True
+    for f in facts:
+        if not isinstance(f, dict):
+            return True
+        v = f.get("value")
+        try:
+            float(str(v).replace(",", "").replace("$", "").replace("%", "")) if v not in (None, "") else None
+        except Exception:
+            return True
+        u = str(f.get("unit", "")).strip().lower(); sc = str(f.get("scale", "")).strip().lower()
+        if (u and u not in _OLD_UNITS) or (sc and sc not in _OLD_SCALES):
+            return True
+        p = str(f.get("period", "")).strip()
+        if not p or not _PERIOD_RE.search(p):
+            return True
+    return False
+
+
+_SYS = "You are a financial analyst. Extract numeric facts, then answer with a number. Return ONLY JSON."
+_USR = ('FINANCIAL TEXT:\n{refs}\n\nQUESTION: {q}\n\nReturn JSON: {{"facts":[{{"name":"...","value":<number>,'
+        '"unit":"...","scale":"...","period":"...","company":"..."}}],"answer":"..."}}')
+_JS = "You grade financial answers. Return ONLY JSON."
+_CU = 'QUESTION: {q}\nGOLD: {gold}\nMODEL: {ans}\nIs MODEL numerically correct vs GOLD? JSON {{"correct":true|false}}'
+_KU = ('QUESTION: {q}\nGOLD: {gold}\nMODEL: {ans}\nFACTS: {facts}\nAnswer is WRONG. Error "structural" '
+       '(wrong/missing/mis-typed fact) or "arithmetic" (facts ok, math wrong)? JSON {{"error_type":"..."}}')
+
+
+def _retry(fn, attempts=5, base=2.0):
+    last = None
+    for i in range(attempts):
+        try:
+            return fn()
+        except Exception as e:
+            last = e
+            if any(s in str(e).lower() for s in ("429", "rate limit", "timeout", "temporarily")):
+                time.sleep(base * (2 ** i)); continue
+            raise
+    raise last
+
+
+def load_cases(per_type, max_chars):
+    from huggingface_hub import hf_hub_download
+    import pandas as pd
+    df = pd.read_parquet(hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset"))
+    cases = []
+    for t in NUMERIC_TYPES:
+        n = 0
+        for _, row in df[df["type"] == t].sort_values("_id").iterrows():
+            refs = row["references"]
+            text = " ".join(map(str, refs)) if hasattr(refs, "__iter__") and not isinstance(refs, str) else str(refs)
+            if len(text.strip()) < 80:
+                continue
+            cases.append({"id": str(row["_id"]), "type": t, "refs": text.strip()[:max_chars],
+                          "q": str(row["text"]), "gold": str(row["answer"])})
+            n += 1
+            if n >= per_type:
+                break
+    return cases
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--per-type", type=int, default=16)
+    ap.add_argument("--max-chars", type=int, default=3500)
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--model", default="DeepSeek-V3.1")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    be = create_llm_backend(provider="mara", model=args.model, api_key=key)
+    cases = load_cases(args.per_type, args.max_chars)
+    print(f"{len(cases)} cases")
+    done = {"n": 0}; lock = Lock()
+
+    def run(case):
+        o = {"id": case["id"], "type": case["type"]}
+        try:
+            ex = _retry(lambda: structured_complete(be, system=_SYS, user=_USR.format(refs=case["refs"], q=case["q"]),
+                                                    model=args.model, task_hint="json_extraction"))
+            facts = ex.get("facts", []) if isinstance(ex, dict) else []
+            ans = str(ex.get("answer", ""))
+            o["old_flagged"] = old_flags(facts)
+            o["new_flagged"] = bool(validate_numeric_facts(facts).warnings)
+            o["grounded_flagged"] = ground_facts(facts, case["refs"]).any_ungrounded
+            jc = _retry(lambda: structured_complete(be, system=_JS, user=_CU.format(q=case["q"], gold=case["gold"], ans=ans), model=args.model))
+            o["correct"] = bool(jc.get("correct"))
+            if not o["correct"]:
+                jt = _retry(lambda: structured_complete(be, system=_JS, user=_KU.format(q=case["q"], gold=case["gold"], ans=ans, facts=json.dumps(facts)[:1500]), model=args.model))
+                o["error_type"] = jt.get("error_type")
+        except Exception as e:
+            o["error"] = f"{type(e).__name__}: {str(e)[:80]}"
+        with lock:
+            done["n"] += 1
+            if done["n"] % 20 == 0 or done["n"] == len(cases):
+                print(f"  ... {done['n']}/{len(cases)}")
+        return o
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        results = list(pool.map(run, cases))
+
+    scored = [r for r in results if "correct" in r]
+    correct = [r for r in scored if r["correct"]]
+    structural = [r for r in scored if not r["correct"] and r.get("error_type") == "structural"]
+
+    def rate(sub, key):
+        return round(sum(1 for r in sub if r.get(key)) / len(sub), 4) if sub else None
+
+    summary = {"n_scored": len(scored), "n_correct": len(correct), "n_structural_wrong": len(structural)}
+    for v, key in [("OLD", "old_flagged"), ("NEW", "new_flagged"), ("GROUNDED", "grounded_flagged")]:
+        summary[v] = {"recall_on_structural": rate(structural, key), "false_positive_on_correct": rate(correct, key)}
+    rec = {"experiment": "P3v3-grounded-validator", "model": args.model, "summary": summary, "results": results}
+    Path(args.out).write_text(json.dumps(rec, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"\n[written] {args.out}\nscored={len(scored)} correct={len(correct)} structural_wrong={len(structural)}")
+    for v in ("OLD", "NEW", "GROUNDED"):
+        print(f"{v:9s}: recall={summary[v]['recall_on_structural']} FP_on_correct={summary[v]['false_positive_on_correct']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/numeric_validation.py
+++ b/src/seocho/numeric_validation.py
@@ -106,9 +106,18 @@ class NumericValidationResult:
         }
 
 
-def validate_numeric_facts(facts: List[Dict[str, Any]]) -> NumericValidationResult:
+def validate_numeric_facts(
+    facts: List[Dict[str, Any]],
+    *,
+    source_text: Optional[str] = None,
+) -> NumericValidationResult:
     """Soft, precision-first validation. Confidence drops only on ``warn`` findings;
-    ``info`` (relaxed signals like a missing period or unknown unit) does not."""
+    ``info`` (relaxed signals like a missing period or unknown unit) does not.
+
+    When ``source_text`` is supplied, also grounds each value against the numbers
+    present in the source (ADR-0131): an extracted value absent from the source is
+    a ``warn`` (``ungrounded_value``) — the recall lever for wrong/fabricated
+    numbers that isolated-fact rules cannot see (ADR-0130)."""
     findings: List[NumericFinding] = []
     repairs: List[str] = []
     parsed = [NumericFact.from_dict(f) for f in facts if isinstance(f, dict)]
@@ -136,6 +145,12 @@ def validate_numeric_facts(facts: List[Dict[str, Any]]) -> NumericValidationResu
         if finding is not None:
             findings.append(finding)
             repairs.append(f"reconcile components of '{group['total'].name}'")
+
+    # source grounding (the recall lever — ADR-0131)
+    if source_text:
+        grounding = ground_facts(facts, source_text)
+        findings.extend(grounding.findings)
+        repairs.extend(f"verify '{f.fact}' against the source" for f in grounding.findings)
 
     n_warn = sum(1 for f in findings if f.severity == "warn")
     confidence = max(0.0, 1.0 - 0.34 * n_warn)
@@ -170,3 +185,99 @@ def find_reconciliation_groups(facts: List[NumericFact]) -> List[Dict[str, Any]]
         if len(parts) >= 2:
             groups.append({"total": total, "parts": parts})
     return groups
+
+
+# ---------------------------------------------------------------------------
+# Source-grounded numeric check (ADR-0131): the recall lever ADR-0130 identified.
+# The dominant structural error is "wrong number pulled" — a plausible value that
+# is wrong. Isolated-fact rules can't see it, but we CAN check whether an
+# extracted value actually appears in the source text. A value absent from the
+# source was fabricated or mis-computed → flag it.
+# ---------------------------------------------------------------------------
+
+_SCALE_MULT = {"thousand": 1e3, "million": 1e6, "billion": 1e9}
+# a number, optionally $-prefixed / %-suffixed / parenthesised-negative, with commas/decimals
+_NUM_RE = re.compile(r"\(?\$?\s*-?\d{1,3}(?:,\d{3})+(?:\.\d+)?|\(?\$?\s*-?\d+(?:\.\d+)?")
+_SCALE_AFTER_RE = re.compile(r"\s*(thousand|million|billion)s?\b", re.I)
+
+
+def extract_source_numbers(text: str) -> List[float]:
+    """All numeric values present in the source text, including scale-expanded
+    forms (``$539.2 million`` contributes both 539.2 and 539_200_000) and
+    parenthesised negatives. Used to ground extracted fact values."""
+    if not text:
+        return []
+    out: set = set()
+    for m in _NUM_RE.finditer(text):
+        tok = m.group(0)
+        neg = tok.strip().startswith("(")
+        cleaned = tok.replace("(", "").replace(")", "").replace("$", "").replace(",", "").strip()
+        try:
+            val = float(cleaned)
+        except Exception:
+            continue
+        if neg:
+            val = -abs(val)
+        out.add(val)
+        # scale word immediately after the number → add the scaled value too
+        after = text[m.end():m.end() + 12]
+        sm = _SCALE_AFTER_RE.match(after)
+        if sm:
+            out.add(round(val * _SCALE_MULT[sm.group(1).lower()], 6))
+    return sorted(out)
+
+
+def _matches(value: float, source_numbers: List[float], *, rel_tol: float, scale: str = "") -> bool:
+    candidates = [value]
+    mult = _SCALE_MULT.get((scale or "").strip().lower())
+    if mult:
+        candidates += [value * mult, value / mult]
+    for c in candidates:
+        for s in source_numbers:
+            denom = max(abs(s), abs(c), 1.0)
+            if abs(c - s) / denom <= rel_tol:
+                return True
+    return False
+
+
+@dataclass(slots=True)
+class GroundingResult:
+    findings: List[NumericFinding] = field(default_factory=list)
+    grounded: int = 0
+    checked: int = 0
+
+    @property
+    def grounded_ratio(self) -> float:
+        return round(self.grounded / self.checked, 4) if self.checked else 1.0
+
+    @property
+    def any_ungrounded(self) -> bool:
+        return any(f.code == "ungrounded_value" for f in self.findings)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"findings": [f.to_dict() for f in self.findings],
+                "grounded": self.grounded, "checked": self.checked,
+                "grounded_ratio": self.grounded_ratio}
+
+
+def ground_facts(facts: List[Dict[str, Any]], source_text: str, *, rel_tol: float = 0.01) -> GroundingResult:
+    """Check each extracted fact's value against the numbers actually present in
+    ``source_text``. An extracted value with no source match is ``warn``
+    (``ungrounded_value``) — the catch for fabricated / mis-computed numbers that
+    isolated-fact rules (ADR-0130) cannot see."""
+    src = extract_source_numbers(source_text)
+    res = GroundingResult()
+    for f in facts:
+        if not isinstance(f, dict):
+            continue
+        fct = NumericFact.from_dict(f)
+        if fct.value is None:
+            continue
+        res.checked += 1
+        if _matches(fct.value, src, rel_tol=rel_tol, scale=fct.scale):
+            res.grounded += 1
+        else:
+            res.findings.append(NumericFinding(
+                "warn", "ungrounded_value", fct.name or "(unnamed)",
+                f"value {fct.value} not found in the source text (possible wrong/fabricated number)"))
+    return res

--- a/tests/seocho/test_numeric_validation.py
+++ b/tests/seocho/test_numeric_validation.py
@@ -60,3 +60,41 @@ def test_reconciliation_group_detected_end_to_end():
         {"name": "total revenue", "value": 10},  # 3+4 != 10
     ])
     assert any(f.code == "reconciliation" for f in res.findings)
+
+
+# --- source-grounded numeric check (ADR-0131) ---
+from seocho.numeric_validation import extract_source_numbers, ground_facts
+
+
+def test_extract_source_numbers_handles_formats():
+    nums = extract_source_numbers("Revenue was $1,234.5 million, up from (200) in 2021; margin 12.5%.")
+    assert 1234.5 in nums
+    assert 1234500000.0 in nums          # scale-expanded ($1,234.5 million)
+    assert -200.0 in nums                # parenthesised negative
+    assert 12.5 in nums
+
+
+def test_grounded_value_passes_ungrounded_warns():
+    src = "Total revenue was 539.2 million in FY2023; cost of sales 111.5 million."
+    grounded = ground_facts([{"name": "revenue", "value": 539.2, "scale": "million"}], src)
+    assert grounded.any_ungrounded is False and grounded.grounded == 1
+    # a fabricated/wrong number not in the source → ungrounded warn
+    bad = ground_facts([{"name": "revenue", "value": 612.7, "scale": "million"}], src)
+    assert bad.any_ungrounded is True
+
+
+def test_scale_aware_grounding():
+    src = "Net income of $539.2 million."
+    # extractor reported absolute value 539200000 with scale million — still grounded
+    res = ground_facts([{"name": "net income", "value": 539200000, "scale": ""}], src)
+    assert res.grounded == 1
+
+
+def test_validate_with_source_text_folds_grounding():
+    src = "Revenue 100 in FY2023."
+    res = validate_numeric_facts([{"name": "revenue", "value": 999, "period": "FY2023"}], source_text=src)
+    assert any(f.code == "ungrounded_value" for f in res.warnings)
+    assert res.confidence < 1.0
+    # without source_text, no grounding warn (precision preserved)
+    clean = validate_numeric_facts([{"name": "revenue", "value": 999, "period": "FY2023"}])
+    assert not any(f.code == "ungrounded_value" for f in clean.findings)


### PR DESCRIPTION
extract_source_numbers / ground_facts + validate_numeric_facts(source_text=): an extracted value absent from the source is flagged (catches fabricated/wrong numbers isolated-fact rules miss, ADR-0130). Measured P3 v3 (MARA, 80 FinDER): GROUNDED recall 0.22/FP 0.51 vs OLD 0.94/0.91 and NEW 0.00/0.00. Honest: grounding recovers real recall but over-flags derived values — derived-vs-quoted filtering is the next step before gating. 4 tests + run_basic_ci 631 passed.