### PR TITLE
[Draft] Fix accessibility contrast on accent backgrounds

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+- Palantir AIP theme colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) require dark text (`#0d1117` or `#000000`) instead of white (`#fff`) to meet WCAG 2 AA contrast guidelines.

--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
### What
Fixed a color contrast accessibility issue on solid accent-colored buttons (`#ingestBtn`, `#oneClickDemoBtn`, and `.composer button`) by changing their text color from `#fff` (white) to `#0d1117` (dark theme background).

Files modified:
- `evaluation/static/styles.css`
- `.jules/palette.md`

### Why
The Palantir AIP theme defines solid accent colors (`--accent-green` as `#3fb950` and `--accent-blue` as `#2f81f7`). When paired with a white foreground (`#fff`), these colors fail to meet WCAG 2 AA contrast ratio guidelines for legibility.

### Accessibility / UX Impact
- **Accessibility:** Greatly improves text legibility for users with visual impairments by providing a higher contrast ratio on primary action buttons.
- **UX:** Ensures the call-to-action text on primary buttons is clearly readable.

### Validation
- **Visual Verification:** Rendered the local `uvicorn` evaluation server and verified via Playwright screenshot that the buttons now display highly readable dark text on the solid green/blue backgrounds.
- **Automated Tests:** Verified that `bash scripts/ci/run_basic_ci.sh` passed locally.

### Risks
- **Low Risk:** This is a highly localized CSS text-color change targeting specific solid-background buttons. It does not affect application functionality or layout. The change was intentionally scoped to avoid altering "ghost" theme variables where white text is correct against the dark panel background.

---
*PR created automatically by Jules for task [4242218119906198883](https://jules.google.com/task/4242218119906198883) started by @tteon*