### PR TITLE
Improve contrast for accent buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Change text color of accent buttons to #0d1117. Why: Ensure contrast ratios on button backgrounds meet accessibility guidelines. Accessibility / UX Impact: Better readability. Validation: Verified visual appearance in local uvicorn frontend. Risks: None.

---
*PR created automatically by Jules for task [5861850496596953180](https://jules.google.com/task/5861850496596953180) started by @tteon*