### PR TITLE
Optimize memory usage for file loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 - Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).
+- When applying automated patch scripts that modify pure Python files (especially involving indentation or loop structures), explicitly verify the syntax using `python -m py_compile <file>` to catch `SyntaxError`s early. Do not run `py_compile` directly on shell scripts (`.sh`) that embed Python code, as the surrounding bash syntax will cause false syntax errors.

--- a/scripts/beads-path-guard.sh
+++ b/scripts/beads-path-guard.sh
@@ -84,12 +84,13 @@ REDIRECT_MARKERS = [
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            line = raw.rstrip("\n").strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 

--- a/scripts/gt-doctor.sh
+++ b/scripts/gt-doctor.sh
@@ -153,12 +153,13 @@ def _is_true(value: Any) -> bool:
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            line = raw.rstrip("\n").strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 

--- a/scripts/task-context-trail.sh
+++ b/scripts/task-context-trail.sh
@@ -113,17 +113,18 @@ def _load_events(path: Path, task_id: str) -> tuple[list[dict[str, Any]], int]:
         return [], 0
     events: list[dict[str, Any]] = []
     invalid_lines = 0
-    for raw in path.read_text().splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if isinstance(event, dict) and event.get("task_id") == task_id:
-            events.append(event)
+    with path.open() as f:
+        for raw in f:
+            line = raw.rstrip("\n").strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if isinstance(event, dict) and event.get("task_id") == task_id:
+                events.append(event)
     events.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("event_id", ""))))
     return events, invalid_lines
 


### PR DESCRIPTION
**What**
Replaced `Path.read_text().splitlines()` with a lazy file iterator (`with path.open() as f: for raw in f:`) in several maintenance scripts (`scripts/beads-path-guard.sh`, `scripts/gt-doctor.sh`, `scripts/task-context-trail.sh`) that use embedded Python code.

**Why**
Calling `read_text().splitlines()` loads the entire file into memory as a single string and then duplicates it into a list of strings. This creates avoidable JSONL and file I/O overhead. Iterating line-by-line prevents large files from causing memory spikes, specifically improving the `task-context-trail.sh` which often reads large JSONL events.

**Expected Impact**
Qualitative only: The change strictly preserves existing functionality but makes the script considerably more memory-efficient when handling very large config or event log files by streaming them lazily.

**Validation**
- `bash scripts/ci/run_basic_ci.sh` passed successfully.
- Code review validated that the logic exactly matches original loop behavior with preserved string formatting semantics, after a manual indentation fix.

**Risks**
Very low. Standard `path.open()` matches `path.read_text()` default file opening logic, and line processing behavior is kept identical via explicit line ending trimming (`raw.rstrip("\n")`).

---
*PR created automatically by Jules for task [15799096307716180170](https://jules.google.com/task/15799096307716180170) started by @tteon*