### PR TITLE
[Draft] perf: optimize file I/O for text splitting in JSONL files

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,3 @@
 - Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).
+
+- When optimizing memory usage for large JSONL files (e.g., addressing 'avoidable file I/O or JSONL overhead'), replace `Path.read_text().splitlines()` with lazy, line-by-line iteration using a context manager (`with open(...) as f: for line in f:`). When doing this refactoring, ensure that you correctly handle string termination by applying `.rstrip("\n")` to match `.splitlines()` exact behavior without creating a giant intermediate list of strings.

--- a/scripts/benchmarks/finder_full_corpus_profile.py
+++ b/scripts/benchmarks/finder_full_corpus_profile.py
@@ -50,11 +50,13 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
     jp = Path(jsonl_path); jp.parent.mkdir(parents=True, exist_ok=True)
     done_ids = set()
     if resume and jp.exists():
-        for line in jp.read_text(encoding="utf-8").splitlines():
-            try:
-                done_ids.add(json.loads(line)["id"])
-            except Exception:
-                pass
+        with jp.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                try:
+                    done_ids.add(json.loads(line)["id"])
+                except Exception:
+                    pass
     docs = []
     for _, row in df.iterrows():
         _id = str(row["_id"])
@@ -96,14 +98,16 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
 def build_profile_from_jsonl(jsonl_path):
     from collections import Counter
     freqs = Counter(); ndoc = 0
-    for line in Path(jsonl_path).read_text(encoding="utf-8").splitlines():
-        try:
-            rec = json.loads(line)
-        except Exception:
-            continue
-        ndoc += 1
-        for l in rec.get("labels", []):
-            freqs[l] += 1
+    with Path(jsonl_path).open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            ndoc += 1
+            for l in rec.get("labels", []):
+                freqs[l] += 1
     return dict(freqs), ndoc
 
 

--- a/scripts/benchmarks/okx_risk_llm_e2e.py
+++ b/scripts/benchmarks/okx_risk_llm_e2e.py
@@ -18,9 +18,11 @@ from seocho.store.llm import MaraBackend
 
 def _load(path: Path) -> list[dict[str, Any]]:
     rows = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            rows.append(json.loads(line))
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.strip():
+                rows.append(json.loads(line))
     return rows
 
 

--- a/scripts/ci/triage_metadata.py
+++ b/scripts/ci/triage_metadata.py
@@ -205,7 +205,8 @@ def infer_labels(event: dict[str, object], changed_files: Iterable[str]) -> list
 def read_changed_files(path: Path | None) -> list[str]:
     if path is None or not path.exists():
         return []
-    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    with path.open("r", encoding="utf-8") as f:
+        return [line.strip() for line in f]
 
 
 def format_labels(labels: list[str], output_format: str) -> str:


### PR DESCRIPTION
What: Replace `path.read_text().splitlines()` with lazy file context iteration in `scripts/benchmarks/okx_risk_llm_e2e.py` and `scripts/benchmarks/finder_full_corpus_profile.py`.
Why: Memory optimization to prevent avoidable file I/O and JSONL overhead.
Expected Impact: Reduces memory usage especially on large JSONL dataset parsing. Expected impact is qualitative.
Validation: Ran `bash scripts/ci/run_basic_ci.sh`.
Risks: Changes in exact string splitting behavior in downstream consumers, though very low given tests pass and `rstrip` was used to mimic `splitlines`.

---
*PR created automatically by Jules for task [6754976203959658552](https://jules.google.com/task/6754976203959658552) started by @tteon*