### PR TITLE
perf: lazy line evaluation in bash embedded python scripts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 - Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).
+- Optimized memory usage for large shell embedded python scripts by replacing path.read_text().splitlines() with lazy iteration (with open(...) as f: for line in f:)

--- a/scripts/beads-path-guard.sh
+++ b/scripts/beads-path-guard.sh
@@ -84,12 +84,13 @@ REDIRECT_MARKERS = [
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 

--- a/scripts/gt-doctor.sh
+++ b/scripts/gt-doctor.sh
@@ -153,12 +153,13 @@ def _is_true(value: Any) -> bool:
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 
@@ -228,21 +229,22 @@ def _load_issues_from_jsonl(issues_file: Path) -> tuple[list[dict[str, Any]], in
 
     rows: list[dict[str, Any]] = []
     invalid_lines = 0
-    for line_no, raw in enumerate(issues_file.read_text().splitlines(), start=1):
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if not isinstance(parsed, dict):
-            invalid_lines += 1
-            continue
-        row = dict(parsed)
-        row["_doctor_line_no"] = line_no
-        rows.append(row)
+    with issues_file.open() as f:
+        for line_no, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if not isinstance(parsed, dict):
+                invalid_lines += 1
+                continue
+            row = dict(parsed)
+            row["_doctor_line_no"] = line_no
+            rows.append(row)
     return rows, invalid_lines, ""
 
 

--- a/scripts/task-context-trail.sh
+++ b/scripts/task-context-trail.sh
@@ -113,17 +113,18 @@ def _load_events(path: Path, task_id: str) -> tuple[list[dict[str, Any]], int]:
         return [], 0
     events: list[dict[str, Any]] = []
     invalid_lines = 0
-    for raw in path.read_text().splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if isinstance(event, dict) and event.get("task_id") == task_id:
-            events.append(event)
+    with path.open() as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if isinstance(event, dict) and event.get("task_id") == task_id:
+                events.append(event)
     events.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("event_id", ""))))
     return events, invalid_lines
 


### PR DESCRIPTION
What
Replaced `path.read_text().splitlines()` with lazy line-by-line iteration (`with open(...) as f: for line in f:`) in `scripts/beads-path-guard.sh` and `scripts/gt-doctor.sh`.

Why
To avoid unnecessary file I/O overhead and optimize memory usage for processing configuration and JSONL files.

Expected Impact
Reduced memory overhead and potentially faster processing for large configuration and JSONL files.

Validation
Ran and passed `bash scripts/ci/run_basic_ci.sh`.

Risks
None, as behavior is fully preserved.

---
*PR created automatically by Jules for task [3843642881731064247](https://jules.google.com/task/3843642881731064247) started by @tteon*