### PR TITLE
chore: add focus-visible parity to hover states in evaluation UI

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -114,7 +114,8 @@ body {
   border-left: 2px solid transparent;
 }
 
-.rail-btn:hover {
+.rail-btn:hover,
+.rail-btn:focus-visible {
   color: var(--text-main);
 }
 
@@ -254,6 +255,11 @@ body {
   cursor: not-allowed;
 }
 
+#ingestBtn:hover:not(:disabled),
+#ingestBtn:focus-visible:not(:disabled) {
+  opacity: 0.9;
+}
+
 #oneClickDemoBtn {
   background: var(--accent-blue);
   color: #fff;
@@ -268,6 +274,11 @@ body {
 #oneClickDemoBtn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+#oneClickDemoBtn:hover:not(:disabled),
+#oneClickDemoBtn:focus-visible:not(:disabled) {
+  opacity: 0.9;
 }
 
 /* Dual Pane Workspace */
@@ -367,7 +378,8 @@ body {
   cursor: not-allowed;
 }
 
-.composer button:hover:not(:disabled) {
+.composer button:hover:not(:disabled),
+.composer button:focus-visible:not(:disabled) {
   opacity: 0.9;
 }
 
@@ -441,7 +453,8 @@ body {
   transition: transform 0.2s, border-color 0.2s;
 }
 
-.workflow-node:hover {
+.workflow-node:hover,
+.workflow-node:focus-visible {
   transform: translateY(-2px);
   border-color: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
### What
Added `:focus-visible` pseudo-class parity to interactive elements (rail buttons, ingest buttons, composer buttons, and workflow nodes) in the Evaluation UI (`evaluation/static/styles.css`).

### Why
To ensure keyboard users receive the same visual feedback as mouse users when focusing interactive elements. Previously, keyboard users only received the global focus outline without the element-specific hover state changes (like color or opacity), creating a degraded experience.

### Accessibility / UX Impact
- **Accessibility:** Improves keyboard navigation feedback (WCAG 2.1 SC 2.4.7 Focus Visible).
- **UX:** Keyboard navigation now feels as responsive and native as mouse interaction on custom UI components.

### Validation
- Ran frontend verification using Playwright to programmatically focus each updated element and visually verified the styles apply correctly without breaking the layout.
- Ran the basic CI suite (`bash scripts/ci/run_basic_ci.sh`) to ensure no backend regression occurred.
- Verified that the focus indicators strictly apply only on `:focus-visible` to prevent double-outlining for mouse users.

### Risks
- Extremely low risk. This is a purely CSS-additive change mapped exclusively to pseudo-classes. No HTML structure, JavaScript behavior, or backend endpoints were modified.

*Draft PR as per repository constraints.*

---
*PR created automatically by Jules for task [13753631924590177946](https://jules.google.com/task/13753631924590177946) started by @tteon*