### PR TITLE
Enforce workspace filter on dynamic graph queries

### DIFF
--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1457,7 +1457,13 @@ class Seocho:
         """
         if not self._local_mode:
             raise RuntimeError("query() requires local engine mode (ontology + graph_store + llm)")
-        return self.graph_store.query(cypher, params=params, database=database)
+        return self.graph_store.query(
+            cypher,
+            params=params,
+            database=database,
+            workspace_id=self.workspace_id,
+            enforce_workspace_filter=True,
+        )
 
     # ------------------------------------------------------------------
     # Agent-level session API

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -696,7 +696,7 @@ class _LocalEngine:
             llm=self.llm,
             workspace_id=self.workspace_id,
         )
-        executor = GraphQueryExecutor(graph_store=self.graph_store, database=database)
+        executor = GraphQueryExecutor(graph_store=self.graph_store, database=database, workspace_id=self.workspace_id)
         answer_synthesizer = QueryAnswerSynthesizer(
             query_strategy=self._query,
             llm=self.llm,
@@ -1099,6 +1099,7 @@ class _LocalEngine:
         active_executor = executor or GraphQueryExecutor(
             graph_store=self.graph_store,
             database=database,
+            workspace_id=self.workspace_id,
         )
         execution = active_executor.execute(QueryPlan(question="", cypher=cypher, params=params))
         return execution.records, execution.error
@@ -1339,6 +1340,8 @@ class _LocalEngine:
                 "LIMIT $k",
                 params={"workspace_id": self.workspace_id, "kws": kws, "k": 3},
                 database=database,
+                workspace_id=self.workspace_id,
+                enforce_workspace_filter=True,
             )
         except Exception:
             return ""

--- a/src/seocho/ontology_context.py
+++ b/src/seocho/ontology_context.py
@@ -640,6 +640,8 @@ def query_ontology_context_mismatch(
             build_ontology_context_summary_query(),
             params={"workspace_id": workspace_id},
             database=database,
+            workspace_id=workspace_id,
+            enforce_workspace_filter=True,
         )
     except Exception as exc:
         result = assess_ontology_context_mismatch(active_context, [])

--- a/src/seocho/query/arbiter.py
+++ b/src/seocho/query/arbiter.py
@@ -82,11 +82,13 @@ def make_graph_probe(graph_store: Any, database: str = "neo4j",
             rows = graph_store.query(
                 "MATCH (c:Company {cik: $cik})-[:HAS_OBSERVATION]->"
                 "(o:Observation {concept_id: $concept_id}) "
-                "WHERE ($ws = '' OR o.workspace_id = $ws) "
+                "WHERE ($ws = '' OR o.workspace_id = $ws) AND o._workspace_id = $workspace_id AND c._workspace_id = $workspace_id "
                 "RETURN collect(DISTINCT o.period_key) AS periods",
                 params={"cik": slots.entity_cik, "concept_id": slots.concept_id,
-                        "ws": workspace_id},
+                        "ws": workspace_id, "workspace_id": workspace_id},
                 database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
             )
         except Exception:
             return GraphProbe(entity_has_concept=False)

--- a/src/seocho/query/executor.py
+++ b/src/seocho/query/executor.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 class GraphQueryExecutor:
     """Canonical graph query executor for local SDK and adapter runtimes."""
 
-    def __init__(self, *, graph_store: Any, database: str) -> None:
+    def __init__(self, *, graph_store: Any, database: str, workspace_id: str = "default") -> None:
         self.graph_store = graph_store
         self.database = database
+        self.workspace_id = workspace_id
 
     def execute(self, plan: QueryPlan) -> QueryExecution:
         try:
@@ -21,6 +22,8 @@ class GraphQueryExecutor:
                 plan.cypher,
                 params=plan.params,
                 database=self.database,
+                workspace_id=self.workspace_id,
+                enforce_workspace_filter=True,
             )
             return QueryExecution(
                 cypher=plan.cypher,

--- a/src/seocho/query/semantic_query.py
+++ b/src/seocho/query/semantic_query.py
@@ -110,7 +110,13 @@ def semantic_answer(
 
     cypher, params = compile_observation_lookup(slots, workspace_id=workspace_id)
     try:
-        rows = graph_store.query(cypher, params=params, database=database) or []
+        rows = graph_store.query(
+            cypher,
+            params=params,
+            database=database,
+            workspace_id=workspace_id,
+            enforce_workspace_filter=True,
+        ) or []
     except Exception:
         rows = []
     if not rows:

--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -731,9 +731,12 @@ class Session:
             try:
                 sid = memory.memory_id
                 rows = self.graph_store.query(
-                    "MATCH (n) WHERE n._source_id = $sid "
+                    "MATCH (n) WHERE n._source_id = $sid AND n._workspace_id = $workspace_id "
                     "RETURN labels(n)[0] AS label, n.name AS name, properties(n) AS props",
-                    params={"sid": sid}, database=database,
+                    params={"sid": sid, "workspace_id": self.workspace_id},
+                    database=database,
+                    workspace_id=self.workspace_id,
+                    enforce_workspace_filter=True,
                 )
                 for row in rows:
                     extracted_nodes.append({

--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),

--- a/tests/seocho/test_cypher_builder.py
+++ b/tests/seocho/test_cypher_builder.py
@@ -245,7 +245,7 @@ class _FakeGraphStore:
     def get_schema(self, *, database: str = "neo4j") -> dict:
         return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED", "reported"]}
 
-    def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+    def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
         self.calls.append({"cypher": cypher, "params": dict(params or {}), "database": database})
         return [
             {
@@ -312,7 +312,7 @@ def test_local_engine_relationship_answer_includes_titles_from_target_properties
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "Person"], "relationship_types": ["EMPLOYS"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "source": "Alphabet Inc.",
@@ -363,7 +363,7 @@ def test_local_engine_legal_relationship_answer_lists_issues() -> None:
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "LegalIssue"], "relationship_types": ["INVOLVED_IN"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "source": "Microsoft",
@@ -435,7 +435,7 @@ def test_local_engine_legal_neighbors_answer_keeps_specific_issue_sentences() ->
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "LegalIssue"], "relationship_types": ["INVOLVED_IN"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "entity": "Microsoft",
@@ -472,7 +472,7 @@ def test_local_engine_financial_lookup_compares_multiple_years_without_currency_
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "company": "Tesla",
@@ -534,7 +534,7 @@ def test_local_engine_financial_lookup_explains_nvidia_gross_margin_expansion() 
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "company": "NVIDIA",

--- a/tests/seocho/test_ontology_context.py
+++ b/tests/seocho/test_ontology_context.py
@@ -83,7 +83,7 @@ class _MismatchGraphStore(_FakeGraphStore):
         super().__init__()
         self.queries = []
 
-    def query(self, cypher: str, *, params=None, database="neo4j"):  # noqa: ANN001
+    def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
         self.queries.append(cypher)
         return [
             {

--- a/tests/seocho/test_session_agent.py
+++ b/tests/seocho/test_session_agent.py
@@ -117,7 +117,7 @@ class FakeGraphStore:
         })
         return {"nodes_created": len(nodes), "relationships_created": len(relationships), "errors": []}
 
-    def query(self, cypher: str, *, params=None, database="neo4j") -> List[Dict[str, Any]]:
+    def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):
         self.queries.append(cypher)
         return [{"name": "TestCorp", "industry": "Tech"}]
 


### PR DESCRIPTION
**Severity:** High (potential for cross-tenant data access).

**Vulnerability:**
Several core SDK routines, query proxies, and local tools performed dynamic Cypher execution via `graph_store.query()` without enforcing tenant isolation via `workspace_id` parameters, meaning under certain conditions, cross-workspace nodes could be leaked to an active agent or runtime layer. 

**Impact:**
A downstream agent or semantic layer might query or synthesize answers using nodes from another `workspace_id`. 

**Fix:**
Propagated the `enforce_workspace_filter=True` and `workspace_id` kwarg to all dynamic graph executions in `src/seocho/tools.py`, `src/seocho/session.py`, `src/seocho/ontology_context.py`, `src/seocho/local_engine.py`, `src/seocho/client.py`, `src/seocho/query/semantic_query.py`, `src/seocho/query/arbiter.py`, and `src/seocho/query/executor.py`. `GraphQueryExecutor` was updated to accept `workspace_id` on init. Test mock objects were also updated to consume the extra kwargs seamlessly.

**Validation:**
Verified via `bash scripts/ci/run_basic_ci.sh`. All 600+ tests pass with no regressions on existing Cypher extraction paths.

**Risks:**
Low. The changes strictly enhance isolation for existing calls. If a custom `GraphStore` subclass exists outside the SDK that doesn't respect the interface kwargs, it may raise a `TypeError`, but this keeps it fail-safe.

---
*PR created automatically by Jules for task [6321360602265583236](https://jules.google.com/task/6321360602265583236) started by @tteon*