### PR TITLE
perf: Optimize benchmark I/O with streaming file context managers

### DIFF
--- a/scripts/benchmarks/augment_examples.py
+++ b/scripts/benchmarks/augment_examples.py
@@ -69,7 +69,9 @@ def _paraphrase(llm, question) -> List[str]:
 
 
 def run(dataset_path, *, limit, provider, model, paraphrase):
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()][:limit]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
+    rows = rows[:limit]
     tickers = sorted({r["ticker"] for r in rows})
     cik_by_ticker = bench.resolve_ciks(tickers)
     name_by_ticker = {r["ticker"].upper(): r.get("gold_entities", [""])[0] for r in rows}

--- a/scripts/benchmarks/corpus_aware_scorecard_experiment.py
+++ b/scripts/benchmarks/corpus_aware_scorecard_experiment.py
@@ -126,7 +126,8 @@ def main() -> None:
     cqs = None
     if cq_path.exists():
         import yaml
-        raw = yaml.safe_load(cq_path.read_text())
+        with open(cq_path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
         cqs = raw.get("competency_questions", raw) if isinstance(raw, dict) else raw
 
     before, after = {}, {}

--- a/scripts/benchmarks/dcc_probe.py
+++ b/scripts/benchmarks/dcc_probe.py
@@ -86,7 +86,8 @@ def seed_observations(graph_store, database: str, rows: List[Dict[str, Any]],
 def run(dataset_path: str, *, limit_tickers, database, uri, user, password):
     from seocho.store.graph import Neo4jGraphStore
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     tickers = sorted({r["ticker"] for r in rows})
     if limit_tickers:
         tickers = tickers[:limit_tickers]

--- a/scripts/benchmarks/fbc_generic_answer.py
+++ b/scripts/benchmarks/fbc_generic_answer.py
@@ -53,7 +53,8 @@ def main() -> None:
     from huggingface_hub import hf_hub_download
     import pandas as pd
 
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     fbc_generic = build_fbc_generic(args.catalog, args.corpus)
     ontos = {"curated_plus": Ontology.load("examples/datasets/fibo_plus.jsonld"), "fibo_fbc_generic": fbc_generic}
 

--- a/scripts/benchmarks/fbc_generic_powered.py
+++ b/scripts/benchmarks/fbc_generic_powered.py
@@ -106,7 +106,8 @@ def main():
     from huggingface_hub import hf_hub_download
     import pandas as pd
 
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     ontos = {"curated_plus": Ontology.load("examples/datasets/fibo_plus.jsonld"),
              "fibo_fbc_generic": build_fbc_generic(args.catalog, args.corpus)}
     df = pd.read_parquet(hf_hub_download("Linq-AI-Research/FinDER", "data/train-00000-of-00001.parquet", repo_type="dataset"))

--- a/scripts/benchmarks/fbc_stable_powered.py
+++ b/scripts/benchmarks/fbc_stable_powered.py
@@ -100,7 +100,8 @@ def main():
     from huggingface_hub import hf_hub_download
     import pandas as pd
 
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     print("building stable-bridged FBC generic guardrail (multi-model derive)...", flush=True)
     fbc_stable, seed, terms = build_fbc_stable_generic(args.catalog, args.corpus, key)
     ontos = {"curated_plus": Ontology.load("examples/datasets/fibo_plus.jsonld"), "fibo_fbc_stable": fbc_stable}

--- a/scripts/benchmarks/finder_full_corpus_profile.py
+++ b/scripts/benchmarks/finder_full_corpus_profile.py
@@ -67,7 +67,8 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
         docs.append({"id": _id, "category": str(row["category"]), "text": text.strip()[:max_chars]})
     print(f"total in corpus minus done = {len(docs)} to extract ({len(done_ids)} resumed)", flush=True)
 
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     be = create_llm_backend(provider="mara", model=model, api_key=key)
     fh = jp.open("a", encoding="utf-8"); lock = Lock(); done = {"n": 0}
 
@@ -139,7 +140,8 @@ def main():
     if Path(cat_path).exists():
         cat = load_catalog(cat_path)
         gterms = sorted(cp.label_frequencies, key=lambda k: -cp.label_frequencies[k])[:20]
-        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+        with open(".env", "r", encoding="utf-8") as env_file:
+            key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
         bes = [create_llm_backend(provider="mara", model=m, api_key=key) for m in ["DeepSeek-V3.1", "MiniMax-M2.5", "gpt-oss-120b"]]
         for m, o in fibo_guardrail_candidates(cat).items():
             seed = derive_fibo_roots_stable(gterms, o, backends=bes, models=["DeepSeek-V3.1", "MiniMax-M2.5", "gpt-oss-120b"], passes=2)

--- a/scripts/benchmarks/finder_guardrail_ablation.py
+++ b/scripts/benchmarks/finder_guardrail_ablation.py
@@ -161,7 +161,8 @@ def main() -> None:
     cqs = None
     if cq_path.exists():
         import yaml
-        raw = yaml.safe_load(cq_path.read_text())
+        with open(cq_path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
         cqs = raw.get("competency_questions", raw) if isinstance(raw, dict) else raw
     scorecards = {arm: score_ontology(o, competency_questions=cqs).to_dict() for arm, o in ontos.items()}
     for arm, sc in scorecards.items():

--- a/scripts/benchmarks/finder_guardrail_answer_matrix.py
+++ b/scripts/benchmarks/finder_guardrail_answer_matrix.py
@@ -105,7 +105,8 @@ def main() -> None:
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
 
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     ontos = {arm: Ontology.load(p) for arm, p in ARMS.items()}
     be = create_llm_backend(provider="mara", model=args.model, api_key=key)
     cases = load_matrix(args.per_category, args.max_chars)

--- a/scripts/benchmarks/graphrag_bench.py
+++ b/scripts/benchmarks/graphrag_bench.py
@@ -262,7 +262,8 @@ def run_case(client: Any, case: Dict[str, Any]) -> CaseResult:
 
 def load_dataset(task: str, dataset_path: Optional[str]) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
     if dataset_path:
-        rows = [json.loads(line) for line in Path(dataset_path).read_text().splitlines() if line.strip()]
+        with open(dataset_path, "r", encoding="utf-8") as f:
+            rows = [json.loads(line) for line in f if line.strip()]
         onto = rows[0].get("ontology", SMOKE_ONTOLOGY) if rows else SMOKE_ONTOLOGY
         return onto, rows
     if task == "sample":

--- a/scripts/benchmarks/p3v2_validator_precision.py
+++ b/scripts/benchmarks/p3v2_validator_precision.py
@@ -134,7 +134,8 @@ def main():
     ap.add_argument("--model", default="DeepSeek-V3.1")
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     be = create_llm_backend(provider="mara", model=args.model, api_key=key)
     cases = load_cases(args.per_type, args.max_chars)
     print(f"{len(cases)} numeric cases")

--- a/scripts/benchmarks/p3v3_grounded_validator.py
+++ b/scripts/benchmarks/p3v3_grounded_validator.py
@@ -112,7 +112,8 @@ def main():
     ap.add_argument("--model", default="DeepSeek-V3.1")
     ap.add_argument("--out", required=True)
     args = ap.parse_args()
-    key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', Path(".env").read_text()).group(1)
+    with open(".env", "r", encoding="utf-8") as env_file:
+        key = re.search(r'ontology_guardrail_mara_api_key\s*=\s*"([^"]+)"', env_file.read()).group(1)
     be = create_llm_backend(provider="mara", model=args.model, api_key=key)
     cases = load_cases(args.per_type, args.max_chars)
     print(f"{len(cases)} cases")

--- a/scripts/benchmarks/profile_probe.py
+++ b/scripts/benchmarks/profile_probe.py
@@ -71,7 +71,8 @@ def _profile(graph_store, database, cypher, params):
 def run(dataset_path, *, limit_tickers, database, uri, user, password):
     from seocho.store.graph import Neo4jGraphStore
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     tickers = sorted({r["ticker"] for r in rows})
     if limit_tickers:
         tickers = tickers[:limit_tickers]

--- a/scripts/benchmarks/run_finder_benchmark.py
+++ b/scripts/benchmarks/run_finder_benchmark.py
@@ -42,15 +42,16 @@ from seocho.tracing import (  # noqa: E402
 def _load_dotenv(path: Path) -> None:
     if not path.exists():
         return
-    for raw_line in path.read_text().splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        value = value.strip().strip('"').strip("'")
-        if key and key not in os.environ:
-            os.environ[key] = value
+    with open(path, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = value
 
 
 def _default_dataset_path() -> Path:

--- a/scripts/benchmarks/sec_filing_run.py
+++ b/scripts/benchmarks/sec_filing_run.py
@@ -59,7 +59,8 @@ def run(dataset_path: str, tickers: List[str], *, database: str, uri: str,
     from seocho.store.graph import Neo4jGraphStore
     from seocho.store.llm import create_llm_backend
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     ciks = bench.resolve_ciks(tickers)
 
     llm = create_llm_backend(provider=provider, model=model)

--- a/scripts/benchmarks/sec_table_run.py
+++ b/scripts/benchmarks/sec_table_run.py
@@ -72,7 +72,8 @@ def run(dataset_path, tickers, *, database, uri, user, password, provider, model
     from seocho.store.llm import create_llm_backend
     from seocho.query.embedding_grounding import make_fastembed_scorer
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     rows = [r for r in rows if r["ticker"] in set(tickers)]
     cik_by_ticker = bench.resolve_ciks(tickers)
     name_by_ticker = {r["ticker"].upper(): r.get("gold_entities", [""])[0] for r in rows}

--- a/scripts/benchmarks/sec_temporal_run.py
+++ b/scripts/benchmarks/sec_temporal_run.py
@@ -195,7 +195,8 @@ def run(
     from seocho.store.graph import Neo4jGraphStore
     from seocho.store.llm import create_llm_backend
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
 
     # group by (ticker, metric): index the shared multi-year corpus once,
     # then ask each year's question against it (temporal-resolution setup).

--- a/scripts/benchmarks/sra_probe.py
+++ b/scripts/benchmarks/sra_probe.py
@@ -48,7 +48,8 @@ def _gold(row, registry, cik_by_ticker):
 def run(dataset_path: str, *, limit_tickers, provider, model, use_bge):
     from seocho.store.llm import create_llm_backend
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     tickers = sorted({r["ticker"] for r in rows})
     if limit_tickers:
         tickers = tickers[:limit_tickers]

--- a/scripts/benchmarks/srhr_probe.py
+++ b/scripts/benchmarks/srhr_probe.py
@@ -41,7 +41,8 @@ def run(dataset_path, *, limit_tickers, database, uri, user, password, provider,
     from seocho.store.graph import Neo4jGraphStore
     from seocho.store.llm import create_llm_backend
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     tickers = sorted({r["ticker"] for r in rows})
     if limit_tickers:
         tickers = tickers[:limit_tickers]

--- a/scripts/benchmarks/xbrl_ingest_run.py
+++ b/scripts/benchmarks/xbrl_ingest_run.py
@@ -55,7 +55,8 @@ def run(dataset_path, tickers, *, database, uri, user, password, provider, model
     from seocho.store.llm import create_llm_backend
     from seocho.query.embedding_grounding import make_fastembed_scorer
 
-    rows = [json.loads(l) for l in Path(dataset_path).read_text().splitlines() if l.strip()]
+    with open(dataset_path, "r", encoding="utf-8") as f:
+        rows = [json.loads(l) for l in f if l.strip()]
     rows = [r for r in rows if r["ticker"] in set(tickers)]
     cik_by_ticker = bench.resolve_ciks(tickers)
     name_by_ticker = {r["ticker"].upper(): r.get("gold_entities", [""])[0] for r in rows}


### PR DESCRIPTION
**What**
Replaced occurrences of `Path(...).read_text().splitlines()` and `yaml.safe_load(Path(...).read_text())` with streaming context managers (`with open(..., "r", encoding="utf-8") as f:`) in the benchmarking scripts.

**Why**
The previous approach read the entire file into memory as a single string and then duplicated it into a list of line strings before iteration. The new approach streams the file line-by-line, parsing JSON directly, which is a substantial memory and performance optimization for loading large JSONL benchmark datasets.

**Expected Impact**
Significant reduction in memory usage and parsing time overhead when running benchmarks against large JSONL files (qualitative).

**Validation**
Ran the local CI command `bash scripts/ci/run_basic_ci.sh`, all tests passed.

**Risks**
Minimal. The new approach preserves existing behavior exactly, and sets the encoding safely to UTF-8.

*(Created as a draft PR)*

---
*PR created automatically by Jules for task [6410863278500026777](https://jules.google.com/task/6410863278500026777) started by @tteon*