### PR TITLE
fix(ui): make DAG workflow nodes keyboard focusable

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -117,7 +117,7 @@
   </template>
 
   <template id="dagNodeTemplate">
-    <div class="workflow-node">
+    <div class="workflow-node" tabindex="0">
       <div class="node-header">
         <span class="node-agent-name"></span>
         <span class="node-type"></span>


### PR DESCRIPTION
### What
Adds `tabindex="0"` to the DAG `.workflow-node` template in the evaluation UI.

### Why
The DAG trace nodes are custom interactive UI elements injected into the canvas dynamically. Without a `tabindex`, they cannot receive keyboard focus, meaning keyboard-only users cannot navigate the pipeline trace to trigger the existing `:focus-visible` CSS outline styles.

### Accessibility / UX Impact
**High.** This restores keyboard accessibility to the core trace visualization component. Keyboard users can now Tab through the generated execution graph nodes and receive visual focus feedback identical to the mouse hover state.

### Validation
- Validated via Playwright script injecting a node from the template, tabbing into the container, and capturing the active focus ring.
- Repository CI and docs linter run cleanly.

### Risks
**Minimal.** Scoped solely to a single HTML template attribute in a frontend diagnostic tool. No impact on core semantics, agent orchestration, or backend APIs.

---
*PR created automatically by Jules for task [18404200646006180149](https://jules.google.com/task/18404200646006180149) started by @tteon*