### PR TITLE
feat(observability): local OTel stack + structured span trace (ADR-0144)

### DIFF
--- a/docs/decisions/ADR-0144-local-otel-observability-and-span-trace-structure.md
+++ b/docs/decisions/ADR-0144-local-otel-observability-and-span-trace-structure.md
@@ -1,0 +1,201 @@
+# ADR-0144: Local OpenTelemetry Observability and Span-Trace Structure
+
+Date: 2026-06-17
+Status: Proposed
+
+## Context
+
+ADR-0045 established the vendor-neutral tracing contract (`none | console |
+jsonl | opik`, JSONL canonical, Opik explicit opt-in). In practice the only
+*rich* backend is Opik, and self-hosted Opik is too heavy for local development:
+it is an 8-container stack (MySQL, Redis, ZooKeeper, ClickHouse, MinIO +
+init, Java backend, Python backend, frontend). Teams want Opik in the **cloud**
+for evaluation, but local runs need a lightweight alternative.
+
+LMCache's reference observability stack (docs + `examples/observability`) was
+reviewed as a pattern source. Its **metrics** do not apply to us — we run no
+local vLLM+LMCache serving layer; we call external APIs (MARA/OpenAI) through
+`OpenAICompatibleBackend`. But its **topology** does: OTLP Collector →
+Prometheus (metrics) + Tempo (traces) → Grafana, four small containers, local
+disk. That is the right-sized local alternative to self-hosted Opik.
+
+Three review rounds (infra / LLM / ontology, then GraphRAG / Graph-DBA / prompt)
+surfaced that the harder problem is not the backend but **what spans we emit**:
+
+- `local_engine.ask()` runs ~12 internal stages (schema → plan → execute →
+  multi_plan → neighbor_fallback → repair → vector → chunk_fallback →
+  ontology_context_check → deterministic_answer → generation) but emits **one
+  flat `sdk.query` span**; stage timings are flattened into a
+  `latency_breakdown_ms` metadata dict, not a nested span tree. `SessionTrace`
+  already supports parent/child nesting but `ask()` does not use it.
+- Cypher execution (`store/graph.py:query`, `query/executor.py`) is a bare
+  `session.run()` — **no span, no DB-side timing, no row count**; failures only
+  hit the Python logger. `workspace_id` is a parameter, never a span attribute,
+  so the multi-tenant contract is invisible to observability.
+- ADR-0111 adopted `neo4j-rust-ext` (a Rust PackStream codec drop-in, selected
+  at install time, logged once per process as `rust-ext active` /
+  `pure-python active`). Its measurement showed **71–91% of client-side query
+  cost is result deserialization/hydration** (W2: 3.57× speedup). But that
+  hydration time is buried inside `[record.data() for record in result]` and
+  the active codec is invisible to traces — so the rust-ext win cannot be
+  observed or regression-monitored (e.g. a deploy that loses the wheel silently
+  falls back to pure-python and ~3.5× slower hydration).
+- **Retrieved context is dark**: the `records` (and chunks/observations) fed to
+  synthesis are never captured — only the final answer is. For Graph-RAG, the
+  retrieved evidence is the first thing you need to debug "why this answer".
+- Because we call **external** LLM APIs, the prompt is the main lever we control,
+  yet prompt observability is the weakest: native spans capture only
+  `text_preview[:200]`, with no system/user split, no temperature/model params,
+  and no template identity. Full prompt capture exists **only** via Opik's
+  `track_openai`, so dropping Opik locally drops prompt visibility entirely.
+  Two already-computed signals are never emitted: the `prompt_version` hash
+  (`index/metadata.py`, stamped on `MENTIONS` edges) and
+  `CompiledOntologyContext.kv_cache_layout().stable_prefix_hash`
+  (`ontology_context.py`) — the latter is exactly the prefix-cache reuse signal
+  that governs external-API cost.
+- Ontology governance is under-traced: enforcement mode (strict/guided/open),
+  per-error validation detail, reified-Observation counts, and guardrail-selector
+  (ADR-0123) decisions are logged to stdout or returned as objects, not emitted
+  as structured spans/metrics.
+
+## Decision
+
+Extend ADR-0045 with a local OpenTelemetry path and a structured span tree,
+keeping Opik as the unchanged cloud team backend.
+
+### 1. New `otlp` tracing backend (extends ADR-0045)
+
+- Add `otlp` to the supported `SEOCHO_TRACE_BACKEND` values:
+  `none | console | jsonl | opik | otlp`.
+- `OTLPBackend` implements the existing `TracingBackend` ABC and exports spans
+  over OTLP gRPC to a Collector. Because `tracing.py` already accepts a backend
+  **list**, the same spans can fan out to both Opik (cloud) and OTLP (local)
+  with no duplicate instrumentation. Intended split: `opik` in cloud, `otlp`
+  locally; JSONL remains the canonical neutral artifact.
+- Config additions: `SEOCHO_TRACE_OTLP_ENDPOINT` (default
+  `http://localhost:4317`), `OTEL_SERVICE_NAME` (default `seocho`).
+
+### 2. Content-capture policy (the root fix for "Opik felt heavy")
+
+- **Attributes are always emitted** (cheap, joinable): hashes, versions, token
+  counts, model/params, row counts, `workspace_id`.
+- **Content is gated** (expensive): full prompt/completion text, full Cypher,
+  retrieved-record bodies emit only when `SEOCHO_TRACE_CAPTURE_CONTENT=1`, with
+  truncation and head-sampling. Default off → light by default, deep on demand.
+- Metric labels never carry raw Cypher/prompt text — only a `*_template_hash`
+  (reuse the existing `_short_hash` pattern) to avoid cardinality blow-up.
+
+### 3. Nested span tree for `ask()` (no new framework)
+
+Promote the existing `StageTimer` context managers to span emission and use the
+existing `SessionTrace` as the root, yielding:
+
+```
+rag.ask                 (root = SessionTrace; attrs: workspace_id, request_id)
+├─ rag.decompose        slots, resolved/missing
+├─ rag.arbitrate        route, rationale         (fold in today's semantic.route)
+├─ rag.compile_cypher   intent, query_template_hash
+├─ rag.execute          db.name, db.rows_returned, db.duration_ms, workspace_id
+├─ rag.retrieve_ctx     n_nodes, n_chunks, scores            ★ new, top priority
+└─ rag.synthesize       gen_ai.* + prompt_version + stable_prefix_hash
+```
+
+`sdk.query` / `sdk.extraction` remain as aggregate spans for backward
+compatibility; the new spans nest under the `rag.ask` root.
+
+### 4. First-class `workspace_id` + DB instrumentation
+
+`rag.execute` wraps `graph_store.query()` with OTel `db.*` semantic-convention
+attributes (`db.system=neo4j`, `db.name`, `db.statement` content-gated,
+`db.rows_returned`) and carries `workspace_id` as a first-class attribute on
+every span. `X-Request-ID` (already in middleware) is threaded into a Cypher
+comment for DB-log ↔ trace correlation. Slow-query `PROFILE` capture is sampled,
+not always-on.
+
+**Rust-ext-aware timing split (ADR-0111).** Because hydration dominates
+client-side cost, `rag.execute` splits the single timing into three attributes
+instead of one `db.duration_ms`:
+
+- `db.duration_server_ms` — from the cheap `ResultSummary`
+  (`result_available_after` / `result_consumed_after`), no `PROFILE` needed
+- `db.duration_hydrate_ms` — time spent in the `record.data()` loop (the codec
+  cost rust-ext targets)
+- `db.rows_returned` — denominator for per-row hydration cost
+
+The active PackStream codec (`rust-ext` / `pure-python`, already detected at
+init) is emitted as an OTel **resource attribute** `db.client.codec` (process-
+global, not per query), so every trace records which codec produced its
+latency and a silent fallback to pure-python is immediately visible.
+`execute_write()` additionally surfaces `result.consume().counters`
+(`db.nodes_created`, `db.relationships_created`, `db.properties_set`) as span
+attributes — already computed today, currently unused for observability.
+
+### 5. GenAI prompt observability via OTel conventions
+
+`rag.synthesize` (and the extraction LLM call) adopt `gen_ai.*` semantic
+conventions: `gen_ai.request.model`, `gen_ai.request.temperature`,
+`gen_ai.usage.input_tokens/output_tokens`, plus SEOCHO attributes
+`prompt_version`, `prompt_template`, `ontology_context_hash`,
+`stable_prefix_hash`. `gen_ai.prompt`/`gen_ai.completion` are content-gated.
+This restores on the local OTLP path what Opik's `track_openai` gives for free
+on cloud, and makes "prompt variant ↔ cache reuse ↔ answer quality" joinable.
+
+### 6. Ontology governance spans/metrics
+
+Emit `enforcement_mode` and per-error validation detail on the extraction span;
+add `seocho_validation_errors_total{mode,ontology}`,
+`seocho_observations_reified_total`, `seocho_arbiter_route_total{route}`; and
+give the guardrail selector (ADR-0123) an audit span when invoked.
+
+### 7. Local compose profile (pattern, not LMCache manifest copy)
+
+Add `docker-compose.observability.yml` under a `--profile observability`:
+OTel Collector + Tempo + Prometheus + Grafana, reusing the existing
+`seocho-net`, pinned image tags, traces→Tempo / metrics→Prometheus →
+Grafana. Dev-grade defaults are acceptable (local only); production hardening
+(auth, durable storage) is out of scope and noted as such.
+
+## Validation
+
+This ADR is **Proposed**; no measurement yet. Acceptance for the implementation
+slices (tracked as `seocho-*` beads under this ADR):
+
+- with `SEOCHO_TRACE_BACKEND=otlp`, a single `ask()` produces a nested
+  `rag.ask` trace in Tempo with the six child spans, queryable by TraceQL
+  (`{ name="rag.execute" && span.workspace_id="..." }`).
+- `workspace_id` present on every span; `db.rows_returned` and `db.duration_ms`
+  populated on `rag.execute`.
+- `prompt_version` and `stable_prefix_hash` present on `rag.synthesize`;
+  full prompt text present **only** when `SEOCHO_TRACE_CAPTURE_CONTENT=1`.
+- `opik` (cloud) behavior unchanged when `otlp` is not in the backend list.
+- the four-container profile boots and Grafana shows the trace + the
+  `seocho_*` metrics. Per the team's ontology-experiment rule, before/after
+  observability deltas are recorded under `docs/decisions/`.
+
+## Consequences
+
+- Local development gets rich observability at ~4 containers instead of Opik's
+  ~8, with Opik untouched as the cloud team backend — matching the stated
+  "cloud=Opik / local=separate" split.
+- Multi-stage Graph-RAG failures become debuggable: each stage is its own span,
+  and retrieved context (the previously dark `rag.retrieve_ctx`) is captured.
+- Prompt/cache observability — the real control surface in an external-API
+  deployment — is restored on the neutral/local path, not just in Opik.
+- The content-capture policy makes heaviness opt-in, addressing the original
+  "Opik is too heavy" complaint at its root (always-on full-text capture).
+- Tradeoffs: adopting `gen_ai.*`/`db.*` conventions and a span tree adds
+  surface area to `tracing.py` and the `ask()` hot path; span emission must stay
+  exception-isolated (as today) so observability never breaks answering. The
+  LMCache metrics families remain inapplicable until/unless a local vLLM+LMCache
+  serving layer is introduced — at which point it scrapes the same Prometheus.
+- Making the server/hydration split observable turns the ADR-0111 rust-ext
+  investment into a monitored, regression-guarded property rather than a
+  one-off benchmark — and the same span attributes apply unchanged under either
+  codec.
+- Related: ADR-0045 (tracing contract, extended here), ADR-0031 (evidence
+  bundle — the `rag.retrieve_ctx` payload source), ADR-0103 (arbiter, whose
+  `semantic.route` span folds into `rag.arbitrate`), ADR-0111 (neo4j-rust-ext,
+  whose hydration win the `rag.execute` timing split makes observable),
+  ADR-0123 (guardrail selector audit span). Ticket `seocho-ub5` (provider/model-
+  aware meta-prompt) is adjacent but distinct (output robustness, not
+  observability).

--- a/docs/decisions/ADR-0144-local-otel-observability-and-span-trace-structure.md
+++ b/docs/decisions/ADR-0144-local-otel-observability-and-span-trace-structure.md
@@ -105,12 +105,15 @@ compatibility; the new spans nest under the `rag.ask` root.
 
 ### 4. First-class `workspace_id` + DB instrumentation
 
-`rag.execute` wraps `graph_store.query()` with OTel `db.*` semantic-convention
-attributes (`db.system=neo4j`, `db.name`, `db.statement` content-gated,
-`db.rows_returned`) and carries `workspace_id` as a first-class attribute on
-every span. `X-Request-ID` (already in middleware) is threaded into a Cypher
-comment for DB-log ↔ trace correlation. Slow-query `PROFILE` capture is sampled,
-not always-on.
+`rag.execute` is the engine *stage*; the actual DB round-trip is a nested
+`db.query` span emitted inside `graph_store.query()` (and `db.execute_write`
+inside `execute_write()`), so every execution path — main, repair, fallback,
+and non-`ask()` callers like the runtime query proxy — is covered, not just the
+main lane. The `db.*` span carries OTel semantic-convention attributes
+(`db.system=neo4j`, `db.name`, `db.statement` content-gated, `db.rows_returned`)
+and `workspace_id` as a first-class attribute. `X-Request-ID` (already in
+middleware) is threaded into a Cypher comment for DB-log ↔ trace correlation.
+Slow-query `PROFILE` capture is sampled, not always-on.
 
 **Rust-ext-aware timing split (ADR-0111).** Because hydration dominates
 client-side cost, `rag.execute` splits the single timing into three attributes
@@ -122,10 +125,13 @@ instead of one `db.duration_ms`:
   cost rust-ext targets)
 - `db.rows_returned` — denominator for per-row hydration cost
 
-The active PackStream codec (`rust-ext` / `pure-python`, already detected at
-init) is emitted as an OTel **resource attribute** `db.client.codec` (process-
-global, not per query), so every trace records which codec produced its
-latency and a silent fallback to pure-python is immediately visible.
+The active PackStream codec (`rust-ext` / `pure-python` / `unknown`, detected
+once and cached via `packstream_codec()`) is stamped as `db.client.codec` on
+each `db.query` span, so every trace records which codec produced its latency
+and a silent fallback to pure-python is immediately visible as elevated
+`db.duration_hydrate_ms`. (Span attribute rather than an OTel resource
+attribute: the resource is fixed at provider-init, which may precede graph-
+store construction; a per-span stamp avoids that ordering coupling.)
 `execute_write()` additionally surfaces `result.consume().counters`
 (`db.nodes_created`, `db.relationships_created`, `db.properties_set`) as span
 attributes — already computed today, currently unused for observability.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -3,6 +3,26 @@
 This file is the lightweight index of architecture/product decisions.
 Each entry must link to a full ADR when impact is non-trivial.
 
+## 2026-06-17
+
+- [Proposed] ADR-0144 local-otel-observability-and-span-trace-structure
+  - extends ADR-0045: add `otlp` tracing backend → lightweight local stack
+    (OTel Collector + Tempo + Prometheus + Grafana, 4 containers) as the
+    alternative to heavy self-hosted Opik; Opik stays the cloud team backend,
+    JSONL stays canonical. LMCache's topology was the pattern source; its
+    metrics don't apply (no local vLLM+LMCache serving)
+  - replace the single flat `sdk.query` span with a nested `rag.ask` tree
+    (decompose → arbitrate → compile_cypher → execute → retrieve_ctx →
+    synthesize) using existing `StageTimer` + `SessionTrace`; `retrieve_ctx`
+    (what was fed to the LLM) is new and top-priority
+  - external-API deployment → prompt is the control surface: adopt `gen_ai.*`
+    conventions + surface `prompt_version` and `stable_prefix_hash`;
+    content-capture (full prompt/Cypher/records) gated behind
+    `SEOCHO_TRACE_CAPTURE_CONTENT` (root fix for "Opik felt heavy")
+  - `workspace_id` first-class on every span; `rag.execute` splits
+    server vs hydration time + `db.client.codec` resource attr, making the
+    ADR-0111 neo4j-rust-ext hydration win observable/regression-guarded
+
 ## 2026-06-16
 
 - [Proposed] ADR-0143 full-corpus-finder-profile

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,60 @@
+# Local observability stack (ADR-0144)
+
+A lightweight, local OpenTelemetry stack for SEOCHO traces — the alternative to
+self-hosted Opik (8 containers) when you just want local visibility. Opik stays
+the **cloud** team backend; this is for local development.
+
+Four containers:
+
+| Service | Image | Host port | Role |
+|---|---|---|---|
+| `otel-collector` | `otel/opentelemetry-collector-contrib:0.119.0` | 4317 / 4318 / 8889 | receives OTLP, fans out |
+| `tempo` | `grafana/tempo:2.7.2` | 3200 | trace store |
+| `prometheus` | `prom/prometheus:v2.55.1` | 9091 | metrics store |
+| `grafana` | `grafana/grafana:11.5.1` | 3000 | dashboards / Explore |
+
+Flow: `SEOCHO → OTLP gRPC → Collector → Tempo (traces) + Prometheus (metrics) → Grafana`.
+
+> Pattern borrowed from [LMCache's `examples/observability`](https://github.com/LMCache/LMCache/tree/dev/examples/observability),
+> **not** a copy — SEOCHO services push to the collector by container name, so no
+> `host.docker.internal` is needed. LMCache's KV-cache metrics don't apply here
+> (SEOCHO calls external LLM APIs; no local vLLM+LMCache serving).
+
+## Run
+
+The stack joins the **external** `seocho-net` network created by the repo's main
+`docker-compose.yml`, so bring the main stack up first, then:
+
+```bash
+docker compose -f examples/observability/docker-compose.observability.yml \
+    --profile observability up -d
+```
+
+Point SEOCHO at the collector:
+
+```bash
+# app running inside the compose network:
+export SEOCHO_TRACE_BACKEND=otlp
+export SEOCHO_TRACE_OTLP_ENDPOINT=http://otel-collector:4317
+# app running on the host: the default http://localhost:4317 already works
+export SEOCHO_TRACE_BACKEND=otlp
+```
+
+Install the exporter deps the backend needs: `pip install 'seocho[otel]'`.
+
+Open Grafana at <http://localhost:3000> (anonymous admin) → **Explore → Tempo**:
+
+```
+{ name = "rag.ask" }
+{ name = "db.query" && span.db.duration_hydrate_ms > 50 }   # pure-python codec fallback
+{ span.workspace_id = "<workspace>" }
+```
+
+## Caveats (dev-grade)
+
+- Anonymous-admin Grafana, login disabled, local-disk storage, 7-day retention.
+  Fine for local dev; **harden (auth + durable backends) before any shared/prod
+  use.** Image tags are pinned — bump deliberately.
+- Full prompt/Cypher bodies are only captured with `SEOCHO_TRACE_CAPTURE_CONTENT=1`
+  (off by default). Attributes (ids, hashes, counts, timings) always flow.
+- Port `9091` (not 9090) avoids clashing with the `opik` profile's MinIO console.

--- a/examples/observability/docker-compose.observability.yml
+++ b/examples/observability/docker-compose.observability.yml
@@ -1,0 +1,90 @@
+# ADR-0144: lightweight local OpenTelemetry observability stack.
+#
+# Four containers (Collector + Tempo + Prometheus + Grafana) — the local
+# alternative to self-hosted Opik (8 containers). Opik stays the cloud team
+# backend; this is for local development. Pattern borrowed from LMCache's
+# examples/observability (NOT a manifest copy): SEOCHO services push OTLP to the
+# collector by container name, so no host.docker.internal is needed.
+#
+# Run alongside the main stack (shares the external seocho-net created by
+# docker-compose.yml):
+#
+#   docker compose -f examples/observability/docker-compose.observability.yml \
+#       --profile observability up -d
+#
+# Then point SEOCHO at the collector (in-compose app → otel-collector:4317;
+# host-run app → localhost:4317, the default):
+#
+#   SEOCHO_TRACE_BACKEND=otlp
+#   SEOCHO_TRACE_OTLP_ENDPOINT=http://otel-collector:4317   # in-compose
+#
+# Grafana: http://localhost:3000 (anonymous admin — DEV ONLY; harden for prod).
+# Image tags are pinned (ADR-0144); bump deliberately.
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.119.0
+    container_name: seocho-otel-collector
+    profiles: ["observability"]
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - ./otel-collector.yaml:/etc/otel-collector.yaml:ro
+    ports:
+      - "4317:4317"   # OTLP gRPC (SEOCHO_TRACE_OTLP_ENDPOINT)
+      - "4318:4318"   # OTLP HTTP
+      - "8889:8889"   # Prometheus exposition (scraped by prometheus)
+    networks: [seocho-net]
+    depends_on: [tempo, prometheus]
+
+  tempo:
+    image: grafana/tempo:2.7.2
+    container_name: seocho-tempo
+    profiles: ["observability"]
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    ports:
+      - "3200:3200"   # Tempo query API (Grafana datasource)
+    networks: [seocho-net]
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: seocho-prometheus
+    profiles: ["observability"]
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=7d
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9091:9090"   # 9091 host to avoid clashing with the opik profile
+    networks: [seocho-net]
+
+  grafana:
+    image: grafana/grafana:11.5.1
+    container_name: seocho-grafana
+    profiles: ["observability"]
+    environment:
+      # DEV ONLY: anonymous admin, login disabled. Do not use in production.
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"   # already in SEOCHO_CORS_ORIGINS by default
+    networks: [seocho-net]
+    depends_on: [prometheus, tempo]
+
+networks:
+  seocho-net:
+    external: true
+    name: seocho-net
+
+volumes:
+  tempo-data:
+  prometheus-data:
+  grafana-data:

--- a/examples/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/examples/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: seocho
+    orgId: 1
+    folder: SEOCHO
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/examples/observability/grafana/provisioning/dashboards/seocho-rag.json
+++ b/examples/observability/grafana/provisioning/dashboards/seocho-rag.json
@@ -1,0 +1,40 @@
+{
+  "uid": "seocho-rag",
+  "title": "SEOCHO RAG (ADR-0144)",
+  "tags": ["seocho", "rag", "adr-0144"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "About",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "options": {
+        "mode": "markdown",
+        "content": "## SEOCHO span trace (ADR-0144)\n\nEach `ask()` is a **`rag.ask`** root span over nested stages: `rag.compile_cypher` -> `rag.execute` -> `db.query` -> `rag.retrieve_ctx` -> `rag.synthesize`.\n\n- **Explore -> Tempo** with TraceQL, e.g. `{ name=\"rag.ask\" }`, `{ name=\"db.query\" && span.db.duration_hydrate_ms > 50 }` (catches pure-python codec fallback), or `{ span.workspace_id=\"<ws>\" }`.\n- Set `SEOCHO_TRACE_BACKEND=otlp`; full prompt/Cypher bodies only appear with `SEOCHO_TRACE_CAPTURE_CONTENT=1`.\n- `seocho_*` Prometheus metrics arrive once ADR-0144 ts6 (governance metrics) lands."
+      }
+    },
+    {
+      "id": 2,
+      "type": "table",
+      "title": "Recent rag.ask traces",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 6 },
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "queryType": "traceqlSearch",
+          "query": "{ name = \"rag.ask\" }",
+          "limit": 50,
+          "tableType": "traces"
+        }
+      ],
+      "options": { "showHeader": true }
+    }
+  ]
+}

--- a/examples/observability/grafana/provisioning/datasources/datasources.yml
+++ b/examples/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 15s
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      # Link Tempo spans to Prometheus metrics via the service graph.
+      serviceMap:
+        datasourceUid: prometheus

--- a/examples/observability/otel-collector.yaml
+++ b/examples/observability/otel-collector.yaml
@@ -1,0 +1,34 @@
+# OTel Collector: receive OTLP from SEOCHO, fan out to Tempo (traces) and
+# expose metrics for Prometheus to scrape. ADR-0144.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    # Turn OTel resource attributes into metric labels (service.name, etc.).
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]

--- a/examples/observability/prometheus.yml
+++ b/examples/observability/prometheus.yml
@@ -1,0 +1,9 @@
+# Prometheus scrapes the collector's Prometheus exposition endpoint, where
+# SEOCHO's OTLP metrics (seocho_*, ADR-0144 §6 follow-ups) are re-exposed.
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: seocho-otel-collector
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/examples/observability/tempo.yaml
+++ b/examples/observability/tempo.yaml
@@ -1,0 +1,26 @@
+# Tempo: single-binary, local filesystem storage. Dev-grade (no clustering,
+# no durable backend) — fine for local SEOCHO traces. ADR-0144.
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 168h   # 7 days, matching Prometheus retention
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,12 @@ embedded = [
 pdf = [
     "opendataloader-pdf",
 ]
+otel = [
+    # ADR-0144: local OpenTelemetry tracing backend (otlp). Lightweight
+    # alternative to self-hosted Opik; exports spans to an OTel Collector.
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-grpc",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["extraction/tests", "tests"]

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -238,6 +238,7 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
         "flush_tracing",
         "is_backend_enabled",
         "is_tracing_enabled",
+        "record_metric",
         "start_span",
     ],
     ".runtime_bundle": [
@@ -448,6 +449,7 @@ __all__ = [
     "flush_tracing",
     "start_span",
     "capture_text",
+    "record_metric",
     # Errors users catch
     "SeochoError",
     "SeochoConnectionError",

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -229,13 +229,16 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
     ".tracing": [
         "SessionTrace",
         "begin_session",
+        "capture_text",
         "configure_tracing_from_env",
+        "content_capture_enabled",
         "current_backend_names",
         "disable_tracing",
         "enable_tracing",
         "flush_tracing",
         "is_backend_enabled",
         "is_tracing_enabled",
+        "start_span",
     ],
     ".runtime_bundle": [
         "PortablePromptTemplate",
@@ -443,6 +446,8 @@ __all__ = [
     "enable_tracing",
     "disable_tracing",
     "flush_tracing",
+    "start_span",
+    "capture_text",
     # Errors users catch
     "SeochoError",
     "SeochoConnectionError",

--- a/src/seocho/guardrail_selector.py
+++ b/src/seocho/guardrail_selector.py
@@ -135,10 +135,32 @@ def select_guardrail(
             advisories.append("Mixed numeric/entity corpus — consider splitting by sub-domain and "
                               "selecting a guardrail per split.")
 
-    return GuardrailRecommendation(
+    recommendation = GuardrailRecommendation(
         chosen=chosen, domain_kind=domain_kind, numeric_intensity=ni,
         rationale=rationale, advisories=advisories, candidate_scores=scores,
     )
+
+    # ADR-0144 §6: the selection was previously returned but logged nowhere.
+    # Emit an audit span so the decision (and its inputs) is observable.
+    try:
+        from .tracing import is_tracing_enabled, log_span
+
+        if is_tracing_enabled():
+            log_span(
+                "ontology.guardrail_select",
+                input_data={"candidates": sorted(candidates)},
+                output_data={
+                    "chosen": chosen,
+                    "domain_kind": domain_kind,
+                    "numeric_intensity": ni,
+                },
+                metadata={"rationale": rationale, "candidate_scores": scores},
+                tags=["ontology", "guardrail"],
+            )
+    except Exception:
+        pass
+
+    return recommendation
 
 
 def select_per_domain(

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -621,6 +621,16 @@ class IndexingPipeline:
                     ensure_observation_constraint(self.graph_store, database)
                     all_nodes = list(all_nodes) + obs_nodes
                     all_rels = list(all_rels) + obs_rels
+                    try:  # ADR-0144 §6: reification was previously silent
+                        from seocho.tracing import record_metric
+
+                        record_metric(
+                            "seocho_observations_reified",
+                            len(obs_nodes),
+                            attributes={"ontology": self.ontology.name},
+                        )
+                    except Exception:
+                        pass
             except Exception as exc:  # never let reification break ingestion
                 logger.warning("Observation dual-write skipped: %s", exc)
 
@@ -1033,10 +1043,27 @@ class IndexingPipeline:
             except Exception:
                 pass
 
-        # --- Tracing ---
+        # --- Tracing (ADR-0144 §6: governance observability) ---
         try:
-            from seocho.tracing import log_extraction, is_tracing_enabled
+            from seocho.tracing import (
+                capture_text,
+                is_tracing_enabled,
+                log_extraction,
+                record_metric,
+            )
             if is_tracing_enabled():
+                _mode = self.enforcement_policy.mode
+                _meta: Dict[str, Any] = {"enforcement_mode": _mode}
+                if _total_usage:
+                    _meta["usage"] = _total_usage
+                # Per-error validation detail (content-gated): the actual
+                # failures, not just the count, when capture is enabled.
+                if result.validation_errors:
+                    _detail = capture_text(
+                        "; ".join(str(e) for e in result.validation_errors[:20])
+                    )
+                    if _detail:
+                        _meta["validation_errors_detail"] = _detail
                 log_extraction(
                     text_preview=content[:200] if content else "",
                     ontology_name=self.ontology.name,
@@ -1046,7 +1073,12 @@ class IndexingPipeline:
                     score=_score,
                     validation_errors=len(result.validation_errors),
                     elapsed_seconds=_pipeline_elapsed,
-                    metadata={"usage": _total_usage} if _total_usage else None,
+                    metadata=_meta,
+                )
+                record_metric(
+                    "seocho_validation_errors",
+                    len(result.validation_errors),
+                    attributes={"mode": _mode, "ontology": self.ontology.name},
                 )
         except Exception:
             pass

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -624,6 +624,53 @@ class _LocalEngine:
             ):
                 yield
 
+    def _annotate_synthesis_span(
+        self,
+        span: Any,
+        synthesizer: Any,
+        ontology_context: Any,
+    ) -> None:
+        """Stamp gen_ai.* + prompt/cache identity on rag.synthesize (ADR-0144).
+
+        External-API deployments control the prompt, not the model internals, so
+        the joinable signal is (model, params, tokens) + the cacheable system-
+        prompt prefix hash (stable_prefix_hash / ontology_context_hash).
+        """
+        from .tracing import is_tracing_enabled
+
+        if not is_tracing_enabled():
+            return
+        try:
+            attrs: Dict[str, Any] = {
+                "gen_ai.request.model": getattr(self.llm, "model", "unknown"),
+            }
+            provider = getattr(self.llm, "provider", "") or getattr(
+                self.llm, "provider_name", ""
+            )
+            if provider:
+                attrs["gen_ai.system"] = str(provider)
+            temp = getattr(synthesizer, "last_temperature", None)
+            if temp is not None:
+                attrs["gen_ai.request.temperature"] = temp
+            usage = getattr(synthesizer, "last_usage", None) or {}
+            if usage.get("prompt_tokens"):
+                attrs["gen_ai.usage.input_tokens"] = int(usage["prompt_tokens"])
+            if usage.get("completion_tokens"):
+                attrs["gen_ai.usage.output_tokens"] = int(usage["completion_tokens"])
+            if usage.get("total_tokens"):
+                attrs["gen_ai.usage.total_tokens"] = int(usage["total_tokens"])
+            try:
+                layout = ontology_context.kv_cache_layout()
+                if layout.get("stable_prefix_hash"):
+                    attrs["stable_prefix_hash"] = layout["stable_prefix_hash"]
+                if layout.get("context_hash"):
+                    attrs["ontology_context_hash"] = layout["context_hash"]
+            except Exception:
+                pass
+            span.set_metadata(attrs)
+        except Exception:
+            pass
+
     def _run_query_pipeline(
         self,
         question: str,
@@ -911,18 +958,18 @@ class _LocalEngine:
             with start_span(
                 "rag.synthesize",
                 output_data={"result_count": len(records) if records else 0},
-                metadata={
-                    "workspace_id": self.workspace_id,
-                    "model": getattr(self.llm, "model", "unknown"),
-                },
+                metadata={"workspace_id": self.workspace_id},
                 tags=["rag"],
-            ):
+            ) as syn_span:
                 answer_text = answer_synthesizer.synthesize(
                     question,
                     records,
                     reasoning_trace=reasoning_trace,
                     vector_context=vector_context,
                     answer_shape=answer_shape,
+                )
+                self._annotate_synthesis_span(
+                    syn_span, answer_synthesizer, ontology_context
                 )
 
         timer.mark_total()

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -4,7 +4,8 @@ import json
 import logging
 import os
 import re
-from typing import Any, Dict, List, Optional, Sequence
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 from .curation_design import CurationDesignSpec, load_curation_design_spec
 from .graph_projector import GraphProjector
@@ -580,12 +581,67 @@ class _LocalEngine:
             except Exception as exc:  # never let the new lane break ask()
                 logger.warning("Semantic-layer lane skipped: %s", exc)
 
+        # ADR-0144: wrap the retrieval pipeline in a single rag.ask root span so
+        # its stages (compile_cypher -> execute -> retrieve_ctx -> synthesize)
+        # nest as a tree in Tempo/Opik instead of one flat sdk.query event.
+        from .tracing import start_span
+
+        with start_span(
+            "rag.ask",
+            input_data={"question": question[:200]},
+            metadata={
+                "workspace_id": self.workspace_id,
+                "query_mode": query_mode,
+                "ontology": getattr(active_ontology, "name", ""),
+            },
+            tags=["rag"],
+        ):
+            return self._run_query_pipeline(
+                question,
+                database=database,
+                reasoning_mode=reasoning_mode,
+                repair_budget=repair_budget,
+                query_mode=query_mode,
+                active_ontology=active_ontology,
+                ontology_context=ontology_context,
+            )
+
+    @contextmanager
+    def _traced_stage(
+        self,
+        timer: StageTimer,
+        timer_key: str,
+        span_name: Optional[str] = None,
+    ) -> Iterator[None]:
+        """Run a StageTimer stage and emit a nested rag.* span (ADR-0144)."""
+        from .tracing import start_span
+
+        with timer.stage(timer_key):
+            with start_span(
+                span_name or f"rag.{timer_key}",
+                metadata={"workspace_id": self.workspace_id},
+                tags=["rag"],
+            ):
+                yield
+
+    def _run_query_pipeline(
+        self,
+        question: str,
+        *,
+        database: str,
+        reasoning_mode: bool,
+        repair_budget: int,
+        query_mode: str,
+        active_ontology: Any,
+        ontology_context: Any,
+    ) -> str:
+        """Retrieval pipeline body for ask(), wrapped by the rag.ask span."""
         timer = StageTimer()
         agent_design_pattern = str(self.agent_config.extra.get("agent_design_pattern", "") or "")
         if query_mode == "graph_cot" and not agent_design_pattern:
             agent_design_pattern = "graph_cot"
 
-        with timer.stage("schema"):
+        with self._traced_stage(timer, "schema"):
             schema_info = self._get_schema_info(database)
         self._query.schema_info = schema_info
         planner = DeterministicQueryPlanner(
@@ -599,7 +655,7 @@ class _LocalEngine:
             llm=self.llm,
         )
 
-        with timer.stage("plan"):
+        with self._traced_stage(timer, "plan", "rag.compile_cypher"):
             cypher, params, intent_data, error = self._generate_cypher(
                 question,
                 active_ontology,
@@ -630,7 +686,7 @@ class _LocalEngine:
             )
             return error
 
-        with timer.stage("execute"):
+        with self._traced_stage(timer, "execute", "rag.execute"):
             records, exec_error = self._execute_cypher(
                 cypher,
                 params,
@@ -766,7 +822,7 @@ class _LocalEngine:
                 if chunk_ctx:
                     vector_context = chunk_ctx
 
-        with timer.stage("ontology_context_check"):
+        with self._traced_stage(timer, "ontology_context_check"):
             ontology_context_mismatch = self._query_ontology_context_mismatch(database, ontology_context)
         if ontology_context_mismatch.get("mismatch"):
             logger.warning(
@@ -776,7 +832,7 @@ class _LocalEngine:
                 ontology_context_mismatch.get("indexed_context_hashes", []),
             )
 
-        with timer.stage("deterministic_answer"):
+        with self._traced_stage(timer, "deterministic_answer"):
             deterministic_answer = self._build_deterministic_answer(
                 question,
                 records,
@@ -821,6 +877,26 @@ class _LocalEngine:
         if reasoning_mode and attempts:
             reasoning_trace = json.dumps(attempts, default=str)
 
+        # ADR-0144: capture WHAT is fed to synthesis (the previously-dark
+        # retrieved context). Bodies are content-gated; counts/intent always.
+        from .tracing import capture_text, start_span
+
+        _rec_preview = capture_text(json.dumps(records[:5], default=str)) if records else None
+        with start_span(
+            "rag.retrieve_ctx",
+            output_data={
+                "n_records": len(records) if records else 0,
+                "has_vector_context": bool(vector_context),
+                "intent": intent_data.get("intent") if intent_data else None,
+            },
+            metadata={
+                "workspace_id": self.workspace_id,
+                **({"records_preview": _rec_preview} if _rec_preview else {}),
+            },
+            tags=["rag"],
+        ):
+            pass
+
         with timer.stage("generation"):
             # AnswerShape (opik-derived): classify the question's expected
             # answer shape and steer the synthesizer toward a terse
@@ -832,13 +908,22 @@ class _LocalEngine:
 
             if answer_shape_enabled():
                 answer_shape = classify_answer_shape(question)
-            answer_text = answer_synthesizer.synthesize(
-                question,
-                records,
-                reasoning_trace=reasoning_trace,
-                vector_context=vector_context,
-                answer_shape=answer_shape,
-            )
+            with start_span(
+                "rag.synthesize",
+                output_data={"result_count": len(records) if records else 0},
+                metadata={
+                    "workspace_id": self.workspace_id,
+                    "model": getattr(self.llm, "model", "unknown"),
+                },
+                tags=["rag"],
+            ):
+                answer_text = answer_synthesizer.synthesize(
+                    question,
+                    records,
+                    reasoning_trace=reasoning_trace,
+                    vector_context=vector_context,
+                    answer_shape=answer_shape,
+                )
 
         timer.mark_total()
         self._last_query_metadata = build_local_query_metadata(

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -1037,7 +1037,7 @@ class _LocalEngine:
     def _log_semantic_route(self, question: str, sr: Any) -> None:
         """Emit the arbiter route (ADR-0103 H3) as a tracing span for observability."""
         try:
-            from .tracing import is_tracing_enabled, log_span
+            from .tracing import is_tracing_enabled, log_span, record_metric
 
             if not is_tracing_enabled():
                 return
@@ -1049,6 +1049,7 @@ class _LocalEngine:
                 metadata=(hint.to_span() if hint is not None else {"arbiter.route": sr.route}),
                 tags=["semantic-layer", f"route:{sr.route}"],
             )
+            record_metric("seocho_arbiter_route", 1, attributes={"route": sr.route})
         except Exception:
             pass
 

--- a/src/seocho/query/answering.py
+++ b/src/seocho/query/answering.py
@@ -74,6 +74,9 @@ class QueryAnswerSynthesizer:
     def __init__(self, *, query_strategy: Any, llm: Any) -> None:
         self.query_strategy = query_strategy
         self.llm = llm
+        # ADR-0144: last LLM-synthesis usage/params, surfaced on rag.synthesize.
+        self.last_usage: Optional[Dict[str, int]] = None
+        self.last_temperature: Optional[float] = None
 
     def build_deterministic_answer(
         self,
@@ -130,14 +133,17 @@ class QueryAnswerSynthesizer:
             directive = terse_directive(answer_shape)
             if directive:
                 user_ans += f"\n\nOutput format requirement: {directive}"
-        return complete_with_task_hints(
+        resp = complete_with_task_hints(
             self.llm,
             system=system_ans,
             user=user_ans,
             temperature=0.1,
             reasoning_mode=False,
             task_hint="answer_synthesis",
-        ).text
+        )
+        self.last_usage = getattr(resp, "usage", None)
+        self.last_temperature = 0.1
+        return resp.text
 
     def _build_financial_answer(
         self,

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -312,6 +312,26 @@ class GraphStore(ABC):
 
 
 _packstream_codec_logged = False
+_packstream_codec: Optional[str] = None
+
+
+def packstream_codec() -> str:
+    """Active PackStream codec: ``rust-ext`` | ``pure-python`` | ``unknown``.
+
+    ADR-0111: the ``neo4j-rust-ext`` codec is an install-time drop-in whose win
+    is result hydration. ADR-0144 stamps this on ``db.query`` spans so a silent
+    fallback to pure-python (e.g. a lost wheel) shows up as elevated hydration
+    latency in traces instead of going unnoticed. Cached after first probe.
+    """
+    global _packstream_codec
+    if _packstream_codec is not None:
+        return _packstream_codec
+    try:
+        from neo4j._codec.packstream import RUST_AVAILABLE
+        _packstream_codec = "rust-ext" if RUST_AVAILABLE else "pure-python"
+    except ImportError:  # private flag moved — report honestly, don't guess
+        _packstream_codec = "unknown"
+    return _packstream_codec
 
 
 def _log_packstream_codec_once() -> None:
@@ -325,12 +345,7 @@ def _log_packstream_codec_once() -> None:
     if _packstream_codec_logged:
         return
     _packstream_codec_logged = True
-    try:
-        from neo4j._codec.packstream import RUST_AVAILABLE
-        codec = "rust-ext" if RUST_AVAILABLE else "pure-python"
-    except ImportError:  # private flag moved — report honestly, don't guess
-        codec = "unknown (neo4j._codec.packstream.RUST_AVAILABLE not found)"
-    logger.info("neo4j packstream codec: %s active", codec)
+    logger.info("neo4j packstream codec: %s active", packstream_codec())
 
 
 class Neo4jGraphStore(GraphStore):
@@ -571,9 +586,54 @@ class Neo4jGraphStore(GraphStore):
             merged_params["workspace_id"] = workspace_id
         if enforce_workspace_filter and "$workspace_id" not in cypher:
             raise WorkspaceFilterMissingError(cypher)
-        with self._driver.session(database=database) as session:
-            result = session.run(cypher, parameters=merged_params)
-            return [record.data() for record in result]
+
+        from ..tracing import (
+            capture_text,
+            content_capture_enabled,
+            is_tracing_enabled,
+            start_span,
+        )
+
+        ws = workspace_id or merged_params.get("workspace_id") or ""
+        if not is_tracing_enabled():
+            with self._driver.session(database=database) as session:
+                result = session.run(cypher, parameters=merged_params)
+                return [record.data() for record in result]
+
+        # ADR-0144: instrument the read at the execution boundary. The
+        # record.data() loop is where the PackStream codec runs, so we split
+        # server time (ResultSummary) from client hydration — the slice the
+        # ADR-0111 rust-ext win lives in — and stamp the active codec.
+        with start_span(
+            "db.query",
+            metadata={"db.system": "neo4j", "db.name": database, "workspace_id": ws},
+            tags=["db"],
+        ) as span:
+            with self._driver.session(database=database) as session:
+                started = time.perf_counter()
+                result = session.run(cypher, parameters=merged_params)
+                rows = [record.data() for record in result]
+                wall_ms = (time.perf_counter() - started) * 1000.0
+                try:
+                    summary = result.consume()
+                    server_ms = float(getattr(summary, "result_available_after", 0) or 0) + float(
+                        getattr(summary, "result_consumed_after", 0) or 0
+                    )
+                except Exception:
+                    server_ms = None
+            attrs: Dict[str, Any] = {
+                "db.rows_returned": len(rows),
+                "db.client.codec": packstream_codec(),
+            }
+            if server_ms is not None:
+                attrs["db.duration_server_ms"] = round(server_ms, 2)
+                attrs["db.duration_hydrate_ms"] = round(max(0.0, wall_ms - server_ms), 2)
+            if content_capture_enabled():
+                stmt = capture_text(cypher)
+                if stmt:
+                    attrs["db.statement"] = stmt
+            span.set_metadata(attrs)
+            return rows
 
     def execute_write(
         self,
@@ -591,20 +651,45 @@ class Neo4jGraphStore(GraphStore):
             merged_params["workspace_id"] = workspace_id
         if enforce_workspace_filter and "$workspace_id" not in cypher:
             raise WorkspaceFilterMissingError(cypher)
-        with self._driver.session(database=database) as session:
-            result = session.run(cypher, parameters=merged_params)
-            counters = result.consume().counters
-            return {
-                "nodes_affected": (
-                    getattr(counters, "nodes_created", 0)
-                    + getattr(counters, "nodes_deleted", 0)
-                ),
-                "relationships_affected": (
-                    getattr(counters, "relationships_created", 0)
-                    + getattr(counters, "relationships_deleted", 0)
-                ),
-                "properties_set": getattr(counters, "properties_set", 0),
-            }
+        from ..tracing import is_tracing_enabled, start_span
+
+        ws = workspace_id or merged_params.get("workspace_id") or ""
+
+        def _run() -> Any:
+            with self._driver.session(database=database) as session:
+                result = session.run(cypher, parameters=merged_params)
+                return result.consume().counters
+
+        if is_tracing_enabled():
+            with start_span(
+                "db.execute_write",
+                metadata={"db.system": "neo4j", "db.name": database, "workspace_id": ws},
+                tags=["db", "write"],
+            ) as span:
+                counters = _run()
+                span.set_metadata(
+                    {
+                        "db.client.codec": packstream_codec(),
+                        "db.nodes_created": getattr(counters, "nodes_created", 0),
+                        "db.nodes_deleted": getattr(counters, "nodes_deleted", 0),
+                        "db.relationships_created": getattr(counters, "relationships_created", 0),
+                        "db.relationships_deleted": getattr(counters, "relationships_deleted", 0),
+                        "db.properties_set": getattr(counters, "properties_set", 0),
+                    }
+                )
+        else:
+            counters = _run()
+        return {
+            "nodes_affected": (
+                getattr(counters, "nodes_created", 0)
+                + getattr(counters, "nodes_deleted", 0)
+            ),
+            "relationships_affected": (
+                getattr(counters, "relationships_created", 0)
+                + getattr(counters, "relationships_deleted", 0)
+            ),
+            "properties_set": getattr(counters, "properties_set", 0),
+        }
 
     def ensure_constraints(
         self,

--- a/src/seocho/tracing.py
+++ b/src/seocho/tracing.py
@@ -751,9 +751,9 @@ def log_span(
 class _NullSpan:
     """Returned by start_span() when tracing is disabled — zero overhead."""
 
-    def set_input(self, **_kw: Any) -> None: ...
-    def set_output(self, **_kw: Any) -> None: ...
-    def set_metadata(self, **_kw: Any) -> None: ...
+    def set_input(self, *_a: Any, **_kw: Any) -> None: ...
+    def set_output(self, *_a: Any, **_kw: Any) -> None: ...
+    def set_metadata(self, *_a: Any, **_kw: Any) -> None: ...
     def set_tags(self, *_tags: str) -> None: ...
 
 
@@ -771,14 +771,25 @@ class SpanHandle:
         self._metadata: Dict[str, Any] = {}
         self._tags: List[str] = []
 
-    def set_input(self, **kw: Any) -> None:
-        self._input.update(kw)
+    def set_input(self, mapping: Optional[Dict[str, Any]] = None, **kw: Any) -> None:
+        if mapping:
+            self._input.update(mapping)
+        if kw:
+            self._input.update(kw)
 
-    def set_output(self, **kw: Any) -> None:
-        self._output.update(kw)
+    def set_output(self, mapping: Optional[Dict[str, Any]] = None, **kw: Any) -> None:
+        if mapping:
+            self._output.update(mapping)
+        if kw:
+            self._output.update(kw)
 
-    def set_metadata(self, **kw: Any) -> None:
-        self._metadata.update(kw)
+    def set_metadata(self, mapping: Optional[Dict[str, Any]] = None, **kw: Any) -> None:
+        # ``mapping`` carries dotted OTel keys (db.name, gen_ai.*); kwargs are
+        # the convenience form for plain identifiers.
+        if mapping:
+            self._metadata.update(mapping)
+        if kw:
+            self._metadata.update(kw)
 
     def set_tags(self, *tags: str) -> None:
         self._tags.extend(tags)

--- a/src/seocho/tracing.py
+++ b/src/seocho/tracing.py
@@ -396,6 +396,9 @@ class OTLPBackend(TracingBackend):
         self._Status = Status
         self._StatusCode = StatusCode
 
+        self._meter = None
+        self._meter_provider = None
+        self._counters: Dict[str, Any] = {}
         try:
             resource = Resource.create({"service.name": self._service_name})
             provider = TracerProvider(resource=resource)
@@ -407,6 +410,29 @@ class OTLPBackend(TracingBackend):
             self._provider = provider
             self._tracer = provider.get_tracer("seocho.tracing")
             self._init_error: Optional[str] = None
+            # Metrics pipeline (ADR-0144 §6): isolated so a missing/old metrics
+            # SDK never disables tracing.
+            try:
+                from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                    OTLPMetricExporter,
+                )
+                from opentelemetry.sdk.metrics import MeterProvider
+                from opentelemetry.sdk.metrics.export import (
+                    PeriodicExportingMetricReader,
+                )
+
+                reader = PeriodicExportingMetricReader(
+                    OTLPMetricExporter(
+                        endpoint=self._endpoint,
+                        insecure=self._endpoint.startswith("http://"),
+                    )
+                )
+                self._meter_provider = MeterProvider(
+                    resource=resource, metric_readers=[reader]
+                )
+                self._meter = self._meter_provider.get_meter("seocho.tracing")
+            except Exception as exc:
+                logger.debug("OTLP meter init skipped: %s", exc)
         except Exception as exc:
             logger.warning("OTLP backend init failed: %s", exc)
             self._provider = None
@@ -494,10 +520,34 @@ class OTLPBackend(TracingBackend):
             except Exception:
                 pass
 
+    def record_metric(
+        self,
+        name: str,
+        value: float = 1,
+        *,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Add to a monotonic counter (Prometheus appends ``_total``)."""
+        if self._meter is None:
+            return
+        try:
+            counter = self._counters.get(name)
+            if counter is None:
+                counter = self._meter.create_counter(name)
+                self._counters[name] = counter
+            counter.add(value, attributes or {})
+        except Exception as exc:
+            logger.debug("OTLP record_metric failed: %s", exc)
+
     def flush(self) -> None:
         if self._provider is not None:
             try:
                 self._provider.force_flush()
+            except Exception:
+                pass
+        if self._meter_provider is not None:
+            try:
+                self._meter_provider.force_flush()
             except Exception:
                 pass
 
@@ -505,6 +555,11 @@ class OTLPBackend(TracingBackend):
         if self._provider is not None:
             try:
                 self._provider.shutdown()
+            except Exception:
+                pass
+        if self._meter_provider is not None:
+            try:
+                self._meter_provider.shutdown()
             except Exception:
                 pass
 
@@ -740,6 +795,28 @@ def log_span(
                 metadata=metadata,
                 tags=tags,
             )
+        except Exception:
+            pass
+
+
+def record_metric(
+    name: str,
+    value: float = 1,
+    *,
+    attributes: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Record a counter metric on backends that support metrics (OTLP → Prometheus).
+
+    No-op on flat backends. Counter names are emitted as-is; the OTel→Prometheus
+    exporter appends ``_total`` (so ``seocho_validation_errors`` →
+    ``seocho_validation_errors_total``). ADR-0144 §6.
+    """
+    for b in _BACKENDS:
+        fn = getattr(b, "record_metric", None)
+        if fn is None:
+            continue
+        try:
+            fn(name, value, attributes=attributes)
         except Exception:
             pass
 

--- a/src/seocho/tracing.py
+++ b/src/seocho/tracing.py
@@ -30,26 +30,66 @@ Multiple backends supported::
 
 from __future__ import annotations
 
+import contextvars
 import functools
 import json
 import logging
 import os
 import time
+import uuid
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Union
 
 logger = logging.getLogger(__name__)
 
 TRACE_BACKEND_ENV = "SEOCHO_TRACE_BACKEND"
 TRACE_JSONL_PATH_ENV = "SEOCHO_TRACE_JSONL_PATH"
 TRACE_OPIK_MODE_ENV = "SEOCHO_TRACE_OPIK_MODE"
-_VALID_BACKEND_NAMES = {"none", "console", "jsonl", "opik"}
+TRACE_OTLP_ENDPOINT_ENV = "SEOCHO_TRACE_OTLP_ENDPOINT"
+TRACE_CONTENT_CAPTURE_ENV = "SEOCHO_TRACE_CAPTURE_CONTENT"
+_VALID_BACKEND_NAMES = {"none", "console", "jsonl", "opik", "otlp"}
+_TRUTHY = {"1", "true", "yes", "on"}
 
 # Module-level state
 _BACKENDS: List["TracingBackend"] = []
 _BACKEND_NAMES: List[str] = []
+
+# Nesting stack for start_span(): a tuple ``(trace_id, span_id, span_id, ...)``
+# where element 0 is the trace id and the last element is the immediate parent.
+_span_stack: contextvars.ContextVar = contextvars.ContextVar(
+    "seocho_span_stack", default=()
+)
+
+
+# ======================================================================
+# Content-capture policy (ADR-0144)
+# ======================================================================
+
+def content_capture_enabled() -> bool:
+    """True when full content (prompts, Cypher, retrieved bodies) may be traced.
+
+    Span *attributes* (hashes, versions, counts, ids) are always emitted; large
+    *content* is gated behind ``SEOCHO_TRACE_CAPTURE_CONTENT`` so the default
+    trace stays light. This is the root mitigation for "tracing is too heavy".
+    """
+    return str(os.getenv(TRACE_CONTENT_CAPTURE_ENV, "") or "").strip().lower() in _TRUTHY
+
+
+def capture_text(text: Any, *, max_chars: int = 2000) -> Optional[str]:
+    """Return text for tracing only when content capture is on, else ``None``.
+
+    Truncates to ``max_chars`` with a marker. Callers should omit the field when
+    this returns ``None`` so disabled-capture traces carry no content at all.
+    """
+    if text is None or not content_capture_enabled():
+        return None
+    s = text if isinstance(text, str) else str(text)
+    if len(s) > max_chars:
+        return s[:max_chars] + f"...[+{len(s) - max_chars} chars]"
+    return s
 
 
 # ======================================================================
@@ -272,6 +312,203 @@ class ConsoleBackend(TracingBackend):
         print("  ".join(parts))
 
 
+def _flatten_attributes(
+    data: Optional[Dict[str, Any]], prefix: str = ""
+) -> Dict[str, Any]:
+    """Flatten a nested dict into OTel-safe attributes (primitives / lists).
+
+    OpenTelemetry attributes must be primitives or homogeneous sequences of
+    primitives. Nested dicts become dotted keys; mixed/complex values are
+    JSON-encoded; ``None`` values are dropped.
+    """
+    attrs: Dict[str, Any] = {}
+    if not data:
+        return attrs
+    for key, value in data.items():
+        attr_key = f"{prefix}{key}"
+        if value is None:
+            continue
+        if isinstance(value, bool) or isinstance(value, (str, int, float)):
+            attrs[attr_key] = value
+        elif isinstance(value, dict):
+            attrs.update(_flatten_attributes(value, prefix=f"{attr_key}."))
+        elif isinstance(value, (list, tuple)):
+            if all(isinstance(x, (str, bool, int, float)) for x in value):
+                attrs[attr_key] = list(value)
+            else:
+                attrs[attr_key] = json.dumps(value, default=str)
+        else:
+            attrs[attr_key] = str(value)
+    return attrs
+
+
+class OTLPBackend(TracingBackend):
+    """Export spans over OTLP gRPC to an OpenTelemetry Collector (ADR-0144).
+
+    The lightweight local alternative to self-hosted Opik: spans flow to a
+    Collector and on to Tempo (traces) / Prometheus (metrics) / Grafana. Opik
+    stays the cloud team backend; both can run together via a backend list.
+
+    Requires the OTel SDK + OTLP exporter::
+
+        pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc
+
+    Config: ``SEOCHO_TRACE_OTLP_ENDPOINT`` (default ``http://localhost:4317``),
+    ``OTEL_SERVICE_NAME`` (default ``seocho``).
+
+    Unlike the flat backends, this one supports real parent/child nesting via
+    :func:`start_span` (``open_span`` / ``close_span`` drive the OTel context),
+    so a single ``ask()`` lands as a span tree in Tempo.
+    """
+
+    def __init__(
+        self,
+        *,
+        endpoint: Optional[str] = None,
+        service_name: Optional[str] = None,
+    ) -> None:
+        try:
+            from opentelemetry import context as _ot_context
+            from opentelemetry import trace as _ot_trace
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+            from opentelemetry.trace import Status, StatusCode
+        except ImportError as exc:
+            raise ImportError(
+                "OTLPBackend requires opentelemetry: pip install "
+                "opentelemetry-sdk opentelemetry-exporter-otlp-proto-grpc"
+            ) from exc
+
+        self._endpoint = (
+            endpoint
+            or os.getenv(TRACE_OTLP_ENDPOINT_ENV, "")
+            or "http://localhost:4317"
+        )
+        self._service_name = (
+            service_name or os.getenv("OTEL_SERVICE_NAME", "") or "seocho"
+        )
+        self._ot_trace = _ot_trace
+        self._ot_context = _ot_context
+        self._Status = Status
+        self._StatusCode = StatusCode
+
+        try:
+            resource = Resource.create({"service.name": self._service_name})
+            provider = TracerProvider(resource=resource)
+            exporter = OTLPSpanExporter(
+                endpoint=self._endpoint,
+                insecure=self._endpoint.startswith("http://"),
+            )
+            provider.add_span_processor(BatchSpanProcessor(exporter))
+            self._provider = provider
+            self._tracer = provider.get_tracer("seocho.tracing")
+            self._init_error: Optional[str] = None
+        except Exception as exc:
+            logger.warning("OTLP backend init failed: %s", exc)
+            self._provider = None
+            self._tracer = None
+            self._init_error = f"{type(exc).__name__}: {exc}"
+
+    def _attributes(
+        self,
+        input_data: Optional[Dict[str, Any]],
+        output_data: Optional[Dict[str, Any]],
+        metadata: Optional[Dict[str, Any]],
+        tags: Optional[List[str]],
+    ) -> Dict[str, Any]:
+        attrs: Dict[str, Any] = {}
+        attrs.update(_flatten_attributes(input_data, prefix="input."))
+        attrs.update(_flatten_attributes(output_data, prefix="output."))
+        attrs.update(_flatten_attributes(metadata))
+        if tags:
+            attrs["seocho.tags"] = list(tags)
+        return attrs
+
+    def log_span(
+        self,
+        name: str,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        output_data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        # Leaf/point event: a one-shot span under whatever context is current,
+        # so it nests under any active start_span().
+        if self._tracer is None:
+            return
+        try:
+            span = self._tracer.start_span(name)
+            for k, v in self._attributes(input_data, output_data, metadata, tags).items():
+                span.set_attribute(k, v)
+            span.end()
+        except Exception as exc:
+            logger.debug("OTLP log_span failed: %s", exc)
+
+    def open_span(self, name: str, *, attributes: Optional[Dict[str, Any]] = None) -> Any:
+        """Open a span, attach it as current context, return a handle for close_span."""
+        if self._tracer is None:
+            return None
+        try:
+            span = self._tracer.start_span(name)
+            if attributes:
+                for k, v in attributes.items():
+                    span.set_attribute(k, v)
+            ctx = self._ot_trace.set_span_in_context(span)
+            token = self._ot_context.attach(ctx)
+            return (span, token)
+        except Exception as exc:
+            logger.debug("OTLP open_span failed: %s", exc)
+            return None
+
+    def close_span(
+        self,
+        handle: Any,
+        *,
+        attributes: Optional[Dict[str, Any]] = None,
+        error: Optional[BaseException] = None,
+    ) -> None:
+        if not handle:
+            return
+        span, token = handle
+        try:
+            if attributes:
+                for k, v in attributes.items():
+                    span.set_attribute(k, v)
+            if error is not None:
+                span.record_exception(error)
+                span.set_status(self._Status(self._StatusCode.ERROR))
+        except Exception as exc:
+            logger.debug("OTLP close_span failed: %s", exc)
+        finally:
+            try:
+                self._ot_context.detach(token)
+            except Exception:
+                pass
+            try:
+                span.end()
+            except Exception:
+                pass
+
+    def flush(self) -> None:
+        if self._provider is not None:
+            try:
+                self._provider.force_flush()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self._provider is not None:
+            try:
+                self._provider.shutdown()
+            except Exception:
+                pass
+
+
 # ======================================================================
 # Public API
 # ======================================================================
@@ -280,6 +517,7 @@ _BACKEND_MAP = {
     "opik": OpikBackend,
     "jsonl": JSONLBackend,
     "console": ConsoleBackend,
+    "otlp": OTLPBackend,
 }
 
 
@@ -337,7 +575,7 @@ def configure_tracing_from_env() -> bool:
     """Enable tracing from the repository's env contract.
 
     Supported values for ``SEOCHO_TRACE_BACKEND``:
-    ``none | console | jsonl | opik``.
+    ``none | console | jsonl | opik | otlp``.
     """
     backend_name = str(os.getenv(TRACE_BACKEND_ENV, "none") or "none").strip().lower()
     if backend_name not in _VALID_BACKEND_NAMES:
@@ -427,6 +665,9 @@ def enable_tracing(
                 elif b == "console":
                     new_backends.append(ConsoleBackend())
                     active_backend_names.append("console")
+                elif b == "otlp":
+                    new_backends.append(OTLPBackend())
+                    active_backend_names.append("otlp")
                 elif b == "none":
                     continue
                 else:
@@ -501,6 +742,160 @@ def log_span(
             )
         except Exception:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Structured spans with parent/child nesting (ADR-0144)
+# ---------------------------------------------------------------------------
+
+class _NullSpan:
+    """Returned by start_span() when tracing is disabled — zero overhead."""
+
+    def set_input(self, **_kw: Any) -> None: ...
+    def set_output(self, **_kw: Any) -> None: ...
+    def set_metadata(self, **_kw: Any) -> None: ...
+    def set_tags(self, *_tags: str) -> None: ...
+
+
+class SpanHandle:
+    """Mutable handle yielded by :func:`start_span` to enrich a span in-flight."""
+
+    def __init__(self, name: str, span_id: str, parent_span_id: Optional[str], trace_id: str) -> None:
+        self.name = name
+        self.span_id = span_id
+        self.parent_span_id = parent_span_id
+        self.trace_id = trace_id
+        self.error: Optional[BaseException] = None
+        self._input: Dict[str, Any] = {}
+        self._output: Dict[str, Any] = {}
+        self._metadata: Dict[str, Any] = {}
+        self._tags: List[str] = []
+
+    def set_input(self, **kw: Any) -> None:
+        self._input.update(kw)
+
+    def set_output(self, **kw: Any) -> None:
+        self._output.update(kw)
+
+    def set_metadata(self, **kw: Any) -> None:
+        self._metadata.update(kw)
+
+    def set_tags(self, *tags: str) -> None:
+        self._tags.extend(tags)
+
+
+@contextmanager
+def start_span(
+    name: str,
+    *,
+    input_data: Optional[Dict[str, Any]] = None,
+    output_data: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
+) -> Iterator[Any]:
+    """Open a timed span with parent/child nesting, across all backends.
+
+    Backends exposing ``open_span``/``close_span`` (OTLP) get real nested spans
+    via the OTel context, so an ``ask()`` lands as a tree in Tempo. Flat
+    backends (JSONL, console, Opik) receive one record at span close, carrying
+    ``span_id`` / ``parent_span_id`` / ``trace_id`` / ``duration_ms`` so the
+    tree is reconstructable offline.
+
+    No-op with zero overhead when tracing is disabled. Body exceptions
+    propagate (they are recorded on the span first); tracing-internal failures
+    never escape.
+    """
+    if not _BACKENDS:
+        yield _NullSpan()
+        return
+
+    parent = _span_stack.get()
+    if parent:
+        trace_id = parent[0]
+        parent_span_id: Optional[str] = parent[-1]
+        new_stack = parent
+    else:
+        trace_id = uuid.uuid4().hex
+        parent_span_id = None
+        new_stack = (trace_id,)
+    span_id = uuid.uuid4().hex[:16]
+    new_stack = new_stack + (span_id,)
+
+    handle = SpanHandle(name, span_id, parent_span_id, trace_id)
+    handle._input = dict(input_data or {})
+    handle._output = dict(output_data or {})
+    handle._metadata = dict(metadata or {})
+    handle._tags = list(tags or [])
+
+    # Open native nested spans on capable backends (OTLP).
+    opened: List[Any] = []
+    for b in _BACKENDS:
+        opener = getattr(b, "open_span", None)
+        if opener is None:
+            continue
+        try:
+            init_attrs = (
+                b._attributes(handle._input, None, handle._metadata, handle._tags)
+                if hasattr(b, "_attributes")
+                else None
+            )
+            native = opener(name, attributes=init_attrs)
+            if native is not None:
+                opened.append((b, native))
+        except Exception:
+            pass
+
+    stack_token = _span_stack.set(new_stack)
+    start = time.perf_counter()
+    try:
+        yield handle
+    except BaseException as exc:  # record then re-raise — never swallow business errors
+        handle.error = exc
+        raise
+    finally:
+        duration_ms = round((time.perf_counter() - start) * 1000.0, 2)
+        try:
+            _span_stack.reset(stack_token)
+        except Exception:
+            pass
+
+        # Close native spans (OTLP): final output + duration + error status.
+        for b, native in opened:
+            try:
+                close_attrs = (
+                    b._attributes(None, handle._output, {"duration_ms": duration_ms}, None)
+                    if hasattr(b, "_attributes")
+                    else None
+                )
+                b.close_span(native, attributes=close_attrs, error=handle.error)
+            except Exception:
+                pass
+
+        # Emit one record to flat backends (those without open_span).
+        meta = {
+            **handle._metadata,
+            "span_id": span_id,
+            "trace_id": trace_id,
+            "duration_ms": duration_ms,
+        }
+        if parent_span_id:
+            meta["parent_span_id"] = parent_span_id
+        if handle.error is not None:
+            meta["error"] = str(handle.error)
+        out_tags = handle._tags + (["error"] if handle.error is not None else [])
+        for b in _BACKENDS:
+            if getattr(b, "open_span", None) is not None:
+                continue
+            try:
+                b.log_span(
+                    name,
+                    input_data=handle._input or None,
+                    output_data=handle._output or None,
+                    metadata=meta,
+                    tags=out_tags or None,
+                )
+            except Exception:
+                pass
 
 
 def log_extraction(

--- a/tests/seocho/test_governance_observability.py
+++ b/tests/seocho/test_governance_observability.py
@@ -1,0 +1,134 @@
+"""ADR-0144 / seocho-d6x.4: governance metrics + guardrail audit span.
+
+Covers the metrics counter API (record_metric) and the guardrail-selector audit
+span. The extraction-span enrichment (enforcement_mode + validation detail) is
+exercised by the existing pipeline tests; here we cover the standalone pieces.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from seocho.guardrail_selector import select_guardrail
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology_scorecard import build_corpus_profile
+from seocho.tracing import (
+    TracingBackend,
+    disable_tracing,
+    enable_tracing,
+    record_metric,
+)
+
+
+class _Recorder(TracingBackend):
+    def __init__(self) -> None:
+        self.spans: List[Dict[str, Any]] = []
+        self.metrics: List[Dict[str, Any]] = []
+
+    def log_span(
+        self,
+        name: str,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        output_data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        self.spans.append(
+            {"name": name, "output": output_data or {}, "metadata": metadata or {}}
+        )
+
+    def record_metric(
+        self,
+        name: str,
+        value: float = 1,
+        *,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.metrics.append({"name": name, "value": value, "attributes": attributes or {}})
+
+
+class _FlatBackend(TracingBackend):
+    """A backend that does NOT implement record_metric."""
+
+    def __init__(self) -> None:
+        self.spans: List[str] = []
+
+    def log_span(self, name: str, **_kw: Any) -> None:
+        self.spans.append(name)
+
+
+def test_record_metric_routes_to_capable_backend() -> None:
+    rec = _Recorder()
+    try:
+        enable_tracing(backend=rec)
+        record_metric(
+            "seocho_validation_errors",
+            3,
+            attributes={"mode": "strict", "ontology": "finance"},
+        )
+        record_metric("seocho_arbiter_route", 1, attributes={"route": "NARRATIVE"})
+    finally:
+        disable_tracing()
+
+    assert rec.metrics == [
+        {
+            "name": "seocho_validation_errors",
+            "value": 3,
+            "attributes": {"mode": "strict", "ontology": "finance"},
+        },
+        {"name": "seocho_arbiter_route", "value": 1, "attributes": {"route": "NARRATIVE"}},
+    ]
+
+
+def test_record_metric_is_noop_on_flat_backend() -> None:
+    flat = _FlatBackend()
+    try:
+        enable_tracing(backend=flat)
+        record_metric("seocho_observations_reified", 5)  # must not raise
+    finally:
+        disable_tracing()
+    assert flat.spans == []
+
+
+def _lean() -> Ontology:
+    return Ontology(
+        "lean",
+        nodes={
+            "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+            "FinancialMetric": NodeDef(description="A metric.", properties={"name": P(str, unique=True)}),
+        },
+    )
+
+
+def _rich() -> Ontology:
+    return Ontology(
+        "rich",
+        nodes={
+            "Company": NodeDef(description="A company.", properties={"name": P(str, unique=True)}),
+            "Person": NodeDef(description="A person.", properties={"name": P(str, unique=True)}),
+            "Regulation": NodeDef(description="A rule.", properties={"name": P(str, unique=True)}),
+            "Risk": NodeDef(description="A risk.", properties={"name": P(str, unique=True)}),
+        },
+    )
+
+
+def test_guardrail_select_emits_audit_span() -> None:
+    corpus = build_corpus_profile(
+        [
+            {"nodes": [{"label": "Person"}, {"label": "Regulation"}]},
+            {"nodes": [{"label": "Risk"}, {"label": "Person"}]},
+        ]
+    )
+    rec = _Recorder()
+    try:
+        enable_tracing(backend=rec)
+        recommendation = select_guardrail({"lean": _lean(), "rich": _rich()}, corpus)
+    finally:
+        disable_tracing()
+
+    audit = next(s for s in rec.spans if s["name"] == "ontology.guardrail_select")
+    assert audit["output"]["chosen"] == recommendation.chosen
+    assert "domain_kind" in audit["output"]
+    assert "rationale" in audit["metadata"]
+    assert "candidate_scores" in audit["metadata"]

--- a/tests/seocho/test_graph_db_span.py
+++ b/tests/seocho/test_graph_db_span.py
@@ -1,0 +1,179 @@
+"""ADR-0144 / seocho-d6x.5: db.query + db.execute_write spans.
+
+Covers the Cypher execution-boundary instrumentation: the server-vs-hydration
+timing split (the ADR-0111 rust-ext slice), the active PackStream codec, row
+counts, write counters, workspace_id, and content gating — all without a live
+DozerDB (a fake driver stands in for the neo4j session).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from seocho.store.graph import Neo4jGraphStore, packstream_codec
+from seocho.tracing import (
+    TracingBackend,
+    disable_tracing,
+    enable_tracing,
+)
+
+
+class _Recorder(TracingBackend):
+    def __init__(self) -> None:
+        self.spans: List[Dict[str, Any]] = []
+
+    def log_span(
+        self,
+        name: str,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        output_data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        self.spans.append({"name": name, "metadata": dict(metadata or {})})
+
+
+# --- fake neo4j driver -----------------------------------------------------
+
+class _FakeRecord:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+
+    def data(self) -> Dict[str, Any]:
+        return self._data
+
+
+class _FakeSummary:
+    result_available_after = 5
+    result_consumed_after = 7
+
+
+class _FakeCounters:
+    nodes_created = 3
+    nodes_deleted = 1
+    relationships_created = 2
+    relationships_deleted = 0
+    properties_set = 9
+
+
+class _FakeResult:
+    def __init__(self, rows: List[Dict[str, Any]]) -> None:
+        self._rows = [_FakeRecord(r) for r in rows]
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def consume(self) -> Any:
+        s = _FakeSummary()
+        s.counters = _FakeCounters()  # type: ignore[attr-defined]
+        return s
+
+
+class _FakeSession:
+    def __init__(self, rows: List[Dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def __enter__(self) -> "_FakeSession":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def run(self, cypher: str, parameters: Optional[Dict[str, Any]] = None) -> _FakeResult:
+        return _FakeResult(self._rows)
+
+
+class _FakeDriver:
+    def __init__(self, rows: List[Dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def session(self, database: Optional[str] = None) -> _FakeSession:
+        return _FakeSession(self._rows)
+
+
+def _store(rows: List[Dict[str, Any]]) -> Neo4jGraphStore:
+    store = Neo4jGraphStore.__new__(Neo4jGraphStore)
+    store._driver = _FakeDriver(rows)  # type: ignore[attr-defined]
+    return store
+
+
+# --- tests -----------------------------------------------------------------
+
+def test_packstream_codec_is_known() -> None:
+    assert packstream_codec() in {"rust-ext", "pure-python", "unknown"}
+
+
+def test_query_emits_no_span_when_disabled() -> None:
+    disable_tracing()
+    rec = _Recorder()
+    store = _store([{"x": 1}])
+    # backend not enabled -> hot path untouched, rows still returned
+    assert store.query("RETURN 1", database="neo4j") == [{"x": 1}]
+    assert rec.spans == []
+
+
+def test_query_span_carries_db_attributes_and_timing_split() -> None:
+    rec = _Recorder()
+    store = _store([{"x": 1}, {"x": 2}])
+    try:
+        enable_tracing(backend=rec)
+        rows = store.query("MATCH (n) RETURN n", database="neo4j", workspace_id="ws9")
+    finally:
+        disable_tracing()
+
+    assert rows == [{"x": 1}, {"x": 2}]
+    md = next(s["metadata"] for s in rec.spans if s["name"] == "db.query")
+    assert md["db.system"] == "neo4j"
+    assert md["db.name"] == "neo4j"
+    assert md["db.rows_returned"] == 2
+    assert md["workspace_id"] == "ws9"
+    assert md["db.client.codec"] in {"rust-ext", "pure-python", "unknown"}
+    # server time = result_available_after + result_consumed_after = 12.0
+    assert md["db.duration_server_ms"] == 12.0
+    assert "db.duration_hydrate_ms" in md
+
+
+def test_query_statement_is_content_gated(monkeypatch) -> None:
+    rec = _Recorder()
+    store = _store([{"x": 1}])
+    monkeypatch.delenv("SEOCHO_TRACE_CAPTURE_CONTENT", raising=False)
+    try:
+        enable_tracing(backend=rec)
+        store.query("MATCH (secret) RETURN secret", database="neo4j")
+    finally:
+        disable_tracing()
+    md = next(s["metadata"] for s in rec.spans if s["name"] == "db.query")
+    assert "db.statement" not in md
+
+    rec2 = _Recorder()
+    monkeypatch.setenv("SEOCHO_TRACE_CAPTURE_CONTENT", "1")
+    try:
+        enable_tracing(backend=rec2)
+        store.query("MATCH (secret) RETURN secret", database="neo4j")
+    finally:
+        disable_tracing()
+    md2 = next(s["metadata"] for s in rec2.spans if s["name"] == "db.query")
+    assert "MATCH (secret)" in md2["db.statement"]
+
+
+def test_execute_write_span_carries_counters() -> None:
+    rec = _Recorder()
+    store = _store([])
+    try:
+        enable_tracing(backend=rec)
+        out = store.execute_write("CREATE (n)", database="neo4j", workspace_id="ws1")
+    finally:
+        disable_tracing()
+
+    assert out == {
+        "nodes_affected": 4,  # created 3 + deleted 1
+        "relationships_affected": 2,
+        "properties_set": 9,
+    }
+    md = next(s["metadata"] for s in rec.spans if s["name"] == "db.execute_write")
+    assert md["db.nodes_created"] == 3
+    assert md["db.relationships_created"] == 2
+    assert md["db.properties_set"] == 9
+    assert md["workspace_id"] == "ws1"
+    assert md["db.client.codec"] in {"rust-ext", "pure-python", "unknown"}

--- a/tests/seocho/test_synthesis_span.py
+++ b/tests/seocho/test_synthesis_span.py
@@ -1,0 +1,98 @@
+"""ADR-0144 / seocho-d6x.6: gen_ai.* + prompt/cache identity on rag.synthesize.
+
+External-API deployments control the prompt, so the joinable signals are model,
+params, token usage, and the cacheable system-prompt prefix hash.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from seocho.local_engine import _LocalEngine
+from seocho.query.answering import QueryAnswerSynthesizer
+from seocho.tracing import (
+    TracingBackend,
+    disable_tracing,
+    enable_tracing,
+    start_span,
+)
+
+
+class _Recorder(TracingBackend):
+    def __init__(self) -> None:
+        self.spans: List[Dict[str, Any]] = []
+
+    def log_span(
+        self,
+        name: str,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        output_data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        self.spans.append({"name": name, "metadata": dict(metadata or {})})
+
+
+def test_synthesize_stashes_usage_and_temperature() -> None:
+    class _Resp:
+        text = "the answer"
+        usage = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+
+    class _LLM:
+        model = "mara/MiniMax-M2.5"
+
+        def complete(self, **_kw: Any) -> Any:
+            return _Resp()
+
+    class _Strategy:
+        def render_answer(self, _q: str, _recs: str) -> Any:
+            return ("system prompt", "user prompt")
+
+    synth = QueryAnswerSynthesizer(query_strategy=_Strategy(), llm=_LLM())
+    out = synth.synthesize("q?", [{"a": 1}])
+
+    assert out == "the answer"
+    assert synth.last_usage == {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    assert synth.last_temperature == 0.1
+
+
+def test_annotate_synthesis_span_sets_gen_ai_and_cache_hashes() -> None:
+    rec = _Recorder()
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(model="mara/MiniMax-M2.5", provider="mara")
+    )
+    synth = SimpleNamespace(
+        last_temperature=0.1,
+        last_usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+    octx = SimpleNamespace(
+        kv_cache_layout=lambda: {"stable_prefix_hash": "abc123", "context_hash": "ctx99"}
+    )
+    try:
+        enable_tracing(backend=rec)
+        with start_span("rag.synthesize") as span:
+            _LocalEngine._annotate_synthesis_span(engine, span, synth, octx)
+    finally:
+        disable_tracing()
+
+    md = next(s["metadata"] for s in rec.spans if s["name"] == "rag.synthesize")
+    assert md["gen_ai.request.model"] == "mara/MiniMax-M2.5"
+    assert md["gen_ai.system"] == "mara"
+    assert md["gen_ai.request.temperature"] == 0.1
+    assert md["gen_ai.usage.input_tokens"] == 10
+    assert md["gen_ai.usage.output_tokens"] == 5
+    assert md["gen_ai.usage.total_tokens"] == 15
+    assert md["stable_prefix_hash"] == "abc123"
+    assert md["ontology_context_hash"] == "ctx99"
+
+
+def test_annotate_synthesis_span_is_noop_when_disabled() -> None:
+    disable_tracing()
+    engine = SimpleNamespace(llm=SimpleNamespace(model="m"))
+    synth = SimpleNamespace(last_temperature=None, last_usage=None)
+    octx = SimpleNamespace(kv_cache_layout=lambda: {})
+    # null span + tracing disabled: must not raise
+    with start_span("rag.synthesize") as span:
+        _LocalEngine._annotate_synthesis_span(engine, span, synth, octx)

--- a/tests/seocho/test_tracing_otel.py
+++ b/tests/seocho/test_tracing_otel.py
@@ -1,0 +1,165 @@
+"""ADR-0144: OTLP backend, content-capture policy, and nested start_span().
+
+These cover the tracing primitives added for the local OpenTelemetry path and
+the structured span tree, independent of any live Collector.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from seocho.tracing import (
+    TracingBackend,
+    _flatten_attributes,
+    capture_text,
+    configure_tracing_from_env,
+    content_capture_enabled,
+    current_backend_names,
+    disable_tracing,
+    enable_tracing,
+    start_span,
+)
+
+
+class _Recorder(TracingBackend):
+    """Flat backend (no open_span) that records every emitted span."""
+
+    def __init__(self) -> None:
+        self.spans: List[Dict[str, Any]] = []
+
+    def log_span(
+        self,
+        name: str,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        output_data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        self.spans.append(
+            {
+                "name": name,
+                "input": input_data or {},
+                "output": output_data or {},
+                "metadata": metadata or {},
+                "tags": tags or [],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# content-capture policy
+# ---------------------------------------------------------------------------
+
+def test_content_capture_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("SEOCHO_TRACE_CAPTURE_CONTENT", raising=False)
+    assert content_capture_enabled() is False
+    assert capture_text("secret prompt") is None
+
+
+def test_content_capture_enabled_truncates(monkeypatch) -> None:
+    monkeypatch.setenv("SEOCHO_TRACE_CAPTURE_CONTENT", "1")
+    assert content_capture_enabled() is True
+    out = capture_text("x" * 10, max_chars=4)
+    assert out is not None and out.startswith("xxxx") and "+6 chars" in out
+    assert capture_text(None) is None
+
+
+def test_flatten_attributes_otel_safe() -> None:
+    flat = _flatten_attributes(
+        {"a": 1, "b": {"c": "d"}, "e": [1, 2], "f": [{"x": 1}], "g": None}
+    )
+    assert flat == {"a": 1, "b.c": "d", "e": [1, 2], "f": '[{"x": 1}]'}
+
+
+# ---------------------------------------------------------------------------
+# start_span nesting
+# ---------------------------------------------------------------------------
+
+def test_start_span_noop_when_disabled() -> None:
+    disable_tracing()
+    with start_span("rag.ask") as handle:
+        handle.set_output(ok=True)  # must not raise on the null handle
+
+
+def test_start_span_builds_nested_tree() -> None:
+    rec = _Recorder()
+    try:
+        enable_tracing(backend=rec)
+        with start_span("rag.ask", metadata={"workspace_id": "ws1"}):
+            with start_span("rag.execute") as child:
+                child.set_output(rows=3)
+            with start_span("rag.synthesize"):
+                pass
+    finally:
+        disable_tracing()
+
+    by_name = {s["name"]: s for s in rec.spans}
+    assert set(by_name) == {"rag.ask", "rag.execute", "rag.synthesize"}
+
+    root = by_name["rag.ask"]["metadata"]
+    execute = by_name["rag.execute"]["metadata"]
+    synth = by_name["rag.synthesize"]["metadata"]
+
+    # root carries ids + duration + workspace, and has no parent
+    assert {"trace_id", "span_id", "duration_ms"} <= set(root)
+    assert "parent_span_id" not in root
+    assert root["workspace_id"] == "ws1"
+
+    # children share the root trace and point at the root span
+    assert execute["trace_id"] == root["trace_id"] == synth["trace_id"]
+    assert execute["parent_span_id"] == root["span_id"]
+    assert synth["parent_span_id"] == root["span_id"]
+
+    # in-flight output is emitted on close
+    assert by_name["rag.execute"]["output"].get("rows") == 3
+
+
+def test_start_span_records_error_and_reraises() -> None:
+    rec = _Recorder()
+    try:
+        enable_tracing(backend=rec)
+        with pytest.raises(ValueError):
+            with start_span("rag.ask"):
+                raise ValueError("boom")
+    finally:
+        disable_tracing()
+
+    span = rec.spans[-1]
+    assert span["name"] == "rag.ask"
+    assert "error" in span["metadata"]
+    assert "error" in span["tags"]
+
+
+# ---------------------------------------------------------------------------
+# otlp backend registration
+# ---------------------------------------------------------------------------
+
+def test_otlp_is_a_valid_backend_name(monkeypatch) -> None:
+    # The env contract must accept 'otlp' (not reject it as unsupported),
+    # regardless of whether the exporter is installed.
+    monkeypatch.setenv("SEOCHO_TRACE_BACKEND", "otlp")
+    try:
+        configure_tracing_from_env()  # returns False without exporter; must not raise
+    finally:
+        disable_tracing()
+
+
+def test_otlp_backend_real_init_when_available() -> None:
+    pytest.importorskip("opentelemetry.exporter.otlp.proto.grpc.trace_exporter")
+    from seocho.tracing import OTLPBackend
+
+    backend = OTLPBackend(endpoint="http://localhost:4317", service_name="seocho-test")
+    assert backend._init_error is None
+    try:
+        enable_tracing(backend=backend)
+        assert "otlp" not in current_backend_names()  # custom instance, not named
+        # open/close/log must not raise even with no live Collector
+        with start_span("rag.ask"):
+            with start_span("rag.execute") as child:
+                child.set_output(rows=1)
+        backend.log_span("leaf", output_data={"k": "v"})
+    finally:
+        disable_tracing()


### PR DESCRIPTION
## What

Local OpenTelemetry observability + a structured span trace for SEOCHO, per **ADR-0144** (extends ADR-0045's vendor-neutral tracing contract).

The motivation: self-hosted Opik is too heavy for local dev (8 containers), and the harder problem was *what* we trace — an `ask()` collapsed into a single flat `sdk.query` event, Cypher execution was a dark `session.run()`, retrieved context was never captured, and prompt/token visibility only existed via Opik's `track_openai`. Opik stays the **cloud** team backend; this adds a lightweight **local** path and a real span tree.

## Changes (tracked as `seocho-d6x.1`–`.6`)

| # | Commit | What |
|---|---|---|
| ADR | `261d409` | ADR-0144 + DECISION_LOG entry |
| .1 | `b89acdd` | `otlp` tracing backend + content-capture policy (`SEOCHO_TRACE_CAPTURE_CONTENT`) + nested `start_span()` |
| .2 | `8bb2ec7` | nested `rag.ask` span tree over `ask()` (compile_cypher → execute → retrieve_ctx → synthesize) |
| .5 | `dcad60f` | `db.query`/`db.execute_write` spans: server-vs-hydration split + `db.client.codec` (ADR-0111 rust-ext) |
| .3 | `75e27a8` | `examples/observability/` — 4-container local stack (Collector + Tempo + Prometheus + Grafana) |
| .6 | `0289175` | `gen_ai.*` + `stable_prefix_hash`/`ontology_context_hash` on `rag.synthesize` |
| .4 | `0978a87` | governance metrics (`record_metric` + OTLP meter) + guardrail-selector audit span |

### Highlights
- **`otlp` backend** fans out alongside Opik via the existing backend list — no duplicate instrumentation. `pip install 'seocho[otel]'`.
- **Content-capture is opt-in** (full prompt/Cypher/record bodies gated behind `SEOCHO_TRACE_CAPTURE_CONTENT`); attributes (ids, hashes, counts, timings) always flow. This is the root fix for "tracing felt heavy".
- **`rag.ask` tree** reuses the existing `StageTimer` + `SessionTrace`; `rag.retrieve_ctx` captures *what is fed to the LLM* (previously dark).
- **`db.query` split** surfaces `db.duration_server_ms` vs `db.duration_hydrate_ms` + the active PackStream codec, so a silent rust-ext → pure-python fallback shows up as elevated hydration latency (ADR-0111).
- **`workspace_id`** rides on every span; metric labels carry no raw text (cardinality-safe).
- **Governance**: `enforcement_mode` + validation detail on `sdk.extraction`; counters `seocho_validation_errors{mode,ontology}`, `seocho_observations_reified{ontology}`, `seocho_arbiter_route{route}`; guardrail decisions now audited.

LMCache's `examples/observability` was the **topology** source (not a manifest copy); its KV-cache metrics don't apply (SEOCHO calls external LLM APIs, no local vLLM+LMCache serving).

## Testing
- `tests/seocho/`: **1353 passed**, 7 skipped (OTLP real-export self-skips without the exporter). The only 2 failures (`test_package_discovery`, `test_semantic_decompose`) are **pre-existing on `main`** (confirmed via stash) and unrelated.
- New: `test_tracing_otel.py`, `test_graph_db_span.py`, `test_synthesis_span.py`, `test_governance_observability.py`.
- Contracts: doc-contracts, module-ownership, runtime-shell, root-hierarchy all pass; `git diff --check` clean. `docker compose config` validates the observability overlay.
- All span/metric emission is exception-isolated and no-op when tracing is disabled; the no-tracing hot path in `graph.query()` is byte-for-byte unchanged.

## Notes
- ADR-0144 is **Proposed**; before/after observability deltas to be recorded under `docs/decisions/` per the ontology-experiment convention.
- Dev-grade `examples/observability/` defaults (anonymous Grafana, local storage) are documented as such — harden before any shared/prod use.
- Follow-ups remain for `gen_ai` token capture on non-synthesis LLM calls and a richer Grafana dashboard once metrics accrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
