### PR TITLE
fix(ontology): handle list-valued FIBO domain/range in catalog loader

### DIFF
--- a/src/seocho/fibo_catalog.py
+++ b/src/seocho/fibo_catalog.py
@@ -42,6 +42,20 @@ def _local_name(iri: str) -> str:
     return frag
 
 
+def _first_iri(value: Any) -> str:
+    """Coerce a domain/range/subClassOf cell to a single IRI string. FIBO
+    properties may carry a list of IRIs (multiple domains/ranges) or a string."""
+    if isinstance(value, (list, tuple)):
+        return str(value[0]) if value else ""
+    return str(value or "")
+
+
+def _iri_list(value: Any) -> List[str]:
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value if v]
+    return [str(value)] if value else []
+
+
 def _label_for(resource: Dict[str, Any], iri: str) -> str:
     """A valid SEOCHO class label: prefer the IRI local name (usually PascalCase),
     else a sanitized human label."""
@@ -77,7 +91,7 @@ def catalog_module_to_ontology(
         label = iri_to_label[iri]
         human = str(r.get("label", "")).strip()
         aliases = [human] if human and human != label else []
-        broader = [iri_to_label[p] for p in (r.get("subclass_of") or []) if p in iri_to_label]
+        broader = [iri_to_label[p] for p in _iri_list(r.get("subclass_of")) if p in iri_to_label]
         nodes[label] = NodeDef(
             description=str(definitions.get(iri, "")).strip(),
             aliases=aliases, broader=sorted(set(broader)), same_as=iri,
@@ -88,8 +102,8 @@ def catalog_module_to_ontology(
         if r.get("kind") not in _PROP_KINDS:
             continue
         rtype = re.sub(r"[^A-Za-z0-9]", "_", iri_to_label[iri]).upper() or "RELATED_TO"
-        src = iri_to_label.get(r.get("domain") or "", "Any")
-        tgt = iri_to_label.get(r.get("range") or "", "Any")
+        src = iri_to_label.get(_first_iri(r.get("domain")), "Any")
+        tgt = iri_to_label.get(_first_iri(r.get("range")), "Any")
         relationships[rtype] = RelDef(source=src or "Any", target=tgt or "Any",
                                       description=str(definitions.get(iri, "")).strip())
 

--- a/tests/seocho/test_fibo_catalog.py
+++ b/tests/seocho/test_fibo_catalog.py
@@ -74,3 +74,24 @@ def test_candidates_feed_guardrail_selector():
     rec = select_guardrail(cands, corpus)
     assert rec.chosen == "BE"
     assert rec.candidate_scores["BE"]["corpus_coverage"] > 0
+
+
+def test_handles_list_valued_domain_range_and_subclass():
+    """Real FIBO properties carry list-valued domain/range/subClassOf — must not
+    crash (regression: 'unhashable type: list')."""
+    BE = "https://spec.edmcouncil.org/fibo/ontology/BE/"
+    catalog = {
+        "schema_version": "seocho.fibo_catalog.v1", "snapshot_hash": "h", "fibo_commit": "c",
+        "modules": {"BE": {"code": "BE", "iri_prefix": BE, "summary": "s",
+            "label_index": {}, "definitions": {},
+            "resources": {
+                BE + "A": {"kind": "class", "local_name": "A", "label": "A", "subclass_of": [], "domain": "", "range": ""},
+                BE + "B": {"kind": "class", "local_name": "B", "label": "B",
+                           "subclass_of": [BE + "A", BE + "Missing"], "domain": "", "range": ""},
+                BE + "rel": {"kind": "object_property", "local_name": "rel", "label": "rel",
+                             "domain": [BE + "A", BE + "B"], "range": [BE + "B"], "subclass_of": []},
+            }}}}
+    onto = catalog_module_to_ontology(catalog, "BE")
+    assert onto.nodes["B"].broader == ["A"]              # missing parent dropped, list handled
+    assert onto.relationships["REL"].source == "A"        # first of domain list
+    assert onto.relationships["REL"].target == "B"        # first of range list


### PR DESCRIPTION
Real compiled FIBO has list-valued domain/range/subClassOf; the ADR-0133 loader crashed ('unhashable type: list'). Coerce to first-IRI. Verified on the real 13,958-resource catalog (BE/FBC/FND/SEC build cleanly). Regression test added; run_basic_ci passes.