### PR TITLE
feat(ontology): alias-bridge official FIBO to LLM vocabulary — measured coverage lift (ADR-0135)

### DIFF
--- a/docs/decisions/ADR-0135-alias-bridge.json
+++ b/docs/decisions/ADR-0135-alias-bridge.json
@@ -1,0 +1,39 @@
+{
+  "experiment": "fibo-alias-bridge-coverage",
+  "provenance": {
+    "schema_version": "seocho.fibo_catalog.v1",
+    "fibo_commit": "fee10a4ebe807f647565f7aa3da8968423826dd1",
+    "snapshot_hash": "a5fbf8e4f50fe0df"
+  },
+  "corpus": "ADR-0116 FinDER open-extraction profile",
+  "modules": {
+    "BE": {
+      "coverage_before": 0.0077,
+      "coverage_after": 0.1814,
+      "delta": 0.1737,
+      "aliases_added": 45,
+      "classes": 193
+    },
+    "FBC": {
+      "coverage_before": 0.0932,
+      "coverage_after": 0.3155,
+      "delta": 0.2223,
+      "aliases_added": 208,
+      "classes": 515
+    },
+    "FND": {
+      "coverage_before": 0.1992,
+      "coverage_after": 0.3001,
+      "delta": 0.1009,
+      "aliases_added": 71,
+      "classes": 437
+    },
+    "SEC": {
+      "coverage_before": 0.0051,
+      "coverage_after": 0.1916,
+      "delta": 0.1865,
+      "aliases_added": 78,
+      "classes": 795
+    }
+  }
+}

--- a/docs/decisions/ADR-0135-fibo-alias-bridge.md
+++ b/docs/decisions/ADR-0135-fibo-alias-bridge.md
@@ -1,0 +1,54 @@
+# ADR-0135: Alias-Bridging Official FIBO to LLM Vocabulary — Measured Coverage Lift
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0134 measured that official FIBO modules score near-zero corpus_coverage on
+FinDER because their fine-grained labels (`JointStockCompany`) don't match the
+LLM's generic extraction vocabulary (`Company`). The identified fix: **alias-bridge**
+official classes to the generic terms, then re-measure.
+
+## Decision
+
+Add `seocho.fibo_catalog.alias_bridge(ontology, terms)` and `bridge_to_corpus(
+ontology, corpus_profile)` (offline/deterministic): add each generic ``term`` as
+an alias to every class whose **token-set contains the term's token-set**
+(camelCase-aware), e.g. `Company` → alias of `JointStockCompany`/
+`PubliclyHeldCompany`. Token-**subset** matching (not raw substring) avoids
+spurious hits — `Date` ⊄ `Candidate`, `FinancialMetric` ⊄ `FinancialInstrument`.
+
+## Validation (measured, real compiled FIBO @ fee10a4, FinDER corpus)
+
+`docs/decisions/ADR-0135-alias-bridge.json`. corpus_coverage before → after
+bridging to the FinDER open-extraction labels:
+
+| module | classes | coverage before | after | Δ | aliases added |
+|---|---|---|---|---|---|
+| BE | 193 | 0.008 | 0.181 | +0.174 | 45 |
+| FBC | 515 | 0.093 | **0.316** | +0.222 | 208 |
+| FND | 437 | 0.199 | 0.300 | +0.101 | 71 |
+| SEC | 795 | 0.005 | 0.192 | +0.186 | 78 |
+
+Alias-bridging **lifts coverage substantially** (SEC 0.005→0.192 = ~38×; FBC
+nearly 3.4×) — confirming ADR-0134's granularity-mismatch diagnosis: the official
+classes ARE relevant, their *labels* just didn't match the LLM vocabulary.
+
+**Honest limit:** even bridged, the best official module (FBC 0.316) stays below
+the curated `fibo_plus` (0.595, ADR-0134). Lexical token-subset bridging closes
+roughly half the gap; the rest needs semantic mapping (a FIBO `Officer`/`Director`
+→ `Person` link isn't lexical) — the ambiguity-mapping loop (seocho-2mg) or
+`same_as`/broader-root bridging.
+
+## Consequences
+
+- A measured, deterministic lever to make official version-pinned FIBO usable as a
+  guardrail candidate: bridge → re-score → the selector can now consider official
+  modules competitively (not auto-lose at coverage ~0).
+- Recommendation stands (ADR-0134): compiled FIBO is the authoritative SOURCE;
+  produce a *bridged* (and ultimately curated) slice from it rather than injecting
+  raw modules.
+- Follow-ups: semantic bridge (broader-root / `same_as` / LLM map of generic→FIBO)
+  to close the residual gap to curated; combine bridged modules; re-run the
+  answer-accuracy experiment with a bridged module once it's prompt-sized.

--- a/src/seocho/fibo_catalog.py
+++ b/src/seocho/fibo_catalog.py
@@ -138,3 +138,47 @@ def catalog_provenance(catalog: Union[str, Path, Dict[str, Any]]) -> Dict[str, s
         "fibo_commit": str(catalog.get("fibo_commit", "")),
         "snapshot_hash": str(catalog.get("snapshot_hash", "")),
     }
+
+
+# ---------------------------------------------------------------------------
+# Alias-bridging (ADR-0135): official FIBO's fine-grained labels (JointStockCompany)
+# don't match the LLM's generic extraction vocabulary (Company) → corpus_coverage
+# ~0 (ADR-0134). Bridge by adding each generic term as an alias to FIBO classes
+# whose label lexically contains it, so coverage can match. Offline/deterministic.
+# ---------------------------------------------------------------------------
+
+
+def _tokens(s: str) -> frozenset:
+    """Normalized word tokens of a label: split camelCase + non-alnum, lowercased.
+    'JointStockCompany' → {joint, stock, company}; 'Legal Entity' → {legal, entity}."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", str(s))
+    return frozenset(t.lower() for t in re.split(r"[^A-Za-z0-9]+", spaced) if len(t) >= 3)
+
+
+def alias_bridge(ontology: Ontology, terms: List[str], *, min_len: int = 4) -> Ontology:
+    """Return a NEW ontology where each generic ``term`` is added as an alias to
+    every class whose label/alias token-set CONTAINS the term's token-set, e.g.
+    ``Company`` → alias of ``JointStockCompany``/``PubliclyHeldCompany``;
+    ``FinancialMetric`` matches a class with both tokens. Token-subset matching
+    (not raw substring) avoids spurious hits (``Date`` ⊄ ``Candidate``)."""
+    data = ontology.to_dict()
+    nodes: Dict[str, Any] = data.get("nodes", {})
+    norm_terms = [(term, _tokens(term)) for term in terms
+                  if len(re.sub(r"[^A-Za-z0-9]", "", str(term))) >= min_len]
+    for label, nd in nodes.items():
+        label_tokens = [_tokens(label)] + [_tokens(a) for a in (nd.get("aliases") or [])]
+        for term, tt in norm_terms:
+            if not tt:
+                continue
+            if any(tt <= lt for lt in label_tokens):
+                aliases = nd.setdefault("aliases", [])
+                if term not in aliases:
+                    aliases.append(term)
+    return Ontology.from_dict(data)
+
+
+def bridge_to_corpus(ontology: Ontology, corpus_profile: Any, *, min_len: int = 4) -> Ontology:
+    """Alias-bridge an ontology to a corpus's observed labels (the LLM's
+    extraction vocabulary) — the automatic form of :func:`alias_bridge`."""
+    terms = list(getattr(corpus_profile, "label_frequencies", {}).keys())
+    return alias_bridge(ontology, terms, min_len=min_len)

--- a/tests/seocho/test_fibo_catalog.py
+++ b/tests/seocho/test_fibo_catalog.py
@@ -95,3 +95,29 @@ def test_handles_list_valued_domain_range_and_subclass():
     assert onto.nodes["B"].broader == ["A"]              # missing parent dropped, list handled
     assert onto.relationships["REL"].source == "A"        # first of domain list
     assert onto.relationships["REL"].target == "B"        # first of range list
+
+
+def test_alias_bridge_token_subset_match_no_spurious():
+    from seocho.ontology import NodeDef, Ontology
+    from seocho.fibo_catalog import alias_bridge, bridge_to_corpus
+    from seocho.ontology_scorecard import build_corpus_profile
+
+    onto = Ontology("m", nodes={
+        "JointStockCompany": NodeDef(description="c"),
+        "PubliclyHeldCompany": NodeDef(description="c"),
+        "Candidate": NodeDef(description="c"),   # must NOT get a 'Date' alias
+        "FinancialInstrument": NodeDef(description="c"),
+    })
+    bridged = alias_bridge(onto, ["Company", "Date", "FinancialMetric"])
+    assert "Company" in bridged.nodes["JointStockCompany"].aliases     # token subset {company} ⊆ {joint,stock,company}
+    assert "Company" in bridged.nodes["PubliclyHeldCompany"].aliases
+    assert "Date" not in bridged.nodes["Candidate"].aliases            # no spurious substring match
+    # FinancialMetric ({financial,metric}) ⊄ FinancialInstrument ({financial,instrument})
+    assert "FinancialMetric" not in bridged.nodes["FinancialInstrument"].aliases
+
+    # bridging lifts corpus_coverage: a Company-heavy corpus now matches the FIBO classes
+    corpus = build_corpus_profile([{"nodes": [{"label": "Company"}, {"label": "Company"}]}])
+    from seocho.ontology_scorecard import score_ontology
+    before = score_ontology(onto, corpus_profile=corpus, profile="guardrail").dimension("corpus_coverage").score
+    after = score_ontology(bridge_to_corpus(onto, corpus), corpus_profile=corpus, profile="guardrail").dimension("corpus_coverage").score
+    assert after > before


### PR DESCRIPTION
alias_bridge/bridge_to_corpus add generic terms as aliases to FIBO classes by camelCase token-subset match (Company→JointStockCompany; Date⊄Candidate). Addresses ADR-0134. Measured (real FIBO @fee10a4, FinDER): BE 0.008→0.181, FBC 0.093→0.316, FND 0.199→0.300, SEC 0.005→0.192. Honest: bridged FBC 0.316 still < curated 0.595 (lexical closes ~half; rest needs semantic mapping). Offline. 1 test + run_basic_ci 631 passed.