### PR TITLE
[Draft] Fix local-ask CLI parameter consistency

### DIFF
--- a/src/seocho/cli.py
+++ b/src/seocho/cli.py
@@ -302,7 +302,7 @@ def build_parser() -> argparse.ArgumentParser:
     index_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
     local_ask_parser = subparsers.add_parser("local-ask", help="Ask a question against local graph (no server)")
-    local_ask_parser.add_argument("question", help="Question to ask")
+    local_ask_parser.add_argument("message", help="Message to ask")
     local_ask_parser.add_argument("--database", default="neo4j", help="Target database")
     local_ask_parser.add_argument("--schema", default="schema.jsonld", help="Ontology file")
     local_ask_parser.add_argument("--neo4j-uri", default="bolt://localhost:7687", help="Neo4j URI")
@@ -1576,7 +1576,7 @@ def _cmd_local_ask(args: argparse.Namespace) -> int:
 
     try:
         answer = client.ask(
-            args.question,
+            args.message,
             database=args.database,
             reasoning_mode=args.reasoning,
             repair_budget=args.repair_budget,


### PR DESCRIPTION
## What
Renamed the `local-ask` positional argument from `question` to `message` and updated its help string to `Message to ask` in `src/seocho/cli.py`.

Modified files:
- `src/seocho/cli.py`

## Why
The `ask` and `chat` commands both use `message` as their positional argument. The `local-ask` command previously used `question` as its positional argument, which caused inconsistency and confusion for developers relying on the CLI's standard interface for query commands.

## Accessibility / UX Impact
Improves CLI usability and reduces cognitive load by standardizing argument names (`message`) across all prompt-accepting commands (`chat`, `ask`, `local-ask`). The help outputs are now perfectly consistent.

## Validation
- Verified via `git diff --staged`
- Ran basic CI checks `bash scripts/ci/run_basic_ci.sh`, all tests pass.
- Linted agent docs via `bash scripts/pm/lint-agent-docs.sh` (passed).

## Risks
Very low risk. The change is restricted to CLI argument parsing and does not impact backend functionality or change documented APIs beyond normalizing `--help` text. User scripts using positional arguments (e.g. `seocho local-ask "Hello"`) will still work identically, since positional args map implicitly in argparse.

---
*PR created automatically by Jules for task [2988833664037996083](https://jules.google.com/task/2988833664037996083) started by @tteon*