### PR TITLE
Fix contrast for primary action buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Changed text color for #ingestBtn, #oneClickDemoBtn, and .composer button from #fff to var(--bg-app).
Why: Palantir AIP theme accent colors (green, blue) against white text do not meet WCAG AA contrast ratio requirements.
Accessibility / UX Impact: Ensures text is legible on primary buttons by providing sufficient contrast against accent backgrounds.
Validation: Ran basic CI and visually verified changes using Uvicorn server.
Risks: Minor visual change; no functional risks.

---
*PR created automatically by Jules for task [8704022990310990269](https://jules.google.com/task/8704022990310990269) started by @tteon*