### PR TITLE
[Draft] Fix WCAG contrast issues in Palantir AIP theme

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Changed the text color on primary action buttons from white to a very dark navy (`#0d1117`).

Why: The Palantir AIP theme primary colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) do not have a sufficient contrast ratio when paired with a white foreground (`#fff`). They must use a darker shade (e.g. `#0d1117`) to meet WCAG 2 AA contrast guidelines.

Accessibility / UX Impact: Enhances text readability and WCAG compliance for users with visual impairments by improving the contrast ratio on critical call-to-action buttons (Ingest Raw, Load Sample & Ask, Execute Pipeline).

Validation:
- Visually verified via local server, Playwright, and screenshot.
- Validated via `bash scripts/ci/run_basic_ci.sh` (all tests passed).

Risks: Minimal. The changes are strictly scoped to specific CSS selectors in a single file and only modify the `color` property.

Modified files:
- `evaluation/static/styles.css`
- `.jules/palette.md`

---
*PR created automatically by Jules for task [17139521317823480840](https://jules.google.com/task/17139521317823480840) started by @tteon*