### PR TITLE
fix(ui): add aria-pressed to mode toggle buttons for a11y

### DIFF
--- a/evaluation/static/app.js
+++ b/evaluation/static/app.js
@@ -42,7 +42,9 @@
 
   function updateRailMode(mode) {
     railButtons.forEach((btn) => {
-      btn.classList.toggle("active", btn.dataset.mode === mode);
+      const isActive = btn.dataset.mode === mode;
+      btn.classList.toggle("active", isActive);
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false");
     });
     modeSelect.value = mode;
   }

--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -22,9 +22,9 @@
         <p>SEOCHO</p>
       </div>
       <nav class="rail-nav">
-        <button class="rail-btn active" id="railSemantic" data-mode="semantic">Semantic</button>
-        <button class="rail-btn" id="railDebate" data-mode="debate">Debate</button>
-        <button class="rail-btn" id="railRouter" data-mode="router">Router</button>
+        <button class="rail-btn active" id="railSemantic" data-mode="semantic" aria-pressed="true">Semantic</button>
+        <button class="rail-btn" id="railDebate" data-mode="debate" aria-pressed="false">Debate</button>
+        <button class="rail-btn" id="railRouter" data-mode="router" aria-pressed="false">Router</button>
       </nav>
     </aside>
 


### PR DESCRIPTION
What: Added dynamic `aria-pressed` attributes to the left rail mode toggle buttons (`#railSemantic`, `#railDebate`, `#railRouter`) in the evaluation UI.

Why: These elements function as custom toggle buttons. Previously, they only indicated their active state visually via the `.active` CSS class, leaving screen reader users without explicit feedback about which mode was currently selected.

Accessibility / UX Impact: Screen readers will now correctly announce whether a mode is "pressed" (active) or not, ensuring keyboard/screen reader parity with the visual state.

Validation:
- Tested locally by running a Playwright UI verification script that asserts the `aria-pressed` values correctly toggle between `"true"` and `"false"` when clicked.
- Verified visual output via Playwright screenshot; no styling regressions were introduced.
- Verified test suite (`bash scripts/ci/run_basic_ci.sh`) to ensure nothing else was broken.

Risks: Low risk. This change is confined purely to UI markup and localized state mutation in `app.js`. No backend routing logic or trace presentation logic was modified.

---
*PR created automatically by Jules for task [14131863755197846858](https://jules.google.com/task/14131863755197846858) started by @tteon*