### PR TITLE
fix(llm): M2.7 structured-output robustness — reasoning field fallback + token budget

### DIFF
--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -641,6 +641,42 @@ class OpenAICompatibleBackend(LLMBackend):
         if "Return ONLY valid JSON." not in content:
             messages[0]["content"] = f"{content}\n\nReturn ONLY valid JSON."
 
+    # Provider error text signalling "payload fine, the model ran out of
+    # budget before completing the constrained JSON" (MARA wording).
+    _JSON_GENERATION_FAILURE_MARKERS = (
+        "did not output valid json",
+        "truncated before a complete json",
+    )
+
+    @classmethod
+    def _maybe_boost_json_budget(
+        cls,
+        *,
+        exc: Exception,
+        attempt_kwargs: Dict[str, Any],
+        variants: List[Dict[str, Any]],
+        position: int,
+    ) -> bool:
+        """Insert a same-shape, doubled-budget retry for JSON-truncation 400s.
+
+        These errors are generation failures, not payload rejections: falling
+        straight down the strip ladder removes ``response_format``, and the
+        unconstrained retry produces runaway thinking-in-content prose with no
+        JSON at all (observed 43k-char responses on MARA MiniMax-M2.7). Retry
+        the SAME request shape with more budget first; the strip ladder stays
+        as the final fallback. Returns True if a variant was inserted."""
+        if "response_format" not in attempt_kwargs:
+            return False
+        message = str(exc).lower()
+        if not any(m in message for m in cls._JSON_GENERATION_FAILURE_MARKERS):
+            return False
+        boosted = cls._clone_completion_request_kwargs(attempt_kwargs)
+        boosted["max_tokens"] = max(
+            int(attempt_kwargs.get("max_tokens") or 0) * 2, 16384
+        )
+        variants.insert(position, boosted)
+        return True
+
     def _completion_retry_variants(self, kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
         variants = [self._clone_completion_request_kwargs(kwargs)]
         has_provider_overrides = any(
@@ -759,6 +795,7 @@ class OpenAICompatibleBackend(LLMBackend):
             tags=["gen_ai", f"provider:{self.provider}"],
         ) as span:
             last_exc: Optional[Exception] = None
+            budget_boosted = False
             for attempt, attempt_kwargs in enumerate(variants, start=1):
                 try:
                     resp = self._client.chat.completions.create(**attempt_kwargs)
@@ -809,6 +846,16 @@ class OpenAICompatibleBackend(LLMBackend):
                     return result
                 except Exception as exc:
                     last_exc = exc
+                    if not budget_boosted:
+                        # list.insert during iteration is safe here: the
+                        # boosted variant lands at the position the loop
+                        # visits next.
+                        budget_boosted = self._maybe_boost_json_budget(
+                            exc=exc,
+                            attempt_kwargs=attempt_kwargs,
+                            variants=variants,
+                            position=attempt,
+                        )
                     if attempt < len(variants):
                         metrics.add(
                             "seocho.gen_ai.retry.count",
@@ -890,6 +937,7 @@ class OpenAICompatibleBackend(LLMBackend):
             tags=["gen_ai", f"provider:{self.provider}"],
         ) as span:
             last_exc: Optional[Exception] = None
+            budget_boosted = False
             for attempt, attempt_kwargs in enumerate(variants, start=1):
                 try:
                     resp = await self._async_client.chat.completions.create(**attempt_kwargs)
@@ -940,6 +988,16 @@ class OpenAICompatibleBackend(LLMBackend):
                     return result
                 except Exception as exc:
                     last_exc = exc
+                    if not budget_boosted:
+                        # list.insert during iteration is safe here: the
+                        # boosted variant lands at the position the loop
+                        # visits next.
+                        budget_boosted = self._maybe_boost_json_budget(
+                            exc=exc,
+                            attempt_kwargs=attempt_kwargs,
+                            variants=variants,
+                            position=attempt,
+                        )
                     if attempt < len(variants):
                         metrics.add(
                             "seocho.gen_ai.retry.count",

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -348,6 +348,18 @@ def complete_with_task_hints(
         "user": user,
         "temperature": temperature,
     }
+    if max_tokens is None and _strip_text(task_hint).lower() in (
+        "json_extraction",
+        "json_extraction_retry",
+        "entity_linking",
+    ):
+        # Structured-output calls on reasoning models (MARA MiniMax-M2.7,
+        # DeepSeek) spend thousands of completion tokens thinking before the
+        # JSON payload. Leaving max_tokens to the server default truncates
+        # mid-reasoning — the response carries reasoning text and no JSON,
+        # or the provider 400s ("token limit reached before a complete JSON
+        # object"). Give these calls an explicit generous budget (seocho-ub5).
+        max_tokens = 8192
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
     if response_format is not None:

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -378,19 +378,33 @@ def complete_with_task_hints(
         kwargs["model"] = model
     if provider_options:
         kwargs["provider_options"] = provider_options
-    try:
-        return llm.complete(**kwargs)
-    except TypeError as exc:
-        if "unexpected keyword argument" not in str(exc):
-            raise
-        # Older backends predate mode/reasoning_mode/task_hint/model — strip
-        # them and retry so this helper stays drop-in for legacy doubles.
-        kwargs.pop("reasoning_mode", None)
-        kwargs.pop("task_hint", None)
-        kwargs.pop("mode", None)
-        kwargs.pop("model", None)
-        kwargs.pop("provider_options", None)
-        return llm.complete(**kwargs)
+    # Older backends predate some optional kwargs (mode/reasoning_mode/
+    # task_hint/model/provider_options, and the task-hint max_tokens
+    # default). Strip ONLY the kwarg each TypeError names, so a double that
+    # accepts reasoning_mode but not max_tokens keeps every kwarg it
+    # understands.
+    import re as _re
+
+    optional_kwargs = (
+        "reasoning_mode", "task_hint", "mode", "model",
+        "provider_options", "max_tokens",
+    )
+    for _ in range(len(optional_kwargs) + 1):
+        try:
+            return llm.complete(**kwargs)
+        except TypeError as exc:
+            message = str(exc)
+            if "unexpected keyword argument" not in message:
+                raise
+            match = _re.search(r"unexpected keyword argument '([^']*)'", message)
+            offender = match.group(1) if match else None
+            if offender in optional_kwargs and offender in kwargs:
+                kwargs.pop(offender)
+                continue
+            # Unparseable message — legacy blanket strip as a last resort.
+            for key in optional_kwargs:
+                kwargs.pop(key, None)
+    return llm.complete(**kwargs)
 
 
 class EmbeddingBackend(ABC):

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -1047,12 +1047,22 @@ class OpenAICompatibleBackend(LLMBackend):
                 "total_tokens": int(getattr(resp.usage, "total_tokens", 0) or 0),
                 "cached_tokens": int(cached_tokens or 0),
             }
-        # Reasoning models (e.g. Kimi K2.5) may return the answer in
-        # ``reasoning_content`` when ``content`` is empty — typically
-        # when the generation was cut short by max_tokens.
+        # Reasoning models may return the answer in a reasoning field when
+        # ``content`` is empty — typically when generation was cut short by
+        # max_tokens. Field name varies by provider: ``reasoning_content``
+        # (Kimi K2.5) vs ``reasoning`` (MARA MiniMax-M2.7). Unknown fields
+        # land in the SDK model's ``model_extra``, so check both surfaces.
         text = getattr(choice.message, "content", "") or ""
         if not text:
-            text = getattr(choice.message, "reasoning_content", "") or ""
+            extra = getattr(choice.message, "model_extra", None) or {}
+            for field_name in ("reasoning_content", "reasoning"):
+                text = (
+                    getattr(choice.message, field_name, "")
+                    or extra.get(field_name)
+                    or ""
+                )
+                if text:
+                    break
         return LLMResponse(
             text=text,
             model=getattr(resp, "model", "") or "",

--- a/tests/seocho/test_llm_backends.py
+++ b/tests/seocho/test_llm_backends.py
@@ -967,3 +967,77 @@ def test_task_hint_json_extraction_gets_default_max_tokens():
         FakeLLM(), system="s", user="u", task_hint="answer_synthesis"
     )
     assert "max_tokens" not in captured  # non-structured hints unchanged
+
+
+def test_json_truncation_400_boosts_budget_before_stripping_response_format(monkeypatch):
+    """seocho-ub5: a provider 'JSON truncated by token limit' 400 must retry
+    the SAME shape with a doubled budget, not fall straight to the variant
+    that strips response_format (which yields runaway non-JSON prose)."""
+    from types import SimpleNamespace
+
+    from seocho.store.llm import OpenAICompatibleBackend
+
+    backend = OpenAICompatibleBackend(provider="mara", model="MiniMax-M2.7", api_key="k")
+
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError(
+                "Error code: 400 - Model did not output valid JSON. The output "
+                "was truncated before a complete JSON object could be generated"
+            )
+        msg = SimpleNamespace(content='{"nodes": []}')
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=msg, finish_reason="stop")],
+            usage=None, model="MiniMax-M2.7",
+        )
+
+    backend._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+    )
+
+    result = backend.complete(
+        system="s", user="u",
+        max_tokens=8192,
+        response_format={"type": "json_object"},
+        task_hint="json_extraction",
+    )
+    assert result.json() == {"nodes": []}
+    assert len(calls) == 2
+    # retry keeps the JSON constraint and doubles the budget
+    assert calls[1]["response_format"] == {"type": "json_object"}
+    assert calls[1]["max_tokens"] == 16384
+
+
+def test_non_json_400_still_walks_strip_ladder():
+    """Payload-incompatibility errors keep the original strip behavior."""
+    from types import SimpleNamespace
+
+    from seocho.store.llm import OpenAICompatibleBackend
+
+    backend = OpenAICompatibleBackend(provider="mara", model="MiniMax-M2.7", api_key="k")
+
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        if "response_format" in kwargs:
+            raise RuntimeError("Error code: 400 - response_format is not supported")
+        msg = SimpleNamespace(content='{"ok": true}')
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=msg, finish_reason="stop")],
+            usage=None, model="MiniMax-M2.7",
+        )
+
+    backend._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+    )
+
+    result = backend.complete(
+        system="s", user="u",
+        response_format={"type": "json_object"},
+    )
+    assert result.json() == {"ok": True}
+    assert "response_format" not in calls[-1]

--- a/tests/seocho/test_llm_backends.py
+++ b/tests/seocho/test_llm_backends.py
@@ -936,3 +936,34 @@ def test_build_response_falls_back_to_provider_reasoning_fields():
     # content wins when present
     both = SimpleNamespace(content='{"d": 4}', reasoning='{"ignored": 0}')
     assert OpenAICompatibleBackend._build_response(_resp(both)).json() == {"d": 4}
+
+
+def test_task_hint_json_extraction_gets_default_max_tokens():
+    """seocho-ub5: structured-output task hints must carry an explicit
+    token budget so reasoning models don't truncate mid-thinking."""
+    from seocho.store.llm import complete_with_task_hints
+
+    captured = {}
+
+    class FakeLLM:
+        def complete(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    complete_with_task_hints(
+        FakeLLM(), system="s", user="u", task_hint="json_extraction"
+    )
+    assert captured["max_tokens"] == 8192
+
+    captured.clear()
+    complete_with_task_hints(
+        FakeLLM(), system="s", user="u",
+        task_hint="json_extraction", max_tokens=1234,
+    )
+    assert captured["max_tokens"] == 1234  # explicit caller value wins
+
+    captured.clear()
+    complete_with_task_hints(
+        FakeLLM(), system="s", user="u", task_hint="answer_synthesis"
+    )
+    assert "max_tokens" not in captured  # non-structured hints unchanged

--- a/tests/seocho/test_llm_backends.py
+++ b/tests/seocho/test_llm_backends.py
@@ -906,3 +906,33 @@ def test_vllm_to_agents_sdk_model_binding(
     assert sdk_provider.kwargs["base_url"] == "http://localhost:8000/v1"
     assert sdk_provider.kwargs["use_responses"] is False
     assert run_config.model.model == "Qwen2.5-7B-Instruct"
+
+
+def test_build_response_falls_back_to_provider_reasoning_fields():
+    """seocho-ub5: MARA MiniMax-M2.7 emits `reasoning` (not
+    `reasoning_content`) and may leave `content` empty; empty content must
+    not reach json.loads as ''."""
+    from types import SimpleNamespace
+
+    from seocho.store.llm import OpenAICompatibleBackend
+
+    def _resp(message):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message)], usage=None, model="m"
+        )
+
+    # kimi-style reasoning_content still works
+    kimi = SimpleNamespace(content="", reasoning_content='{"a": 1}')
+    assert OpenAICompatibleBackend._build_response(_resp(kimi)).json() == {"a": 1}
+
+    # mara/M2.7-style `reasoning` attribute
+    mara = SimpleNamespace(content="", reasoning='{"b": 2}')
+    assert OpenAICompatibleBackend._build_response(_resp(mara)).json() == {"b": 2}
+
+    # SDK models park unknown fields in model_extra
+    extra = SimpleNamespace(content="", model_extra={"reasoning": '{"c": 3}'})
+    assert OpenAICompatibleBackend._build_response(_resp(extra)).json() == {"c": 3}
+
+    # content wins when present
+    both = SimpleNamespace(content='{"d": 4}', reasoning='{"ignored": 0}')
+    assert OpenAICompatibleBackend._build_response(_resp(both)).json() == {"d": 4}


### PR DESCRIPTION
## What

Four coupled fixes making structured-output calls robust on MARA MiniMax-M2.7, found while smoke-testing the EnterpriseRAG-Bench ingest (seocho-vdw.6):

1. **`reasoning` field fallback** — `_build_response` reads M2.7's `reasoning` message field (Kimi uses `reasoning_content`) from attributes and `model_extra` when `content` is empty. Previously those responses became `LLMResponse(text='')` and every `json()` parse failed at char 0.
2. **Explicit token budget for structured-output task hints** — M2.7 spends up to ~3.3k completion tokens reasoning before the JSON payload; server-default budgets truncate mid-reasoning. `complete_with_task_hints` defaults `max_tokens=8192` for `json_extraction` / `json_extraction_retry` / `entity_linking`; explicit caller values win.
3. **Budget-boost retry before the strip ladder** — MARA's 400 *"model did not output valid JSON — token limit reached"* is a generation failure, not a payload rejection. The retry ladder used to strip `response_format`, and the unconstrained retry leaked thinking into content (observed 43k-char prose, no JSON). Now a same-shape variant with doubled budget (≥16384) is tried first, in both sync and async loops; the strip ladder remains the final fallback.
4. **Precise legacy-compat stripping** — the new max_tokens default exposed a blind spot: the TypeError fallback blanket-stripped every optional kwarg, so doubles accepting `reasoning_mode` but not `max_tokens` lost everything. Now only the kwarg each TypeError names is removed.

## Why it matters

~26% of extraction chunks in a 50-doc ERB smoke silently degraded to heuristic fallback in guided mode. In strict mode these become rejections — confounding the H1 enforcement ablation (seocho-vdw.2): JSON parse luck masquerading as governance effect.

Honest scope note: live validation shows some pathological chunks (long meeting transcripts) still exhaust 16k and fall through to the old fallback path — no regression, but not fully cured. Remaining ub5 escalations: model-fallback retry, smaller chunks for transcript sources, or the local vLLM guided-decoding lane.

## Validation

- `bash scripts/ci/run_basic_ci.sh` — 670 passed, 3 skipped; runtime-shell / module-ownership / root-hierarchy / docs contract checks all passed
- `tests/seocho/test_llm_backends.py` — 40 passed (4 new tests across the fixes)
- Live MARA probes + three instrumented 10-doc ERB ingest runs (raw finish_reason/content/reasoning logging) pinpointing each failure class

Tracked under seocho-ub5.
