### PR TITLE
Remove redundant aria-label attributes from explicitly labeled form inputs in evaluation console

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -46,7 +46,7 @@
       <section class="controls">
         <label class="control">
           <span>Mode</span>
-          <select id="modeSelect" aria-label="Pipeline mode select">
+          <select id="modeSelect">
             <option value="semantic">Semantic (DAG)</option>
             <option value="debate">Debate (Parallel)</option>
             <option value="router">Router (Sequential)</option>
@@ -54,22 +54,22 @@
         </label>
         <label class="control">
           <span>Workspace</span>
-          <input id="workspaceInput" aria-label="Workspace ID input" value="default" />
+          <input id="workspaceInput" value="default" />
         </label>
         <label class="control">
           <span>Databases</span>
-          <input id="databasesInput" aria-label="Target databases input" value="kgnormal,kgfibo" />
+          <input id="databasesInput" value="kgnormal,kgfibo" />
         </label>
       </section>
 
       <section class="ingest-controls">
         <label class="control">
           <span>Ingest DB</span>
-          <input id="ingestDbInput" aria-label="Target database for ingestion" value="kgnormal" />
+          <input id="ingestDbInput" value="kgnormal" />
         </label>
         <label class="control ingest-grow">
           <span>Raw Records (one line per record)</span>
-          <textarea id="ingestInput" aria-label="Raw records for ingestion" rows="2"
+          <textarea id="ingestInput" rows="2"
             placeholder="Example: ACME acquired Beta in 2024.&#10;Example: Beta provides risk analytics to ACME."></textarea>
         </label>
         <button id="ingestBtn" type="button">Ingest Raw</button>


### PR DESCRIPTION
### What
Removed redundant `aria-label` attributes from form input fields (`#modeSelect`, `#workspaceInput`, `#databasesInput`, `#ingestDbInput`, `#ingestInput`) in `evaluation/static/index.html`.

### Why
The form input fields were already properly wrapped in `<label>` tags containing descriptive visible text, which serves as their implicit accessible name. Adding a redundant `aria-label` that duplicates or overrides the visible text violates the WCAG 2.5.3 "Label in Name" criterion. Removing it ensures that the accessible name relies entirely on the visible label, improving accessibility for screen readers and voice dictation software.

### Accessibility / UX Impact
- **Accessibility:** Resolves a WCAG "Label in Name" violation by ensuring the accessible name matches the visible label. This improves compatibility with voice control software and reduces confusion for screen reader users by removing duplicate/conflicting naming mechanisms.
- **UX:** No visual changes. The interface behaves and looks exactly as before for sighted mouse and keyboard users.

### Validation
- **Automated Tests:** Executed the standard basic CI suite (`bash scripts/ci/run_basic_ci.sh`) in a local `uv` environment with no new failures.
- **Visual/Runtime Verification:** Wrote a headless Playwright script to launch the local `uvicorn` evaluation server, navigate to the console, and programmatically verify via `page.evaluate()` that the targeted input elements no longer have `aria-label` attributes in the DOM. Captured a verification screenshot confirming the UI rendered correctly.

### Risks
- **Low Risk:** This change is purely structural and only affects accessibility metadata. The inputs themselves, their data bindings, and their visual styles are unmodified.

---
*PR created automatically by Jules for task [8805459202606874863](https://jules.google.com/task/8805459202606874863) started by @tteon*