### PR TITLE
[Draft] Fix contrast for accent colors in UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,2 @@
+# Palette UX/A11y Learnings
+The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). To meet WCAG 2 AA contrast guidelines, text on backgrounds using these colors must use a darker shade (e.g., `#0d1117` or `#000000`). Also, for ghost backgrounds like `--accent-blue-ghost`, use `--text-main` instead of white.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -321,7 +321,7 @@ body {
 .bubble.user .text {
   background: var(--accent-blue-ghost);
   border-color: rgba(47, 129, 247, 0.3);
-  color: #fff;
+  color: var(--text-main);
 }
 
 .bubble.assistant .text {
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Changed text color on accent-green and accent-blue buttons and chat bubbles from #fff to var(--bg-app) and var(--text-main) for better contrast. Why: The Palantir AIP theme accent colors did not meet WCAG 2 AA contrast guidelines with a white foreground. Accessibility / UX Impact: Improved readability. Validation: Checked visually with Playwright and ran basic CI tests. Risks: Minimal, CSS only.

---
*PR created automatically by Jules for task [10823013424150967650](https://jules.google.com/task/10823013424150967650) started by @tteon*