### PR TITLE
Fix button text contrast in evaluation console

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What:
Updated the text color on primary buttons (`#ingestBtn`, `#oneClickDemoBtn`, and `.composer button`) in the evaluation console from white (`#fff`) to a dark shade (`#0d1117`).

Why:
The Palantir AIP theme accent colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with white text. This change ensures the buttons meet WCAG 2 AA contrast guidelines.

Accessibility / UX Impact:
Improves the visibility and readability of key actionable buttons in the UI for all users.

Validation:
- Verified UI changes using a Playwright script against the local Uvicorn server (`http://localhost:8501`).
- Ran `bash scripts/ci/run_basic_ci.sh` to ensure no regressions.

Risks:
Low risk. The change is isolated to specific button selectors in `styles.css`.

---
*PR created automatically by Jules for task [6392349892336374874](https://jules.google.com/task/6392349892336374874) started by @tteon*