### PR TITLE
perf: optimize memory overhead during file reads and json loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,5 @@
 - Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).
+
+- Replaced multiple instances of `path.read_text().splitlines()` with lazy file iteration `with path.open() as f: for raw in f:` in scripts.
+- Replaced multiple instances of `json.loads(path.read_text())` with `with path.open() as f: json.load(f)` to optimize memory usage by eliminating large intermediate string allocations, aligning with the "avoidable file I/O or JSONL overhead" priority.
+- Preserved exact original crash/exception behavior when applying file context managers, rather than silently catching JSONDecodeError.

--- a/extraction/tests/test_phase5_artifact_ontology_binding.py
+++ b/extraction/tests/test_phase5_artifact_ontology_binding.py
@@ -158,7 +158,8 @@ def test_get_semantic_artifact_legacy_unknown(tmp_path):
         base_dir=str(tmp_path),
     )
     artifact_path = sas._workspace_dir(str(tmp_path), "acme") / f"{payload['artifact_id']}.json"
-    raw = _json.loads(artifact_path.read_text())
+    with artifact_path.open() as f:
+        raw = _json.load(f)
     raw.pop("ontology_identity_hash", None)
     artifact_path.write_text(_json.dumps(raw))
 

--- a/patch_script10.py
+++ b/patch_script10.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+# Revert JSONDecodeError handling in scripts/benchmarks/okx_release_gate.py to preserve original crash behavior
+f = Path("scripts/benchmarks/okx_release_gate.py")
+content = f.read_text()
+content = content.replace(
+    '''    vertical = {}
+    if vertical_path.exists():
+        try:
+            with vertical_path.open() as f:
+                vertical = json.load(f)
+        except json.JSONDecodeError:
+            pass
+    chaos = {}
+    if chaos_path.exists():
+        try:
+            with chaos_path.open() as f:
+                chaos = json.load(f)
+        except json.JSONDecodeError:
+            pass''',
+    '''    vertical = {}
+    if vertical_path.exists():
+        with vertical_path.open() as f:
+            vertical = json.load(f)
+    chaos = {}
+    if chaos_path.exists():
+        with chaos_path.open() as f:
+            chaos = json.load(f)'''
+)
+f.write_text(content)

--- a/patch_script11.py
+++ b/patch_script11.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+for path in ["scripts/beads-path-guard.sh", "scripts/gt-doctor.sh", "scripts/task-context-trail.sh"]:
+    f = Path(path)
+    content = f.read_text()
+    content = content.replace(
+        '''            raw = raw.rstrip("\\n")
+            line = raw.strip()''',
+        '''            line = raw.strip()'''
+    )
+    content = content.replace(
+        '''            raw = raw.rstrip("\\n")
+                line = raw.strip()''',
+        '''            line = raw.strip()'''
+    )
+    f.write_text(content)

--- a/scripts/beads-path-guard.sh
+++ b/scripts/beads-path-guard.sh
@@ -84,12 +84,13 @@ REDIRECT_MARKERS = [
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 

--- a/scripts/benchmarks/customer_query_mara_live.py
+++ b/scripts/benchmarks/customer_query_mara_live.py
@@ -23,7 +23,8 @@ async def run(args: argparse.Namespace) -> dict:
             line = line.strip()
             if line:
                 rows.append(json.loads(line))
-    bulk = json.loads(args.bulk_report.read_text())
+    with args.bulk_report.open() as f:
+        bulk = json.load(f)
     available = {
         source: bool(detail.get("available"))
         for source, detail in bulk["source_details"].items()

--- a/scripts/benchmarks/emit_evaluation_telemetry.py
+++ b/scripts/benchmarks/emit_evaluation_telemetry.py
@@ -17,7 +17,8 @@ from seocho.tracing import disable_tracing, enable_tracing, flush_tracing, start
 
 
 def _load(path: Path) -> dict:
-    return json.loads(path.read_text())
+    with path.open() as f:
+        return json.load(f)
 
 
 def _require_otlp(endpoint: str) -> None:

--- a/scripts/benchmarks/okx_release_gate.py
+++ b/scripts/benchmarks/okx_release_gate.py
@@ -90,8 +90,14 @@ def main() -> None:
             "--output", str(chaos_path),
         ]
     )
-    vertical = json.loads(vertical_path.read_text()) if vertical_path.exists() else {}
-    chaos = json.loads(chaos_path.read_text()) if chaos_path.exists() else {}
+    vertical = {}
+    if vertical_path.exists():
+        with vertical_path.open() as f:
+            vertical = json.load(f)
+    chaos = {}
+    if chaos_path.exists():
+        with chaos_path.open() as f:
+            chaos = json.load(f)
     telemetry = {
         "prometheus": _healthy(args.prometheus + "/-/ready"),
         "tempo": _healthy(args.tempo + "/ready"),

--- a/scripts/gt-doctor.sh
+++ b/scripts/gt-doctor.sh
@@ -153,12 +153,13 @@ def _is_true(value: Any) -> bool:
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 
@@ -228,21 +229,22 @@ def _load_issues_from_jsonl(issues_file: Path) -> tuple[list[dict[str, Any]], in
 
     rows: list[dict[str, Any]] = []
     invalid_lines = 0
-    for line_no, raw in enumerate(issues_file.read_text().splitlines(), start=1):
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if not isinstance(parsed, dict):
-            invalid_lines += 1
-            continue
-        row = dict(parsed)
-        row["_doctor_line_no"] = line_no
-        rows.append(row)
+    with issues_file.open() as f:
+        for line_no, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if not isinstance(parsed, dict):
+                invalid_lines += 1
+                continue
+            row = dict(parsed)
+            row["_doctor_line_no"] = line_no
+            rows.append(row)
     return rows, invalid_lines, ""
 
 

--- a/scripts/profiling/bench_neo4j_driver.py
+++ b/scripts/profiling/bench_neo4j_driver.py
@@ -230,7 +230,8 @@ def run_worker(arm: str, workload: str) -> dict:
     r = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=1800)
     if r.returncode != 0:
         raise SystemExit(f"worker failed ({arm}/{workload}):\n{r.stdout}\n{r.stderr}")
-    return json.loads(out.read_text())
+    with out.open() as f:
+        return json.load(f)
 
 
 def main() -> int:

--- a/scripts/task-context-trail.sh
+++ b/scripts/task-context-trail.sh
@@ -113,17 +113,18 @@ def _load_events(path: Path, task_id: str) -> tuple[list[dict[str, Any]], int]:
         return [], 0
     events: list[dict[str, Any]] = []
     invalid_lines = 0
-    for raw in path.read_text().splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if isinstance(event, dict) and event.get("task_id") == task_id:
-            events.append(event)
+    with path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if isinstance(event, dict) and event.get("task_id") == task_id:
+                events.append(event)
     events.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("event_id", ""))))
     return events, invalid_lines
 


### PR DESCRIPTION
What
Replaced `Path.read_text().splitlines()` and `json.loads(Path.read_text())` with lazy file iteration and loading using context managers (`with Path.open() as f:`).

Why
To reduce memory overhead by avoiding loading entire files into memory at once as strings, especially for large JSON and JSONL artifacts. This aligns with the repository's priority to fix "avoidable file I/O or JSONL overhead".

Expected Impact
Lower peak memory usage when reading large artifacts and log files during local evaluation and CLI execution. Impact is primarily qualitative robustness rather than strict throughput.

Validation
Executed `bash scripts/ci/run_basic_ci.sh` to ensure no functionality is broken by the refactor. Tested script syntax explicitly.

Risks
Negligible risk. Context managers reliably handle file closing, and the semantic behavior of reading the files and parsing the JSON remains exactly the same, preserving any existing error handling (like `JSONDecodeError`).

---
*PR created automatically by Jules for task [530324881783969180](https://jules.google.com/task/530324881783969180) started by @tteon*