### PR TITLE
perf: optimize memory overhead when reading ambiguity quarantines

### DIFF
--- a/src/seocho/ontology_ambiguity.py
+++ b/src/seocho/ontology_ambiguity.py
@@ -142,13 +142,14 @@ class AmbiguityQuarantine:
         if not self.path.exists():
             return []
         out = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                try:
-                    out.append(AmbiguousEntity.from_dict(json.loads(line)))
-                except Exception:
-                    continue
+        with self.path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        out.append(AmbiguousEntity.from_dict(json.loads(line)))
+                    except Exception:
+                        continue
         return out
 
     def clusters(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
### What
Refactored the `AmbiguityQuarantine.all()` method in `src/seocho/ontology_ambiguity.py` to use a lazy file iterator (`with self.path.open() as f: for line in f:`) instead of loading the whole file into memory via `self.path.read_text().splitlines()`.

### Why
`AmbiguityQuarantine` instances are backed by `.jsonl` files that can grow indefinitely as more data is processed. Calling `.read_text().splitlines()` loads the entire raw text string into memory and duplicates it as a large list of strings before iterating. This creates a severe O(N) memory bottleneck and unnecessary string allocation overhead.

### Expected Impact
Greatly reduced peak memory usage and slightly reduced file I/O overhead during the ambiguity review loop when reading large quarantine logs. (Quantitative impact will depend on the size of the quarantine JSONL file). 

### Validation
- Validated via `uv run pytest tests/seocho/test_ontology_ambiguity.py` 
- Validated via `bash scripts/ci/run_basic_ci.sh`

### Risks
Extremely low risk. The refactoring carefully preserves behavior. The trailing newline that `splitlines()` usually removes is safely trimmed by the existing `line.strip()` call. 


---
*PR created automatically by Jules for task [13761798361348516706](https://jules.google.com/task/13761798361348516706) started by @tteon*