### PR TITLE
fix(ui): make workflow canvas pane keyboard accessible

### DIFF
--- a/evaluation/static/index.html
+++ b/evaluation/static/index.html
@@ -92,7 +92,7 @@
         </div>
 
         <!-- Right: AIP Workflow DAG Canvas -->
-        <div class="canvas-pane" id="dagCanvas">
+        <div class="canvas-pane" id="dagCanvas" tabindex="0">
           <div class="canvas-header">Workflow Builder Live Trace Graph</div>
           <div class="canvas-empty" id="canvasEmptyState">
             [ NO ACTIVE RUN ]<br /><br />


### PR DESCRIPTION
### What
Added a `tabindex="0"` attribute to the `#dagCanvas` container element in `evaluation/static/index.html`.

### Why
The axe-core accessibility tool identified a `scrollable-region-focusable` violation on the canvas pane. The canvas pane acts as a custom scrollable region for the DAG visualization, but without a `tabindex`, it could not be focused by keyboard users (particularly in Safari, which enforces this strictly), preventing them from interacting with or scrolling its contents without a mouse.

### Accessibility / UX Impact
- **Accessibility:** Fixes a WCAG 2.1.1 (Keyboard) and 2.1.3 (Keyboard - No Exception) violation. Keyboard-only users and those relying on assistive technologies can now navigate to and scroll the workflow trace canvas pane.
- **UX:** No visual changes. This strictly improves keyboard navigability.

### Validation
- Ran axe-playwright via `test_a11y.js` against the local `evaluation.server` and verified the `scrollable-region-focusable` violation is resolved.
- Ran visual verification with Playwright to ensure the `tabindex="0"` attribute did not unintentionally alter the visual layout or styling of the application.
- Executed `bash scripts/ci/run_basic_ci.sh` to confirm no runtime regressions.

### Risks
Low risk. Adding `tabindex="0"` merely places the element in the natural tab order. It is standard practice for custom interactive or scrollable containers.
- draft: true

---
*PR created automatically by Jules for task [11530969582858727206](https://jules.google.com/task/11530969582858727206) started by @tteon*