### PR TITLE
[Draft] chore(perf): optimize JSONL and config load I/O

### DIFF
--- a/scripts/beads-path-guard.sh
+++ b/scripts/beads-path-guard.sh
@@ -84,12 +84,13 @@ REDIRECT_MARKERS = [
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with open(config_path, encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 

--- a/scripts/gt-doctor.sh
+++ b/scripts/gt-doctor.sh
@@ -153,12 +153,13 @@ def _is_true(value: Any) -> bool:
 def _read_redirect_from_config(config_path: Path) -> str:
     if not config_path.exists():
         return ""
-    for raw in config_path.read_text().splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("redirect:"):
-            return line.split(":", 1)[1].strip().strip("'\"")
+    with open(config_path, encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("redirect:"):
+                return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 
 
@@ -228,21 +229,22 @@ def _load_issues_from_jsonl(issues_file: Path) -> tuple[list[dict[str, Any]], in
 
     rows: list[dict[str, Any]] = []
     invalid_lines = 0
-    for line_no, raw in enumerate(issues_file.read_text().splitlines(), start=1):
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if not isinstance(parsed, dict):
-            invalid_lines += 1
-            continue
-        row = dict(parsed)
-        row["_doctor_line_no"] = line_no
-        rows.append(row)
+    with open(issues_file, encoding="utf-8") as f:
+        for line_no, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if not isinstance(parsed, dict):
+                invalid_lines += 1
+                continue
+            row = dict(parsed)
+            row["_doctor_line_no"] = line_no
+            rows.append(row)
     return rows, invalid_lines, ""
 
 

--- a/scripts/task-context-trail.sh
+++ b/scripts/task-context-trail.sh
@@ -113,17 +113,18 @@ def _load_events(path: Path, task_id: str) -> tuple[list[dict[str, Any]], int]:
         return [], 0
     events: list[dict[str, Any]] = []
     invalid_lines = 0
-    for raw in path.read_text().splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_lines += 1
-            continue
-        if isinstance(event, dict) and event.get("task_id") == task_id:
-            events.append(event)
+    with open(path, encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                continue
+            if isinstance(event, dict) and event.get("task_id") == task_id:
+                events.append(event)
     events.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("event_id", ""))))
     return events, invalid_lines
 


### PR DESCRIPTION
### What
Replaces `path.read_text().splitlines()` with lazy file iteration `with open(path) as f: for raw in f:` across several utility scripts.

### Why
Using `read_text().splitlines()` loads the entire file into memory as a giant string, and then allocates a new massive list of strings. For large JSONL trace files (e.g. in `task-context-trail.sh` or `gt-doctor.sh`), this causes unnecessary memory spikes and slow startup times. Streaming the file line-by-line via an iterator is a classic, safe, and maintainable I/O optimization. 

### Expected Impact
Qualitative reduction in memory overhead and faster execution times for large artifact parsing, especially in local CI/utility scripts.

### Validation
Ran the core CI suite:
`uv pip install -e .[ci,local] && bash scripts/ci/run_basic_ci.sh`
All tests passed.

### Risks
Extremely low. Context managers (`with open(...)`) are used correctly to ensure safe file closure, and `encoding="utf-8"` is explicitly specified to prevent platform-specific encoding drifts.

### Modified Files
- `scripts/beads-path-guard.sh`
- `scripts/gt-doctor.sh`
- `scripts/task-context-trail.sh`

---
*PR created automatically by Jules for task [15000220362907037886](https://jules.google.com/task/15000220362907037886) started by @tteon*