### PR TITLE
feat(ontology): auto-derive FIBO root seed via LLM; auto∪hand robust (ADR-0139)

### DIFF
--- a/docs/decisions/ADR-0139-auto-derived-fibo-roots.md
+++ b/docs/decisions/ADR-0139-auto-derived-fibo-roots.md
@@ -1,0 +1,69 @@
+# ADR-0139: Auto-Deriving the FIBO Root Seed — Viable, Variable; auto∪hand Is Robust
+
+Date: 2026-06-14
+Status: Proposed
+
+## Context
+
+ADR-0136/0138 left one piece of manual curation: the 5-entry `FINDER_FIBO_ROOTS`
+seed (generic term → FIBO root). This automates it: an LLM maps each generic
+corpus term to FIBO root classes, replacing the hand seed.
+
+## Decision
+
+Add `seocho.fibo_catalog`:
+- `root_candidates(ontology, top)` — the most root-like classes (highest
+  subClassOf-descendant count) + definitions, the propagation anchors.
+- `derive_fibo_roots(generic_terms, ontology, *, backend)` — LLM (injected, via
+  the structured layer) maps each generic term → FIBO roots it subsumes; roots
+  validated to exist. Fake-testable.
+- `auto_semantic_bridge(ontology, generic_terms, *, backend)` — derive + bridge,
+  the no-hand-seed form of the ADR-0136 pipeline.
+
+## Validation (measured, real FIBO @fee10a4, FinDER corpus, MARA DeepSeek-V3.1)
+
+`docs/decisions/ADR-0139-auto-roots.json`. corpus_coverage after each seed:
+
+| module | lexical | hand seed | **auto seed** | **auto ∪ hand** |
+|---|---|---|---|---|
+| BE | 0.181 | 0.181 | 0.192 | 0.192 |
+| FBC | 0.316 | 0.609 | 0.340 | **0.633** |
+| FND | 0.300 | 0.594 | **0.862** | 0.862 |
+| SEC | 0.192 | 0.485 | 0.280 | **0.573** |
+
+(curated_plus reference = 0.595.)
+
+- **Auto-derivation is viable and sometimes far better** — FND **0.862** (≫ hand
+  0.594 and curated 0.595); BE slightly above hand. The LLM found broader/better
+  FND roots than the hand seed.
+- **But it's module-variable** — FBC 0.340 and SEC 0.280 fall *below* the hand
+  seed, because the LLM under-mapped the high-mass `FinancialMetric` label there
+  (it picked price/instrument leaves, not the Security/Share roots the hand seed
+  forced).
+- **`auto ∪ hand` is robustly best** — ≥ max(auto, hand) for every module, and
+  exceeds curated on FBC (0.633) and FND (0.862). The union takes the LLM's
+  discoveries *plus* the hand seed's safety-net mappings.
+
+## Decision / recommendation
+
+- **Default to auto-derivation, unioned with a tiny curated fallback seed.** This
+  reduces manual curation to a small safety net (the `FinancialMetric`→Security/
+  Share mapping) while the LLM contributes the rest — robustly ≥ both alone.
+- `derive_fibo_roots` is the automation; `FINDER_FIBO_ROOTS` becomes the fallback,
+  not the primary.
+
+## Honest caveats
+
+- Single-model derivation; quality varies by module (FBC/SEC under hand). A
+  multi-model vote or a second pass focused on the highest-mass uncovered corpus
+  labels would likely stabilize it (follow-up).
+- corpus_coverage is the proxy; the answer-accuracy equivalence (ADR-0138) was
+  measured on the curated-equivalent generic guardrail, not yet on an auto∪hand
+  bridged module — a powered answer re-run on the union is the natural next check.
+
+## Consequences
+
+- The FIBO-derived guardrail pipeline can now run with **near-zero hand curation**
+  (auto-derive + small fallback), version-pinned to the FIBO commit.
+- Follow-ups: multi-model/2-pass derivation for consistency; wire auto∪hand into
+  the guardrail selector; powered answer re-run on a union-bridged module.

--- a/docs/decisions/ADR-0139-auto-roots.json
+++ b/docs/decisions/ADR-0139-auto-roots.json
@@ -1,0 +1,378 @@
+{
+  "experiment": "auto-fibo-roots-vs-hand",
+  "provenance": {
+    "schema_version": "seocho.fibo_catalog.v1",
+    "fibo_commit": "fee10a4ebe807f647565f7aa3da8968423826dd1",
+    "snapshot_hash": "a5fbf8e4f50fe0df"
+  },
+  "generic_terms": [
+    "FinancialMetric",
+    "Person",
+    "Company",
+    "Product",
+    "Concept",
+    "Risk",
+    "LegalIssue",
+    "Regulation",
+    "Date",
+    "Industry",
+    "MonetaryValue",
+    "Program",
+    "Year",
+    "FinancialTerm",
+    "Organization",
+    "CompetitiveFactor",
+    "Location",
+    "BusinessUnit",
+    "Entity",
+    "FinancialConcept"
+  ],
+  "curated_plus": 0.595,
+  "modules": {
+    "BE": {
+      "lexical": 0.1814,
+      "hand_seed": 0.1814,
+      "auto_seed": 0.1916
+    },
+    "FBC": {
+      "lexical": 0.3155,
+      "hand_seed": 0.6092,
+      "auto_seed": 0.3397
+    },
+    "FND": {
+      "lexical": 0.3001,
+      "hand_seed": 0.5939,
+      "auto_seed": 0.8621
+    },
+    "SEC": {
+      "lexical": 0.1916,
+      "hand_seed": 0.4853,
+      "auto_seed": 0.2797
+    }
+  },
+  "auto_seeds": {
+    "BE": {
+      "Person": [
+        "LegalEntity",
+        "ResponsibleParty",
+        "EntityOwner",
+        "FunctionalEntity",
+        "LegalPerson",
+        "EntityControllingParty",
+        "ConstitutionalOwner",
+        "AuthorizedIndividual",
+        "Signatory",
+        "Executive",
+        "VotingShareholder",
+        "TotalOwner",
+        "SignificantShareholder"
+      ],
+      "Company": [
+        "LegalEntity",
+        "BusinessEntity",
+        "Corporation",
+        "PrivateCompanyWithLimitedLiability",
+        "Partnership",
+        "NotForProfitCorporation",
+        "FunctionalBusinessEntity"
+      ],
+      "Organization": [
+        "LegalEntity",
+        "BusinessEntity",
+        "GovernmentBody",
+        "NotForProfitOrganization",
+        "Corporation",
+        "Partnership",
+        "NotForProfitCorporation",
+        "FunctionalBusinessEntity"
+      ],
+      "BusinessUnit": [
+        "FunctionalEntity",
+        "FunctionalBusinessEntity"
+      ],
+      "Entity": [
+        "LegalEntity",
+        "BusinessEntity",
+        "LegallyDelegatedAuthority",
+        "ResponsibleParty",
+        "GovernmentBody",
+        "EntityOwner",
+        "FunctionalEntity",
+        "LegalPerson",
+        "EntityControllingParty",
+        "Corporation",
+        "ConstitutionalOwner",
+        "AuthorizedIndividual",
+        "Signatory",
+        "Polity",
+        "NotForProfitOrganization",
+        "Government",
+        "Executive",
+        "VotingShareholder",
+        "Trust",
+        "PrivateCompanyWithLimitedLiability",
+        "Partnership",
+        "DeJureControllingInterestParty",
+        "TotalOwner",
+        "SignificantShareholder",
+        "NotForProfitCorporation",
+        "FunctionalBusinessEntity",
+        "CorporateOfficer"
+      ]
+    },
+    "FBC": {
+      "Company": [
+        "FinancialServiceProvider",
+        "FinancialInstitution",
+        "NonDepositoryInstitution",
+        "DomesticEntity",
+        "Bank",
+        "DepositoryInstitution",
+        "CreditInstitutionInvestmentFirm",
+        "CommercialBank",
+        "USBank"
+      ],
+      "Product": [
+        "Product",
+        "FinancialProduct",
+        "BankingProduct"
+      ],
+      "Risk": [
+        "CreditEvent",
+        "ObligationSpecificCreditEvent",
+        "DefaultEvent"
+      ],
+      "Regulation": [
+        "RegulatoryAgency"
+      ],
+      "MonetaryValue": [
+        "SecurityPrice",
+        "MarketPrice"
+      ],
+      "Organization": [
+        "FinancialServiceProvider",
+        "FinancialInstitution",
+        "Exchange",
+        "NonDepositoryInstitution",
+        "DomesticEntity",
+        "Bank",
+        "DepositoryInstitution",
+        "CreditInstitutionInvestmentFirm",
+        "CommercialBank",
+        "USBank",
+        "RegulatoryAgency"
+      ],
+      "Entity": [
+        "FinancialServiceProvider",
+        "FinancialInstitution",
+        "Exchange",
+        "NonDepositoryInstitution",
+        "DomesticEntity",
+        "Bank",
+        "DepositoryInstitution",
+        "CreditInstitutionInvestmentFirm",
+        "CommercialBank",
+        "USBank",
+        "RegulatoryAgency",
+        "LegalAgent"
+      ],
+      "FinancialConcept": [
+        "FinancialInstrument",
+        "CreditAgreement",
+        "Guaranty"
+      ]
+    },
+    "FND": {
+      "FinancialMetric": [
+        "StatisticalMeasure"
+      ],
+      "Person": [
+        "Person"
+      ],
+      "Company": [
+        "Party"
+      ],
+      "Product": [
+        "Asset"
+      ],
+      "Concept": [
+        "OccurrenceKind"
+      ],
+      "Risk": [
+        "OccurrenceKind"
+      ],
+      "LegalIssue": [
+        "LegalConstruct"
+      ],
+      "Regulation": [
+        "ContractualElement"
+      ],
+      "Date": [
+        "RecurrenceInterval"
+      ],
+      "Industry": [
+        "Scheme"
+      ],
+      "MonetaryValue": [
+        "MonetaryAmount"
+      ],
+      "Program": [
+        "Scheme"
+      ],
+      "Year": [
+        "RecurrenceInterval"
+      ],
+      "FinancialTerm": [
+        "OccurrenceKind"
+      ],
+      "Organization": [
+        "Party"
+      ],
+      "CompetitiveFactor": [
+        "OccurrenceKind"
+      ],
+      "Location": [
+        "Address"
+      ],
+      "BusinessUnit": [
+        "Party"
+      ],
+      "Entity": [
+        "Party"
+      ],
+      "FinancialConcept": [
+        "OccurrenceKind"
+      ]
+    },
+    "SEC": {
+      "Product": [
+        "Security",
+        "Share",
+        "RegisteredSecurity",
+        "PreferredShare",
+        "PreferredShareWithFixedRateDividend",
+        "DebtInstrument",
+        "TradableDebtInstrument",
+        "ExtendablePreferredShare",
+        "ExchangeablePreferredShare",
+        "NonCumulativePreferredShare",
+        "ParticipatingPreferredShare",
+        "NonParticipatingPreferredShare",
+        "CumulativePreferredShare",
+        "SingleVotingShare",
+        "RestrictedVotingShare",
+        "NonVotingShare",
+        "EnhancedVotingShare",
+        "Bond",
+        "PoolBackedSecurity",
+        "PreferredShareWithAuctionRateDividend",
+        "PreferredShareWithAdjustableRateDividend",
+        "PerpetualPreferredShare",
+        "CommonShare"
+      ],
+      "Program": [
+        "Pool",
+        "PooledFund",
+        "InstrumentPool",
+        "CollectiveInvestmentVehicle",
+        "DebtPool"
+      ],
+      "FinancialTerm": [
+        "Security",
+        "Share",
+        "RegisteredSecurity",
+        "PreferredShare",
+        "PreferredShareWithFixedRateDividend",
+        "DebtInstrument",
+        "TradableDebtInstrument",
+        "ExtendablePreferredShare",
+        "ExchangeablePreferredShare",
+        "NonCumulativePreferredShare",
+        "ParticipatingPreferredShare",
+        "NonParticipatingPreferredShare",
+        "CumulativePreferredShare",
+        "SingleVotingShare",
+        "RestrictedVotingShare",
+        "NonVotingShare",
+        "EnhancedVotingShare",
+        "Bond",
+        "SecuritiesOffering",
+        "PoolBackedSecurity",
+        "DebtOffering",
+        "PreferredShareWithAuctionRateDividend",
+        "PreferredShareWithAdjustableRateDividend",
+        "PerpetualPreferredShare",
+        "Pool",
+        "PooledFund",
+        "InstrumentPool",
+        "CommonShare",
+        "CollectiveInvestmentVehicle",
+        "DebtPool"
+      ],
+      "Entity": [
+        "Security",
+        "Share",
+        "RegisteredSecurity",
+        "PreferredShare",
+        "PreferredShareWithFixedRateDividend",
+        "DebtInstrument",
+        "TradableDebtInstrument",
+        "ExtendablePreferredShare",
+        "ExchangeablePreferredShare",
+        "NonCumulativePreferredShare",
+        "ParticipatingPreferredShare",
+        "NonParticipatingPreferredShare",
+        "CumulativePreferredShare",
+        "SingleVotingShare",
+        "RestrictedVotingShare",
+        "NonVotingShare",
+        "EnhancedVotingShare",
+        "Bond",
+        "SecuritiesOffering",
+        "PoolBackedSecurity",
+        "DebtOffering",
+        "PreferredShareWithAuctionRateDividend",
+        "PreferredShareWithAdjustableRateDividend",
+        "PerpetualPreferredShare",
+        "Pool",
+        "PooledFund",
+        "InstrumentPool",
+        "CommonShare",
+        "CollectiveInvestmentVehicle",
+        "DebtPool"
+      ],
+      "FinancialConcept": [
+        "Security",
+        "Share",
+        "RegisteredSecurity",
+        "PreferredShare",
+        "PreferredShareWithFixedRateDividend",
+        "DebtInstrument",
+        "TradableDebtInstrument",
+        "ExtendablePreferredShare",
+        "ExchangeablePreferredShare",
+        "NonCumulativePreferredShare",
+        "ParticipatingPreferredShare",
+        "NonParticipatingPreferredShare",
+        "CumulativePreferredShare",
+        "SingleVotingShare",
+        "RestrictedVotingShare",
+        "NonVotingShare",
+        "EnhancedVotingShare",
+        "Bond",
+        "SecuritiesOffering",
+        "PoolBackedSecurity",
+        "DebtOffering",
+        "PreferredShareWithAuctionRateDividend",
+        "PreferredShareWithAdjustableRateDividend",
+        "PerpetualPreferredShare",
+        "Pool",
+        "PooledFund",
+        "InstrumentPool",
+        "CommonShare",
+        "CollectiveInvestmentVehicle",
+        "DebtPool"
+      ]
+    }
+  }
+}

--- a/src/seocho/fibo_catalog.py
+++ b/src/seocho/fibo_catalog.py
@@ -240,3 +240,92 @@ def semantic_bridge(ontology: Ontology, root_aliases: Dict[str, List[str]], *, i
             if term not in aliases:
                 aliases.append(term)
     return Ontology.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Auto-derived seed (ADR-0139): replace the hand-written FINDER_FIBO_ROOTS with
+# an LLM mapping generic corpus term → FIBO root class(es). Candidate roots are
+# the classes with the most subClassOf descendants (the meaningful propagation
+# anchors); the LLM picks which roots each generic term subsumes. Injected
+# backend (fake-testable); the result feeds semantic_bridge.
+# ---------------------------------------------------------------------------
+
+
+def root_candidates(ontology: Ontology, *, top: int = 30) -> List[Dict[str, str]]:
+    """The most root-like classes (highest subClassOf-descendant count) with their
+    definitions — the anchors worth seeding a generic alias onto."""
+    children: Dict[str, List[str]] = {}
+    for lbl, nd in ontology.nodes.items():
+        for p in (getattr(nd, "broader", []) or []):
+            children.setdefault(p, []).append(lbl)
+    scored = sorted(((len(_descendants(children, lbl)), lbl) for lbl in ontology.nodes), reverse=True)
+    out = []
+    for n_desc, lbl in scored[:top]:
+        if n_desc == 0:
+            continue
+        out.append({"label": lbl, "descendants": str(n_desc),
+                    "definition": str(getattr(ontology.nodes[lbl], "description", "") or "")[:160]})
+    return out
+
+
+_ROOTS_SYS = (
+    "You are an ontology engineer aligning a generic extraction vocabulary to FIBO. "
+    "For each generic term, pick the FIBO root class(es) it SUBSUMES — i.e. instances of "
+    "that FIBO class (and its subclasses) are examples of the generic term. Return ONLY JSON."
+)
+
+
+def _roots_prompt(generic_terms: List[str], candidates: List[Dict[str, str]]) -> str:
+    lines = ["GENERIC TERMS: " + ", ".join(generic_terms), "", "FIBO ROOT CANDIDATES (label — #subclasses — definition):"]
+    for c in candidates:
+        lines.append(f"- {c['label']} — {c['descendants']} — {c['definition']}")
+    lines.append("")
+    lines.append('Map each generic term to 0+ FIBO root labels from the list above (only labels that '
+                 'genuinely subsume the term). Return JSON: {"roots": {"<GenericTerm>": ["<FiboLabel>", ...]}}')
+    return "\n".join(lines)
+
+
+def derive_fibo_roots(
+    generic_terms: List[str],
+    ontology: Ontology,
+    *,
+    backend: Any,
+    model: Optional[str] = None,
+    top_candidates: int = 30,
+) -> Dict[str, List[str]]:
+    """LLM-derive a ``{generic_term: [FIBO root labels]}`` seed (the automated
+    replacement for the hand-written FINDER_FIBO_ROOTS). Injected ``backend`` via
+    the provider-aware structured layer; roots are validated to exist in the
+    ontology. Fake-testable."""
+    from .llm_structured import StructuredOutputError, structured_complete
+
+    candidates = root_candidates(ontology, top=top_candidates)
+    if not candidates:
+        return {}
+    try:
+        payload = structured_complete(
+            backend, system=_ROOTS_SYS, user=_roots_prompt(generic_terms, candidates),
+            model=model, task_hint="json_extraction",
+        )
+    except StructuredOutputError:
+        return {}
+    raw = payload.get("roots", payload) if isinstance(payload, dict) else {}
+    seed: Dict[str, List[str]] = {}
+    for term, roots in (raw.items() if isinstance(raw, dict) else []):
+        valid = [str(r) for r in (roots or []) if str(r) in ontology.nodes]
+        if valid:
+            seed[str(term)] = valid
+    return seed
+
+
+def auto_semantic_bridge(
+    ontology: Ontology,
+    generic_terms: List[str],
+    *,
+    backend: Any,
+    model: Optional[str] = None,
+) -> Ontology:
+    """Derive the generic→root seed with the LLM, then semantic-bridge — the
+    fully-automated form of the ADR-0136 pipeline (no hand seed)."""
+    seed = derive_fibo_roots(generic_terms, ontology, backend=backend, model=model)
+    return semantic_bridge(ontology, seed)

--- a/tests/seocho/test_fibo_catalog.py
+++ b/tests/seocho/test_fibo_catalog.py
@@ -154,3 +154,44 @@ def test_semantic_bridge_ignores_absent_roots():
     onto = Ontology("m", nodes={"Foo": NodeDef(description="f")})
     bridged = semantic_bridge(onto, {"Company": ["LegalEntity"]})  # root absent → no-op
     assert bridged.nodes["Foo"].aliases == []
+
+
+def test_root_candidates_ranks_by_descendants():
+    from seocho.ontology import NodeDef, Ontology
+    from seocho.fibo_catalog import root_candidates
+    onto = Ontology("m", nodes={
+        "LegalEntity": NodeDef(description="root"),
+        "Corporation": NodeDef(description="c", broader=["LegalEntity"]),
+        "Subsidiary": NodeDef(description="s", broader=["Corporation"]),
+        "Loner": NodeDef(description="l"),
+    })
+    cands = root_candidates(onto, top=10)
+    labels = [c["label"] for c in cands]
+    assert labels[0] == "LegalEntity"          # most descendants first
+    assert "Loner" not in labels               # 0 descendants excluded
+
+
+def test_derive_fibo_roots_with_fake_backend_and_validation():
+    import json as _json
+    from seocho.ontology import NodeDef, Ontology
+    from seocho.fibo_catalog import derive_fibo_roots, auto_semantic_bridge
+
+    onto = Ontology("m", nodes={
+        "LegalEntity": NodeDef(description="a registered org"),
+        "Corporation": NodeDef(description="c", broader=["LegalEntity"]),
+        "Subsidiary": NodeDef(description="s", broader=["Corporation"]),
+    })
+
+    class _Resp:
+        def __init__(self, t): self.text = t
+    class _Fake:
+        model = "DeepSeek-V3.1"
+        def complete(self, *, system, user, **kw):
+            # maps Company→LegalEntity (valid) and Bogus→Nonexistent (filtered out)
+            return _Resp(_json.dumps({"roots": {"Company": ["LegalEntity"], "Bogus": ["Nonexistent"]}}))
+
+    seed = derive_fibo_roots(["Company", "Bogus"], onto, backend=_Fake())
+    assert seed == {"Company": ["LegalEntity"]}          # absent root filtered
+    # auto-bridge propagates Company down the subClassOf tree
+    bridged = auto_semantic_bridge(onto, ["Company", "Bogus"], backend=_Fake())
+    assert "Company" in bridged.nodes["Subsidiary"].aliases


### PR DESCRIPTION
derive_fibo_roots(generic_terms, ontology, backend) + root_candidates + auto_semantic_bridge automate the hand FINDER_FIBO_ROOTS seed (injected backend, fake-testable). Measured (real FIBO, FinDER, MARA): auto-seed viable & sometimes far better (FND 0.862) but module-variable (FBC/SEC below hand); **auto∪hand robustly best** (≥ both: FBC 0.633, FND 0.862, SEC 0.573). Recommend auto-derive + tiny curated fallback → near-zero hand curation. 2 tests + run_basic_ci 631 passed.