### PR TITLE
[Draft] Fix button contrast in UI console

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: var(--bg-input);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-input);
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: var(--bg-input);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
### What
Fixed WCAG AA contrast violations in the SEOCHO AIP Console UI buttons.

### Why
The `--accent-green` (#3fb950) and `--accent-blue` (#2f81f7) background colors used for `#ingestBtn`, `#oneClickDemoBtn`, and `.composer button` failed WCAG AA contrast guidelines when paired with the hardcoded white (`#fff`) text color.

### Accessibility / UX Impact
Improves text readability and ensures the application meets minimum WCAG AA accessibility standards for contrast, making the primary call-to-action buttons easier to read.

### Validation
Verified the UI via manual inspection of CSS changes, confirming the color variables correctly map to the new `--bg-input` which leverages the underlying dark theme correctly. Ran local `bash scripts/ci/run_basic_ci.sh` to ensure no regressions were introduced.

### Risks
Low risk. The change is isolated to the CSS file and does not affect application functionality.

---
*PR created automatically by Jules for task [9979760730475125861](https://jules.google.com/task/9979760730475125861) started by @tteon*