### PR TITLE
[Draft] Fix Palantir AIP button contrast in evaluation static assets

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What:
Changed the foreground text color of three specific primary buttons (`#ingestBtn`, `#oneClickDemoBtn`, and `.composer button`) from white (`#fff`) to dark navy (`#0d1117`) in `evaluation/static/styles.css`, and logged this finding in `.jules/palette.md`.

Why:
The Palantir AIP theme accent colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) used as solid backgrounds on these buttons do not provide a sufficient WCAG 2 AA contrast ratio when paired with pure white text (`#fff`). 

Accessibility / UX Impact:
Improves visual accessibility by ensuring users with low vision can clearly read the text on primary interactive elements. This brings the evaluation app's styling into better compliance with standard contrast guidelines.

Validation:
- Rebuilt and visually verified the frontend UI changes locally via `uvicorn`.
- Ensured ghost buttons (using `--accent-*-ghost` variables with dark backgrounds) were correctly left untouched as they already had sufficient contrast.
- Ran the core test suite via `bash scripts/ci/run_basic_ci.sh` which passed successfully with no regressions.

Risks:
Negligible. The changes are strictly isolated to CSS rules for three specific element selectors and do not modify any runtime logic, APIs, or DOM structures.

Modified Files:
- `evaluation/static/styles.css`
- `.jules/palette.md`

---
*PR created automatically by Jules for task [13785829058627581746](https://jules.google.com/task/13785829058627581746) started by @tteon*