### PR TITLE
[Draft] fix(a11y): Improve contrast of accent-colored buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,2 @@
+
+Palantir AIP theme colors (--accent-green and --accent-blue) lack sufficient contrast with a white foreground (#fff). Ensure text on these backgrounds uses a darker shade like #0d1117 to meet WCAG 2 AA guidelines.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-app);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
**What**
Changes the text color of accent-colored buttons (`#ingestBtn`, `#oneClickDemoBtn`, and `.composer button`) in the evaluation UI from white (`#fff`) to the dark app background color (`var(--bg-app)`).
Also logs Palantir AIP theme color contrast learnings to `.jules/palette.md`.

**Why**
The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) lack sufficient contrast when paired with a white foreground (`#fff`). This creates an accessibility issue for visually impaired users. Using a darker shade like `#0d1117` (`var(--bg-app)`) ensures the text meets WCAG 2 AA contrast guidelines.

**Accessibility / UX Impact**
Improves readability and accessibility of key primary actions in the evaluation console UI, complying with WCAG contrast requirements without fundamentally altering the theme structure.

**Validation**
- Spun up the local Uvicorn server (`evaluation.server:app`).
- Wrote and executed a Playwright script to verify the console loads successfully and visual text contrast on the buttons is improved.
- Ran `bash scripts/ci/run_basic_ci.sh` locally; all tests passed.
- Successfully verified changes via screenshot inspection.

**Risks**
Extremely low risk. The change is scoped strictly to CSS properties on specific button elements. No runtime, semantic retrieval, or multi-agent backend logic is impacted.

---
*PR created automatically by Jules for task [6691733230187766100](https://jules.google.com/task/6691733230187766100) started by @tteon*