### PR TITLE
Fix missing workspace isolation in execute_cypher tool

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,7 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(cypher, params=params, database=database, workspace_id=workspace_id, enforce_workspace_filter=True)
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
## Severity
High

## Vulnerability
The `execute_cypher` tool generated by `make_execute_cypher_tool` in `src/seocho/tools.py` bypasses the `QueryProxy` and directly calls `graph_store.query()` without passing `workspace_id` or `enforce_workspace_filter=True`. This means the query runs without tenant isolation boundaries.

## Impact
An agent generating raw Cypher through this tool could intentionally or accidentally read or modify nodes and relationships belonging to other workspaces, completely breaking multi-tenant isolation.

## Fix
Updated `make_execute_cypher_tool` to pass `workspace_id=workspace_id` and `enforce_workspace_filter=True` to the underlying `graph_store.query()` call, mirroring the exact security controls enforced by `QueryProxy`.

## Validation
- Verified via `git diff` that the correct parameters were added.
- Ran `python -m py_compile src/seocho/tools.py` to ensure syntax is valid.
- Executed `bash scripts/ci/run_basic_ci.sh` locally and all 661 tests passed without any regressions.

## Risks
If any test or agent relied on the broken behavior (querying across workspaces), it will now rightfully fail with a `WorkspaceFilterMissingError` or return filtered results. There is minimal risk of breaking valid tenant-bound workloads.

---
*PR created automatically by Jules for task [369315617704736987](https://jules.google.com/task/369315617704736987) started by @tteon*