### PR TITLE
Fix: Add interactive visual states to primary action buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -247,11 +247,17 @@ body {
   font-size: 0.78rem;
   font-weight: 700;
   cursor: pointer;
+  transition: opacity 0.2s;
 }
 
 #ingestBtn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+#ingestBtn:hover:not(:disabled),
+#ingestBtn:focus-visible:not(:disabled) {
+  opacity: 0.9;
 }
 
 #oneClickDemoBtn {
@@ -263,11 +269,17 @@ body {
   font-size: 0.78rem;
   font-weight: 700;
   cursor: pointer;
+  transition: opacity 0.2s;
 }
 
 #oneClickDemoBtn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+#oneClickDemoBtn:hover:not(:disabled),
+#oneClickDemoBtn:focus-visible:not(:disabled) {
+  opacity: 0.9;
 }
 
 /* Dual Pane Workspace */


### PR DESCRIPTION
### What
Added explicit `:hover` and `:focus-visible` CSS states to the `#ingestBtn` and `#oneClickDemoBtn` elements in the evaluation console.

### Why
These primary action buttons lacked visual feedback when hovered over by a mouse or focused via keyboard navigation, making the UI feel unresponsive and hindering accessibility for keyboard-only users.

### Accessibility / UX Impact
Provides immediate visual confirmation (an opacity shift to 0.9) when users interact with the buttons, bringing parity with other interactive elements on the page (like the composer buttons) and satisfying standard UX/a11y feedback patterns.

### Validation
1. Validated the UI changes using a Playwright script that launched the evaluation server locally, hovered over the elements, and took screenshots confirming the visual changes.
2. Screenshots submitted through `frontend_verification_complete`.
3. Validated that basic CI passes without issue (`bash scripts/ci/run_basic_ci.sh`).

### Risks
Extremely low risk. The changes are strictly confined to a CSS stylesheet file in the evaluation UI and do not touch any runtime Python logic or backend APIs. The `opacity: 0.9` styling is also appropriately protected against `#ingestBtn:disabled` states so it does not falsely hint that disabled buttons are interactable.

---
*PR created automatically by Jules for task [1707655255189322997](https://jules.google.com/task/1707655255189322997) started by @tteon*