### PR TITLE
Fix button color contrast for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+- Fixed WCAG 2 AA contrast for buttons with Palantir AIP theme colors (--accent-green, --accent-blue) by changing text color from #fff to #0d1117.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
### What
Changed the text color of the `#ingestBtn`, `#oneClickDemoBtn`, and `.composer button` elements from `#fff` to `#0d1117` in `evaluation/static/styles.css`.

### Why
The Palantir AIP theme accent colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) used for button backgrounds do not provide sufficient contrast ratio against pure white (`#fff`) text, failing WCAG 2 AA accessibility guidelines.

### Accessibility / UX Impact
Improves readability and ensures the workflow console buttons are accessible to visually impaired users and those with low-contrast sensitivity, providing a more inclusive operator experience.

### Validation
- Local execution of Playwright test script confirmed computed `color` values for all affected buttons correctly resolved to `rgb(13, 17, 23)` (`#0d1117`).
- `bash scripts/ci/run_basic_ci.sh` passed successfully.

### Risks
Extremely low risk. This is a targeted, CSS-only text color change for three specific buttons in the evaluation console. There are zero layout, runtime, or behavioral side effects.

**Draft PR:** True

---
*PR created automatically by Jules for task [17669744092519314469](https://jules.google.com/task/17669744092519314469) started by @tteon*