### PR TITLE
fix: enforce workspace isolation on agent Cypher execution

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
**Severity**: High
**Vulnerability**: Missing authorization / tenant isolation
**Impact**: The `execute_cypher` agent tool was calling `graph_store.query()` without injecting the session's `workspace_id`. If exposed to untrusted inputs or broad agent policies, a malformed or malicious Cypher query could bypass workspace scoping and read or exfiltrate data from other tenants in the graph.
**Fix**: Updated the `graph_store.query()` invocation inside `make_execute_cypher_tool` in `src/seocho/tools.py` to explicitly pass `workspace_id=workspace_id` and set `enforce_workspace_filter=True`. This leverages the store's built-in authorization check, strictly rejecting any Cypher execution that fails to scope to the active `$workspace_id`.
**Validation**: Verified via `uv run pytest tests/seocho/test_session_agent.py tests/seocho/test_graph_cot_design.py tests/seocho/test_tiered_nl2cypher.py` and the global `scripts/ci/run_basic_ci.sh` CI script. All tests pass successfully, confirming that the tool signature change does not break existing agent execution paths while appropriately hardening the endpoint.
**Risks**: Agents attempting to execute legitimate but overly broad global queries (without a `$workspace_id` filter) will now explicitly fail with a `WorkspaceFilterMissingError`. This is intended behavior, but might require agents to be prompted to always include the filter in raw Cypher steps if they aren't already.

**Modified Files:**
- `src/seocho/tools.py`

---
*PR created automatically by Jules for task [7610383325867457388](https://jules.google.com/task/7610383325867457388) started by @tteon*