### PR TITLE
fix: enforce workspace filter in execute_cypher tool

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
### Severity
High

### Vulnerability
The `execute_cypher` tool in `src/seocho/tools.py` was previously calling `graph_store.query()` without passing `workspace_id=workspace_id` or `enforce_workspace_filter=True`. This allowed the dynamic Cypher execution tool to query or modify data across all workspaces in the database without any tenant isolation being enforced by the underlying graph store.

### Impact
If a multi-tenant setup is used, an agent orchestrating queries using the `execute_cypher` tool could potentially retrieve, modify, or leak data belonging to other workspaces or tenants, violating data privacy and security boundaries.

### Fix
Added `workspace_id=workspace_id` and `enforce_workspace_filter=True` to the `graph_store.query` call inside the `execute_cypher` tool in `src/seocho/tools.py`. This ensures that any dynamically constructed Cypher query executed by this tool is strictly scoped and validated against the provided workspace identifier, effectively closing the tenant isolation bypass.

### Validation
- Validated via `uv run pytest tests/seocho/test_query_proxy_workspace_enforcement.py` to ensure workspace isolation behaviors remain intact.
- Validated via full standard testing script `bash scripts/ci/run_basic_ci.sh`, all tests passed without regressions.

### Risks
Low risk. The fix utilizes the existing internal `enforce_workspace_filter` mechanism. Agents currently generating valid workspace-scoped queries will see no change in behavior, while queries missing the filter will safely raise a `WorkspaceFilterMissingError`.

### Modified Files
- `src/seocho/tools.py`

---
*PR created automatically by Jules for task [11783270275938298603](https://jules.google.com/task/11783270275938298603) started by @tteon*