### PR TITLE
[Draft] Fix a11y contrast for accent buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) require a dark text color (e.g., `#0d1117` or `#000000`) for WCAG 2 AA compliance; avoid using `#fff` foregrounds with these background colors.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Update text color for buttons with accent background in evaluation/static/styles.css to use a dark color (#0d1117). Added .jules/palette.md.
Why: To ensure sufficient contrast with the accent colors per WCAG 2 AA guidelines.
Accessibility / UX Impact: The button text is now legible with proper contrast ratio.
Validation: Visually verified contrast using frontend Playwright script and ran the basic CI script successfully.
Risks: None.
Modified files: evaluation/static/styles.css, .jules/palette.md

---
*PR created automatically by Jules for task [1896506085938397699](https://jules.google.com/task/1896506085938397699) started by @tteon*