### PR TITLE
[Draft] perf: stream yaml file loads to reduce avoidable I/O memory overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 - Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).
+- Optimized memory usage and reduced avoidable file I/O overhead when parsing YAML files by replacing inline full-file string reads (`yaml.safe_load(path.read_text())`) with streaming context managers (`with path.open('r', encoding='utf-8') as f: yaml.safe_load(f)`).

--- a/src/seocho/connectors/config.py
+++ b/src/seocho/connectors/config.py
@@ -218,7 +218,8 @@ def load_connector_config(path: "str | Path" = DEFAULT_CONNECTORS_CONFIG_FILENAM
     config_path = Path(path)
     errors: list[str] = []
     try:
-        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        with config_path.open("r", encoding="utf-8") as f:
+            payload = yaml.safe_load(f)
     except FileNotFoundError as exc:
         raise ConnectorConfigError([f"{config_path} not found. Run: seocho connect init"]) from exc
     except yaml.YAMLError as exc:

--- a/src/seocho/curation_design.py
+++ b/src/seocho/curation_design.py
@@ -126,7 +126,8 @@ class CurationDesignSpec:
     def from_yaml(cls, path: str | Path) -> "CurationDesignSpec":
         import yaml
 
-        payload = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        with Path(path).open("r", encoding="utf-8") as f:
+            payload = yaml.safe_load(f) or {}
         if not isinstance(payload, Mapping):
             raise ValueError("Curation design YAML must decode to a mapping.")
         return cls.from_dict(payload)

--- a/src/seocho/ontology_ambiguity.py
+++ b/src/seocho/ontology_ambiguity.py
@@ -265,7 +265,8 @@ def _bump_minor(version: str) -> str:
 
 def load_mapping_spec(path: str | Path) -> Dict[str, Any]:
     import yaml
-    return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+    with Path(path).open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
 
 
 # ---------------------------------------------------------------------------

--- a/src/seocho/ontology_governance.py
+++ b/src/seocho/ontology_governance.py
@@ -179,7 +179,8 @@ def load_competency_questions(path: str | Path) -> List[Dict[str, Any]]:
     source = Path(path)
     if not source.exists():
         raise FileNotFoundError(f"Competency-question file not found: {source}")
-    data = yaml.safe_load(source.read_text(encoding="utf-8")) or {}
+    with source.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
     questions = data.get("competency_questions", [])
     if not isinstance(questions, list):
         raise ValueError(f"{source}: 'competency_questions' must be a list.")


### PR DESCRIPTION
**What**
Replaced `yaml.safe_load(path.read_text(encoding="utf-8"))` with streaming file reads (`with path.open("r", encoding="utf-8") as f: yaml.safe_load(f)`) in the following files:
* `src/seocho/connectors/config.py`
* `src/seocho/curation_design.py`
* `src/seocho/ontology_ambiguity.py`
* `src/seocho/ontology_governance.py`

**Why**
Calling `.read_text()` loads the entire file into a single contiguous string in memory before passing it to `yaml.safe_load()`. This introduces avoidable overhead, particularly for large YAML configuration files. Using a context manager allows PyYAML to stream the file contents directly, lowering peak memory usage and eliminating redundant string allocations.

**Expected Impact**
* **Performance:** Lower peak memory usage and marginally faster parse times when processing large YAML files (e.g. ontology mappings, large design specs).
* **Maintainability:** Standardizes on more memory-efficient file I/O idioms without altering program logic.

**Validation**
* Verified identical structural parsing logic (syntax-checked via `py_compile`).
* Executed the entire repository basic CI test suite (`bash scripts/ci/run_basic_ci.sh`) successfully in the local virtual environment.
* All checks passed, meaning no behavioral regressions were observed in loading connectors, curing design files, parsing governance documents, etc.

**Risks**
* **Negligible:** This is a syntactically identical structural optimization at the Python level. `yaml.safe_load` natively supports file objects and handles streaming automatically. Standard file-closing semantics are preserved through the `with` block.

---
*PR created automatically by Jules for task [6191380789071223825](https://jules.google.com/task/6191380789071223825) started by @tteon*