### PR TITLE
Enforce workspace filters on internal graph_store.query calls

### DIFF
--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1457,7 +1457,13 @@ class Seocho:
         """
         if not self._local_mode:
             raise RuntimeError("query() requires local engine mode (ontology + graph_store + llm)")
-        return self.graph_store.query(cypher, params=params, database=database)
+        return self.graph_store.query(
+            cypher,
+            params=params,
+            database=database,
+            workspace_id=self.workspace_id,
+            enforce_workspace_filter=True,
+        )
 
     # ------------------------------------------------------------------
     # Agent-level session API

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -696,7 +696,7 @@ class _LocalEngine:
             llm=self.llm,
             workspace_id=self.workspace_id,
         )
-        executor = GraphQueryExecutor(graph_store=self.graph_store, database=database)
+        executor = GraphQueryExecutor(graph_store=self.graph_store, database=database, workspace_id=self.workspace_id)
         answer_synthesizer = QueryAnswerSynthesizer(
             query_strategy=self._query,
             llm=self.llm,
@@ -1099,6 +1099,7 @@ class _LocalEngine:
         active_executor = executor or GraphQueryExecutor(
             graph_store=self.graph_store,
             database=database,
+            workspace_id=self.workspace_id,
         )
         execution = active_executor.execute(QueryPlan(question="", cypher=cypher, params=params))
         return execution.records, execution.error

--- a/src/seocho/ontology.py
+++ b/src/seocho/ontology.py
@@ -2512,6 +2512,7 @@ class Ontology:
         graph_store: Any,
         *,
         database: str = "neo4j",
+        workspace_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Compute ontology coverage statistics against a live graph.
 
@@ -2547,7 +2548,10 @@ class Ontology:
                 for label in chunk
             ])
             try:
-                results = graph_store.query(query, database=database)
+                if workspace_id:
+                    results = graph_store.query(query, database=database, workspace_id=workspace_id, enforce_workspace_filter=True)
+                else:
+                    results = graph_store.query(query, database=database)
                 counts = {r["element"]: int(r["cnt"]) for r in results}
             except Exception:
                 counts = {}
@@ -2557,10 +2561,18 @@ class Ontology:
                     count = counts[label]
                 else:
                     try:
-                        result = graph_store.query(
-                            f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
-                            database=database,
-                        )
+                        if workspace_id:
+                            result = graph_store.query(
+                                f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
+                                database=database,
+                                workspace_id=workspace_id,
+                                enforce_workspace_filter=True,
+                            )
+                        else:
+                            result = graph_store.query(
+                                f"MATCH (n:`{label}`) RETURN count(n) AS cnt",
+                                database=database,
+                            )
                         count = int(result[0]["cnt"]) if result else 0
                     except Exception:
                         count = 0
@@ -2581,7 +2593,10 @@ class Ontology:
                 for rtype in chunk
             ])
             try:
-                results = graph_store.query(query, database=database)
+                if workspace_id:
+                    results = graph_store.query(query, database=database, workspace_id=workspace_id, enforce_workspace_filter=True)
+                else:
+                    results = graph_store.query(query, database=database)
                 counts = {r["element"]: int(r["cnt"]) for r in results}
             except Exception:
                 counts = {}
@@ -2591,10 +2606,18 @@ class Ontology:
                     count = counts[rtype]
                 else:
                     try:
-                        result = graph_store.query(
-                            f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
-                            database=database,
-                        )
+                        if workspace_id:
+                            result = graph_store.query(
+                                f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
+                                database=database,
+                                workspace_id=workspace_id,
+                                enforce_workspace_filter=True,
+                            )
+                        else:
+                            result = graph_store.query(
+                                f"MATCH ()-[r:`{rtype}`]->() RETURN count(r) AS cnt",
+                                database=database,
+                            )
                         count = int(result[0]["cnt"]) if result else 0
                     except Exception:
                         count = 0

--- a/src/seocho/ontology_context.py
+++ b/src/seocho/ontology_context.py
@@ -640,6 +640,8 @@ def query_ontology_context_mismatch(
             build_ontology_context_summary_query(),
             params={"workspace_id": workspace_id},
             database=database,
+            workspace_id=workspace_id,
+            enforce_workspace_filter=True,
         )
     except Exception as exc:
         result = assess_ontology_context_mismatch(active_context, [])

--- a/src/seocho/query/arbiter.py
+++ b/src/seocho/query/arbiter.py
@@ -87,6 +87,8 @@ def make_graph_probe(graph_store: Any, database: str = "neo4j",
                 params={"cik": slots.entity_cik, "concept_id": slots.concept_id,
                         "ws": workspace_id},
                 database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
             )
         except Exception:
             return GraphProbe(entity_has_concept=False)

--- a/src/seocho/query/executor.py
+++ b/src/seocho/query/executor.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 class GraphQueryExecutor:
     """Canonical graph query executor for local SDK and adapter runtimes."""
 
-    def __init__(self, *, graph_store: Any, database: str) -> None:
+    def __init__(self, *, graph_store: Any, database: str, workspace_id: str = "default") -> None:
         self.graph_store = graph_store
         self.database = database
+        self.workspace_id = workspace_id
 
     def execute(self, plan: QueryPlan) -> QueryExecution:
         try:
@@ -21,6 +22,8 @@ class GraphQueryExecutor:
                 plan.cypher,
                 params=plan.params,
                 database=self.database,
+                workspace_id=self.workspace_id,
+                enforce_workspace_filter=True,
             )
             return QueryExecution(
                 cypher=plan.cypher,

--- a/src/seocho/query/semantic_query.py
+++ b/src/seocho/query/semantic_query.py
@@ -110,7 +110,13 @@ def semantic_answer(
 
     cypher, params = compile_observation_lookup(slots, workspace_id=workspace_id)
     try:
-        rows = graph_store.query(cypher, params=params, database=database) or []
+        rows = graph_store.query(
+            cypher,
+            params=params,
+            database=database,
+            workspace_id=workspace_id,
+            enforce_workspace_filter=True,
+        ) or []
     except Exception:
         rows = []
     if not rows:

--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -734,6 +734,8 @@ class Session:
                     "MATCH (n) WHERE n._source_id = $sid "
                     "RETURN labels(n)[0] AS label, n.name AS name, properties(n) AS props",
                     params={"sid": sid}, database=database,
+                    workspace_id=self.workspace_id,
+                    enforce_workspace_filter=True,
                 )
                 for row in rows:
                     extracted_nodes.append({

--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),

--- a/tests/seocho/test_cypher_builder.py
+++ b/tests/seocho/test_cypher_builder.py
@@ -245,7 +245,7 @@ class _FakeGraphStore:
     def get_schema(self, *, database: str = "neo4j") -> dict:
         return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED", "reported"]}
 
-    def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+    def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
         self.calls.append({"cypher": cypher, "params": dict(params or {}), "database": database})
         return [
             {
@@ -312,7 +312,7 @@ def test_local_engine_relationship_answer_includes_titles_from_target_properties
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "Person"], "relationship_types": ["EMPLOYS"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "source": "Alphabet Inc.",
@@ -363,7 +363,7 @@ def test_local_engine_legal_relationship_answer_lists_issues() -> None:
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "LegalIssue"], "relationship_types": ["INVOLVED_IN"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "source": "Microsoft",
@@ -435,7 +435,7 @@ def test_local_engine_legal_neighbors_answer_keeps_specific_issue_sentences() ->
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "LegalIssue"], "relationship_types": ["INVOLVED_IN"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "entity": "Microsoft",
@@ -472,7 +472,7 @@ def test_local_engine_financial_lookup_compares_multiple_years_without_currency_
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "company": "Tesla",
@@ -534,7 +534,7 @@ def test_local_engine_financial_lookup_explains_nvidia_gross_margin_expansion() 
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "company": "NVIDIA",

--- a/tests/seocho/test_ontology_context.py
+++ b/tests/seocho/test_ontology_context.py
@@ -83,7 +83,7 @@ class _MismatchGraphStore(_FakeGraphStore):
         super().__init__()
         self.queries = []
 
-    def query(self, cypher: str, *, params=None, database="neo4j"):  # noqa: ANN001
+    def query(self, cypher: str, *, params=None, database="neo4j", **kwargs):  # noqa: ANN001
         self.queries.append(cypher)
         return [
             {

--- a/tests/seocho/test_session_agent.py
+++ b/tests/seocho/test_session_agent.py
@@ -117,7 +117,7 @@ class FakeGraphStore:
         })
         return {"nodes_created": len(nodes), "relationships_created": len(relationships), "errors": []}
 
-    def query(self, cypher: str, *, params=None, database="neo4j") -> List[Dict[str, Any]]:
+    def query(self, cypher: str, *, params=None, database="neo4j", **kwargs) -> List[Dict[str, Any]]:
         self.queries.append(cypher)
         return [{"name": "TestCorp", "industry": "Tech"}]
 


### PR DESCRIPTION
Severity: High
Vulnerability: `graph_store.query()` calls from various internal components bypass tenant-isolation by not enforcing the `workspace_id` filter.
Impact: In multi-tenant environments, queries could fetch cross-tenant data.
Fix: Thread `workspace_id` and explicitly set `enforce_workspace_filter=True` across `src/seocho/client.py`, `src/seocho/local_engine.py`, `src/seocho/ontology.py`, `src/seocho/ontology_context.py`, `src/seocho/query/arbiter.py`, `src/seocho/query/executor.py`, `src/seocho/query/semantic_query.py`, `src/seocho/session.py`, and `src/seocho/tools.py` when calling `graph_store.query()`. Additionally, updated dummy store `query` definitions in `tests/seocho/test_cypher_builder.py`, `tests/seocho/test_ontology_context.py`, and `tests/seocho/test_session_agent.py` to correctly accept arbitrary keyword arguments like `workspace_id` to pass testing.
Validation: Verified tests run using `bash scripts/ci/run_basic_ci.sh`.
Risks: Bounding this to explicit queries ensures the data layer properly scopes multi-tenant workloads. Test updates correctly reflect the required signature.

---
*PR created automatically by Jules for task [14568487883025112307](https://jules.google.com/task/14568487883025112307) started by @tteon*