### PR TITLE
Fix contrast issues with Palantir AIP theme accent colors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+Learned: When Palantir AIP theme colors (--accent-green #3fb950 and --accent-blue #2f81f7) are used as background with #fff foreground, they do not provide sufficient contrast. The foreground color must be darker (e.g., #0d1117 / var(--bg-app)) to meet WCAG 2 AA contrast guidelines.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -321,7 +321,7 @@ body {
 .bubble.user .text {
   background: var(--accent-blue-ghost);
   border-color: rgba(47, 129, 247, 0.3);
-  color: #fff;
+  color: var(--text-main);
 }
 
 .bubble.assistant .text {
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;
@@ -603,7 +603,7 @@ textarea:focus {
 
 #resetSessionBtn:hover,
 #resetSessionBtn:focus-visible {
-  color: #fff;
+  color: var(--text-main);
 }
 
 


### PR DESCRIPTION
What:
Replaced `#fff` text color with `var(--bg-app)` and `var(--text-main)` for interactive elements using `--accent-green` and `--accent-blue` backgrounds/accents.

Why:
The Palantir AIP theme colors (`#3fb950` and `#2f81f7`) are too bright to provide sufficient contrast against a pure white (`#fff`) text foreground. This violates WCAG 2 AA contrast guidelines. Switching to the darker `--bg-app` text significantly improves legibility.

Accessibility / UX Impact:
Improves text contrast for buttons and chat bubbles, ensuring the UI remains usable for visually impaired users. Fixes illegible button texts and hover states.

Validation:
- Basic CI script `bash scripts/ci/run_basic_ci.sh` passed.
- Started the server locally and ran a Playwright script taking a screenshot. Visually verified that contrast matches expectations and button text is clearly legible.

Risks:
Very low. This strictly affects the `styles.css` file and updates the text `color` of specific `.bubble.user .text`, `.composer button`, `#ingestBtn`, `#oneClickDemoBtn`, and `#resetSessionBtn` interactive elements.

---
*PR created automatically by Jules for task [2406587313857891741](https://jules.google.com/task/2406587313857891741) started by @tteon*