### PR TITLE
fix: enforce workspace authz on platform chat session endpoints

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -1038,13 +1038,33 @@ async def platform_chat_send(request: PlatformChatRequest):
 @app.get(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_get")
 async def platform_chat_session_get(session_id: str):
-    history = [PlatformTurn(**row) for row in platform_session_store.get(session_id)]
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_rows:
+        workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
+    history = [PlatformTurn(**row) for row in history_rows]
     return PlatformSessionResponse(session_id=session_id, history=history)
 
 
 @app.delete(RuntimePath.PLATFORM_CHAT_SESSION, response_model=PlatformSessionResponse)
 @track("agent_server.platform_chat_session_reset")
 async def platform_chat_session_reset(session_id: str):
+    history_rows = platform_session_store.get(session_id)
+    workspace_id = "default"
+    if history_rows:
+        workspace_id = (history_rows[0].get("metadata") or {}).get("workspace_id", "default")
+
+    try:
+        require_runtime_permission(role="user", action="run_platform", workspace_id=workspace_id)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+
     platform_session_store.clear(session_id)
     return PlatformSessionResponse(session_id=session_id, history=[])
 


### PR DESCRIPTION
Added missing `require_runtime_permission` checks to the `platform_chat_session_get` and `platform_chat_session_reset` endpoints in `runtime/agent_server.py`.

The endpoints now securely extract the `workspace_id` from the target session's turn history metadata, rather than accepting it as an untrusted input or bypassing authorization entirely, to satisfy single-tenant MVP routing contracts.