### PR TITLE
[Draft] Fix button color contrast for Palantir AIP theme

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+Palantir AIP theme colors require a dark foreground (#0d1117 or #000000) for WCAG 2 AA contrast compliance

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
## What
Changes the text color of the ingest and demo buttons (`#ingestBtn`, `#oneClickDemoBtn`) as well as the `.composer button` from white (`#fff`) to dark gray (`#0d1117`).

## Why
The Palantir AIP theme uses an accent green (`#3fb950`) and accent blue (`#2f81f7`) for the background color of primary buttons in the evaluation console. The existing white text on these bright accent colors failed WCAG 2 AA contrast ratio guidelines, making the buttons difficult to read.

## Accessibility / UX Impact
- **Impact:** Ensures text contrast is sufficient for visually impaired users.
- **Affected Surfaces:** The "Ingest Raw", "Load Sample & Ask", and "Execute Pipeline" buttons in the evaluation console.

## Validation
- Verified visually using a Playwright script to run the frontend locally, rendering all three buttons in their updated states.
- Ran the basic CI test script (`bash scripts/ci/run_basic_ci.sh`) to ensure no regressions were introduced.

## Risks
- Very low. The change is isolated strictly to the CSS file (`evaluation/static/styles.css`).
- Added a note to `.jules/palette.md` to ensure future design decisions use a dark foreground when paired with these Palantir AIP accent colors.

---
*PR created automatically by Jules for task [9827863901999973535](https://jules.google.com/task/9827863901999973535) started by @tteon*