### PR TITLE
[DRAFT] UX/a11y: Add focus-visible states to interactive buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -114,7 +114,8 @@ body {
   border-left: 2px solid transparent;
 }
 
-.rail-btn:hover {
+.rail-btn:hover,
+.rail-btn:focus-visible {
   color: var(--text-main);
 }
 
@@ -367,7 +368,8 @@ body {
   cursor: not-allowed;
 }
 
-.composer button:hover:not(:disabled) {
+.composer button:hover:not(:disabled),
+.composer button:focus-visible:not(:disabled) {
   opacity: 0.9;
 }
 


### PR DESCRIPTION
What: Added `:focus-visible` states to mirror `:hover` states on interactive buttons.

Why: To ensure keyboard users receive the same visual contrast changes as mouse users, supplementing the global focus rings.

Accessibility / UX Impact: Keyboard users now see the correct text color/opacity when tabbing through buttons, matching the mouse hover state.

Validation: Ran basic CI and visually verified Playwright screenshot showing the focus styles.

Risks: Low risk CSS change.

---
*PR created automatically by Jules for task [2804135623527469313](https://jules.google.com/task/2804135623527469313) started by @tteon*