### PR TITLE
docs: ADR-0154 — provenance-first extraction and evidence-conditional…

### DIFF
--- a/docs/decisions/ADR-0154-provenance-first-extraction-and-evidence-conditional-evaluation.md
+++ b/docs/decisions/ADR-0154-provenance-first-extraction-and-evidence-conditional-evaluation.md
@@ -1,0 +1,53 @@
+# ADR-0154: Provenance-first extraction, ontology-as-validator, and evidence-conditional evaluation
+
+Date: 2026-08-08 · Status: accepted
+
+## Context
+
+The LoG 2026 study (research line `feat/ontology-workbench-gap-closure`;
+submission "Anchor, Don't Name", OpenReview #145; 33 pre-registered
+hypotheses, all verdicts on file with frozen artifacts) measured assumptions
+SEOCHO's pipeline was built on. Several failed, replicated and quantified:
+
+- 26.7% of anchored extracted values are unit-scale misreads; all 1,482
+  measured cross-extractor value conflicts are unit-scale splits.
+- Name-based fact matching hides 80–84% of cross-extractor disagreements;
+  provenance-anchored alignment exposes 1.7–2.8x as many comparable facts.
+- Ontology guidance in the extraction prompt lowered cross-model name
+  agreement and answer-relevant coverage at 280 cases; its only measured
+  positive effects are violation detectability and serving-time type
+  legibility.
+- Naive gold-overlap scoring cannot separate evidence use from memorization;
+  an evidence-conditional decomposition reverses condition orderings per
+  question stratum.
+- Pointer-only provenance decoration (`source=[p@offset]`, no text) raised
+  answer accuracy on two of three models and repaired over-refusal.
+
+## Decisions
+
+1. **Provenance-first ingestion**: extracted figures are anchored to their
+   source token at write time; anchor fields become pipeline-native.
+2. **Alignment keys on provenance, not names**: the linker treats source
+   coordinates as the primary dedup/verification key for figure-bearing
+   nodes.
+3. **Ontology role defaults to validator**: `ontology_role: validate|guide|both`,
+   default `validate` — minimal schema in extraction prompts; ontology runs
+   post-hoc (rules/SHACL) and supplies serving-time type labels. Owlready2
+   stays offline-only (unchanged).
+4. **Provenance-decorated serialization**: the graph-as-context serializer
+   ships type labels, source pointers, a cite instruction, and
+   document-plumbing exclusion.
+5. **Evidence-conditional evaluation**: eval reports grounded-correct /
+   contaminated / honest-abstention / over-refusal, never gold overlap alone.
+6. **Pre-flight verifiability profile**: a diagnostic computes, from one
+   pilot extraction, the shares that gate multi-agent and ontology-guardrail
+   spend. Diagnostic, not predictor — its registered predictive form failed
+   its first prospective test and is reported as such.
+
+## Consequences
+
+The extraction hot path gains one deterministic per-figure verification
+(string search, no LLM). Ontology prompt budgets become lintable. Evaluation
+output schema changes additively. Implementation is tracked in the internal
+tracker (epic: provenance-first product reflection); nothing changes runtime
+contracts until those land.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -876,6 +876,11 @@ Each entry must link to a full ADR when impact is non-trivial.
 
 ## 2026-07-14
 
+- [Accepted] ADR-0154 provenance-first extraction and evidence-conditional evaluation
+  - anchor extracted figures to source tokens at write time; align facts by provenance, not names
+  - ontology_role defaults to validator (SHACL/rules post-hoc + serving-time type labels), not extraction guide
+  - evaluation reports grounded/contaminated/honest-abstention, never gold overlap alone
+
 - [Accepted] ADR-0153 production-agent-harness-and-postgres-resilience
   - add scoped agent principals, bounded delegation, tool-boundary guardrails,
     and versioned harness/rubric promotion gates


### PR DESCRIPTION
… evaluation

The LoG 2026 study's registered verdicts land as architecture decisions: anchor figures to source tokens at write time, key alignment on provenance rather than names, default the ontology to a validator role, decorate serialized graphs with source pointers, and score answers evidence-conditionally. Validation: scripts/ci/check-doc-contracts.sh passed.

## Feature

<!-- What changed? Keep this focused on one behavior, refactor, docs update, or example. -->

## Why

<!-- Why does this belong in SEOCHO's public SDK/runtime/docs surface? -->

## Design

<!-- Note the important implementation choice and the owning module surface. -->

## Validation

<!-- List exact commands run. If a relevant gate was skipped, name the gap. -->

- [ ] `bash scripts/ci/run_basic_ci.sh`

## Risks / Gaps

<!-- Known limitations, deferred follow-ups, migration risk, or live-service gaps. -->

## Docs

- [ ] Public behavior changed and docs were updated
- [ ] No public behavior changed
