### PR TITLE
fix(ui): Add missing focus-visible parity to interactive console buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -114,7 +114,8 @@ body {
   border-left: 2px solid transparent;
 }
 
-.rail-btn:hover {
+.rail-btn:hover,
+.rail-btn:focus-visible {
   color: var(--text-main);
 }
 
@@ -367,7 +368,8 @@ body {
   cursor: not-allowed;
 }
 
-.composer button:hover:not(:disabled) {
+.composer button:hover:not(:disabled),
+.composer button:focus-visible:not(:disabled) {
   opacity: 0.9;
 }
 


### PR DESCRIPTION
### What
Added `:focus-visible` styling parity to `.rail-btn` and `.composer button` interactive elements in the evaluation console UI.

### Why
The existing CSS implemented visual state changes (like color and opacity) only via the `:hover` pseudo-class. Keyboard users navigating via the `Tab` key received the standard focus outline but missed out on these supplementary state-change visuals, creating an inconsistent accessibility experience. 

### Accessibility / UX Impact
- **Keyboard Users:** Now receive the exact same color (`var(--text-main)`) and opacity (`0.9`) visual enhancements upon focusing these buttons as mouse users do when hovering them.
- **Mouse Users:** Unaffected, as they are shielded by `:focus-visible` (which generally does not trigger on mouse click).
- This complements the repository's global focus outline strategy without overriding it.

### Validation
- **Visual Validation:** Created a local Playwright script to programmatically trigger `.focus()` on these elements. Verified the resulting screenshots and videos to ensure the CSS changes apply cleanly.
- **CI Validation:** Ran `bash scripts/ci/run_basic_ci.sh`. All tests pass successfully.

### Risks
- **Low Risk:** The change is strictly additive to CSS pseudo-classes, scoping specifically to elements that already had `:hover` logic defined. It does not alter HTML structure, backend endpoints, or global styling hierarchies.

---
*PR created automatically by Jules for task [8443966831969516861](https://jules.google.com/task/8443966831969516861) started by @tteon*