### PR TITLE
style: improve contrast of primary buttons in evaluation UI

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
### What
Changes the foreground text color of the primary action buttons (`#ingestBtn`, `#oneClickDemoBtn`, and `.composer button`) from white (`#fff`) to dark gray (`#0d1117`). Also creates and updates `.jules/palette.md` to document this design rule.

Modified files:
- `evaluation/static/styles.css`
- `.jules/palette.md`

### Why
The Palantir AIP theme colors used for accents (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). This change ensures the text remains easily readable and accessible.

### Accessibility / UX Impact
Improves text legibility on key interactive elements, satisfying WCAG 2 AA contrast guidelines. Users will have an easier time reading the text on the "Ingest Raw", "Load Sample & Ask", and "Execute Pipeline" buttons.

### Validation
- Started the `evaluation.server:app` locally on port 8501.
- Captured a Playwright screenshot of the Workflow Console to visually verify the text contrast on the updated buttons.
- Ran `bash scripts/ci/run_basic_ci.sh` which passed successfully.

### Risks
Extremely low risk. This is a targeted CSS change confined only to the specific button IDs/classes in the evaluation UI.

---
*PR created automatically by Jules for task [159510296248288852](https://jules.google.com/task/159510296248288852) started by @tteon*