### PR TITLE
feat(ontology): productionize FIBO-derived guardrail builder (selector + run-spec) (ADR-0142)

### DIFF
--- a/docs/RUN_SPECS.md
+++ b/docs/RUN_SPECS.md
@@ -155,6 +155,25 @@ ontology:
   enforcement: guided
 ```
 
+Candidates can instead be built automatically from a compiled FIBO catalog
+(ADR-0142): `select.fibo.catalog` points at `catalog.json`; each module is
+corpus-bridged (lexical + semantic) and the best is chosen. `bridge: stable`
+derives a multi-model auto seed (uses the MARA provider — ADR-0140);
+`bridge: lexical` stays offline. The chosen guardrail is held in memory
+(version-pinned to the FIBO commit), no file needed.
+
+```yaml
+ontology:
+  select:
+    fibo:
+      catalog: ./outputs/semantic_artifacts/fibo/latest/catalog.json
+      modules: [BE, FBC, FND, SEC]   # omit → all modules
+      bridge: stable                 # stable (multi-model auto seed) | lexical (offline)
+      derive_models: [DeepSeek-V3.1, MiniMax-M2.5, gpt-oss-120b]
+    corpus_profile: ./corpus_profile.json
+  enforcement: guided
+```
+
 The corpus profile comes from an open (ontology-free) extraction over the corpus
 (`seocho.ontology_scorecard.build_corpus_profile`). At run time the chosen
 ontology is logged (`[guardrail] selected '<name>' …`) and recorded on the run.

--- a/docs/decisions/ADR-0142-productionize-fibo-guardrail-builder.md
+++ b/docs/decisions/ADR-0142-productionize-fibo-guardrail-builder.md
@@ -1,0 +1,51 @@
+# ADR-0142: Productionize the FIBO-Derived Guardrail Builder (Selector + Run-Spec)
+
+Date: 2026-06-16
+Status: Proposed
+
+## Context
+
+The FIBO arc (ADR-0132→0141) established that a fully-automated, version-pinned
+FIBO-derived guardrail equals the hand-curated slice on answers and exceeds it on
+coverage. Those pieces lived only in benchmark scripts. This wires them into the
+SDK + run-spec as first-class builders so a run can use a FIBO-derived guardrail
+declaratively.
+
+## Decision
+
+`seocho.fibo_catalog`:
+- `build_fibo_guardrail(catalog, corpus_profile, module, *, backends=None, models=None,
+  collapse=False, fallback_seed=None)` — corpus-bridge one FIBO module (lexical +
+  semantic). `backends` → stable multi-model auto seed (ADR-0140); else
+  `fallback_seed`/`FINDER_FIBO_ROOTS` (offline). `collapse=True` → small generic
+  guardrail (version-pinned).
+- `select_fibo_guardrail(catalog, corpus_profile, *, modules=None, backends=None,
+  models=None, collapse=True, extra_candidates=None)` — build bridged module
+  candidates + pick the best via `guardrail_selector.select_guardrail`; returns
+  `(recommendation, {name: Ontology})`.
+
+Run-spec (`ontology.select.fibo`): `{catalog, modules?, bridge: stable|lexical,
+derive_models?}` + `corpus_profile`. `e2e.resolve_guardrail` builds the bridged
+candidates and selects; the chosen guardrail is held in memory
+(`spec.resolved_ontology`, no file), and `build()` uses it directly. `bridge:
+stable` derives the seed via the MARA provider; `lexical` is offline.
+`RUN_SPECS.md` documents the block.
+
+## Validation
+
+`tests/seocho/test_fibo_catalog.py` (+2): `build_fibo_guardrail` collapse + version
+pin; `select_fibo_guardrail` picks the corpus-relevant FIBO module over an
+irrelevant curated candidate (offline fallback seed).
+`tests/seocho/test_run_spec_guardrail_select.py` (+3): parse `select.fibo`; require
+candidates-or-fibo; `resolve_guardrail` (offline lexical) builds an in-memory
+FIBO-derived guardrail and selects it. `run_basic_ci` + `check-doc-contracts` pass.
+
+## Consequences
+
+- A run can declare an official, version-pinned FIBO-derived guardrail in YAML —
+  no hand-made slice, no Python. The selector picks the best-covering module,
+  bridged to the run's corpus.
+- `bridge: stable` spends a few MARA derive calls at resolve time; `bridge: lexical`
+  is free/offline. Default `stable`.
+- Follow-up: a full-corpus FinDER coverage profile to ship as a default
+  `corpus_profile` for financial runs (ADR-0143, in progress).

--- a/src/seocho/e2e.py
+++ b/src/seocho/e2e.py
@@ -191,14 +191,34 @@ def resolve_guardrail(spec: RunSpec) -> RunSpec:
     declared (ADR-0123): score the candidates against the corpus profile and set
     ``spec.ontology_path`` to the chosen candidate, recording the recommendation
     on ``spec.selected_guardrail``. No-op when a fixed ``ontology.path`` is set."""
-    if spec.ontology_path or not spec.guardrail_candidates:
+    if spec.ontology_path or not (spec.guardrail_candidates or spec.guardrail_fibo_catalog):
         return spec
     from .guardrail_selector import load_corpus_profile, select_guardrail
     from .ontology import Ontology
 
+    corpus_profile = load_corpus_profile(_resolve(spec, spec.guardrail_corpus_profile))
+
+    if spec.guardrail_fibo_catalog:
+        # FIBO-catalog-derived candidates (ADR-0142): build bridged module
+        # ontologies and pick. "stable" bridge derives a multi-model seed (needs a
+        # provider); "lexical"/"none" stays offline via the fallback seed.
+        from .fibo_catalog import select_fibo_guardrail
+        backends = models = None
+        if spec.guardrail_fibo_bridge == "stable":
+            from .store.llm import create_llm_backend
+            models = spec.guardrail_fibo_derive_models or [spec.indexing_model()]
+            backends = [create_llm_backend(provider="mara", model=m) for m in models]
+        extra = {name: Ontology.load(_resolve(spec, p)) for name, p in spec.guardrail_candidates.items()}
+        rec, cands = select_fibo_guardrail(
+            _resolve(spec, spec.guardrail_fibo_catalog), corpus_profile,
+            modules=spec.guardrail_fibo_modules or None, backends=backends, models=models,
+            collapse=True, extra_candidates=extra or None)
+        spec.resolved_ontology = cands[rec.chosen]
+        spec.selected_guardrail = rec.to_dict()
+        return spec
+
     candidates = {name: Ontology.load(_resolve(spec, path))
                   for name, path in spec.guardrail_candidates.items()}
-    corpus_profile = load_corpus_profile(_resolve(spec, spec.guardrail_corpus_profile))
     rec = select_guardrail(candidates, corpus_profile)
     spec.ontology_path = spec.guardrail_candidates[rec.chosen]
     spec.selected_guardrail = rec.to_dict()
@@ -213,12 +233,14 @@ def build(spec: RunSpec) -> RunContext:
     resolve_guardrail(spec)
     if spec.selected_guardrail:
         rec = spec.selected_guardrail
-        print(f"[guardrail] selected '{rec['chosen']}' ({spec.ontology_path}) for "
+        where = spec.ontology_path or f"in-memory:{rec['chosen']}"
+        print(f"[guardrail] selected '{rec['chosen']}' ({where}) for "
               f"{rec['domain_kind']} corpus (numeric_intensity={rec['numeric_intensity']})")
         for advisory in rec.get("advisories", []):
             print(f"[guardrail] · {advisory}")
 
-    ontology = Ontology.load(_resolve(spec, spec.ontology_path))
+    # A FIBO-derived guardrail is resolved in-memory (no file); else load the path.
+    ontology = spec.resolved_ontology if spec.resolved_ontology is not None else Ontology.load(_resolve(spec, spec.ontology_path))
 
     client_kwargs: Dict[str, Any] = {
         "ontology": ontology,

--- a/src/seocho/fibo_catalog.py
+++ b/src/seocho/fibo_catalog.py
@@ -393,3 +393,73 @@ def derive_fibo_roots_stable(
             break
         _merge_seed(seed, more)
     return seed
+
+
+# ---------------------------------------------------------------------------
+# Productionized builders (ADR-0142): one-call FIBO-derived guardrail candidates
+# for the selector / run-spec. catalog + corpus → bridged module ontologies →
+# select. backends given → fully-auto stable bridge (ADR-0140); else the
+# FINDER_FIBO_ROOTS fallback (lexical+seed, offline).
+# ---------------------------------------------------------------------------
+
+
+def build_fibo_guardrail(
+    catalog: Union[str, Path, Dict[str, Any]],
+    corpus_profile: Any,
+    module: str,
+    *,
+    backends: Optional[List[Any]] = None,
+    models: Optional[List[Optional[str]]] = None,
+    collapse: bool = False,
+    fallback_seed: Optional[Dict[str, List[str]]] = None,
+    top_generic: int = 20,
+) -> Ontology:
+    """Build one corpus-bridged FIBO-module guardrail. Lexical-bridges to the
+    corpus, then semantic-bridges with either a stable multi-model auto seed (if
+    ``backends`` given) or ``fallback_seed`` / FINDER_FIBO_ROOTS (offline). When
+    ``collapse`` is set, returns a small generic-vocabulary guardrail (prompt-sized,
+    version-pinned)."""
+    cat = load_catalog(catalog)
+    onto = catalog_module_to_ontology(cat, module)
+    gterms = sorted(getattr(corpus_profile, "label_frequencies", {}),
+                    key=lambda k: -corpus_profile.label_frequencies[k])[:top_generic]
+    if backends:
+        seed = derive_fibo_roots_stable(gterms, onto, backends=backends, models=models, passes=2)
+    else:
+        seed = fallback_seed if fallback_seed is not None else FINDER_FIBO_ROOTS
+    bridged = semantic_bridge(bridge_to_corpus(onto, corpus_profile), seed)
+    if not collapse:
+        return bridged
+    generic = set(corpus_profile.label_frequencies) | set(seed)
+    terms = sorted({a for nd in bridged.nodes.values() for a in nd.aliases if a in generic})
+    return Ontology(f"fibo_{module}_generic", package_id=f"fibo.{module}.generic",
+                    version=catalog_provenance(cat)["fibo_commit"][:12],
+                    nodes={t: NodeDef(description=f"{t} (FIBO-{module} derived).") for t in terms})
+
+
+def select_fibo_guardrail(
+    catalog: Union[str, Path, Dict[str, Any]],
+    corpus_profile: Any,
+    *,
+    modules: Optional[List[str]] = None,
+    backends: Optional[List[Any]] = None,
+    models: Optional[List[Optional[str]]] = None,
+    collapse: bool = True,
+    extra_candidates: Optional[Dict[str, Ontology]] = None,
+):
+    """Build corpus-bridged guardrail candidates from FIBO catalog modules and
+    pick the best for the corpus (composes with ``guardrail_selector``). Returns
+    ``(recommendation, {name: Ontology})``. ``extra_candidates`` (e.g. a curated
+    slice) are scored alongside."""
+    from .guardrail_selector import select_guardrail
+
+    cat = load_catalog(catalog)
+    codes = modules if modules is not None else list(cat["modules"].keys())
+    cands: Dict[str, Ontology] = {
+        f"fibo_{m}": build_fibo_guardrail(cat, corpus_profile, m, backends=backends, models=models, collapse=collapse)
+        for m in codes if m in cat["modules"]
+    }
+    if extra_candidates:
+        cands.update(extra_candidates)
+    rec = select_guardrail(cands, corpus_profile)
+    return rec, cands

--- a/src/seocho/run_spec.py
+++ b/src/seocho/run_spec.py
@@ -209,6 +209,16 @@ class RunSpec:
     guardrail_candidates: Dict[str, str] = field(default_factory=dict)
     guardrail_corpus_profile: str = ""
     selected_guardrail: Optional[Dict[str, Any]] = None
+    # Optional FIBO-catalog-derived candidates (ADR-0142): build guardrail
+    # candidates from a compiled FIBO catalog, bridged to the corpus.
+    # bridge: "stable" (multi-model auto seed) | "lexical"/"none" (offline seed).
+    guardrail_fibo_catalog: str = ""
+    guardrail_fibo_modules: List[str] = field(default_factory=list)
+    guardrail_fibo_bridge: str = "stable"
+    guardrail_fibo_derive_models: List[str] = field(default_factory=list)
+    # In-memory ontology chosen at resolve time (FIBO-derived guardrails have no
+    # file path); build() uses this when set, else loads ontology_path.
+    resolved_ontology: Any = None
 
     # -- model resolution ------------------------------------------------
 
@@ -320,19 +330,37 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
     ontology = _path_or_mapping(payload, "ontology", errors=errors)
     documents = _path_or_mapping(payload, "documents", errors=errors)
 
-    # Optional domain-adaptive guardrail selection (ADR-0123).
+    # Optional domain-adaptive guardrail selection (ADR-0123/0142).
     select = ontology.get("select")
     guardrail_candidates: Dict[str, str] = {}
     guardrail_corpus_profile = ""
+    g_fibo_catalog = ""
+    g_fibo_modules: List[str] = []
+    g_fibo_bridge = "stable"
+    g_fibo_models: List[str] = []
     if select is not None:
         if not isinstance(select, Mapping):
-            errors.append("at ontology.select: must be a mapping with 'candidates' and 'corpus_profile'.")
+            errors.append("at ontology.select: must be a mapping with 'corpus_profile' and 'candidates' or 'fibo'.")
         else:
             cands = select.get("candidates") or {}
-            if not isinstance(cands, Mapping) or not cands:
-                errors.append("at ontology.select.candidates: a non-empty mapping of name -> ontology path is required.")
-            else:
-                guardrail_candidates = {str(k): _string(v) for k, v in cands.items()}
+            if cands:
+                if not isinstance(cands, Mapping):
+                    errors.append("at ontology.select.candidates: must be a mapping of name -> ontology path.")
+                else:
+                    guardrail_candidates = {str(k): _string(v) for k, v in cands.items()}
+            fibo = select.get("fibo")
+            if fibo is not None:
+                if not isinstance(fibo, Mapping) or not _string(fibo.get("catalog")):
+                    errors.append("at ontology.select.fibo: must be a mapping with a 'catalog' path.")
+                else:
+                    g_fibo_catalog = _string(fibo.get("catalog"))
+                    mods = fibo.get("modules") or []
+                    g_fibo_modules = [str(x) for x in mods] if isinstance(mods, (list, tuple)) else []
+                    g_fibo_bridge = _string(fibo.get("bridge")).lower() or "stable"
+                    dm = fibo.get("derive_models") or []
+                    g_fibo_models = [str(x) for x in dm] if isinstance(dm, (list, tuple)) else []
+            if not guardrail_candidates and not g_fibo_catalog:
+                errors.append("at ontology.select: provide 'candidates' (name->path) or 'fibo' (catalog).")
             guardrail_corpus_profile = _string(select.get("corpus_profile"))
             if not guardrail_corpus_profile:
                 errors.append("at ontology.select.corpus_profile: a corpus-profile path is required.")
@@ -394,11 +422,16 @@ def parse_run_spec(payload: Any, *, source_path: str = "") -> RunSpec:
         source_path=source_path,
         guardrail_candidates=guardrail_candidates,
         guardrail_corpus_profile=guardrail_corpus_profile,
+        guardrail_fibo_catalog=g_fibo_catalog,
+        guardrail_fibo_modules=g_fibo_modules,
+        guardrail_fibo_bridge=g_fibo_bridge,
+        guardrail_fibo_derive_models=g_fibo_models,
     )
 
-    if not spec.ontology_path and not (spec.guardrail_candidates and spec.guardrail_corpus_profile):
+    _has_select = (spec.guardrail_candidates or spec.guardrail_fibo_catalog) and spec.guardrail_corpus_profile
+    if not spec.ontology_path and not _has_select:
         errors.append("at ontology: a run spec requires ontology (path/mapping with 'path', "
-                      "or 'select' with candidates + corpus_profile).")
+                      "or 'select' with corpus_profile + candidates/fibo).")
     if not spec.documents_path:
         errors.append("at documents: a run spec requires documents (path or mapping with 'path').")
     if spec.enforcement not in _ALLOWED_ENFORCEMENT_MODES:

--- a/tests/seocho/test_fibo_catalog.py
+++ b/tests/seocho/test_fibo_catalog.py
@@ -246,3 +246,39 @@ def test_derive_fibo_roots_stable_second_pass_rescues_missing():
     seed = derive_fibo_roots_stable(["Company", "FinancialMetric"], onto, backends=[_Pass()], models=["m"], passes=2)
     assert seed.get("Company") == ["LegalEntity"]
     assert seed.get("FinancialMetric") == ["Security"]   # rescued by pass 2
+
+
+def _bridge_catalog():
+    BE = "https://spec.edmcouncil.org/fibo/ontology/BE/"
+    return {"schema_version": "seocho.fibo_catalog.v1", "snapshot_hash": "h", "fibo_commit": "deadbeefcafe",
+        "modules": {"BE": {"code": "BE", "iri_prefix": BE, "summary": "Business entities.",
+            "label_index": {}, "definitions": {},
+            "resources": {
+                BE + "LegalEntity": {"kind": "class", "local_name": "LegalEntity", "label": "Legal Entity", "subclass_of": [], "domain": "", "range": ""},
+                BE + "Corporation": {"kind": "class", "local_name": "Corporation", "label": "Corporation", "subclass_of": [BE + "LegalEntity"], "domain": "", "range": ""},
+            }}}}
+
+
+def test_build_fibo_guardrail_collapse_with_fallback_seed():
+    from seocho.fibo_catalog import build_fibo_guardrail
+    from seocho.ontology_scorecard import build_corpus_profile
+    cp = build_corpus_profile([{"nodes": [{"label": "Company"}, {"label": "Company"}]}])
+    # fallback seed maps Company → LegalEntity (a real root in the synthetic catalog)
+    g = build_fibo_guardrail(_bridge_catalog(), cp, "BE", collapse=True,
+                             fallback_seed={"Company": ["LegalEntity"]})
+    assert "Company" in g.nodes              # collapsed to the generic term it surfaced
+    assert g.version == "deadbeefcafe"       # version-pinned to the FIBO commit
+    assert g.package_id == "fibo.BE.generic"
+
+
+def test_select_fibo_guardrail_picks_module():
+    from seocho.fibo_catalog import select_fibo_guardrail
+    from seocho.ontology import NodeDef, Ontology
+    from seocho.ontology_scorecard import build_corpus_profile
+    cp = build_corpus_profile([{"nodes": [{"label": "Company"}, {"label": "LegalEntity"}]}])
+    curated = Ontology("curated", nodes={"Widget": NodeDef(description="w")})  # irrelevant to corpus
+    rec, cands = select_fibo_guardrail(_bridge_catalog(), cp, collapse=False,
+                                       extra_candidates={"curated": curated},
+                                       backends=None)  # offline (FINDER_FIBO_ROOTS fallback)
+    assert "fibo_BE" in cands and "curated" in cands
+    assert rec.chosen == "fibo_BE"           # FIBO module covers the corpus; curated doesn't

--- a/tests/seocho/test_run_spec_guardrail_select.py
+++ b/tests/seocho/test_run_spec_guardrail_select.py
@@ -77,3 +77,48 @@ def test_resolve_guardrail_noop_when_path_fixed(tmp_path):
     resolve_guardrail(spec)
     assert spec.ontology_path == "./schema.yaml"
     assert spec.selected_guardrail is None
+
+
+def test_parse_select_fibo_block():
+    spec = parse_run_spec({
+        "ontology": {"select": {
+            "fibo": {"catalog": "cat.json", "modules": ["BE", "FBC"], "bridge": "lexical"},
+            "corpus_profile": "profile.json",
+        }},
+        "documents": "./docs", "questions": ["q?"],
+    })
+    assert spec.guardrail_fibo_catalog == "cat.json"
+    assert spec.guardrail_fibo_modules == ["BE", "FBC"]
+    assert spec.guardrail_fibo_bridge == "lexical"
+    assert spec.ontology_path == ""
+
+
+def test_parse_select_requires_candidates_or_fibo():
+    with pytest.raises(RunSpecError):
+        parse_run_spec({"ontology": {"select": {"corpus_profile": "p.json"}},
+                        "documents": "./docs", "questions": ["q?"]})
+
+
+def test_resolve_guardrail_fibo_offline(tmp_path):
+    import json
+    BE = "https://spec.edmcouncil.org/fibo/ontology/BE/"
+    catalog = {"schema_version": "seocho.fibo_catalog.v1", "snapshot_hash": "h", "fibo_commit": "abc123",
+        "modules": {"BE": {"code": "BE", "iri_prefix": BE, "summary": "s", "label_index": {}, "definitions": {},
+            "resources": {
+                BE + "LegalEntity": {"kind": "class", "local_name": "LegalEntity", "label": "Legal Entity", "subclass_of": [], "domain": "", "range": ""},
+                BE + "Corporation": {"kind": "class", "local_name": "Corporation", "label": "Corporation", "subclass_of": [BE + "LegalEntity"], "domain": "", "range": ""},
+            }}}}
+    (tmp_path / "cat.json").write_text(json.dumps(catalog))
+    (tmp_path / "profile.json").write_text(json.dumps({"label_frequencies": {"Company": 9, "LegalEntity": 4}}))
+    (tmp_path / "run.yaml").write_text("x")
+
+    spec = parse_run_spec({
+        "ontology": {"select": {"fibo": {"catalog": "cat.json", "modules": ["BE"], "bridge": "lexical"},
+                                "corpus_profile": "profile.json"}},
+        "documents": "./docs", "questions": ["q?"],
+    }, source_path=str(tmp_path / "run.yaml"))
+
+    resolve_guardrail(spec)
+    assert spec.resolved_ontology is not None           # in-memory FIBO-derived guardrail
+    assert spec.selected_guardrail["chosen"] == "fibo_BE"
+    assert "Company" in spec.resolved_ontology.nodes     # collapsed generic guardrail covers the corpus


### PR DESCRIPTION
build_fibo_guardrail / select_fibo_guardrail + run-spec 'ontology.select.fibo' {catalog, modules, bridge: stable|lexical}. e2e.resolve_guardrail builds bridged FIBO-module candidates, picks the best, holds it in memory (version-pinned, no file); build() uses it. RUN_SPECS documents it. Declarative official-FIBO guardrail in YAML. 5 tests + run_basic_ci 631 + doc-contracts pass. (Full-corpus profile = ADR-0143, in progress.)