### PR TITLE
[Draft] fix: improve wcag contrast for evaluation buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
### What
Changed the text color of three main buttons (`#ingestBtn`, `#oneClickDemoBtn`, and `.composer button`) in `evaluation/static/styles.css` from white (`#fff`) to dark gray/black (`#0d1117`).

### Why
The Palantir AIP theme accent colors (`--accent-green` `#3fb950` and `--accent-blue` `#2f81f7`) used for these buttons do not provide sufficient contrast when paired with white foreground text (`#fff`). For example, the contrast ratio for the green accent is ~2.54:1, which fails WCAG 2 AA guidelines.

### Accessibility / UX Impact
- Vastly improves readability for visually impaired users.
- Meets WCAG 2 AA contrast ratio guidelines for large and regular text (contrast ratio is >4.5:1).
- Note: Did not modify the ghost background variants (e.g., `--accent-blue-ghost`), as those provide sufficient contrast against a dark container.

### Validation
- Validated via local python script (`wcag-contrast-ratio`) checking luminosity formulas.
- Ran `bash scripts/ci/run_basic_ci.sh` to ensure no functionality is broken (All checks passed).
- Checked `.bubble.user .text` to ensure non-opaque ghost styles were intentionally skipped.

### Risks
- Purely cosmetic change in an isolated static CSS file. Very low risk of functional regression.

---
*PR created automatically by Jules for task [364856538095919236](https://jules.google.com/task/364856538095919236) started by @tteon*