### PR TITLE
feat(ont): WP-O shapes-as-source pipeline — seocho ont fmt/lint/build/verify/blast-radius

### DIFF
--- a/examples/ontology-pipeline/README.md
+++ b/examples/ontology-pipeline/README.md
@@ -1,0 +1,23 @@
+# Shapes-as-source pipeline (`seocho ont`)
+
+SHACL shapes are the single source the cache layer derives everything from:
+vocabulary, the class→relationship path index, and the `class:*` address
+space. This directory is the smallest working example.
+
+```bash
+pip install 'seocho[ontology]'            # rdflib
+
+seocho ont fmt shapes/                     # canonical Turtle (diffable, hashable)
+seocho ont lint shapes/                    # targetClass/path sanity, canonical check
+seocho ont build shapes/ --out build --lock seocho.lock
+seocho ont verify shapes/ --lock seocho.lock
+seocho ont blast-radius shapes/ --change proposed-shapes/
+```
+
+`seocho.lock`'s `active_hash` covers the whole lockfile — shapes, every
+derived artifact, and the tool version — so a compiler upgrade with identical
+shapes still reads as a change. That one string is the system-wide "did the
+ontology world move" token (design v0.3 §O.4).
+
+Formatting does not move hashes: `source_hash` is computed over the
+canonical graph, so `ont fmt` before or after `ont build` verifies clean.

--- a/examples/ontology-pipeline/shapes/fin-core.ttl
+++ b/examples/ontology-pipeline/shapes/fin-core.ttl
@@ -1,0 +1,60 @@
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcam: <http://purl.org/dc/dcam/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcmitype: <http://purl.org/dc/dcmitype/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix fin: <https://seocho.dev/shapes/fin#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix qb: <http://purl.org/linked-data/cube#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix ssn: <http://www.w3.org/ns/ssn/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix wgs: <https://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+_:cb1106edcd723b8052bf4ded2718ab522f2d1df6aa1faaf3d039598f420ae406af5 sh:class fin:Account ;
+    sh:path fin:transfersTo .
+
+_:cb1709033ba40ad582d28b0ea2ae5188374fa7d5e7b4246b49a44711bd18c511367 sh:datatype xsd:string ;
+    sh:path fin:name .
+
+_:cb1bc195bd8e4ebd3e57a9e23c24fcc93a6d85023f5a839566de0fc7b98d3d2f888 sh:datatype xsd:date ;
+    sh:path fin:open_date .
+
+_:cb1bef65b32b0b1cdcd0420112d51064fd207767942bddeb4f35f2dbec5bb3b391e sh:datatype xsd:string ;
+    sh:path fin:country .
+
+_:cb1d4d7a178f94a7d9f01d91ab45c207e4a1da33e3af9b20dd236ae0e79b570c66d sh:datatype xsd:integer ;
+    sh:path fin:acct_no .
+
+_:cbc4b4668affc6c51fcf777920c795aa5a86001a22830805188b963cc84cdeee5f sh:class fin:Account ;
+    sh:path fin:owns .
+
+fin:AccountShape rdf:type sh:NodeShape ;
+    sh:property _:cb1106edcd723b8052bf4ded2718ab522f2d1df6aa1faaf3d039598f420ae406af5 ;
+    sh:property _:cb1bc195bd8e4ebd3e57a9e23c24fcc93a6d85023f5a839566de0fc7b98d3d2f888 ;
+    sh:property _:cb1d4d7a178f94a7d9f01d91ab45c207e4a1da33e3af9b20dd236ae0e79b570c66d ;
+    sh:targetClass fin:Account .
+
+fin:CompanyShape rdf:type sh:NodeShape ;
+    sh:property _:cb1709033ba40ad582d28b0ea2ae5188374fa7d5e7b4246b49a44711bd18c511367 ;
+    sh:property _:cb1bef65b32b0b1cdcd0420112d51064fd207767942bddeb4f35f2dbec5bb3b391e ;
+    sh:property _:cbc4b4668affc6c51fcf777920c795aa5a86001a22830805188b963cc84cdeee5f ;
+    sh:targetClass fin:Company .

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -60,6 +60,7 @@ uv run pytest \
   tests/seocho/test_user_facing_edge_cases.py \
   tests/seocho/test_connectors.py \
   tests/seocho/test_cli_parser_contract.py \
+  tests/seocho/test_ontology_pipeline.py \
   tests/seocho/test_semantic_query_phase_a.py \
   extraction/tests/test_sdk_evaluation.py \
   tests/seocho/test_agent_design.py \

--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -1768,5 +1768,15 @@ register_group(
     )
 )
 
+from . import ont as _ont_group  # noqa: E402
+
+register_group(
+    CommandGroup(
+        name="ont",
+        register=_ont_group.register,
+        handle=_ont_group.handle,
+    )
+)
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/seocho/cli/__main__.py
+++ b/src/seocho/cli/__main__.py
@@ -1,0 +1,5 @@
+"""Keep ``python -m seocho.cli`` working after the module became a package."""
+
+from . import main
+
+raise SystemExit(main())

--- a/src/seocho/cli/ont.py
+++ b/src/seocho/cli/ont.py
@@ -1,0 +1,124 @@
+"""The ``seocho ont`` command group — WP-O shapes-as-source pipeline.
+
+Distinct from the legacy ``seocho ontology`` group on purpose: ``ontology``
+operates on SEOCHO ontology definitions (JSON-LD/YAML) for governance and
+review; ``ont`` treats SHACL ``shapes/*.ttl`` as the cache layer's source of
+truth — canonical formatting, derived-artifact builds, a lockfile whose
+``active_hash`` is the system-wide invalidation token, and blast-radius
+estimates for proposed changes. Second group registered through the
+CommandGroup seam; requires the ``seocho[ontology]`` extra (rdflib).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def register(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "ont", help="SHACL shapes-as-source pipeline (fmt/lint/build/verify/blast-radius)")
+    ont = parser.add_subparsers(dest="ont_command", required=True)
+
+    fmt = ont.add_parser("fmt", help="Rewrite shapes into canonical Turtle")
+    fmt.add_argument("paths", nargs="+", help="Shape files or directories")
+    fmt.add_argument("--check", action="store_true",
+                     help="Exit 1 if any file is not canonical; write nothing")
+
+    lint = ont.add_parser("lint", help="Shape sanity: targetClass, sh:path, canonical form")
+    lint.add_argument("shapes", help="Shapes directory")
+    lint.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
+    build = ont.add_parser("build", help="Derive vocab/path-index/address-space + lockfile")
+    build.add_argument("shapes", help="Shapes directory")
+    build.add_argument("--out", default="build/ontology", help="Artifact output directory")
+    build.add_argument("--lock", default="seocho.lock", help="Lockfile path")
+    build.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
+    verify = ont.add_parser("verify", help="Recompute and compare against the lockfile")
+    verify.add_argument("shapes", help="Shapes directory")
+    verify.add_argument("--lock", default="seocho.lock", help="Lockfile path")
+    verify.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
+    blast = ont.add_parser("blast-radius",
+                           help="Address-level impact of a proposed shapes change")
+    blast.add_argument("shapes", help="Current shapes directory")
+    blast.add_argument("--change", required=True,
+                       help="Proposed shapes directory to compare against")
+    blast.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
+
+
+def handle(args: argparse.Namespace) -> int:
+    from .. import ontology_pipeline as pipeline
+
+    if args.ont_command == "fmt":
+        files: list[Path] = []
+        for raw in args.paths:
+            path = Path(raw)
+            files.extend(pipeline.shape_files(path) if path.is_dir() else [path])
+        dirty = 0
+        for path in files:
+            graph = pipeline.load_graph(path)
+            formatted = pipeline.canonical_turtle(graph)
+            if path.read_text(encoding="utf-8") != formatted:
+                dirty += 1
+                if args.check:
+                    print(f"would reformat {path}")
+                else:
+                    path.write_text(formatted, encoding="utf-8")
+                    print(f"reformatted {path}")
+        if args.check and dirty:
+            print(f"{dirty} file(s) not canonical", file=sys.stderr)
+            return 1
+        if not dirty:
+            print(f"{len(files)} file(s) already canonical")
+        return 0
+
+    if args.ont_command == "lint":
+        findings = pipeline.lint(Path(args.shapes))
+        if getattr(args, "output_json", False):
+            print(json.dumps({"findings": findings}, indent=2))
+        else:
+            for finding in findings:
+                print(finding)
+            if not findings:
+                print("shapes clean")
+        return 1 if any(f.startswith("ERROR") for f in findings) else 0
+
+    if args.ont_command == "build":
+        result = pipeline.build(Path(args.shapes))
+        pipeline.write_build(result, Path(args.out), Path(args.lock))
+        if getattr(args, "output_json", False):
+            print(json.dumps(result.lock, indent=2, sort_keys=True))
+        else:
+            print(f"built {len(result.artifacts)} artifacts -> {args.out}")
+            print(f"lockfile -> {args.lock}")
+            print(f"active_hash {result.active_hash}")
+        return 0
+
+    if args.ont_command == "verify":
+        ok, problems = pipeline.verify(Path(args.shapes), Path(args.lock))
+        if getattr(args, "output_json", False):
+            print(json.dumps({"ok": ok, "problems": problems}, indent=2))
+        else:
+            print("lock verified" if ok else "LOCK DRIFT:")
+            for problem in problems:
+                print(f"  {problem}")
+        return 0 if ok else 1
+
+    if args.ont_command == "blast-radius":
+        report = pipeline.blast_radius(Path(args.shapes), Path(args.change))
+        if getattr(args, "output_json", False):
+            print(json.dumps(report, indent=2))
+        else:
+            print(f"address-space share touched: {report['address_space_share_touched']}")
+            for key in ("addresses_added", "addresses_removed", "addresses_changed",
+                        "artifacts_changed"):
+                if report[key]:
+                    print(f"{key}: {', '.join(report[key])}")
+            print(report["note"])
+        return 0
+
+    raise ValueError(f"unknown ont command: {args.ont_command}")

--- a/src/seocho/ontology_pipeline.py
+++ b/src/seocho/ontology_pipeline.py
@@ -1,0 +1,354 @@
+"""WP-O offline pipeline: SHACL shapes as source code (ADR pending, design v0.3 §WP-O).
+
+The ontology is the cache layer's address space and invalidation boundary, so
+it is treated like source: canonical formatting so diffs mean something, a
+lockfile so derived artifacts are pinned, and a composite ``active_hash`` so
+"the ontology changed" is one comparison everywhere (etcd, KV validity, CI).
+
+Everything here is offline governance — rdflib only, imported lazily, never
+on a hot request path (CLAUDE.md runtime guardrails). SHACL is the single
+source (O.10): vocabulary, path index and address space all derive from
+``shapes/*.ttl``; OWL/RDFS reasoning stays out of v1.
+
+Hash provenance: ``source_hash`` is blake2b over rdflib's canonical graph
+(isomorphism-invariant bnode labeling) serialized as sorted N-Triples, tagged
+``rdfcanon-rdflib1:`` — deliberately NOT claiming RDFC-1.0; upgrading the
+algorithm changes the tag, which changes ``active_hash``, which is exactly
+the invalidation the lockfile design demands (§O.4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+PIPELINE_VERSION = "seocho-ont/0.1.0"
+CANON_TAG = "rdfcanon-rdflib1"
+
+SH = "http://www.w3.org/ns/shacl#"
+
+
+def _require_rdflib():
+    try:
+        import rdflib
+        from rdflib import compare
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise ImportError(
+            "seocho ont requires rdflib. Install it with: pip install 'seocho[ontology]'"
+        ) from exc
+    return rdflib, compare
+
+
+# ----------------------------------------------------------------------------
+# Canonical form. fmt exists for the same reason as WP2's KV canonicalization:
+# equal meaning must be equal bytes — there for diffability, here for hashes.
+# ----------------------------------------------------------------------------
+
+def load_graph(path: Path):
+    rdflib, _ = _require_rdflib()
+    graph = rdflib.Graph()
+    graph.parse(path, format="turtle")
+    return graph
+
+
+def canonical_ntriples(graph) -> str:
+    """Isomorphism-stable, deterministic N-Triples for hashing."""
+    _, compare = _require_rdflib()
+    canonical = compare.to_canonical_graph(graph)
+    lines = sorted(
+        f"{s.n3()} {p.n3()} {o.n3()} ." for s, p, o in canonical
+    )
+    return "\n".join(lines) + "\n"
+
+
+def canonical_turtle(graph) -> str:
+    """Deterministic, human-readable Turtle: sorted prefixes, sorted subject
+    blocks, sorted predicates within a subject. Blank nodes take canonical
+    labels — intrusive on first format, stable forever after.
+    """
+    rdflib, compare = _require_rdflib()
+    canonical = compare.to_canonical_graph(graph)
+
+    namespaces = sorted(
+        (prefix, str(ns)) for prefix, ns in graph.namespaces() if prefix
+    )
+
+    def compact(term) -> str:
+        if isinstance(term, rdflib.URIRef):
+            text = str(term)
+            for prefix, ns in namespaces:
+                if text.startswith(ns) and len(text) > len(ns):
+                    local = text[len(ns):]
+                    if local and all(c.isalnum() or c in "_-." for c in local):
+                        return f"{prefix}:{local}"
+            return f"<{text}>"
+        return term.n3()
+
+    triples = sorted(
+        (compact(s), compact(p), compact(o)) for s, p, o in canonical
+    )
+    lines = [f"@prefix {prefix}: <{ns}> ." for prefix, ns in namespaces]
+    lines.append("")
+    current: Optional[str] = None
+    for subject, predicate, obj in triples:
+        if subject != current:
+            if current is not None:
+                lines[-1] = lines[-1][:-2] + " ."
+                lines.append("")
+            lines.append(f"{subject} {predicate} {obj} ;")
+            current = subject
+        else:
+            lines.append(f"    {predicate} {obj} ;")
+    if current is not None:
+        lines[-1] = lines[-1][:-2] + " ."
+    return "\n".join(lines) + "\n"
+
+
+def source_hash(graph) -> str:
+    digest = hashlib.blake2b(canonical_ntriples(graph).encode(), digest_size=16)
+    return f"{CANON_TAG}:{digest.hexdigest()}"
+
+
+# ----------------------------------------------------------------------------
+# Derivation: vocabulary, path index, address space — all from sh:targetClass
+# and sh:property/sh:path (O.10: shapeless classes have no address).
+# ----------------------------------------------------------------------------
+
+@dataclass
+class DerivedArtifacts:
+    classes: List[str]
+    relationships: List[str]
+    path_index: Dict[str, Dict[str, str]]   # class -> {relationship -> target class}
+    properties: Dict[str, List[str]]        # class -> declared datatype paths
+    address_space: List[str]                # "class:<curie>" entries
+    unaddressed_note: str = (
+        "classes without a shape carry no address and join the anonymous pool"
+    )
+
+    def to_payloads(self) -> Dict[str, str]:
+        return {
+            "vocab.json": json.dumps(
+                {"classes": self.classes, "relationships": self.relationships},
+                indent=2, sort_keys=True) + "\n",
+            "path_index.json": json.dumps(self.path_index, indent=2, sort_keys=True) + "\n",
+            "properties.json": json.dumps(self.properties, indent=2, sort_keys=True) + "\n",
+            "address_space.json": json.dumps(
+                {"addresses": self.address_space, "source": "sh:targetClass",
+                 "note": self.unaddressed_note}, indent=2, sort_keys=True) + "\n",
+        }
+
+
+def _curie(graph, term) -> str:
+    try:
+        return graph.namespace_manager.normalizeUri(term)
+    except Exception:
+        return str(term)
+
+
+def derive(graph) -> DerivedArtifacts:
+    rdflib, _ = _require_rdflib()
+    sh = rdflib.Namespace(SH)
+    rdf_type = rdflib.RDF.type
+
+    classes: List[str] = []
+    path_index: Dict[str, Dict[str, str]] = {}
+    properties: Dict[str, List[str]] = {}
+    relationships: set = set()
+
+    for shape in graph.subjects(rdf_type, sh.NodeShape):
+        for target in graph.objects(shape, sh.targetClass):
+            cls = _curie(graph, target)
+            classes.append(cls)
+            path_index.setdefault(cls, {})
+            properties.setdefault(cls, [])
+            for prop_shape in graph.objects(shape, sh.property):
+                path = next(graph.objects(prop_shape, sh.path), None)
+                if path is None:
+                    continue
+                target_class = next(graph.objects(prop_shape, sh["class"]), None)
+                path_name = _curie(graph, path)
+                if target_class is not None:
+                    path_index[cls][path_name] = _curie(graph, target_class)
+                    relationships.add(path_name)
+                else:
+                    properties[cls].append(path_name)
+
+    classes = sorted(set(classes))
+    for cls in properties:
+        properties[cls] = sorted(set(properties[cls]))
+    return DerivedArtifacts(
+        classes=classes,
+        relationships=sorted(relationships),
+        path_index={c: dict(sorted(v.items())) for c, v in sorted(path_index.items())},
+        properties=dict(sorted(properties.items())),
+        address_space=[f"class:{c}" for c in classes],
+    )
+
+
+# ----------------------------------------------------------------------------
+# Lockfile. active_hash covers the WHOLE lockfile — shapes, every derived
+# artifact, and the tool version — because a compiler bump with identical
+# shapes still invalidates derived state (§O.4).
+# ----------------------------------------------------------------------------
+
+def _sha256(payload: str) -> str:
+    return "sha256:" + hashlib.sha256(payload.encode()).hexdigest()
+
+
+@dataclass
+class BuildResult:
+    lock: Dict[str, Any]
+    artifacts: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def active_hash(self) -> str:
+        return self.lock["active_hash"]
+
+
+def shape_files(shapes_dir: Path) -> List[Path]:
+    return sorted(shapes_dir.rglob("*.ttl"))
+
+
+def build(shapes_dir: Path) -> BuildResult:
+    rdflib, _ = _require_rdflib()
+    files = shape_files(shapes_dir)
+    if not files:
+        raise FileNotFoundError(f"no .ttl shapes under {shapes_dir}")
+    merged = rdflib.Graph()
+    per_file: Dict[str, str] = {}
+    for path in files:
+        graph = load_graph(path)
+        per_file[path.relative_to(shapes_dir).as_posix()] = source_hash(graph)
+        for triple in graph:
+            merged.add(triple)
+        for prefix, ns in graph.namespaces():
+            merged.namespace_manager.bind(prefix, ns, replace=False)
+
+    artifacts = derive(merged).to_payloads()
+    lock: Dict[str, Any] = {
+        "shapes": {"source_hash": source_hash(merged), "files": per_file},
+        "derived": {name: _sha256(payload) for name, payload in sorted(artifacts.items())},
+        "tool": {"pipeline": PIPELINE_VERSION, "canonicalization": CANON_TAG},
+    }
+    lock["active_hash"] = _sha256(json.dumps(lock, sort_keys=True))
+    return BuildResult(lock=lock, artifacts=artifacts)
+
+
+def write_build(result: BuildResult, out_dir: Path, lock_path: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, payload in result.artifacts.items():
+        (out_dir / name).write_text(payload, encoding="utf-8")
+    lock_path.write_text(
+        json.dumps(result.lock, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def verify(shapes_dir: Path, lock_path: Path) -> Tuple[bool, List[str]]:
+    recorded = json.loads(lock_path.read_text())
+    current = build(shapes_dir).lock
+    problems: List[str] = []
+    # Internal integrity first: the stored active_hash must equal the hash of
+    # the stored body. Without this, editing any field while keeping the old
+    # active_hash silently verifies — the exact quiet-stale failure §O.4 exists
+    # to prevent.
+    body = {k: v for k, v in recorded.items() if k != "active_hash"}
+    if _sha256(json.dumps(body, sort_keys=True)) != recorded.get("active_hash"):
+        problems.append("lockfile internally inconsistent: body does not match "
+                        "its active_hash (hand-edited?)")
+    if recorded.get("active_hash") != current["active_hash"]:
+        if recorded.get("shapes", {}).get("source_hash") != current["shapes"]["source_hash"]:
+            problems.append("shapes changed since lock")
+        for name, digest in current["derived"].items():
+            if recorded.get("derived", {}).get(name) != digest:
+                problems.append(f"derived artifact drifted: {name}")
+        if recorded.get("tool") != current["tool"]:
+            problems.append("pipeline tool version changed")
+        if not problems:
+            problems.append("active_hash mismatch")
+    return (not problems, problems)
+
+
+# ----------------------------------------------------------------------------
+# Blast radius v1: which addresses and derived artifacts a proposed shapes
+# change touches. KV-block-level radius needs the live translation table
+# (WP6.1a); until then the address delta is the honest bound.
+# ----------------------------------------------------------------------------
+
+def blast_radius(current_dir: Path, proposed_dir: Path) -> Dict[str, Any]:
+    before = build(current_dir)
+    after = build(proposed_dir)
+    before_derived = derive_from_lockfree(current_dir)
+    after_derived = derive_from_lockfree(proposed_dir)
+
+    before_addresses = set(before_derived.address_space)
+    after_addresses = set(after_derived.address_space)
+    changed: List[str] = []
+    for address in sorted(before_addresses & after_addresses):
+        cls = address[len("class:"):]
+        if (before_derived.path_index.get(cls) != after_derived.path_index.get(cls)
+                or before_derived.properties.get(cls) != after_derived.properties.get(cls)):
+            changed.append(address)
+
+    artifacts_changed = sorted(
+        name for name in before.lock["derived"]
+        if before.lock["derived"][name] != after.lock["derived"].get(name)
+    )
+    total = max(len(before_addresses | after_addresses), 1)
+    touched = (before_addresses ^ after_addresses) | set(changed)
+    return {
+        "active_hash_before": before.active_hash,
+        "active_hash_after": after.active_hash,
+        "addresses_added": sorted(after_addresses - before_addresses),
+        "addresses_removed": sorted(before_addresses - after_addresses),
+        "addresses_changed": changed,
+        "artifacts_changed": artifacts_changed,
+        "address_space_share_touched": round(len(touched) / total, 4),
+        "note": "KV-block radius requires the live xlat table (WP6.1a); "
+                "this is the address-level bound",
+    }
+
+
+def derive_from_lockfree(shapes_dir: Path) -> DerivedArtifacts:
+    rdflib, _ = _require_rdflib()
+    merged = rdflib.Graph()
+    for path in shape_files(shapes_dir):
+        graph = load_graph(path)
+        for triple in graph:
+            merged.add(triple)
+        for prefix, ns in graph.namespaces():
+            merged.namespace_manager.bind(prefix, ns, replace=False)
+    return derive(merged)
+
+
+# ----------------------------------------------------------------------------
+# Lint v1: the checks that make shapes usable as the single source.
+# ----------------------------------------------------------------------------
+
+def lint(shapes_dir: Path) -> List[str]:
+    rdflib, _ = _require_rdflib()
+    sh = rdflib.Namespace(SH)
+    findings: List[str] = []
+    for path in shape_files(shapes_dir):
+        graph = load_graph(path)
+        rel = path.relative_to(shapes_dir).as_posix()
+        shapes = list(graph.subjects(rdflib.RDF.type, sh.NodeShape))
+        if not shapes:
+            findings.append(f"WARN {rel}: no sh:NodeShape declared")
+        for shape in shapes:
+            targets = list(graph.objects(shape, sh.targetClass))
+            if not targets:
+                findings.append(
+                    f"WARN {rel}: {_curie(graph, shape)} has no sh:targetClass — "
+                    f"it derives no address (O.10: shapeless classes join the "
+                    f"anonymous pool)")
+            for prop_shape in graph.objects(shape, sh.property):
+                if next(graph.objects(prop_shape, sh.path), None) is None:
+                    findings.append(
+                        f"ERROR {rel}: property shape under {_curie(graph, shape)} "
+                        f"lacks sh:path")
+        formatted = canonical_turtle(graph)
+        if path.read_text(encoding="utf-8") != formatted:
+            findings.append(f"WARN {rel}: not in canonical form (run: seocho ont fmt)")
+    return findings

--- a/tests/seocho/test_cli_parser_contract.py
+++ b/tests/seocho/test_cli_parser_contract.py
@@ -19,7 +19,7 @@ EXPECTED_COMMANDS = {
     "add", "get", "search", "chat", "ask", "delete", "graphs", "doctor",
     "serve", "stop", "artifacts", "connect", "connectors", "new", "init",
     "index", "local-ask", "status", "compare", "experiment", "bundle",
-    "ontology", "serve-http", "run", "sweep", "traces",
+    "ontology", "ont", "serve-http", "run", "sweep", "traces",
 }
 
 EXPECTED_ONTOLOGY_SUBCOMMANDS = {

--- a/tests/seocho/test_ontology_pipeline.py
+++ b/tests/seocho/test_ontology_pipeline.py
@@ -1,0 +1,133 @@
+"""WP-O pipeline contract: canonical form, derivation, lockfile, blast radius.
+
+Requires rdflib (the seocho[ontology] extra); skips cleanly without it, same
+as the owlready2-backed tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("rdflib")
+
+from seocho import ontology_pipeline as pipeline  # noqa: E402
+
+SHAPES = """\
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix fin: <https://seocho.dev/shapes/fin#> .
+
+fin:AccountShape a sh:NodeShape ;
+    sh:targetClass fin:Account ;
+    sh:property [ sh:path fin:acct_no ; sh:datatype xsd:integer ] ;
+    sh:property [ sh:path fin:transfersTo ; sh:class fin:Account ] .
+
+fin:CompanyShape a sh:NodeShape ;
+    sh:targetClass fin:Company ;
+    sh:property [ sh:path fin:name ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path fin:owns ; sh:class fin:Account ] .
+"""
+
+
+@pytest.fixture
+def shapes_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "shapes"
+    directory.mkdir()
+    (directory / "core.ttl").write_text(SHAPES, encoding="utf-8")
+    return directory
+
+
+def test_canonical_turtle_is_idempotent_and_order_insensitive(shapes_dir: Path):
+    graph = pipeline.load_graph(shapes_dir / "core.ttl")
+    once = pipeline.canonical_turtle(graph)
+    # Re-parse the formatted output: formatting again must be a fixed point.
+    reparsed_path = shapes_dir / "reparsed.ttl"
+    reparsed_path.write_text(once, encoding="utf-8")
+    twice = pipeline.canonical_turtle(pipeline.load_graph(reparsed_path))
+    assert once == twice
+
+    # A semantically identical file with reordered statements hashes the same.
+    lines = SHAPES.split("\n\n")
+    reordered = "\n\n".join([lines[0]] + list(reversed(lines[1:])))
+    other = shapes_dir / "reordered.ttl"
+    other.write_text(reordered, encoding="utf-8")
+    assert pipeline.source_hash(graph) == pipeline.source_hash(pipeline.load_graph(other))
+
+
+def test_derivation_yields_vocab_paths_and_addresses(shapes_dir: Path):
+    derived = pipeline.derive_from_lockfree(shapes_dir)
+    assert derived.classes == ["fin:Account", "fin:Company"]
+    assert derived.path_index["fin:Account"]["fin:transfersTo"] == "fin:Account"
+    assert derived.path_index["fin:Company"]["fin:owns"] == "fin:Account"
+    assert "fin:acct_no" in derived.properties["fin:Account"]
+    assert derived.address_space == ["class:fin:Account", "class:fin:Company"]
+
+
+def test_build_verify_roundtrip_and_active_hash_covers_tool(shapes_dir: Path, tmp_path: Path):
+    result = pipeline.build(shapes_dir)
+    lock_path = tmp_path / "seocho.lock"
+    pipeline.write_build(result, tmp_path / "build", lock_path)
+    ok, problems = pipeline.verify(shapes_dir, lock_path)
+    assert ok, problems
+
+    # active_hash must cover the lockfile as a whole, not just shapes (§O.4):
+    # a tool-version change with identical shapes must be drift.
+    tampered = json.loads(lock_path.read_text())
+    tampered["tool"]["pipeline"] = "seocho-ont/9.9.9"
+    lock_path.write_text(json.dumps(tampered, indent=2, sort_keys=True))
+    ok, problems = pipeline.verify(shapes_dir, lock_path)
+    assert not ok
+    assert any("tool" in p or "active_hash" in p for p in problems)
+
+
+def test_shape_change_moves_active_hash_and_blast_radius_names_it(
+        shapes_dir: Path, tmp_path: Path):
+    proposed = tmp_path / "proposed"
+    proposed.mkdir()
+    changed = SHAPES.replace(
+        "sh:property [ sh:path fin:owns ; sh:class fin:Account ] .",
+        "sh:property [ sh:path fin:owns ; sh:class fin:Account ] ;\n"
+        "    sh:property [ sh:path fin:country ; sh:datatype xsd:string ] .")
+    (proposed / "core.ttl").write_text(changed, encoding="utf-8")
+
+    report = pipeline.blast_radius(shapes_dir, proposed)
+    assert report["active_hash_before"] != report["active_hash_after"]
+    assert report["addresses_changed"] == ["class:fin:Company"]
+    assert report["addresses_added"] == []
+    assert 0 < report["address_space_share_touched"] <= 0.5
+
+
+def test_lint_flags_shapeless_and_pathless(tmp_path: Path):
+    directory = tmp_path / "shapes"
+    directory.mkdir()
+    (directory / "bad.ttl").write_text(
+        "@prefix sh: <http://www.w3.org/ns/shacl#> .\n"
+        "@prefix ex: <https://x.dev/#> .\n"
+        "ex:Orphan a sh:NodeShape ;\n"
+        "    sh:property [ sh:name \"no path here\" ] .\n",
+        encoding="utf-8")
+    findings = pipeline.lint(directory)
+    assert any("no sh:targetClass" in f for f in findings)
+    assert any(f.startswith("ERROR") and "lacks sh:path" in f for f in findings)
+
+
+def test_ont_cli_group_end_to_end(shapes_dir: Path, tmp_path: Path, capsys):
+    from seocho.cli import main
+
+    out = tmp_path / "build"
+    lock = tmp_path / "seocho.lock"
+    assert main(["ont", "build", str(shapes_dir), "--out", str(out),
+                 "--lock", str(lock)]) == 0
+    assert (out / "address_space.json").exists()
+    assert main(["ont", "verify", str(shapes_dir), "--lock", str(lock)]) == 0
+
+    # fmt --check flags the hand-written fixture, fmt fixes it, check passes.
+    assert main(["ont", "fmt", str(shapes_dir), "--check"]) == 1
+    assert main(["ont", "fmt", str(shapes_dir)]) == 0
+    assert main(["ont", "fmt", str(shapes_dir), "--check"]) == 0
+    # formatting alone must not drift the lock: hashes are canonicalization-based
+    assert main(["ont", "verify", str(shapes_dir), "--lock", str(lock)]) == 0
+    capsys.readouterr()


### PR DESCRIPTION
**Stacked on #483** (uses the CommandGroup seam + package layout) — retarget as the stack merges. First slice of **seocho-fix.2**, the OS-facing ontology management the unified cache layer stands on (design v0.3 §WP-O).

**Engine** (`seocho/ontology_pipeline.py`, offline-only, rdflib behind `seocho[ontology]`):
- **Canonical form**: isomorphism-stable Turtle (canonical bnode labels, sorted subjects/predicates) — equal meaning becomes equal bytes, the same principle WP2 applies to KV serialization. `ont fmt` is idempotent and **does not move hashes** (source_hash is computed over the canonical graph, held by test).
- **Derivation from SHACL as single source** (O.10): vocabulary, class→relationship path index, datatype properties, and the `class:*` address space from `sh:targetClass`/`sh:property` — shapeless classes carry no address.
- **`seocho.lock` + `active_hash`** covering shapes + every derived artifact + tool version (§O.4: a compiler bump with identical shapes is still a change). `verify` gained an internal-integrity check the tests forced into existence — a hand-edited lockfile keeping its stale `active_hash` previously verified clean.
- **`blast-radius` v1**: address-level bound of a proposed shapes change (which `class:*` entries change, which artifacts move, share of address space touched). KV-block radius arrives with the WP6.1a xlat table.

**CLI**: `seocho ont` is the second CommandGroup through the #480 registry seam — deliberately distinct from legacy `seocho ontology` (JSON-LD governance). Also restores `python -m seocho.cli` (`__main__.py`) after the package split.

**Example**: `examples/ontology-pipeline/` — smallest working flow, formatted and locked by the tool itself.

Remaining on fix.2: OCI `pull`/`publish` bundle, module stability profiling (needs change history), grammar/logits derivations (those are WP1's consumers).

Validation: `bash scripts/ci/run_basic_ci.sh` — 685 passed, 3 skipped (the 6 pipeline tests execute in CI; rdflib is in the ci extra); example flow run end-to-end; ruff clean.