### PR TITLE
[Draft] Optimize JSONL read

### DIFF
--- a/scripts/benchmarks/finder_full_corpus_profile.py
+++ b/scripts/benchmarks/finder_full_corpus_profile.py
@@ -50,11 +50,13 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
     jp = Path(jsonl_path); jp.parent.mkdir(parents=True, exist_ok=True)
     done_ids = set()
     if resume and jp.exists():
-        for line in jp.read_text(encoding="utf-8").splitlines():
-            try:
-                done_ids.add(json.loads(line)["id"])
-            except Exception:
-                pass
+        with jp.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip('\n')
+                try:
+                    done_ids.add(json.loads(line)["id"])
+                except Exception:
+                    pass
     docs = []
     for _, row in df.iterrows():
         _id = str(row["_id"])
@@ -96,14 +98,16 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
 def build_profile_from_jsonl(jsonl_path):
     from collections import Counter
     freqs = Counter(); ndoc = 0
-    for line in Path(jsonl_path).read_text(encoding="utf-8").splitlines():
-        try:
-            rec = json.loads(line)
-        except Exception:
-            continue
-        ndoc += 1
-        for l in rec.get("labels", []):
-            freqs[l] += 1
+    with Path(jsonl_path).open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip('\n')
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            ndoc += 1
+            for l in rec.get("labels", []):
+                freqs[l] += 1
     return dict(freqs), ndoc
 
 


### PR DESCRIPTION
### What
Replaced inline `Path.read_text().splitlines()` with lazy file iteration (`with path.open() as f: for line in f:`) when parsing JSONL files in `scripts/benchmarks/finder_full_corpus_profile.py`. 

### Why
`Path.read_text().splitlines()` reads the entire JSONL file into memory at once as a single string, and then allocates a massive list of strings. For large JSONL corpus files, this creates a severe and entirely avoidable memory overhead (O(N) peak memory footprint instead of O(1)). Using an explicit loop and context manager allows line-by-line processing, effectively addressing one of the core repository performance priorities ("avoidable file I/O or JSONL overhead").

### Expected Impact
Greatly reduced peak memory footprint and elimination of unnecessary large-scale memory allocations when processing large JSONL files during benchmarks/corpus profiling. This optimization is primarily targeted at mitigating OOM errors on large datasets (qualitative impact).

### Validation
- Validated syntax with `python -m py_compile scripts/benchmarks/finder_full_corpus_profile.py`.
- Successfully ran the core validation script (`uv pip install -e .[ci,local] && bash scripts/ci/run_basic_ci.sh`) passing all 661 tests.
- Confirmed the behavior remains identical because `open("r")` defaults to universal newlines, and stripping trailing newlines `rstrip('\n')` cleanly simulates the behavior of `splitlines()` for each line, and `json.loads` is resilient to remaining whitespace.

### Risks
Minimal. File handling translates cleanly to lazy streaming, and exceptions are gracefully handled within the inner loop exactly as before.

### Modified Files
- `scripts/benchmarks/finder_full_corpus_profile.py`

---
*PR created automatically by Jules for task [6659986581680369038](https://jules.google.com/task/6659986581680369038) started by @tteon*