### PR TITLE
feat(ontology): multi-model + 2-pass seed derivation stabilizes auto-roots (ADR-0140)

### DIFF
--- a/docs/decisions/ADR-0140-stable-multimodel-2pass-roots.md
+++ b/docs/decisions/ADR-0140-stable-multimodel-2pass-roots.md
@@ -1,0 +1,64 @@
+# ADR-0140: Multi-Model + 2-Pass Seed Derivation Stabilizes Auto-Roots — Zero Hand Curation, Beats Curated
+
+Date: 2026-06-14
+Status: Accepted
+
+## Context
+
+ADR-0139's single-model auto-seed was module-variable (FBC 0.340, SEC 0.280 below
+the hand seed) because one model under-mapped some high-mass corpus labels. Goal:
+stabilize so auto-derivation reaches/exceeds the hand seed on every module —
+removing the last hand curation.
+
+## Decision
+
+Add `seocho.fibo_catalog`:
+- `derive_fibo_roots_multi(generic_terms, ontology, *, backends, models)` — union
+  `derive_fibo_roots` across several models (each surfaces more valid roots).
+- `derive_fibo_roots_stable(..., passes=2)` — pass 1 unions across models; each
+  further pass re-derives ONLY the still-unmapped terms with a wider candidate
+  window. Multi-model coverage + a rescue pass for misses.
+
+## Validation (measured, real FIBO @fee10a4, FinDER, 3 MARA models: DeepSeek-V3.1 + MiniMax-M2.5 + gpt-oss-120b, 2 passes)
+
+`docs/decisions/ADR-0140-stable-roots.json`. corpus_coverage:
+
+| module | lexical | hand seed | single-model auto | **stable (multi+2pass)** |
+|---|---|---|---|---|
+| BE | 0.181 | 0.181 | 0.192 | **0.227** |
+| FBC | 0.316 | 0.609 | 0.340 | **0.784** |
+| FND | 0.300 | 0.594 | 0.862 | **0.862** |
+| SEC | 0.192 | 0.485 | 0.280 | **0.613** |
+
+(curated_plus reference = 0.595.)
+
+- **Stable ≥ hand AND ≥ single-auto on every module** — the multi-model union +
+  2-pass rescue eliminated the single-model variability that sank FBC/SEC.
+- **FBC 0.784, FND 0.862, SEC 0.613 all now exceed curated_plus (0.595)** — and
+  this uses **zero hand curation** (no `FINDER_FIBO_ROOTS`).
+- BE (0.227) stays low — it genuinely lacks financial-metric roots; module fit,
+  not seed quality.
+
+## Conclusion
+
+**Fully-automated, multi-model + 2-pass seed derivation removes ALL manual
+curation and produces FIBO-derived guardrails that beat both the hand seed and the
+hand-curated slice on coverage.** The FIBO-guardrail pipeline is now end-to-end
+automatic and version-pinned:
+
+`compiled catalog → lexical bridge → multi-model+2-pass semantic bridge → guardrail`
+
+`FINDER_FIBO_ROOTS` is retained only as an optional fallback; it is no longer
+needed for the stable path.
+
+## Consequences
+
+- Caps the FIBO arc (ADR-0132→0140): official FIBO is the authoritative,
+  version-pinned source; a fully-automated bridge yields guardrails ≥ curated on
+  coverage with no hand curation.
+- Cost: 3 models × up to 2 passes = a handful of derive calls per module (offline
+  scoring otherwise). Cheap relative to its payoff.
+- Follow-up: a powered ANSWER-accuracy re-run (ADR-0138 method) on a
+  stable-bridged module to confirm the coverage gain carries to answers; wire
+  `derive_fibo_roots_stable` into the guardrail selector as the default candidate
+  builder.

--- a/docs/decisions/ADR-0140-stable-roots.json
+++ b/docs/decisions/ADR-0140-stable-roots.json
@@ -1,0 +1,120 @@
+{
+  "experiment": "stable-multimodel-2pass-roots",
+  "provenance": {
+    "schema_version": "seocho.fibo_catalog.v1",
+    "fibo_commit": "fee10a4ebe807f647565f7aa3da8968423826dd1",
+    "snapshot_hash": "a5fbf8e4f50fe0df"
+  },
+  "models": [
+    "DeepSeek-V3.1",
+    "MiniMax-M2.5",
+    "gpt-oss-120b"
+  ],
+  "curated_plus": 0.595,
+  "generic_terms": [
+    "FinancialMetric",
+    "Person",
+    "Company",
+    "Product",
+    "Concept",
+    "Risk",
+    "LegalIssue",
+    "Regulation",
+    "Date",
+    "Industry",
+    "MonetaryValue",
+    "Program",
+    "Year",
+    "FinancialTerm",
+    "Organization",
+    "CompetitiveFactor",
+    "Location",
+    "BusinessUnit",
+    "Entity",
+    "FinancialConcept"
+  ],
+  "modules": {
+    "BE": {
+      "lexical": 0.1814,
+      "hand": 0.1814,
+      "single_auto": 0.1916,
+      "stable_multi2pass": 0.2273,
+      "seed_terms": [
+        "BusinessUnit",
+        "Company",
+        "Entity",
+        "Industry",
+        "Organization",
+        "Person",
+        "Program"
+      ]
+    },
+    "FBC": {
+      "lexical": 0.3155,
+      "hand": 0.6092,
+      "single_auto": 0.3397,
+      "stable_multi2pass": 0.7842,
+      "seed_terms": [
+        "BusinessUnit",
+        "Company",
+        "Entity",
+        "FinancialConcept",
+        "FinancialMetric",
+        "FinancialTerm",
+        "LegalIssue",
+        "Location",
+        "MonetaryValue",
+        "Organization",
+        "Person",
+        "Product",
+        "Program",
+        "Regulation",
+        "Risk"
+      ]
+    },
+    "FND": {
+      "lexical": 0.3001,
+      "hand": 0.5939,
+      "single_auto": 0.8621,
+      "stable_multi2pass": 0.8621,
+      "seed_terms": [
+        "BusinessUnit",
+        "Company",
+        "CompetitiveFactor",
+        "Concept",
+        "Date",
+        "Entity",
+        "FinancialConcept",
+        "FinancialMetric",
+        "FinancialTerm",
+        "Industry",
+        "LegalIssue",
+        "Location",
+        "MonetaryValue",
+        "Organization",
+        "Person",
+        "Product",
+        "Program",
+        "Regulation",
+        "Risk",
+        "Year"
+      ]
+    },
+    "SEC": {
+      "lexical": 0.1916,
+      "hand": 0.4853,
+      "single_auto": 0.2797,
+      "stable_multi2pass": 0.613,
+      "seed_terms": [
+        "Entity",
+        "FinancialConcept",
+        "FinancialMetric",
+        "FinancialTerm",
+        "LegalIssue",
+        "MonetaryValue",
+        "Product",
+        "Regulation"
+      ]
+    }
+  }
+}

--- a/src/seocho/fibo_catalog.py
+++ b/src/seocho/fibo_catalog.py
@@ -329,3 +329,67 @@ def auto_semantic_bridge(
     fully-automated form of the ADR-0136 pipeline (no hand seed)."""
     seed = derive_fibo_roots(generic_terms, ontology, backend=backend, model=model)
     return semantic_bridge(ontology, seed)
+
+
+# ---------------------------------------------------------------------------
+# Stabilized seed derivation (ADR-0140): single-model auto-seed was module-variable
+# (ADR-0139, FBC/SEC < hand). Stabilize by (a) unioning the mapping across several
+# models and (b) a 2nd pass that re-derives only the generic terms the 1st pass
+# left unmapped. More models surface more valid roots; the 2nd pass rescues misses.
+# ---------------------------------------------------------------------------
+
+
+def _merge_seed(into: Dict[str, List[str]], add: Dict[str, List[str]]) -> Dict[str, List[str]]:
+    for term, roots in add.items():
+        bucket = into.setdefault(term, [])
+        for r in roots:
+            if r not in bucket:
+                bucket.append(r)
+    return into
+
+
+def derive_fibo_roots_multi(
+    generic_terms: List[str],
+    ontology: Ontology,
+    *,
+    backends: List[Any],
+    models: Optional[List[Optional[str]]] = None,
+    top_candidates: int = 30,
+) -> Dict[str, List[str]]:
+    """Union ``derive_fibo_roots`` across several model backends — more models
+    surface more valid roots (each result is validated against the ontology).
+    ``backends`` and ``models`` are parallel lists; ``models[i]`` may be None."""
+    models = models or [None] * len(backends)
+    merged: Dict[str, List[str]] = {}
+    for be, model in zip(backends, models):
+        try:
+            seed = derive_fibo_roots(generic_terms, ontology, backend=be, model=model, top_candidates=top_candidates)
+        except Exception:
+            seed = {}
+        _merge_seed(merged, seed)
+    return merged
+
+
+def derive_fibo_roots_stable(
+    generic_terms: List[str],
+    ontology: Ontology,
+    *,
+    backends: List[Any],
+    models: Optional[List[Optional[str]]] = None,
+    passes: int = 2,
+    top_candidates: int = 30,
+    top_candidates_p2: int = 60,
+) -> Dict[str, List[str]]:
+    """Multi-model + multi-pass seed derivation. Pass 1 unions across models;
+    each further pass re-derives ONLY the terms still unmapped, with a wider
+    candidate window. Returns the merged seed."""
+    seed = derive_fibo_roots_multi(generic_terms, ontology, backends=backends, models=models, top_candidates=top_candidates)
+    for _ in range(max(0, passes - 1)):
+        missing = [t for t in generic_terms if not seed.get(t)]
+        if not missing:
+            break
+        more = derive_fibo_roots_multi(missing, ontology, backends=backends, models=models, top_candidates=top_candidates_p2)
+        if not more:
+            break
+        _merge_seed(seed, more)
+    return seed

--- a/tests/seocho/test_fibo_catalog.py
+++ b/tests/seocho/test_fibo_catalog.py
@@ -195,3 +195,54 @@ def test_derive_fibo_roots_with_fake_backend_and_validation():
     # auto-bridge propagates Company down the subClassOf tree
     bridged = auto_semantic_bridge(onto, ["Company", "Bogus"], backend=_Fake())
     assert "Company" in bridged.nodes["Subsidiary"].aliases
+
+
+def test_derive_fibo_roots_multi_unions_models():
+    import json as _json
+    from seocho.ontology import NodeDef, Ontology
+    from seocho.fibo_catalog import derive_fibo_roots_multi, derive_fibo_roots_stable
+
+    onto = Ontology("m", nodes={
+        "LegalEntity": NodeDef(description="org"), "Security": NodeDef(description="sec"),
+        "Corporation": NodeDef(description="c", broader=["LegalEntity"]),
+    })
+
+    class _R:
+        def __init__(self, t): self.text = t
+    class _M1:
+        model = "m1"
+        def complete(self, *, system, user, **kw):
+            return _R(_json.dumps({"roots": {"Company": ["LegalEntity"]}}))  # only Company
+    class _M2:
+        model = "m2"
+        def complete(self, *, system, user, **kw):
+            return _R(_json.dumps({"roots": {"FinancialMetric": ["Security"]}}))  # only FinancialMetric
+
+    merged = derive_fibo_roots_multi(["Company", "FinancialMetric"], onto, backends=[_M1(), _M2()], models=["m1", "m2"])
+    assert merged == {"Company": ["LegalEntity"], "FinancialMetric": ["Security"]}  # union of both models
+
+
+def test_derive_fibo_roots_stable_second_pass_rescues_missing():
+    import json as _json
+    from seocho.ontology import NodeDef, Ontology
+    from seocho.fibo_catalog import derive_fibo_roots_stable
+
+    onto = Ontology("m", nodes={
+        "LegalEntity": NodeDef(description="o"), "Corporation": NodeDef(description="c", broader=["LegalEntity"]),
+        "Security": NodeDef(description="s"), "Bond": NodeDef(description="b", broader=["Security"]),
+    })
+
+    class _R:
+        def __init__(self, t): self.text = t
+    class _Pass:
+        """Pass 1 maps only Company; when re-asked (pass 2) with just the missing
+        term, it maps FinancialMetric."""
+        model = "m"
+        def complete(self, *, system, user, **kw):
+            if "FinancialMetric" in user and "Company" not in user:   # pass-2 focused prompt
+                return _R(_json.dumps({"roots": {"FinancialMetric": ["Security"]}}))
+            return _R(_json.dumps({"roots": {"Company": ["LegalEntity"]}}))
+
+    seed = derive_fibo_roots_stable(["Company", "FinancialMetric"], onto, backends=[_Pass()], models=["m"], passes=2)
+    assert seed.get("Company") == ["LegalEntity"]
+    assert seed.get("FinancialMetric") == ["Security"]   # rescued by pass 2


### PR DESCRIPTION
derive_fibo_roots_multi + derive_fibo_roots_stable: union across models + a rescue pass for unmapped terms. Fixes ADR-0139 variability. Measured (real FIBO, FinDER, 3 models, 2 passes): stable coverage BE 0.227 / FBC 0.784 / FND 0.862 / SEC 0.613 — ≥ hand AND ≥ single-auto every module; FBC/FND/SEC exceed curated (0.595) with ZERO hand curation. Pipeline now fully automatic + version-pinned. 2 tests + run_basic_ci 631 passed.