### PR TITLE
perf: refactor jsonl parsing in benchmark scripts to reduce I/O overhead

### DIFF
--- a/scripts/benchmarks/customer_query_bulk_live.py
+++ b/scripts/benchmarks/customer_query_bulk_live.py
@@ -83,7 +83,11 @@ def main() -> None:
     for source in ("order_history", "fill_history", "withdrawal_history", "counterparty_history", "funding_history", "answer_receipt", "context_graph"):
         sources[source] = sources["postgresql_revision"]
 
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
+    rows = []
+    with open(args.dataset, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
     outcomes: Counter[str] = Counter()
     by_intent: dict[str, Counter[str]] = defaultdict(Counter)
     durations = []

--- a/scripts/benchmarks/customer_query_intent_mara_live.py
+++ b/scripts/benchmarks/customer_query_intent_mara_live.py
@@ -31,8 +31,16 @@ _INTENT_DEFINITIONS = {
 
 
 async def run(args: argparse.Namespace) -> dict:
-    clear_rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
-    challenge_rows = [json.loads(line) for line in args.challenges.read_text().splitlines() if line]
+    clear_rows = []
+    with open(args.dataset, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                clear_rows.append(json.loads(line))
+    challenge_rows = []
+    with open(args.challenges, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                challenge_rows.append(json.loads(line))
     selected = []
     counts: dict[tuple[str, str], int] = defaultdict(int)
     for row in clear_rows:

--- a/scripts/benchmarks/customer_query_mara_live.py
+++ b/scripts/benchmarks/customer_query_mara_live.py
@@ -17,7 +17,11 @@ from seocho.tracing import disable_tracing, enable_tracing, flush_tracing, start
 
 
 async def run(args: argparse.Namespace) -> dict:
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
+    rows = []
+    with open(args.dataset, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
     bulk = json.loads(args.bulk_report.read_text())
     available = {
         source: bool(detail.get("available"))
@@ -45,15 +49,17 @@ async def run(args: argparse.Namespace) -> dict:
     checkpoint: Path | None = getattr(args, "checkpoint", None)
     completed: dict[str, dict] = {}
     if checkpoint and checkpoint.exists():
-        for line in checkpoint.read_text().splitlines():
-            if not line:
-                continue
-            try:
-                item = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if query_id := item.get("query_id"):
-                completed[query_id] = item
+        with open(checkpoint, encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if query_id := item.get("query_id"):
+                    completed[query_id] = item
         if getattr(args, "retry_failures", False):
             completed = {
                 query_id: item

--- a/scripts/benchmarks/emit_answer_progress.py
+++ b/scripts/benchmarks/emit_answer_progress.py
@@ -20,11 +20,15 @@ def main() -> None:
     args = parser.parse_args()
     rows = []
     if args.checkpoint.exists():
-        for line in args.checkpoint.read_text().splitlines():
-            try:
-                rows.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
+        with open(args.checkpoint, encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
     latest = {row["query_id"]: row for row in rows if row.get("query_id")}
     completed = len(latest)
     failures = sum(

--- a/scripts/benchmarks/evaluate_customer_query_diversity.py
+++ b/scripts/benchmarks/evaluate_customer_query_diversity.py
@@ -22,8 +22,16 @@ def main() -> None:
     parser.add_argument("--challenges", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
-    challenges = [json.loads(line) for line in args.challenges.read_text().splitlines() if line]
+    rows = []
+    with open(args.dataset, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    challenges = []
+    with open(args.challenges, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                challenges.append(json.loads(line))
     correct = Counter()
     totals = Counter()
     confusion = Counter()

--- a/scripts/benchmarks/evaluate_customer_query_routing.py
+++ b/scripts/benchmarks/evaluate_customer_query_routing.py
@@ -14,7 +14,11 @@ def main() -> None:
     parser.add_argument("--dataset", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
+    rows = []
+    with open(args.dataset, encoding='utf-8') as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
     outcomes = []
     for row in rows:
         routed = classify_customer_query(row["question"])


### PR DESCRIPTION
What: Refactored JSONL parsing in benchmark scripts (`customer_query_bulk_live.py`, `customer_query_intent_mara_live.py`, `customer_query_mara_live.py`, `evaluate_customer_query_diversity.py`, `evaluate_customer_query_routing.py`, and `emit_answer_progress.py`) to stream lines from disk using explicit `for line in f:` loops instead of loading the entire file into memory with `path.read_text().splitlines()`.

Why: In performance benchmarking, reading a large JSONL dataset with `.read_text().splitlines()` inside a list comprehension creates significant, avoidable file I/O overhead and massively spikes peak memory usage by creating a massive intermediate list of strings. Streaming the files line-by-line is a much more efficient approach.

Expected Impact: Significantly reduced peak memory usage and slightly faster initialization when executing these customer-query benchmarks against large datasets.

Validation: Executed the basic CI test suite (`bash scripts/ci/run_basic_ci.sh`) and explicitly verified that the benchmark scripts (`pytest scripts/benchmarks/`) continue to function correctly and pass all tests.

Risks: Minimal. The logic remains functionally identical, and `json.loads` behaves identically. The primary risk is a typo in the explicit iterations, which is mitigated by the test suites continuing to pass.

---
*PR created automatically by Jules for task [7775719616937197547](https://jules.google.com/task/7775719616937197547) started by @tteon*