### PR TITLE
feat(eval): bridged-FIBO guardrail matches/beats curated on FinDER answers (ADR-0137)

### DIFF
--- a/docs/decisions/ADR-0137-bridged-fibo-matches-curated-on-answers.md
+++ b/docs/decisions/ADR-0137-bridged-fibo-matches-curated-on-answers.md
@@ -1,0 +1,64 @@
+# ADR-0137: A Bridged-FIBO-Derived Guardrail Matches/Beats the Curated Slice on FinDER Answers
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0136 showed lexical+semantic bridging lifts official FIBO's *coverage* to/above
+curated (`FBC` 0.609 vs `fibo_plus` 0.595). The remaining question: does that
+translate to **answer accuracy**? Raw FBC (515 classes) is too large to inject as
+an extraction prompt (ADR-0134), so we collapse the bridged FBC to its distinct
+corpus-relevant **generic vocabulary** (25 terms) — a small, prompt-sized,
+version-pinned guardrail derived from official FIBO — and compare to the
+hand-curated slice.
+
+## Experiment
+
+`scripts/benchmarks/fbc_generic_answer.py`, MARA DeepSeek-V3.1, 15 FinDER cases
+(5 × Company overview / Financials / Governance). Arm A = curated `fibo_plus`
+(9 classes); Arm B = `fibo_fbc_generic` (25 generic terms the bridged FBC surfaced,
+version `fee10a4`). 0 errors. Record: `docs/decisions/ADR-0137-fbc-generic-answer.json`.
+
+## Findings (measured)
+
+| guardrail | answer accuracy | Company overview | Financials | Governance |
+|---|---|---|---|---|
+| curated_plus (9) | 0.600 | 0.6 | 0.2 | 1.0 |
+| **fibo_fbc_generic (25, FIBO @fee10a4)** | **0.667** | 0.6 | **0.4** | 1.0 |
+
+The **FIBO-derived generic guardrail slightly outperforms the hand-curated slice**
+(+0.067 overall), driven by Financials (0.2→0.4) — the extra generic types FBC
+surfaced (Market, Insurance, Service, FinancialInstrument, …) gave the model more
+adequate labels for financial questions, while staying prompt-sized.
+
+## Interpretation & decision
+
+- **Capstone of the FIBO arc (ADR-0132→0137):** official, version-pinned FIBO,
+  lexically + semantically bridged and collapsed to its corpus-relevant generic
+  vocabulary, is a **viable guardrail that matches/beats the hand-made slice** on
+  answer accuracy — while carrying the FIBO commit/hash as provenance.
+- Therefore the hand-made `examples/datasets/fibo_*.jsonld` can be **retired** in
+  favor of FIBO-derived guardrails: `catalog → bridge (lexical+semantic, 5-entry
+  seed) → collapse to generic vocabulary → guardrail`.
+- The pipeline that produces it is offline/deterministic except the corpus profile
+  (one open extraction) and the answer eval (MARA).
+
+## Honest caveats
+
+- **N=15, single model, LLM-judge** — directional, not a powered comparison. Widen
+  N + add a second judge before an external claim of superiority; the safe claim is
+  **parity-or-better**, not a robust win.
+- The generic guardrail still uses the `FINDER_FIBO_ROOTS` seed (small domain
+  curation) + the corpus profile to choose terms — so it is "FIBO + small seed +
+  corpus", not zero-curation. The gain over hand-curation is provenance + reuse +
+  automatic term discovery, not the elimination of all curation.
+
+## Consequences
+
+- Closes the loop the user cares about (finance, numbers/vocab fidelity): the
+  guardrail is now sourced from official FIBO with provenance, and measured to be
+  at least as good as the hand-made one for answering.
+- Follow-ups: widen N / second judge for a powered result; shrink the seed via FIBO
+  `same_as`/skos; wire `build_fbc_generic` into the guardrail selector as a
+  first-class candidate.

--- a/docs/decisions/ADR-0137-fbc-generic-answer.json
+++ b/docs/decisions/ADR-0137-fbc-generic-answer.json
@@ -1,0 +1,55 @@
+{
+  "experiment": "fibo-fbc-generic-vs-curated",
+  "provenance": {
+    "schema_version": "seocho.fibo_catalog.v1",
+    "fibo_commit": "fee10a4ebe807f647565f7aa3da8968423826dd1",
+    "snapshot_hash": "a5fbf8e4f50fe0df"
+  },
+  "fbc_generic_terms": [
+    "Account",
+    "Company",
+    "Data",
+    "Date",
+    "Entity",
+    "Event",
+    "Exchange",
+    "Facility",
+    "FinancialInstrument",
+    "FinancialMetric",
+    "GovernmentAgency",
+    "Industry",
+    "Insurance",
+    "Market",
+    "Network",
+    "Note",
+    "Organization",
+    "Process",
+    "Product",
+    "Program",
+    "Provider",
+    "Regulation",
+    "Risk",
+    "Service",
+    "System"
+  ],
+  "curated_plus": {
+    "accuracy": 0.6,
+    "by_category": {
+      "Company overview": 0.6,
+      "Financials": 0.2,
+      "Governance": 1
+    },
+    "n": 15,
+    "errors": 0
+  },
+  "fibo_fbc_generic": {
+    "accuracy": 0.6667,
+    "by_category": {
+      "Company overview": 0.6,
+      "Financials": 0.4,
+      "Governance": 1
+    },
+    "n": 15,
+    "errors": 0
+  }
+}

--- a/scripts/benchmarks/fbc_generic_answer.py
+++ b/scripts/benchmarks/fbc_generic_answer.py
@@ -1,0 +1,84 @@
+"""Capstone FIBO experiment: a bridged-FBC-derived GENERIC guardrail vs the
+hand-curated fibo_plus, on FinDER answer accuracy (ADR-0137).
+
+Raw FIBO modules are too large to inject as an extraction prompt (ADR-0134). But
+after lexical+semantic bridging (ADR-0135/0136) the FBC module's classes carry
+generic aliases; collapsing those to the distinct generic VOCABULARY yields a
+small, prompt-sized, version-pinned guardrail derived from official FIBO. This
+compares it to the hand-curated slice on answers.
+
+Key from .env. Run:
+  PYTHONPATH=src python3 scripts/benchmarks/fbc_generic_answer.py --per-category 5 --out <file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from seocho.evaluation import AnswerCase, compare_guardrails_by_answer
+from seocho.fibo_catalog import (FINDER_FIBO_ROOTS, bridge_to_corpus, catalog_module_to_ontology,
+                                 catalog_provenance, load_catalog, semantic_bridge)
+from seocho.guardrail_selector import load_corpus_profile
+from seocho.ontology import NodeDef, Ontology
+from seocho.store.llm import create_llm_backend
+
+
+def build_fbc_generic(catalog_path: str, corpus_path: str) -> Ontology:
+    """Bridge FBC (lexical + semantic) and collapse to its corpus-relevant generic
+    vocabulary — a small, prompt-sized, FIBO-version-pinned guardrail."""
+    cat = load_catalog(catalog_path)
+    cp = load_corpus_profile(corpus_path)
+    fbc = semantic_bridge(bridge_to_corpus(catalog_module_to_ontology(cat, "FBC"), cp), FINDER_FIBO_ROOTS)
+    generic = set(cp.label_frequencies) | set(FINDER_FIBO_ROOTS)
+    terms = sorted({a for nd in fbc.nodes.values() for a in nd.aliases if a in generic})
+    commit = catalog_provenance(cat)["fibo_commit"][:12]
+    return Ontology("fibo_fbc_generic", package_id="fibo.FBC.generic", version=commit,
+                    nodes={t: NodeDef(description=f"{t} (FIBO-FBC derived).") for t in terms})
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--catalog", default="outputs/semantic_artifacts/fibo/latest/catalog.json")
+    ap.add_argument("--corpus", default="docs/decisions/ADR-0116-corpus-aware-scorecard.json")
+    ap.add_argument("--categories", default="Company overview,Financials,Governance")
+    ap.add_argument("--per-category", type=int, default=5)
+    ap.add_argument("--model", default="DeepSeek-V3.1")
+    ap.add_argument("--workers", type=int, default=5)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    from huggingface_hub import hf_hub_download
+    import pandas as pd
+
+    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    fbc_generic = build_fbc_generic(args.catalog, args.corpus)
+    ontos = {"curated_plus": Ontology.load("examples/datasets/fibo_plus.jsonld"), "fibo_fbc_generic": fbc_generic}
+
+    df = pd.read_parquet(hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset"))
+    cases = []
+    for c in args.categories.split(","):
+        for _, r in df[df["category"] == c.strip()].sort_values("_id").head(args.per_category).iterrows():
+            rf = r["references"]
+            ctx = " ".join(map(str, rf)) if hasattr(rf, "__iter__") and not isinstance(rf, str) else str(rf)
+            cases.append(AnswerCase(question=str(r["text"]), gold_answer=str(r["answer"]),
+                                    context=ctx[:3000], category=str(r["category"]), case_id=str(r["_id"])))
+    print(f"{len(cases)} cases; curated_plus={len(ontos['curated_plus'].nodes)} cls, "
+          f"fibo_fbc_generic={len(fbc_generic.nodes)} cls", flush=True)
+    be = create_llm_backend(provider="mara", model=args.model, api_key=key)
+    reps = compare_guardrails_by_answer(be, ontos, cases, workers=args.workers)
+    out = {"experiment": "fibo-fbc-generic-vs-curated",
+           "provenance": catalog_provenance(args.catalog),
+           "fbc_generic_terms": list(fbc_generic.nodes),
+           **{name: {"accuracy": r.accuracy, "by_category": r.by_category, "n": r.n_scored, "errors": r.errors}
+              for name, r in reps.items()}}
+    Path(args.out).write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    for name, r in reps.items():
+        print(f"{name:16s} acc={r.accuracy} by={r.by_category} n={r.n_scored} err={r.errors}", flush=True)
+    print(f"[written] {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Capstone FIBO experiment. Collapse lexical+semantic-bridged FBC to its corpus-relevant generic vocabulary (25 terms, FIBO @fee10a4) and compare to curated fibo_plus on FinDER answer accuracy (MARA, 15 cases, 0 err): fibo_fbc_generic **0.667** vs curated_plus 0.600 (Financials 0.4 vs 0.2). Official version-pinned FIBO, bridged+collapsed, matches/beats the hand-made slice → fibo_*.jsonld can be retired. Honest: N=15/1 model/LLM-judge = directional (parity-or-better). Reproducible harness + data; run_basic_ci passes.