### PR TITLE
[Draft] Improve button text contrast for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,2 @@
+File not found
+Learned: The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). To meet WCAG 2 AA contrast guidelines, text on backgrounds using these colors must use a darker shade (e.g., `#0d1117` or `#000000`).

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
- **What**: Change button text color from white (`#fff`) to dark navy (`#0d1117`) on accent backgrounds. Modified files: `evaluation/static/styles.css` and `.jules/palette.md`.
- **Why**: The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) paired with a white foreground (`color: #fff`) fail WCAG 2 AA contrast guidelines.
- **Accessibility / UX Impact**: Ensures button text is readable by users with low vision or color vision deficiencies.
- **Validation**: Visual verification through Playwright rendering; basic CI script passed.
- **Risks**: Negligible, scoped exclusively to isolated UI buttons.

---
*PR created automatically by Jules for task [11169611469712551012](https://jules.google.com/task/11169611469712551012) started by @tteon*