### PR TITLE
perf: optimize JSONL file reads in scripts

### DIFF
--- a/scripts/beads-path-guard.sh
+++ b/scripts/beads-path-guard.sh
@@ -84,12 +84,14 @@ REDIRECT_MARKERS = [
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            raw = raw.rstrip("\n")
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 

--- a/scripts/gt-doctor.sh
+++ b/scripts/gt-doctor.sh
@@ -153,12 +153,14 @@ def _is_true(value: Any) -> bool:
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with config_path.open() as f:
+        for raw in f:
+            raw = raw.rstrip("\n")
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 
@@ -228,21 +230,22 @@ def _load_issues_from_jsonl(issues_file: Path) -> tuple[list[dict[str, Any]], in
 
     rows: list[dict[str, Any]] = []
     invalid_lines = 0
-    for line_no, raw in enumerate(issues_file.read_text().splitlines(), start=1):
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if not isinstance(parsed, dict):
-            invalid_lines += 1
-            continue
-        row = dict(parsed)
-        row["_doctor_line_no"] = line_no
-        rows.append(row)
+    with issues_file.open() as f:
+        for line_no, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if not isinstance(parsed, dict):
+                invalid_lines += 1
+                continue
+            row = dict(parsed)
+            row["_doctor_line_no"] = line_no
+            rows.append(row)
     return rows, invalid_lines, ""
 
 

--- a/scripts/task-context-trail.sh
+++ b/scripts/task-context-trail.sh
@@ -113,17 +113,19 @@ def _load_events(path: Path, task_id: str) -> tuple[list[dict[str, Any]], int]:
         return [], 0
     events: list[dict[str, Any]] = []
     invalid_lines = 0
-    for raw in path.read_text().splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if isinstance(event, dict) and event.get("task_id") == task_id:
-            events.append(event)
+    with path.open() as f:
+        for raw in f:
+            raw = raw.rstrip("\n")
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if isinstance(event, dict) and event.get("task_id") == task_id:
+                events.append(event)
     events.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("event_id", ""))))
     return events, invalid_lines
 


### PR DESCRIPTION
What: Replaced `read_text().splitlines()` with lazy file iteration in `scripts/beads-path-guard.sh`, `scripts/gt-doctor.sh`, and `scripts/task-context-trail.sh`.
Why: To reduce memory overhead for parsing large issues and tracing JSONL files, matching priority guidelines.
Expected Impact: O(1) memory instead of O(N) memory scaling for lines in file. No behavior changes.
Validation: Ran `bash scripts/ci/run_basic_ci.sh` and it passed.
Risks: Minor edge case variations with trailing whitespaces depending on `splitlines()` differences compared to `rstrip()`, but strip checks already existed to resolve them.

---
*PR created automatically by Jules for task [18173249724488132526](https://jules.google.com/task/18173249724488132526) started by @tteon*