### PR TITLE
Fix button text contrast for accessibility

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
**What**: Changed text color on primary buttons from white to dark navy.
**Why**: The Palantir AIP theme colors (--accent-green #3fb950 and --accent-blue #2f81f7) do not provide sufficient contrast when paired with a white foreground, failing WCAG 2 AA guidelines.
**Accessibility / UX Impact**: Improves readability and accessibility for users with visual impairments by meeting contrast requirements.
**Validation**: Visually verified via playwright screenshot.
**Risks**: Minor visual change to button appearance.

---
*PR created automatically by Jules for task [10926983927274435633](https://jules.google.com/task/10926983927274435633) started by @tteon*