### PR TITLE
Fix missing authz/policy checks on sensitive endpoint in execute_cypher tool

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
Severity: High
Vulnerability: Missing authorization/policy checks on dynamic Cypher execution via execute_cypher tool.
Impact: A user could theoretically bypass tenant-isolation and execute malicious/unintended queries without being restricted to their workspace.
Fix: Added workspace_id=workspace_id and enforce_workspace_filter=True to the graph_store.query() call in make_execute_cypher_tool.
Validation: Ran bash scripts/ci/run_basic_ci.sh.
Risks: This modifies how dynamic Cypher strings are executed by the tools, though standard regression sets did not catch it; edge cases involving cross-tenant queries that were formerly working might be impacted.
Modified Files: src/seocho/tools.py

---
*PR created automatically by Jules for task [16733962793301327793](https://jules.google.com/task/16733962793301327793) started by @tteon*