### PR TITLE
Security: Enforce workspace isolation in execute_cypher tool

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
## Modified Files
* `src/seocho/tools.py`

## Severity
High

## Vulnerability
The `make_execute_cypher_tool` factory in `src/seocho/tools.py` executed raw Cypher queries passed from the LLM agent via `graph_store.query()` without enforcing workspace isolation. The `workspace_id` and `enforce_workspace_filter=True` arguments were missing, bypassing the repository's strict tenant isolation mechanisms.

## Impact
An LLM agent (or a compromised prompt) could generate a Cypher query without a `WHERE n._workspace_id = $workspace_id` clause, allowing it to read or manipulate nodes and relationships belonging to other tenants/workspaces in the shared graph database.

## Fix
Modified the `graph_store.query()` call within the `execute_cypher` inner function to explicitly pass `workspace_id=workspace_id` and `enforce_workspace_filter=True`. This ensures that the underlying query engine validates the presence of the workspace filter and injects the correct parameter.

## Validation
* Ran the canonical local CI suite (`bash scripts/ci/run_basic_ci.sh`), which passed completely. 

## Risks
If an existing agent relied on querying cross-workspace data using this tool (which violates the repository's isolation policy), those queries will now be rejected with a `WorkspaceFilterMissingError`. This is intended behavior for a secure multi-tenant environment.

---
*PR created automatically by Jules for task [12200734963796265992](https://jules.google.com/task/12200734963796265992) started by @tteon*