### PR TITLE
fix: enforce workspace filter in execute_cypher tool

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,7 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(cypher, params=params, database=database, workspace_id=workspace_id, enforce_workspace_filter=True)
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** The `execute_cypher` agent tool executes arbitrary, dynamic Cypher queries via `graph_store.query()` without enforcing tenant isolation filters.
**Impact:** A compromised or malicious agent could construct Cypher queries that access or modify data belonging to other workspaces, completely bypassing the repository's tenant isolation (`workspace_id`) controls.
**Fix:** Explicitly pass `workspace_id=workspace_id` and `enforce_workspace_filter=True` to `graph_store.query()` inside `make_execute_cypher_tool` in `src/seocho/tools.py`. This forces the query executor to validate that the query correctly scopes to the current `$workspace_id`.
**Validation:** Validated locally by running `bash scripts/ci/run_basic_ci.sh`, confirming no regressions.
**Risks:** Low. The `execute_cypher` tool is designed for scoped operation within a session. If any existing legitimate agent queries omit the workspace filter, they will now be safely rejected rather than executing broadly.

---
*PR created automatically by Jules for task [5718300135095956078](https://jules.google.com/task/5718300135095956078) started by @tteon*