### PR TITLE
[Draft] Fix button text color contrast in AIP Console UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). To meet WCAG 2 AA contrast guidelines, text on backgrounds using these colors must use a darker shade (e.g., `#0d1117` or `#000000`).

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What:
Changed the text color for the `Ingest Raw`, `Load Sample & Ask`, and `Execute Pipeline` buttons from `#fff` to `#0d1117` in the AIP Console UI styles. Also updated the `.jules/palette.md` memory tracking file with the WCAG 2 AA contrast ratio lesson.

Why:
The Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not provide sufficient contrast when paired with a white foreground (`color: #fff`). To meet WCAG 2 AA guidelines for legibility, text on these backgrounds requires a darker shade.

Accessibility / UX Impact:
Fixes a small accessibility and UX issue in the platform UI by resolving contrast violations, ensuring primary UI form buttons are easily readable for all users.

Validation:
- Basic CI coverage passes.
- Used Playwright and generated a video + screenshot trace confirming the buttons correctly render dark text on the bright accent backgrounds in the browser.

Risks:
No architectural or logic changes introduced; risk is limited to CSS specificity conflicts, which were avoided by targeting existing specific identifiers.

Files Modified:
- `evaluation/static/styles.css`
- `.jules/palette.md`

---
*PR created automatically by Jules for task [5829022530404624744](https://jules.google.com/task/5829022530404624744) started by @tteon*