### PR TITLE
[Draft] Optimize memory usage for large JSONL files

### DIFF
--- a/examples/finder/lib/bench_common.py
+++ b/examples/finder/lib/bench_common.py
@@ -63,20 +63,21 @@ def load_env_files(roots: Iterable[Path] = DEFAULT_ENV_FILES) -> EnvReport:
         if not path.is_file():
             continue
         loaded.append(str(path))
-        for raw in path.read_text(encoding="utf-8").splitlines():
-            line = raw.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            k = k.strip()
-            v = v.strip().strip('"').strip("'")
-            if not k:
-                continue
-            if k in os.environ:
-                skipped.append(k)
-                continue
-            os.environ[k] = v
-            set_keys.append(k)
+        with path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.rstrip("\n").strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                if not k:
+                    continue
+                if k in os.environ:
+                    skipped.append(k)
+                    continue
+                os.environ[k] = v
+                set_keys.append(k)
     return EnvReport(tuple(loaded), tuple(set_keys), tuple(skipped))
 
 

--- a/scripts/benchmarks/finder_full_corpus_profile.py
+++ b/scripts/benchmarks/finder_full_corpus_profile.py
@@ -50,11 +50,13 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
     jp = Path(jsonl_path); jp.parent.mkdir(parents=True, exist_ok=True)
     done_ids = set()
     if resume and jp.exists():
-        for line in jp.read_text(encoding="utf-8").splitlines():
-            try:
-                done_ids.add(json.loads(line)["id"])
-            except Exception:
-                pass
+        with jp.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                try:
+                    done_ids.add(json.loads(line)["id"])
+                except Exception:
+                    pass
     docs = []
     for _, row in df.iterrows():
         _id = str(row["_id"])
@@ -96,14 +98,16 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
 def build_profile_from_jsonl(jsonl_path):
     from collections import Counter
     freqs = Counter(); ndoc = 0
-    for line in Path(jsonl_path).read_text(encoding="utf-8").splitlines():
-        try:
-            rec = json.loads(line)
-        except Exception:
-            continue
-        ndoc += 1
-        for l in rec.get("labels", []):
-            freqs[l] += 1
+    with Path(jsonl_path).open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            ndoc += 1
+            for l in rec.get("labels", []):
+                freqs[l] += 1
     return dict(freqs), ndoc
 
 

--- a/scripts/benchmarks/okx_risk_llm_e2e.py
+++ b/scripts/benchmarks/okx_risk_llm_e2e.py
@@ -18,9 +18,11 @@ from seocho.store.llm import MaraBackend
 
 def _load(path: Path) -> list[dict[str, Any]]:
     rows = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            rows.append(json.loads(line))
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.strip():
+                rows.append(json.loads(line))
     return rows
 
 

--- a/scripts/ci/triage_metadata.py
+++ b/scripts/ci/triage_metadata.py
@@ -206,7 +206,8 @@ def infer_labels(event: dict[str, object], changed_files: Iterable[str]) -> list
 def read_changed_files(path: Path | None) -> list[str]:
     if path is None or not path.exists():
         return []
-    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    with path.open("r", encoding="utf-8") as f:
+        return [line.rstrip("\n").strip() for line in f]
 
 
 def format_labels(labels: list[str], output_format: str) -> str:


### PR DESCRIPTION
## What
Replaced memory-heavy `.read_text().splitlines()` calls with lazy, line-by-line file iteration using a context manager (`with path.open("r", encoding="utf-8") as f: for line in f:`).

Modified files:
- `examples/finder/lib/bench_common.py`
- `scripts/benchmarks/okx_risk_llm_e2e.py`
- `scripts/benchmarks/finder_full_corpus_profile.py`
- `scripts/ci/triage_metadata.py`
- `.jules/bolt.md`

## Why
Calling `.read_text().splitlines()` on large text files reads the entire file into a single string in memory, and then allocates a massive list containing every individual line as a separate string. This introduces avoidable file I/O and JSONL parsing overhead, significantly increasing peak memory footprint and garbage collection latency. Streaming the file lazily line-by-line using standard iteration avoids this overhead.

## Expected Impact
- Reduced peak memory footprint when parsing large JSONL profiles and datasets.
- Minor latency reduction during initial startup and JSONL aggregation phases due to avoided list allocations.
- (Impact is mostly qualitative overhead reduction and scaling safety, especially in `finder_full_corpus_profile`).

## Validation
- Ran the basic CI suite (`bash scripts/ci/run_basic_ci.sh`) - all test assertions still pass.
- Verified syntax with `python -m py_compile` to ensure no `SyntaxError`s or indentation issues were introduced.

## Risks
- Trailing newlines that were implicitly dropped by `splitlines()` need to be manually stripped. The fix includes `.rstrip("\n")` calls, but any unexpected whitespace logic dependent purely on `splitlines()` behavior might subtly shift. (Tested well in CI to bound this risk).

---
*PR created automatically by Jules for task [10129422124280224169](https://jules.google.com/task/10129422124280224169) started by @tteon*