### PR TITLE
fix: Enforce workspace isolation in execute_cypher tool

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
### Severity
High

### Vulnerability
Missing Authorization Check. The `execute_cypher` dynamic tool construction in `src/seocho/tools.py` permitted executing arbitrary, unfiltered Cypher against the graph store directly from agent calls without enforcing the `$workspace_id` tenant isolation filter.

### Impact
Agents could successfully execute dynamic graph-query lookups across tenant bounds when crafting targeted `MATCH (n)` queries that omitted the workspace restriction.

### Fix
Injected `workspace_id=workspace_id` and `enforce_workspace_filter=True` into the underlying `graph_store.query()` backend call inside `make_execute_cypher_tool` (`src/seocho/tools.py`). This strictly leverages the existing safe `WorkspaceFilterMissingError` enforcement mechanism provided by `GraphStore`.

### Validation
- `uv run ruff check src/seocho/tools.py` successfully completed.
- `bash scripts/ci/run_basic_ci.sh` tests executed cleanly and verified test stability.

### Risks
None. Agents providing non-compliant queries without `$workspace_id` will now intentionally error and fail rather than leak un-authorized data, which aligns with the correct API contract.

---
*PR created automatically by Jules for task [13573340727461104134](https://jules.google.com/task/13573340727461104134) started by @tteon*