### PR TITLE
feat(sdk): expose ontology enforcement mode on Seocho client and Seocho.local

### DIFF
--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -214,6 +214,7 @@ class Seocho:
         extraction_prompt: Optional[Any] = None,  # seocho.query.PromptTemplate
         agent_config: Optional[Any] = None,  # seocho.agent_config.AgentConfig
         ontology_profile: str = "default",
+        enforcement: Optional[str] = None,  # "strict" | "guided" | "open"
         # --- HTTP client mode ---
         base_url: Optional[str] = None,
         workspace_id: Optional[str] = None,
@@ -240,6 +241,14 @@ class Seocho:
             extraction_prompt: Custom extraction prompt template.
             agent_config: Agent-level configuration (quality thresholds, reasoning defaults).
             ontology_profile: Stable context profile name shared by indexing, query, and agent runs.
+            enforcement: Ontology write-admission mode for the local indexing
+                pipeline: ``"strict"`` (closed validation, non-conforming
+                extraction rejected), ``"guided"`` (default; ontology guides,
+                violations warn), or ``"open"`` (admit everything,
+                out-of-ontology elements annotated). An explicit value
+                overrides ``agent_config.ontology_enforcement``, mirroring the
+                ``ontology.enforcement`` precedence in run specs. Local engine
+                mode only — HTTP-mode clients inherit the server's policy.
             base_url: SEOCHO server URL (HTTP mode). Defaults to ``SEOCHO_BASE_URL`` env
                 var or ``http://localhost:8001``.
             workspace_id: Workspace identifier propagated to all API calls.
@@ -272,6 +281,24 @@ class Seocho:
         if agent_config is None:
             from .agent_config import AgentConfig
             agent_config = AgentConfig()
+        if enforcement is not None:
+            normalized_enforcement = str(enforcement).strip().lower()
+            if normalized_enforcement not in ("strict", "guided", "open"):
+                raise ValueError(
+                    "enforcement must be 'strict', 'guided', or 'open', "
+                    f"got {enforcement!r}"
+                )
+            if ontology is None or graph_store is None or llm is None:
+                raise ValueError(
+                    "enforcement is a local-engine indexing option and requires "
+                    "local engine mode (ontology + graph_store + llm, or "
+                    "Seocho.local). HTTP-mode clients inherit the server's "
+                    "enforcement policy."
+                )
+            from dataclasses import replace as _dc_replace
+            agent_config = _dc_replace(
+                agent_config, ontology_enforcement=normalized_enforcement
+            )
         self.agent_config = agent_config
 
         # Default database — auto-generated from ontology if not specified
@@ -339,6 +366,7 @@ class Seocho:
         neo4j_user: str = "neo4j",
         neo4j_password: str = "password",
         api_key: Optional[str] = None,
+        enforcement: Optional[str] = None,
         **kwargs: Any,
     ) -> "Seocho":
         """Create a local-engine ``Seocho`` with sensible defaults.
@@ -368,6 +396,9 @@ class Seocho:
             api_key: Optional API key override for the LLM provider.
                 Falls back to the provider's env var (``MARA_API_KEY``,
                 ``OPENAI_API_KEY``, etc.).
+            enforcement: Ontology write-admission mode for indexing —
+                ``"strict"``, ``"guided"`` (default), or ``"open"``. See
+                :meth:`Seocho.__init__` for precedence semantics.
             **kwargs: Extra arguments forwarded to the :class:`Seocho`
                 constructor (``workspace_id``, ``agent_config``,
                 ``extraction_prompt``, …).
@@ -401,6 +432,7 @@ class Seocho:
             ontology=ontology,
             graph_store=graph_store,
             llm=llm_backend,
+            enforcement=enforcement,
             **kwargs,
         )
 

--- a/tests/seocho/test_ontology_enforcement.py
+++ b/tests/seocho/test_ontology_enforcement.py
@@ -464,3 +464,62 @@ def test_run_spec_inline_enforcement_lands_on_agent_config() -> None:
     config = e2e.build_agent_config(spec)
     assert config.ontology_enforcement == "strict"
     assert config.validation_on_fail == "reject"
+
+
+# ---------------------------------------------------------------------------
+# Client wiring: Seocho(...) / Seocho.local(...) enforcement kwarg (seocho-vdw.5)
+# ---------------------------------------------------------------------------
+
+
+class _StubGraphStore:
+    pass
+
+
+class _StubLLM:
+    model = "stub-model"
+
+
+def _local_client(**kwargs: Any):
+    from seocho.client import Seocho
+
+    return Seocho(
+        ontology=_ontology(),
+        graph_store=_StubGraphStore(),
+        llm=_StubLLM(),
+        **kwargs,
+    )
+
+
+def test_client_enforcement_kwarg_reaches_pipeline_policy() -> None:
+    for mode in ("strict", "guided", "open"):
+        client = _local_client(enforcement=mode)
+        assert client._engine._indexing.enforcement_policy.mode == mode
+        assert client.agent_config.ontology_enforcement == mode
+
+
+def test_client_enforcement_default_stays_guided() -> None:
+    client = _local_client()
+    assert client._engine._indexing.enforcement_policy.mode == "guided"
+
+
+def test_client_enforcement_overrides_agent_config_without_mutation() -> None:
+    from seocho.agent_config import AgentConfig
+
+    supplied = AgentConfig(ontology_enforcement="open")
+    client = _local_client(agent_config=supplied, enforcement="strict")
+    assert client._engine._indexing.enforcement_policy.mode == "strict"
+    assert client.agent_config.ontology_enforcement == "strict"
+    # explicit kwarg must not mutate the caller's config object
+    assert supplied.ontology_enforcement == "open"
+
+
+def test_client_enforcement_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="strict"):
+        _local_client(enforcement="paranoid")
+
+
+def test_client_enforcement_requires_local_mode() -> None:
+    from seocho.client import Seocho
+
+    with pytest.raises(ValueError, match="local-engine"):
+        Seocho(base_url="http://localhost:8001", enforcement="strict")


### PR DESCRIPTION
## What

Adds a first-class `enforcement` kwarg (`strict`/`guided`/`open`) to `Seocho()` and `Seocho.local()`.

## Why

The admission mechanism already exists end-to-end — `IndexingPipeline(enforcement=...)` and the run-spec YAML `ontology.enforcement` key — but the client path had no direct surface: callers had to know to pass `agent_config=AgentConfig(ontology_enforcement=...)`. This closes that ergonomics gap for client-path users (including the H1 governance-ablation harness, tracked as seocho-vdw.5).

## Semantics

- Explicit `enforcement` overrides `agent_config.ontology_enforcement` via `dataclasses.replace` (caller's config object is not mutated) — mirrors the run-spec precedence rule where an explicit `ontology.enforcement` overrides an agent design's value.
- Unknown modes raise `ValueError` instead of silently coercing to guided (unlike `EnforcementPolicy.from_mode`, which stays lenient for internal callers).
- HTTP-mode use raises `ValueError` — the server owns the policy there; silent no-op would be worse.
- Default behavior unchanged: no kwarg → `guided`.

## Validation

- `python3 -m pytest tests/seocho/test_ontology_enforcement.py` — 26 passed (5 new: three-mode propagation to `enforcement_policy.mode`, guided default, override-without-mutation, unknown-mode rejection, HTTP-mode rejection)
- `bash scripts/ci/run_basic_ci.sh` — 671 passed, 3 skipped; runtime-shell / module-ownership / root-hierarchy / docs contracts all passed
- Not run: live DozerDB/MARA integration paths (no behavior change beyond config plumbing)