### PR TITLE
feat(ontology): compiled FIBO catalog → guardrail-candidate ontologies (ADR-0133)

### DIFF
--- a/docs/decisions/ADR-0133-fibo-catalog-as-guardrail-candidates.md
+++ b/docs/decisions/ADR-0133-fibo-catalog-as-guardrail-candidates.md
@@ -1,0 +1,50 @@
+# ADR-0133: Compiled FIBO Catalog → Guardrail-Candidate Ontologies
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0132 vendors official FIBO as a pinned submodule and compiles it into
+`catalog.json` (`seocho.fibo_catalog.v1`: per-module label/definition/IRI
+indexes). Meanwhile the guardrail selector (ADR-0123) and scorecard (ADR-0114)
+were scoring **hand-made** candidates (`examples/datasets/fibo_{minus,base,plus}
+.jsonld`). The authoritative, version-pinned catalog should feed them instead.
+
+## Decision
+
+Add `seocho.fibo_catalog` (pure/offline; consumes the compiled JSON, never raw
+OWL — ADR-0132 boundary):
+
+- `catalog_module_to_ontology(catalog, module_code)` — one `Ontology` per FIBO
+  module: classes → nodes (IRI local-name as label, human label as alias,
+  definition, `same_as` = IRI, `broader` from subClassOf within the module);
+  object/datatype properties → relationships (domain/range mapped to class
+  labels). `package_id = fibo.<module>`, `version = <fibo_commit>` so the choice
+  is version-pinned.
+- `fibo_guardrail_candidates(catalog, modules=None)` → `{module: Ontology}` map,
+  fed directly to `guardrail_selector.select_guardrail`.
+- `catalog_provenance(catalog)` → `{schema_version, fibo_commit, snapshot_hash}`
+  to attach to a snapshot/run (composes with `OntologySnapshotStore`, ADR-0117).
+
+## Validation
+
+`tests/seocho/test_fibo_catalog.py` (4): catalog schema validation; module →
+ontology builds nodes/relationships, maps subClassOf to `broader`, human label →
+alias, `same_as`/`package_id`/`version` (pinned to the FIBO commit); provenance;
+candidates feed `select_guardrail` and score corpus_coverage > 0. Built against a
+synthetic `seocho.fibo_catalog.v1` fixture (no submodule/compiler run needed).
+`run_basic_ci` green.
+
+## Consequences
+
+- The guardrail selector / scorecard can now score the **official, version-pinned
+  FIBO** modules as candidates, not hand-made slices — closing the loop between
+  ADR-0132's upstream pipeline and the ontology-management stack.
+- A guardrail choice carries the FIBO commit + snapshot hash → reproducible,
+  citable runs.
+- Follow-ups: run the real compiler (`git submodule update --init` +
+  `compile_fibo_snapshot.py`) and re-run the FinDER guardrail/answer experiments
+  against the pinned catalog; record `catalog_provenance` in snapshot store
+  provenance; wire `examples/finder/datasets/fibo_modules` curated slices vs the
+  catalog compatibility report into the scorecard.

--- a/src/seocho/fibo_catalog.py
+++ b/src/seocho/fibo_catalog.py
@@ -1,0 +1,126 @@
+"""Build guardrail-candidate Ontologies from a compiled FIBO catalog (ADR-0133).
+
+ADR-0132 added a pinned FIBO submodule + an offline compiler emitting
+`catalog.json` (schema `seocho.fibo_catalog.v1`): per-module label/definition/IRI
+indexes. This module turns that authoritative, version-pinned catalog into SEOCHO
+``Ontology`` objects usable as guardrail candidates by
+``guardrail_selector.select_guardrail`` and ``ontology_scorecard.score_ontology``
+— replacing the hand-made ``examples/datasets/fibo_{minus,base,plus}.jsonld``.
+
+Pure/offline: consumes the compiled JSON (a dict or a path); never reads raw
+OWL/RDF (ADR-0132 boundary). The FIBO commit + snapshot hash from the catalog flow
+into ``Ontology.package_id``/``version`` so a guardrail choice is version-pinned
+provenance (composes with ``OntologySnapshotStore``, ADR-0117).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from .ontology import NodeDef, Ontology, RelDef
+
+_CLASS_KINDS = {"class"}
+_PROP_KINDS = {"object_property", "datatype_property"}
+
+
+def load_catalog(data: Union[str, Path, Dict[str, Any]]) -> Dict[str, Any]:
+    """Load a compiled FIBO catalog from a path or accept a dict. Validates the
+    schema marker."""
+    if isinstance(data, (str, Path)):
+        data = json.loads(Path(data).read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "modules" not in data:
+        raise ValueError("not a FIBO catalog (missing 'modules')")
+    return data
+
+
+def _local_name(iri: str) -> str:
+    text = str(iri or "").rstrip("/")
+    frag = re.split(r"[#/]", text)[-1] if text else ""
+    return frag
+
+
+def _label_for(resource: Dict[str, Any], iri: str) -> str:
+    """A valid SEOCHO class label: prefer the IRI local name (usually PascalCase),
+    else a sanitized human label."""
+    ln = str(resource.get("local_name") or _local_name(iri)).strip()
+    if ln:
+        return re.sub(r"[^A-Za-z0-9]", "", ln) or ln
+    return re.sub(r"[^A-Za-z0-9]", "", str(resource.get("label", "")).title()) or "Entity"
+
+
+def catalog_module_to_ontology(
+    catalog: Dict[str, Any],
+    module_code: str,
+    *,
+    name: Optional[str] = None,
+) -> Ontology:
+    """Build one ``Ontology`` from a catalog module: classes → nodes (human label
+    as alias, definition, ``same_as`` = IRI, ``broader`` from subClassOf within
+    the module); object properties → relationships (domain/range mapped to class
+    labels)."""
+    catalog = load_catalog(catalog)
+    module = catalog["modules"].get(module_code)
+    if module is None:
+        raise KeyError(f"module '{module_code}' not in catalog")
+
+    resources: Dict[str, Dict[str, Any]] = module.get("resources", {})
+    definitions: Dict[str, str] = module.get("definitions", {})
+    iri_to_label: Dict[str, str] = {iri: _label_for(r, iri) for iri, r in resources.items()}
+
+    nodes: Dict[str, NodeDef] = {}
+    for iri, r in resources.items():
+        if r.get("kind") not in _CLASS_KINDS:
+            continue
+        label = iri_to_label[iri]
+        human = str(r.get("label", "")).strip()
+        aliases = [human] if human and human != label else []
+        broader = [iri_to_label[p] for p in (r.get("subclass_of") or []) if p in iri_to_label]
+        nodes[label] = NodeDef(
+            description=str(definitions.get(iri, "")).strip(),
+            aliases=aliases, broader=sorted(set(broader)), same_as=iri,
+        )
+
+    relationships: Dict[str, RelDef] = {}
+    for iri, r in resources.items():
+        if r.get("kind") not in _PROP_KINDS:
+            continue
+        rtype = re.sub(r"[^A-Za-z0-9]", "_", iri_to_label[iri]).upper() or "RELATED_TO"
+        src = iri_to_label.get(r.get("domain") or "", "Any")
+        tgt = iri_to_label.get(r.get("range") or "", "Any")
+        relationships[rtype] = RelDef(source=src or "Any", target=tgt or "Any",
+                                      description=str(definitions.get(iri, "")).strip())
+
+    onto = Ontology(
+        name or f"fibo-{module_code}",
+        package_id=f"fibo.{module_code}",
+        version=str(catalog.get("fibo_commit", "0"))[:12] or "0.0.0",
+        description=str(module.get("summary", "")).strip(),
+        nodes=nodes, relationships=relationships,
+    )
+    return onto
+
+
+def fibo_guardrail_candidates(
+    catalog: Union[str, Path, Dict[str, Any]],
+    *,
+    modules: Optional[List[str]] = None,
+) -> Dict[str, Ontology]:
+    """Build a ``{module_code: Ontology}`` map of guardrail candidates from a
+    compiled FIBO catalog — feed directly to ``guardrail_selector.select_guardrail``
+    (e.g. select the FIBO module whose vocabulary best covers a corpus)."""
+    catalog = load_catalog(catalog)
+    codes = modules if modules is not None else list(catalog["modules"].keys())
+    return {code: catalog_module_to_ontology(catalog, code) for code in codes if code in catalog["modules"]}
+
+
+def catalog_provenance(catalog: Union[str, Path, Dict[str, Any]]) -> Dict[str, str]:
+    """The version-pinning provenance to attach to a snapshot / run."""
+    catalog = load_catalog(catalog)
+    return {
+        "schema_version": str(catalog.get("schema_version", "")),
+        "fibo_commit": str(catalog.get("fibo_commit", "")),
+        "snapshot_hash": str(catalog.get("snapshot_hash", "")),
+    }

--- a/tests/seocho/test_fibo_catalog.py
+++ b/tests/seocho/test_fibo_catalog.py
@@ -1,0 +1,76 @@
+"""Tests for the compiled-FIBO-catalog → guardrail-candidate loader (ADR-0133)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from seocho.fibo_catalog import (
+    catalog_module_to_ontology,
+    catalog_provenance,
+    fibo_guardrail_candidates,
+    load_catalog,
+)
+from seocho.guardrail_selector import select_guardrail
+from seocho.ontology_scorecard import build_corpus_profile
+
+
+def _catalog() -> dict:
+    """A minimal catalog in the compiler's `seocho.fibo_catalog.v1` shape."""
+    BE = "https://spec.edmcouncil.org/fibo/ontology/BE/"
+    return {
+        "schema_version": "seocho.fibo_catalog.v1",
+        "snapshot_hash": "abc123",
+        "fibo_commit": "fee10a4ebe80",
+        "modules": {
+            "BE": {
+                "code": "BE", "iri_prefix": BE, "summary": "Business Entities.",
+                "label_index": {"Legal Entity": BE + "LegalEntity", "Person": BE + "Person"},
+                "definitions": {BE + "LegalEntity": "A registered business.", BE + "Subsidiary": "A controlled entity."},
+                "resources": {
+                    BE + "LegalEntity": {"kind": "class", "local_name": "LegalEntity", "label": "Legal Entity",
+                                         "subclass_of": [], "domain": "", "range": ""},
+                    BE + "Subsidiary": {"kind": "class", "local_name": "Subsidiary", "label": "Subsidiary",
+                                        "subclass_of": [BE + "LegalEntity"], "domain": "", "range": ""},
+                    BE + "hasSubsidiary": {"kind": "object_property", "local_name": "hasSubsidiary",
+                                           "label": "has subsidiary", "domain": BE + "LegalEntity",
+                                           "range": BE + "Subsidiary", "subclass_of": []},
+                },
+            },
+        },
+    }
+
+
+def test_load_catalog_validates():
+    assert load_catalog(_catalog())["schema_version"] == "seocho.fibo_catalog.v1"
+    with pytest.raises(ValueError):
+        load_catalog({"not": "a catalog"})
+
+
+def test_module_to_ontology_builds_nodes_rels_broader():
+    onto = catalog_module_to_ontology(_catalog(), "BE")
+    assert set(onto.nodes) == {"LegalEntity", "Subsidiary"}
+    assert onto.nodes["LegalEntity"].aliases == ["Legal Entity"]   # human label → alias
+    assert onto.nodes["LegalEntity"].same_as.endswith("LegalEntity")
+    assert onto.nodes["Subsidiary"].broader == ["LegalEntity"]      # subClassOf mapped
+    assert "HASSUBSIDIARY" in onto.relationships
+    rel = onto.relationships["HASSUBSIDIARY"]
+    assert rel.source == "LegalEntity" and rel.target == "Subsidiary"
+    assert onto.package_id == "fibo.BE"
+    assert onto.version == "fee10a4ebe80"   # version-pinned to the FIBO commit
+
+
+def test_provenance():
+    p = catalog_provenance(_catalog())
+    assert p["fibo_commit"] == "fee10a4ebe80" and p["snapshot_hash"] == "abc123"
+
+
+def test_candidates_feed_guardrail_selector():
+    cands = fibo_guardrail_candidates(_catalog())
+    assert set(cands) == {"BE"}
+    # the BE module covers a legal-entity/subsidiary corpus → usable as a guardrail
+    corpus = build_corpus_profile([{"nodes": [{"label": "LegalEntity"}, {"label": "Subsidiary"}]}])
+    rec = select_guardrail(cands, corpus)
+    assert rec.chosen == "BE"
+    assert rec.candidate_scores["BE"]["corpus_coverage"] > 0


### PR DESCRIPTION
seocho.fibo_catalog turns ADR-0132's compiled catalog.json into Ontology guardrail candidates for select_guardrail/scorecard — official version-pinned FIBO modules instead of hand-made fibo_*.jsonld. catalog_module_to_ontology / fibo_guardrail_candidates / catalog_provenance. Pure/offline (no raw OWL). 4 tests + run_basic_ci 631 passed.