### PR TITLE
fix(ui): improve button text color contrast in evaluation console

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+- The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). To meet WCAG 2 AA contrast guidelines, text on backgrounds using these colors must use a darker shade (e.g., `#0d1117` or `#000000`).

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
### What
Updated the text color on primary action buttons (Ingest Raw, Load Sample & Ask, Execute Pipeline) in the evaluation console UI from white (`#fff`) to dark navy (`#0d1117`).

### Why
The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`#ffffff`), failing WCAG 2 AA guidelines for legibility.

### Accessibility / UX Impact
Improves text readability and ensures accessibility compliance for users with visual impairments by significantly increasing the contrast ratio between the button backgrounds and the foreground text.

### Validation
- Started local `uvicorn` evaluation server.
- Wrote and executed Playwright script to navigate to `http://localhost:8501` and take a screenshot.
- Visually verified via screenshot that the text color on the targeted buttons was correctly updated and legible.
- Ran `bash scripts/ci/run_basic_ci.sh`, all tests passed.
- Added entry to `.jules/palette.md` noting the contrast limitations.

### Risks
Minimal. The change strictly targets the text color property of specific primary buttons in the evaluation console via their CSS selectors without affecting other layouts or components.

---
*PR created automatically by Jules for task [9161519131962810636](https://jules.google.com/task/9161519131962810636) started by @tteon*