### PR TITLE
[Draft] fix: improve button contrast for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+# Palette - UX and Accessibility Log
+
+- The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). To meet WCAG 2 AA contrast guidelines, text on backgrounds using these colors must use a darker shade (e.g., `#0d1117` or `#000000`).

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Update button text color to '#0d1117' and add new palette UX guideline to `.jules/palette.md`.
Why: Palantir AIP colors (--accent-blue, --accent-green) failed WCAG 2 AA contrast guidelines against white.
Accessibility / UX Impact: Ensure contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds.
Validation: Axe accessibility tests found no violations.
Risks: Low risk visual-only change to frontend dashboard.
Files modified:
- evaluation/static/styles.css
- .jules/palette.md

---
*PR created automatically by Jules for task [5892397859656211046](https://jules.google.com/task/5892397859656211046) started by @tteon*