### PR TITLE
perf: Optimize memory usage for large JSONL files using lazy iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+- Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).

--- a/scripts/benchmarks/customer_query_bulk_live.py
+++ b/scripts/benchmarks/customer_query_bulk_live.py
@@ -54,7 +54,9 @@ def main() -> None:
             if available:
                 sources["market_api"] = True
                 source_details["market_api"] = {
-                    "instrument": "BTC spot", "provider": provider, "available": True
+                    "instrument": "BTC spot",
+                    "provider": provider,
+                    "available": True,
                 }
                 break
         except Exception as exc:
@@ -67,23 +69,53 @@ def main() -> None:
         source_details["blockchain_api"] = {"tip_height": height, "available": True}
     except Exception as exc:
         sources["blockchain_api"] = False
-        source_details["blockchain_api"] = {"available": False, "error": type(exc).__name__}
+        source_details["blockchain_api"] = {
+            "available": False,
+            "error": type(exc).__name__,
+        }
     with psycopg.connect(args.dsn) as connection:
-        sources["postgresql_revision"] = connection.execute("SELECT 1").fetchone()[0] == 1
+        sources["postgresql_revision"] = (
+            connection.execute("SELECT 1").fetchone()[0] == 1
+        )
     driver = GraphDatabase.driver(args.bolt_uri, auth=("neo4j", args.graph_password))
     try:
-        sources["graph_projection"] = driver.execute_query("RETURN 1 AS ok").records[0]["ok"] == 1
+        sources["graph_projection"] = (
+            driver.execute_query("RETURN 1 AS ok").records[0]["ok"] == 1
+        )
     finally:
         driver.close()
     for source in (
-        "order_api", "withdrawal_api", "transfer_api",
+        "order_api",
+        "withdrawal_api",
+        "transfer_api",
     ):
         sources[source] = False
-        source_details[source] = {"available": False, "reason": "private_credentials_not_configured"}
-    for source in ("order_history", "fill_history", "withdrawal_history", "counterparty_history", "funding_history", "answer_receipt", "context_graph"):
+        source_details[source] = {
+            "available": False,
+            "reason": "private_credentials_not_configured",
+        }
+    for source in (
+        "order_history",
+        "fill_history",
+        "withdrawal_history",
+        "counterparty_history",
+        "funding_history",
+        "answer_receipt",
+        "context_graph",
+    ):
         sources[source] = sources["postgresql_revision"]
 
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
+    rows = []
+
+    with args.dataset.open(encoding="utf-8") as f:
+
+        for line in f:
+
+            line = line.strip()
+
+            if line:
+
+                rows.append(json.loads(line))
     outcomes: Counter[str] = Counter()
     by_intent: dict[str, Counter[str]] = defaultdict(Counter)
     durations = []
@@ -96,22 +128,37 @@ def main() -> None:
         available = sum(bool(sources.get(source)) for source in required_sources)
         coverage = available / len(required_sources) if required_sources else 1.0
         routing_ok = routed is not None and routed.intent == gold["intent"]
-        outcome = "supported" if routing_ok and coverage == 1 else "partial" if routing_ok and coverage > 0 else "unsupported"
+        outcome = (
+            "supported"
+            if routing_ok and coverage == 1
+            else "partial" if routing_ok and coverage > 0 else "unsupported"
+        )
         elapsed = time.perf_counter() - started
         outcomes[outcome] += 1
         by_intent[gold["intent"]][outcome] += 1
         durations.append(elapsed)
         coverage_values.append(coverage)
-        labels = {"query.class": gold["intent"], "outcome": outcome, "traffic.type": "evaluation"}
+        labels = {
+            "query.class": gold["intent"],
+            "outcome": outcome,
+            "traffic.type": "evaluation",
+        }
         metrics.add("seocho.customer.query.count", attributes=labels)
         metrics.record("seocho.customer.query.duration", elapsed, labels)
-        metrics.record("seocho.customer.evidence.coverage", coverage, {"query.class": gold["intent"]})
+        metrics.record(
+            "seocho.customer.evidence.coverage",
+            coverage,
+            {"query.class": gold["intent"]},
+        )
     age = max(time.time() - snapshot_at, 0)
     for source in ("market_api", "blockchain_api"):
         if sources[source]:
             metrics.record("seocho.customer.source.freshness", age, {"source": source})
         else:
-            metrics.add("seocho.customer.source.failure.count", attributes={"source": source, "reason": "unavailable"})
+            metrics.add(
+                "seocho.customer.source.failure.count",
+                attributes={"source": source, "reason": "unavailable"},
+            )
     shutdown_metrics()
     report = {
         "schema_version": "seocho.customer-query-bulk-live.v1",
@@ -119,7 +166,10 @@ def main() -> None:
         "outcomes": dict(outcomes),
         "by_intent": {key: dict(value) for key, value in sorted(by_intent.items())},
         "mean_evidence_coverage": sum(coverage_values) / len(coverage_values),
-        "duration_ms": {"mean": sum(durations) * 1000 / len(durations), "max": max(durations) * 1000},
+        "duration_ms": {
+            "mean": sum(durations) * 1000 / len(durations),
+            "max": max(durations) * 1000,
+        },
         "source_details": source_details,
         "private_sources_configured": False,
         "passed": len(rows) == sum(outcomes.values())

--- a/scripts/benchmarks/customer_query_intent_mara_live.py
+++ b/scripts/benchmarks/customer_query_intent_mara_live.py
@@ -31,8 +31,18 @@ _INTENT_DEFINITIONS = {
 
 
 async def run(args: argparse.Namespace) -> dict:
-    clear_rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
-    challenge_rows = [json.loads(line) for line in args.challenges.read_text().splitlines() if line]
+    clear_rows = []
+    with args.dataset.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                clear_rows.append(json.loads(line))
+    challenge_rows = []
+    with args.challenges.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                challenge_rows.append(json.loads(line))
     selected = []
     counts: dict[tuple[str, str], int] = defaultdict(int)
     for row in clear_rows:
@@ -64,7 +74,8 @@ async def run(args: argparse.Namespace) -> dict:
         expected_action = row["gold"]["expected_action"] if is_challenge else "route"
         expected_intents = (
             sorted(row["gold"]["acceptable_intents"])
-            if is_challenge else [row["gold"]["intent"]]
+            if is_challenge
+            else [row["gold"]["intent"]]
         )
         boundary = detect_customer_query_boundary(row["question"])
         if boundary is not None:
@@ -94,7 +105,10 @@ async def run(args: argparse.Namespace) -> dict:
                             "Ignore contextual details that do not change the requested operation. Do not answer."
                         ),
                         user=json.dumps(
-                            {"question": row["question"], "intent_ontology": intent_ontology},
+                            {
+                                "question": row["question"],
+                                "intent_ontology": intent_ontology,
+                            },
                             sort_keys=True,
                         ),
                         temperature=0.0,
@@ -108,7 +122,9 @@ async def run(args: argparse.Namespace) -> dict:
                 except Exception as exc:
                     errors.append(type(exc).__name__)
             observed_action = payload.get("action") if payload else None
-            observed_intents = sorted(set(payload.get("intents") or [])) if payload else []
+            observed_intents = (
+                sorted(set(payload.get("intents") or [])) if payload else []
+            )
             valid_ontology = all(intent in intents for intent in observed_intents)
             action_ok = observed_action == expected_action
             intents_ok = observed_intents == expected_intents
@@ -131,15 +147,20 @@ async def run(args: argparse.Namespace) -> dict:
     rows = await asyncio.gather(*(one(row) for row in selected))
     latencies = sorted(row["latency_ms"] for row in rows)
     by_group = {}
-    for group in sorted({row["kind"] if row["split"] == "challenge" else row["split"] for row in rows}):
+    for group in sorted(
+        {row["kind"] if row["split"] == "challenge" else row["split"] for row in rows}
+    ):
         group_rows = [
-            row for row in rows
+            row
+            for row in rows
             if (row["kind"] if row["split"] == "challenge" else row["split"]) == group
         ]
         by_group[group] = {
             "queries": len(group_rows),
-            "action_accuracy": sum(row["action_ok"] for row in group_rows) / len(group_rows),
-            "intent_accuracy": sum(row["intents_ok"] for row in group_rows) / len(group_rows),
+            "action_accuracy": sum(row["action_ok"] for row in group_rows)
+            / len(group_rows),
+            "intent_accuracy": sum(row["intents_ok"] for row in group_rows)
+            / len(group_rows),
         }
     thresholds = {
         "evaluation": ("intent_accuracy", 0.90),
@@ -186,11 +207,19 @@ def main() -> None:
         os.environ["OTEL_SERVICE_INSTANCE_ID"] = "customer-intent-eval"
         enable_tracing(backend="otlp")
     try:
-        with start_span("customer_query.intent.run", metadata={"traffic.type": "evaluation"}):
+        with start_span(
+            "customer_query.intent.run", metadata={"traffic.type": "evaluation"}
+        ):
             report = asyncio.run(run(args))
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
-        print(json.dumps({key: value for key, value in report.items() if key != "rows"}, indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                {key: value for key, value in report.items() if key != "rows"},
+                indent=2,
+                sort_keys=True,
+            )
+        )
     finally:
         if tracing_enabled:
             flush_tracing()

--- a/scripts/benchmarks/customer_query_mara_live.py
+++ b/scripts/benchmarks/customer_query_mara_live.py
@@ -17,7 +17,12 @@ from seocho.tracing import disable_tracing, enable_tracing, flush_tracing, start
 
 
 async def run(args: argparse.Namespace) -> dict:
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
+    rows = []
+    with args.dataset.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
     bulk = json.loads(args.bulk_report.read_text())
     available = {
         source: bool(detail.get("available"))
@@ -45,15 +50,17 @@ async def run(args: argparse.Namespace) -> dict:
     checkpoint: Path | None = getattr(args, "checkpoint", None)
     completed: dict[str, dict] = {}
     if checkpoint and checkpoint.exists():
-        for line in checkpoint.read_text().splitlines():
-            if not line:
-                continue
-            try:
-                item = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if query_id := item.get("query_id"):
-                completed[query_id] = item
+        with checkpoint.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+                try:
+                    item = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if query_id := item.get("query_id"):
+                    completed[query_id] = item
         if getattr(args, "retry_failures", False):
             completed = {
                 query_id: item

--- a/scripts/benchmarks/emit_answer_progress.py
+++ b/scripts/benchmarks/emit_answer_progress.py
@@ -20,11 +20,13 @@ def main() -> None:
     args = parser.parse_args()
     rows = []
     if args.checkpoint.exists():
-        for line in args.checkpoint.read_text().splitlines():
-            try:
-                rows.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
+        with args.checkpoint.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
     latest = {row["query_id"]: row for row in rows if row.get("query_id")}
     completed = len(latest)
     failures = sum(

--- a/scripts/benchmarks/evaluate_customer_query_diversity.py
+++ b/scripts/benchmarks/evaluate_customer_query_diversity.py
@@ -22,8 +22,18 @@ def main() -> None:
     parser.add_argument("--challenges", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
-    challenges = [json.loads(line) for line in args.challenges.read_text().splitlines() if line]
+    rows = []
+    with args.dataset.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    challenges = []
+    with args.challenges.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                challenges.append(json.loads(line))
     correct = Counter()
     totals = Counter()
     confusion = Counter()
@@ -61,7 +71,10 @@ def main() -> None:
         "normalized_unique_questions": normalized_unique,
         "exact_duplicate_rate": 1 - unique / len(rows),
         "template_families": len(family_counts),
-        "family_size": {"min": min(family_counts.values()), "max": max(family_counts.values())},
+        "family_size": {
+            "min": min(family_counts.values()),
+            "max": max(family_counts.values()),
+        },
         "routing_accuracy": {
             "evaluation": evaluation_accuracy,
             "held_out_family": held_out_accuracy,

--- a/scripts/benchmarks/evaluate_customer_query_routing.py
+++ b/scripts/benchmarks/evaluate_customer_query_routing.py
@@ -14,7 +14,12 @@ def main() -> None:
     parser.add_argument("--dataset", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
-    rows = [json.loads(line) for line in args.dataset.read_text().splitlines() if line]
+    rows = []
+    with args.dataset.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
     outcomes = []
     for row in rows:
         routed = classify_customer_query(row["question"])
@@ -24,7 +29,9 @@ def main() -> None:
         "queries": len(rows),
         "accuracy": sum(outcomes) / len(outcomes),
         "errors": len(outcomes) - sum(outcomes),
-        "intent_counts": dict(sorted(Counter(row["gold"]["intent"] for row in rows).items())),
+        "intent_counts": dict(
+            sorted(Counter(row["gold"]["intent"] for row in rows).items())
+        ),
         "passed": all(outcomes),
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/seocho/test_customer_query_mara_checkpoint.py
+++ b/tests/seocho/test_customer_query_mara_checkpoint.py
@@ -74,7 +74,8 @@ def test_checkpoint_is_durable_and_resumable(tmp_path, monkeypatch) -> None:
     assert first["queries"] == 10
     assert first["executed_queries"] == 10
     assert first["resumed_queries"] == 0
-    assert len(args.checkpoint.read_text().splitlines()) == 10
+    with args.checkpoint.open(encoding="utf-8") as f:
+        assert sum(1 for _ in f) == 10
 
     class _MustNotRun(_Backend):
         async def acomplete(self, **kwargs):


### PR DESCRIPTION
**What**
Replaced `Path.read_text().splitlines()` with lazy file iteration `with path.open() as f: for line in f:` in several benchmark scripts and a test file dealing with large JSONL datasets.

**Why**
Loading the entire text of a large JSONL file into memory and then splitting it into a massive list of strings via `splitlines()` causes significant and avoidable memory overhead. Processing the file lazily line-by-line is much more memory efficient.

**Expected Impact**
- Reduced memory consumption when running benchmark scripts over large datasets.
- More stable and scalable execution in CI and local workflows.

**Validation**
- Validated via `bash scripts/ci/run_basic_ci.sh`, which passed successfully.

**Risks**
- Very low risk. The logic behaves identically, dropping trailing newlines appropriately and applying `json.loads` as before.

`draft: true`

---
*PR created automatically by Jules for task [12106825589838853216](https://jules.google.com/task/12106825589838853216) started by @tteon*