### PR TITLE
fix(a11y): remove redundant aria-label attributes from form inputs

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -46,7 +46,7 @@
       <section class="controls">
         <label class="control">
           <span>Mode</span>
-          <select id="modeSelect" aria-label="Pipeline mode select">
+          <select id="modeSelect">
             <option value="semantic">Semantic (DAG)</option>
             <option value="debate">Debate (Parallel)</option>
             <option value="router">Router (Sequential)</option>
@@ -54,22 +54,22 @@
         </label>
         <label class="control">
           <span>Workspace</span>
-          <input id="workspaceInput" aria-label="Workspace ID input" value="default" />
+          <input id="workspaceInput" value="default" />
         </label>
         <label class="control">
           <span>Databases</span>
-          <input id="databasesInput" aria-label="Target databases input" value="kgnormal,kgfibo" />
+          <input id="databasesInput" value="kgnormal,kgfibo" />
         </label>
       </section>
 
       <section class="ingest-controls">
         <label class="control">
           <span>Ingest DB</span>
-          <input id="ingestDbInput" aria-label="Target database for ingestion" value="kgnormal" />
+          <input id="ingestDbInput" value="kgnormal" />
         </label>
         <label class="control ingest-grow">
           <span>Raw Records (one line per record)</span>
-          <textarea id="ingestInput" aria-label="Raw records for ingestion" rows="2"
+          <textarea id="ingestInput" rows="2"
             placeholder="Example: ACME acquired Beta in 2024.&#10;Example: Beta provides risk analytics to ACME."></textarea>
         </label>
         <button id="ingestBtn" type="button">Ingest Raw</button>


### PR DESCRIPTION
### What
Removes redundant `aria-label` attributes from form controls (such as `<select>` and `<input>`) that are already properly wrapped in `<label>` elements with visible descriptive text inside `evaluation/static/index.html`. 

### Why
According to the ARIA specification and WCAG guidelines (specifically WCAG 2.5.3: Label in Name), an `aria-label` attribute overrides the accessible name derived from visible text. When a redundant `aria-label` is applied, screen readers announce something different than what sighted users see, and voice control users may fail to interact with the element if they speak the visible text. Furthermore, including roles like "input" or "select" within an `aria-label` is redundant because assistive technologies already announce the element type.

### Accessibility / UX Impact
- **Screen Reader Users:** Ensure they hear the exact visible label text rather than an overriding, sometimes redundant ARIA label.
- **Voice Control Users:** Can now reliably activate these form controls by speaking their visible text, improving compliance with the "Label in Name" criterion. 

### Validation
- **Visual Validation:** Used Playwright to verify that the UI renders identically and that removing the attribute did not affect any CSS styling or layout.
- **CI Pipeline:** `bash scripts/ci/run_basic_ci.sh` passed locally.

### Risks
- **Extremely Low Risk:** The change only modifies ARIA accessibility metadata and explicitly removes attributes. It does not alter behavior, layout, logic, or functionality.

---
*PR created automatically by Jules for task [9878707039054290776](https://jules.google.com/task/9878707039054290776) started by @tteon*