### PR TITLE
fix(ui): mirror css hover states to focus-visible

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -114,7 +114,8 @@ body {
   border-left: 2px solid transparent;
 }
 
-.rail-btn:hover {
+.rail-btn:hover,
+.rail-btn:focus-visible {
   color: var(--text-main);
 }
 
@@ -367,7 +368,8 @@ body {
   cursor: not-allowed;
 }
 
-.composer button:hover:not(:disabled) {
+.composer button:hover:not(:disabled),
+.composer button:focus-visible:not(:disabled) {
   opacity: 0.9;
 }
 


### PR DESCRIPTION
### What
Added CSS `:focus-visible` pseudo-class mirrors to existing `:hover` states on interactive elements (`.rail-btn` and `.composer button`) in `evaluation/static/styles.css`.

### Why
To improve accessibility. Previously, mouse users hovering over these buttons would receive clear visual feedback (color or opacity changes), but keyboard users navigating via Tab would only see the default focus outline, creating a disparate visual experience.

### Accessibility / UX Impact
Keyboard navigation users now receive parity with mouse users, gaining the same immediate, high-contrast visual confirmation when interactive elements receive focus.

### Validation
- Validated via Playwright verification script capturing focus-visible states after simulating Tab key presses.
- Passed `bash scripts/ci/run_basic_ci.sh` locally.

### Risks
Minimal visual risk as this preserves existing `:hover` behavior and only targets elements explicitly focused by keyboards without modifying the global outline ring pattern.

---
*PR created automatically by Jules for task [6902637383762673018](https://jules.google.com/task/6902637383762673018) started by @tteon*