### PR TITLE
[Draft] perf: optimize file I/O overhead with lazy streaming reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,2 @@
 - Optimized memory usage for large JSONL files by replacing Path.read_text().splitlines() with lazy, line-by-line iteration using a context manager (with open(...) as f: for line in f:).
+- Optimized memory usage for repeated YAML parsing and JSON parsing by converting inline full-file string reads into streaming context managers (with open(...) as f: yaml.safe_load(f)).

--- a/examples/mdm/08_migrate_to_instances.py
+++ b/examples/mdm/08_migrate_to_instances.py
@@ -101,7 +101,8 @@ def migrate_dept(main_driver, dept: str, spec: dict) -> dict:
 def main() -> int:
     from neo4j import GraphDatabase
 
-    spec = yaml.safe_load((MDM_ROOT / "config" / "instances.yaml").read_text())
+    with (MDM_ROOT / "config" / "instances.yaml").open("r", encoding="utf-8") as _f:
+        spec = yaml.safe_load(_f)
     main_driver = GraphDatabase.driver(os.environ["NEO4J_URI"], auth=_auth())
     try:
         results = [migrate_dept(main_driver, dept, inst)

--- a/examples/mdm/lib/federation.py
+++ b/examples/mdm/lib/federation.py
@@ -213,7 +213,8 @@ class Instance:
 def load_instances(path: Path) -> List["Instance"]:
     import yaml
 
-    spec = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    with Path(path).open("r", encoding="utf-8") as _f:
+        spec = yaml.safe_load(_f)
     return [Instance(dept=d, uri=i["uri"], database=i.get("database", "neo4j"),
                      model=i["model"])
             for d, i in spec["instances"].items()]

--- a/scripts/benchmarks/finder_full_corpus_profile.py
+++ b/scripts/benchmarks/finder_full_corpus_profile.py
@@ -50,11 +50,13 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
     jp = Path(jsonl_path); jp.parent.mkdir(parents=True, exist_ok=True)
     done_ids = set()
     if resume and jp.exists():
-        for line in jp.read_text(encoding="utf-8").splitlines():
-            try:
-                done_ids.add(json.loads(line)["id"])
-            except Exception:
-                pass
+        with jp.open("r", encoding="utf-8") as _f:
+            for line in _f:
+                line = line.rstrip("\n")
+                try:
+                    done_ids.add(json.loads(line)["id"])
+                except Exception:
+                    pass
     docs = []
     for _, row in df.iterrows():
         _id = str(row["_id"])
@@ -96,14 +98,16 @@ def open_extract_all(jsonl_path, *, model, workers, max_chars, resume):
 def build_profile_from_jsonl(jsonl_path):
     from collections import Counter
     freqs = Counter(); ndoc = 0
-    for line in Path(jsonl_path).read_text(encoding="utf-8").splitlines():
-        try:
-            rec = json.loads(line)
-        except Exception:
-            continue
-        ndoc += 1
-        for l in rec.get("labels", []):
-            freqs[l] += 1
+    with Path(jsonl_path).open("r", encoding="utf-8") as _f:
+        for line in _f:
+            line = line.rstrip("\n")
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            ndoc += 1
+            for l in rec.get("labels", []):
+                freqs[l] += 1
     return dict(freqs), ndoc
 
 

--- a/scripts/benchmarks/okx_risk_llm_e2e.py
+++ b/scripts/benchmarks/okx_risk_llm_e2e.py
@@ -18,9 +18,11 @@ from seocho.store.llm import MaraBackend
 
 def _load(path: Path) -> list[dict[str, Any]]:
     rows = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            rows.append(json.loads(line))
+    with path.open("r", encoding="utf-8") as _f:
+        for line in _f:
+            line = line.rstrip("\n")
+            if line.strip():
+                rows.append(json.loads(line))
     return rows
 
 

--- a/scripts/ci/triage_metadata.py
+++ b/scripts/ci/triage_metadata.py
@@ -206,7 +206,8 @@ def infer_labels(event: dict[str, object], changed_files: Iterable[str]) -> list
 def read_changed_files(path: Path | None) -> list[str]:
     if path is None or not path.exists():
         return []
-    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    with path.open("r", encoding="utf-8") as _f:
+        return [line.strip() for line in _f]
 
 
 def format_labels(labels: list[str], output_format: str) -> str:

--- a/scripts/ontology/compile_fibo_snapshot.py
+++ b/scripts/ontology/compile_fibo_snapshot.py
@@ -267,7 +267,8 @@ def _load_curated_yaml(yaml_dir: Path) -> dict[str, Any]:
     if not yaml_dir.exists():
         return payload
     for path in sorted(yaml_dir.glob("*.yaml")):
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        with path.open("r", encoding="utf-8") as _f:
+            data = yaml.safe_load(_f) or {}
         code = path.stem.upper()
         labels: set[str] = set()
         same_as: dict[str, str] = {}


### PR DESCRIPTION
### What
Replaced full-file string reads (`.read_text().splitlines()` and `.read_text()`) with memory-efficient streaming iteration context managers for JSONL/text processing and YAML parsing.

Modified files:
- `examples/mdm/08_migrate_to_instances.py`
- `examples/mdm/lib/federation.py`
- `scripts/benchmarks/finder_full_corpus_profile.py`
- `scripts/benchmarks/okx_risk_llm_e2e.py`
- `scripts/ci/triage_metadata.py`
- `scripts/ontology/compile_fibo_snapshot.py`

### Why
Reading large files entirely into memory at once creates significant and avoidable memory allocation overhead, particularly for JSONL benchmark datasets. Utilizing streaming file objects significantly lowers peak memory usage.

### Expected Impact
Lower memory footprint and reduced GC pauses during local pipeline and benchmark runs. The improvement is qualitative for small local runs but prevents OOMs on larger datasets.

### Validation
- Validated via `bash scripts/ci/run_basic_ci.sh`, all tests pass.
- Used `python -m py_compile` to ensure syntax is correct.

### Risks
Low risk. Standard built-in Python file context managers were used. `line = line.rstrip('\n')` ensures it mirrors `.splitlines()` exact output behavior.

---
*PR created automatically by Jules for task [9719236099558404577](https://jules.google.com/task/9719236099558404577) started by @tteon*