### PR TITLE
[Draft] fix(cli): Correct local-ask command in init helper text

### DIFF
--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -1418,7 +1418,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
     print()
     print("Next steps:")
     print("  seocho index ./your_data/")
-    print("  seocho ask --local 'your question here'")
+    print("  seocho local-ask 'your question here'")
     return 0
 
 


### PR DESCRIPTION
**What:**
Fixed an incorrect command suggestion in the CLI `init` output. It now correctly suggests `seocho local-ask 'your question here'` instead of `seocho ask --local 'your question here'`.

**Why:**
The previous command suggestion `seocho ask --local` is an invalid command because `ask` is defined as a global option auto-detecting local/server mode, but the specific local-mode only equivalent is `seocho local-ask` which prevents confusion for new users trying to query their local graphs without running the HTTP server.

**Accessibility / UX Impact:**
Improves developer UX by ensuring the 'Next steps' CLI output provided after initializing a project points to the correct and valid command.

**Validation:**
- Verified the correct string replacement locally.
- Ran `bash scripts/ci/run_basic_ci.sh` which completed successfully with no new regressions.

**Risks:**
Extremely low risk as this only updates a printed helper string and does not change any runtime logic.

---
*PR created automatically by Jules for task [2929129874295477424](https://jules.google.com/task/2929129874295477424) started by @tteon*