### PR TITLE
fix(store): declare and backfill _superseded_by on Ladybug node tables

### DIFF
--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -1274,6 +1274,10 @@ _LADYBUG_COMMON_NODE_STRING_COLUMNS = (
     "_out_of_ontology",
     "_workspace_id",
     "_source_id",
+    # seocho-dgf: Track 3's active-graph predicate filters on
+    # coalesce(n._superseded_by, '') = '' for every node alias; the
+    # schema-typed binder needs the column declared on every node table.
+    "_superseded_by",
 )
 _LADYBUG_COMMON_REL_STRING_COLUMNS = (
     "type",
@@ -1623,6 +1627,18 @@ class LadybugGraphStore(GraphStore):
         except Exception:
             # CALL show_tables() may not be supported; ignore
             pass
+        # seocho-dgf: node tables created before `_superseded_by` joined the
+        # common columns make Track 3's active-graph predicate un-bindable
+        # (Binder exception on read-only opens, where the lazy write-path
+        # backfill never runs). ALTER once per table on open; failures mean
+        # the column already exists.
+        for table_name in list(self._declared_node_tables):
+            try:
+                self._locked_execute(
+                    f"ALTER TABLE `{table_name}` ADD `_superseded_by` STRING"
+                )
+            except Exception:
+                pass
 
     def _discover_table_pk(self, table_name: str) -> str:
         """Return the PRIMARY KEY column of an existing node table.

--- a/tests/seocho/test_ladybug_store.py
+++ b/tests/seocho/test_ladybug_store.py
@@ -810,3 +810,29 @@ class TestCrossDocumentEntityMerge:
             relationships=[], source_id="doc-b",
         )
         assert again["merge_conflicts"] == []
+
+
+class TestSupersededByBackfill:
+    """seocho-dgf: Track 3's active-graph predicate must bind on Ladybug."""
+
+    def test_reopen_backfills_superseded_by_on_legacy_tables(self, tmp_path):
+        # Simulate a pre-Track-3 database: a node table WITHOUT the column.
+        path = str(tmp_path / "legacy.lbug")
+        old = LadybugGraphStore(path)
+        old._locked_execute(
+            "CREATE NODE TABLE IF NOT EXISTS `Legacy` (`name` STRING, `id` STRING, PRIMARY KEY (`id`))"
+        )
+        old._locked_execute("CREATE (:`Legacy` {id: 'l1', name: 'Old Row'})")
+        old.close()
+
+        # Reopen: _load_existing_schema must ALTER the column in, so the
+        # read-only ask path (which never writes) can bind the predicate.
+        reopened = LadybugGraphStore(path)
+        try:
+            rows = reopened.query(
+                "MATCH (n:Legacy) WHERE coalesce(n._superseded_by, '') = '' RETURN n.name",
+                database="neo4j",
+            )
+            assert any("Old Row" in str(r) for r in rows)
+        finally:
+            reopened.close()


### PR DESCRIPTION
## What

Fixes seocho-dgf: every local `ask()` on a Ladybug graph fails with `Binder exception: Cannot find property _superseded_by` because Track 3's active-graph predicate references a column the schema-typed backend never declared. Evidence comes back empty and answers look like retrieval failures.

Two parts:
1. `_superseded_by` joins `_LADYBUG_COMMON_NODE_STRING_COLUMNS` — new node tables declare it (both the ontology `ensure_constraints` path and lazy `_ensure_node_table`).
2. `_load_existing_schema` ALTERs the column into node tables of pre-existing databases on open — covering read-only sessions where a write-path backfill would never run.

Note: the ticket's latest comment ("Track 3 not on main, dormant") was stale — the predicate is live on origin/main and was reproduced against main in the vLLM connector smoke.

## Validation

- `python3 -m pytest tests/seocho/test_ladybug_store.py` — 27 passed, including the previously failing `test_query_supports_legal_relationship_lookup` (red on main before this fix) and a new reopen-backfill regression test simulating a pre-Track-3 database
- `bash scripts/ci/run_basic_ci.sh` — 675 passed, 3 skipped, all contract checks passed
- Not run: DozerDB path (schemaless, unaffected by this predicate binding)

Tracked under seocho-dgf. Context: Ladybug is now low-priority per product direction (DozerDB-first) — this fix is kept minimal to unbreak the embedded path without further investment.