### PR TITLE
Fix overly permissive CORS headers

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -164,7 +164,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
     allow_methods=["POST", "GET"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "Authorization", "X-Request-Id"],
 )
 
 


### PR DESCRIPTION
**Severity**: Medium
**Vulnerability**: Overly permissive CORS configuration (`allow_headers=["*"]`).
**Impact**: Allowing all headers in cross-origin requests increases the attack surface, potentially enabling attackers to bypass client-side security checks or exploit unexpected header handling in the application.
**Fix**: Replaced the wildcard `allow_headers=["*"]` with an explicit list of required headers (`Content-Type`, `Authorization`, `X-Request-Id`) in `runtime/agent_server.py`.
**Validation**: Ran `bash scripts/ci/run_basic_ci.sh` to ensure no tests were broken.
**Risks**: Minor risk of breaking legitimate client requests if they rely on custom headers not included in the allowlist.

draft: true

---
*PR created automatically by Jules for task [9192030771998219497](https://jules.google.com/task/9192030771998219497) started by @tteon*