### PR TITLE
[Draft] UX: Clarify seocho chat command help text

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,2 @@
+- The  command could use clearer help text.
+The `seocho chat` command help text says 'Ask from memories' while `seocho ask` says 'Ask a question (auto-detects local or server mode)'. Since both are doing question asking but chat operates on server side and ask auto-detects, 'chat' might be better clarified. Additionally, 'ask' and 'chat' are somewhat confusingly similar.

--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -40,7 +40,7 @@ def build_parser() -> argparse.ArgumentParser:
     search_parser.add_argument("--database", action="append", dest="databases", default=[], help="Database scope")
     _add_client_options(search_parser, include_scope=True, include_json=True)
 
-    chat_parser = subparsers.add_parser("chat", help="Ask from memories")
+    chat_parser = subparsers.add_parser("chat", help="Ask a question using chat history (server mode)")
     chat_parser.add_argument("message", help="Question to ask")
     chat_parser.add_argument("--limit", type=int, default=5, help="Max number of retrieval results")
     chat_parser.add_argument("--graph-id", action="append", dest="graph_ids", default=[], help="Graph routing hint")


### PR DESCRIPTION
## What
Updates the help string for the `seocho chat` CLI command to make it clearer and distinct from the `seocho ask` command. Also initializes the `.jules/palette.md` memory file.

Modified files:
- `src/seocho/cli.py`
- `.jules/palette.md`

## Why
Previously, the `chat` command's help text was "Ask from memories", while the `ask` command was "Ask a question (auto-detects local or server mode)". This overlap was confusing. By explicitly calling out that `chat` uses "chat history (server mode)", the developer experience and clarity are improved.

## Accessibility / UX Impact
Improves CLI usability and user experience by reducing ambiguity between two similar commands. It provides immediate, contextual guidance to users exploring the CLI capabilities.

## Validation
- Ran `bash scripts/pm/lint-agent-docs.sh` and verified it passes cleanly.
- Installed local dependencies and ran `bash scripts/ci/run_basic_ci.sh` which completed successfully with no regressions.

## Risks
Minimal. This is an isolated, string-only change in the CLI help output layer. No runtime, semantic retrieval, or multi-agent behavior logic is impacted.

---
*PR created automatically by Jules for task [15657881159735904330](https://jules.google.com/task/15657881159735904330) started by @tteon*