### PR TITLE
Add mock coverage for connectors

### DIFF
--- a/tests/seocho/test_connectors.py
+++ b/tests/seocho/test_connectors.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 from dataclasses import dataclass
 
 from seocho.connectors import (
@@ -13,14 +15,15 @@ from seocho.connectors import (
     write_sample_config,
     write_records_jsonl,
 )
+from seocho.connectors import config as connector_config
 from seocho.connectors.config import ConnectorConfigError
-from seocho.connectors.datahub import dataset_entity_to_record
-from seocho.connectors.notion import blocks_to_markdown, page_to_record
+from seocho.connectors.datahub import DataHubGraphQLClient, dataset_entity_to_record
+from seocho.connectors.notion import NotionClient, blocks_to_markdown, page_to_record
 from seocho.connectors.neo4j import records_from_schema_rows as records_from_neo4j_schema_rows
 from seocho.connectors.postgres import records_from_schema_rows
 from seocho.connectors.records import sanitize_metadata
-from seocho.connectors.slack import message_to_record, thread_to_record
-from seocho.cli import build_parser
+from seocho.connectors.slack import SlackClient, message_to_record, thread_to_record
+from seocho.cli import build_parser, main
 from seocho.index.file_reader import read_jsonl_file
 
 
@@ -36,6 +39,47 @@ class _LlamaDoc:
     text: str
     metadata: dict
     id_: str = ""
+
+
+class _MockResponse:
+    def __init__(self, payload, *, status_code: int = 200, headers: dict | None = None) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _MockRequestSession:
+    def __init__(self, responses: list[_MockResponse]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict] = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return self.responses.pop(0)
+
+
+class _MockGetSession:
+    def __init__(self, responses: list[_MockResponse]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict] = []
+
+    def get(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return self.responses.pop(0)
+
+
+class _MockPostSession:
+    def __init__(self, responses: list[_MockResponse]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict] = []
+
+    def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return self.responses.pop(0)
 
 
 def test_langchain_documents_convert_without_optional_dependency(tmp_path) -> None:
@@ -116,6 +160,55 @@ def test_notion_page_and_blocks_materialize_record() -> None:
     assert record.metadata["notion_properties"]["Status"] == "Published"
 
 
+def test_notion_client_paginates_data_source_and_blocks() -> None:
+    page_1 = {
+        "object": "page",
+        "id": "page-1",
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": "Page One"}]}},
+    }
+    page_2 = {
+        "object": "page",
+        "id": "page-2",
+        "properties": {"Name": {"type": "title", "title": [{"plain_text": "Page Two"}]}},
+    }
+    session = _MockRequestSession([
+        _MockResponse({"results": [page_1], "has_more": True, "next_cursor": "cursor-2"}),
+        _MockResponse({"results": [page_2], "has_more": False}),
+        _MockResponse({
+            "results": [
+                {
+                    "id": "child",
+                    "type": "heading_1",
+                    "has_children": True,
+                    "heading_1": {"rich_text": [{"plain_text": "Root"}]},
+                }
+            ],
+            "has_more": False,
+        }),
+        _MockResponse({
+            "results": [
+                {
+                    "id": "grandchild",
+                    "type": "paragraph",
+                    "paragraph": {"rich_text": [{"plain_text": "Nested text"}]},
+                }
+            ],
+            "has_more": False,
+        }),
+    ])
+    client = NotionClient(token="secret", session=session)
+
+    pages = list(client.iter_data_source_pages("ds-1", page_size=500))
+    markdown = client.page_content_markdown("page-1")
+
+    assert [page["id"] for page in pages] == ["page-1", "page-2"]
+    assert session.calls[0]["json"]["page_size"] == 100
+    assert session.calls[1]["json"]["start_cursor"] == "cursor-2"
+    assert session.calls[2]["method"] == "GET"
+    assert "# Root" in markdown
+    assert "Nested text" in markdown
+
+
 def test_slack_message_and_thread_materialize_records() -> None:
     msg = {
         "type": "message",
@@ -137,6 +230,63 @@ def test_slack_message_and_thread_materialize_records() -> None:
     )
     assert thread.source_kind == "slack_thread"
     assert thread.metadata["message_count"] == 2
+
+
+def test_slack_client_paginates_history_and_retries_rate_limit(monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr("seocho.connectors.slack.time.sleep", lambda value: sleeps.append(value))
+    session = _MockGetSession([
+        _MockResponse({"ok": False}, status_code=429, headers={"Retry-After": "2"}),
+        _MockResponse({
+            "ok": True,
+            "messages": [{"type": "message", "ts": "1", "text": "first"}],
+            "response_metadata": {"next_cursor": "cursor-2"},
+        }),
+        _MockResponse({
+            "ok": True,
+            "messages": [{"type": "message", "ts": "2", "text": "second"}],
+            "response_metadata": {"next_cursor": ""},
+        }),
+    ])
+    client = SlackClient(token="xoxb-token", session=session)
+
+    messages = list(client.iter_conversation_history("C123", limit=999))
+
+    assert [message["ts"] for message in messages] == ["1", "2"]
+    assert sleeps == [2.0]
+    assert session.calls[0]["params"]["limit"] == 200
+    assert session.calls[2]["params"]["cursor"] == "cursor-2"
+
+
+def test_slack_fetch_channel_records_groups_threads(monkeypatch) -> None:
+    class FakeSlackClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def iter_conversation_history(self, channel_id, **kwargs):
+            assert channel_id == "C123"
+            yield {
+                "type": "message",
+                "ts": "1",
+                "thread_ts": "1",
+                "text": "root",
+                "user": "U1",
+                "reply_count": 1,
+            }
+
+        def iter_conversation_replies(self, channel_id, thread_ts, **kwargs):
+            assert (channel_id, thread_ts) == ("C123", "1")
+            yield {"type": "message", "ts": "1", "thread_ts": "1", "text": "root", "user": "U1"}
+            yield {"type": "message", "ts": "2", "thread_ts": "1", "text": "reply", "user": "U2"}
+
+    monkeypatch.setattr("seocho.connectors.slack.SlackClient", FakeSlackClient)
+    from seocho.connectors.slack import fetch_channel_records
+
+    records = fetch_channel_records(["C123"], token_env="SLACK_TOKEN", include_threads=True)
+
+    assert len(records) == 1
+    assert records[0].source_kind == "slack_thread"
+    assert "U2: reply" in records[0].content
 
 
 def test_datahub_dataset_entity_materializes_schema_record() -> None:
@@ -161,6 +311,52 @@ def test_datahub_dataset_entity_materializes_schema_record() -> None:
     assert "order_id" in record.content
     assert record.metadata["field_count"] == 1
     assert record.metadata["tags"] == ["pii"]
+
+
+def test_datahub_client_pages_search_and_sets_auth_header() -> None:
+    session = _MockPostSession([
+        _MockResponse({
+            "data": {
+                "search": {
+                    "searchResults": [
+                        {
+                            "entity": {
+                                "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,db.public.orders,PROD)",
+                                "type": "DATASET",
+                                "name": "db.public.orders",
+                                "properties": {"description": "Orders table"},
+                            }
+                        }
+                    ]
+                }
+            }
+        }),
+        _MockResponse({
+            "data": {
+                "search": {
+                    "searchResults": [
+                        {
+                            "entity": {
+                                "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,db.public.customers,PROD)",
+                                "type": "DATASET",
+                                "name": "db.public.customers",
+                                "properties": {"description": "Customers table"},
+                            }
+                        }
+                    ]
+                }
+            }
+        }),
+    ])
+    client = DataHubGraphQLClient(server="https://datahub.example", token="dh-token", session=session)
+
+    entities = list(client.iter_dataset_search(query_text="postgres", page_size=1, max_results=2))
+
+    assert [entity["name"] for entity in entities] == ["db.public.orders", "db.public.customers"]
+    assert session.calls[0]["url"] == "https://datahub.example/api/graphql"
+    assert session.calls[0]["headers"]["Authorization"] == "Bearer dh-token"
+    assert session.calls[0]["json"]["variables"] == {"query": "postgres", "start": 0, "count": 1}
+    assert session.calls[1]["json"]["variables"] == {"query": "postgres", "start": 1, "count": 1}
 
 
 def test_postgres_schema_rows_group_into_table_records() -> None:
@@ -192,6 +388,62 @@ def test_postgres_schema_rows_group_into_table_records() -> None:
     assert records[0].metadata["field_count"] == 2
 
 
+def test_postgres_fetch_schema_records_uses_mock_psycopg(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params):
+            calls["query"] = query
+            calls["params"] = params
+
+        def fetchall(self):
+            return [
+                {
+                    "table_schema": "public",
+                    "table_name": "orders",
+                    "column_name": "order_id",
+                    "ordinal_position": 1,
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                }
+            ]
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    def fake_connect(dsn, row_factory=None):
+        calls["dsn"] = dsn
+        calls["row_factory"] = row_factory
+        return FakeConnection()
+
+    fake_psycopg = types.SimpleNamespace(connect=fake_connect)
+    fake_rows = types.SimpleNamespace(dict_row=object())
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+    monkeypatch.setitem(sys.modules, "psycopg.rows", fake_rows)
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql://example")
+    from seocho.connectors.postgres import fetch_schema_records
+
+    records = fetch_schema_records(dsn_env="TEST_DATABASE_URL", schemas=["public"], database="app")
+
+    assert calls["dsn"] == "postgresql://example"
+    assert calls["params"] == [["public"]]
+    assert "table_schema = any(%s)" in str(calls["query"])
+    assert records[0].id == "postgres:postgres://app.public.orders"
+
+
 def test_neo4j_schema_rows_materialize_schema_record() -> None:
     records = records_from_neo4j_schema_rows(
         node_rows=[
@@ -219,6 +471,68 @@ def test_neo4j_schema_rows_materialize_schema_record() -> None:
     assert ":`Company`" in records[0].content
     assert records[0].metadata["node_types"] == [":`Company`"]
     assert records[0].metadata["relationship_types"] == [":`WORKS_AT`"]
+
+
+def test_neo4j_fetch_schema_records_uses_mock_driver(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeSession:
+        def __init__(self, database) -> None:
+            calls["database"] = database
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def run(self, query):
+            calls.setdefault("queries", []).append(query)
+            if "nodeTypeProperties" in query:
+                return [
+                    {
+                        "nodeType": ":`Company`",
+                        "propertyName": "name",
+                        "propertyTypes": ["String"],
+                        "mandatory": True,
+                    }
+                ]
+            return [
+                {
+                    "relType": ":`WORKS_AT`",
+                    "propertyName": "since",
+                    "propertyTypes": ["Integer"],
+                    "mandatory": False,
+                }
+            ]
+
+    class FakeDriver:
+        def session(self, database=None):
+            return FakeSession(database)
+
+        def close(self):
+            calls["closed"] = True
+
+    class FakeGraphDatabase:
+        @staticmethod
+        def driver(uri, auth=None):
+            calls["uri"] = uri
+            calls["auth"] = auth
+            return FakeDriver()
+
+    monkeypatch.setitem(sys.modules, "neo4j", types.SimpleNamespace(GraphDatabase=FakeGraphDatabase))
+    monkeypatch.setenv("NEO4J_USER", "neo4j")
+    monkeypatch.setenv("NEO4J_PASSWORD", "password")
+    from seocho.connectors.neo4j import fetch_schema_records
+
+    records = fetch_schema_records(uri="bolt://mock", database="neo4j")
+
+    assert calls["uri"] == "bolt://mock"
+    assert calls["auth"] == ("neo4j", "password")
+    assert calls["database"] == "neo4j"
+    assert calls["closed"] is True
+    assert records[0].source_kind == "neo4j_schema"
+    assert ":`WORKS_AT`" in records[0].content
 
 
 def test_sanitize_metadata_redacts_secret_like_keys() -> None:
@@ -364,3 +678,44 @@ sources:
     assert results[0].records == 1
     assert not (output_dir / "graph.jsonl").exists()
     assert not (output_dir / "state.json").exists()
+
+
+def test_connector_run_cli_writes_outputs_with_mock_materializer(tmp_path, monkeypatch, capsys) -> None:
+    config_path = tmp_path / "seocho.connectors.yaml"
+    output_dir = tmp_path / "connectors"
+    state_path = output_dir / "state.json"
+    config_path.write_text(
+        f"""
+version: 1
+output_dir: {output_dir}
+state_path: {state_path}
+sources:
+  - name: graph
+    provider: neo4j
+    output: graph.jsonl
+""".strip(),
+        encoding="utf-8",
+    )
+
+    def fake_materialize(source) -> list[ConnectorRecord]:
+        return [
+            ConnectorRecord(
+                id=f"{source.provider}:schema",
+                content="Mock graph schema",
+                provider=source.provider,
+                source_kind="neo4j_schema",
+                category=source.category,
+            )
+        ]
+
+    monkeypatch.setattr(connector_config, "materialize_source", fake_materialize)
+
+    exit_code = main(["connect", "run", str(config_path)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "wrote 1 connector record(s)" in output
+    assert (output_dir / "graph.jsonl").exists()
+    assert state_path.exists()
+    records = list(read_records_jsonl(output_dir / "graph.jsonl"))
+    assert records[0].id == "neo4j:schema"


### PR DESCRIPTION
## Summary
- Add mock HTTP/session tests for Notion pagination + recursive blocks, Slack pagination/rate-limit retry/thread grouping, and DataHub GraphQL pagination/auth.
- Add mock driver tests for PostgreSQL schema fetch and Neo4j/DozerDB schema fetch.
- Add CLI-level mock test for seocho connect run writing JSONL and state.

## Validation
- uv run ruff check tests/seocho/test_connectors.py src/seocho/connectors src/seocho/cli.py
- uv run pytest tests/seocho/test_connectors.py -q
- bash scripts/ci/run_basic_ci.sh