### PR TITLE
docs+tools: ADR-0156 — H0 gate verdict: the working sets diverge

### DIFF
--- a/docs/decisions/ADR-0156-h0-gate-verdict-working-sets-diverge.md
+++ b/docs/decisions/ADR-0156-h0-gate-verdict-working-sets-diverge.md
@@ -1,0 +1,86 @@
+# ADR-0156: H0 gate verdict — the two caches' working sets diverge with scale
+
+Date: 2026-08-15 · Status: accepted (measurement record)
+
+## Context
+
+The unified-cache-layer plan (epic seocho-fix, design v0.3) made its own
+survival conditional: H0 — "the Neo4j page cache and vLLM KV cache hold
+significantly overlapping working sets" — was the top gate, to be decided in
+WP0 before any joint-budget machinery was built. This ADR records the
+verdict and the pivot it forces, per the repository's rule that ontology and
+cache experiments land with their data.
+
+## Method
+
+The 702-episode FinBench agent<->database run (#462/#478) stored every
+call's Cypher, so the workload replays without a model in the loop.
+Against reloaded `sf1-layers` / `sf10-layers` graphs
+(graphstack/dozerdb:5.26.3.0):
+
+- **DB-side working set**: per call, a shadow query returns `elementId` for
+  every node variable the MATCH..WHERE clause binds (`scripts/cache_sim/
+  collect_finbench_traces.py`). A lower bound on the page working set —
+  DozerDB CE exposes no page identities (measured: no metrics subsystem, no
+  `org.neo4j` MBeans), so index pages and scanned-but-unbound entities are
+  invisible. That bias *raises* measured overlap, which makes a FAIL robust.
+- **KV-side working set**: nodes whose identity survives into the serialized
+  context — RETURN-exposed variables outside aggregates, capped at the row
+  cap the call actually ran with. A `count()` row carries no node into the
+  KV cache.
+- **Metrics**: Jaccard of the universes and of the top-decile
+  (episode-frequency) hot sets; threshold 0.30 set here — below it the hot
+  sets are mostly disjoint and there is nothing shared to co-manage. H1 uses
+  the plan's own threshold (top-decile nodes < 30% of appearances → reject
+  pin/quantization).
+
+Raw numbers: `ADR-0156-h0-gate-verdict.json`. Coverage caveats recorded
+there: 154/234 episodes per scale carry read sets (WITH-scope shadows are
+refused rather than guessed); single-anchor workload; ORDER BY dropped in
+capped context shadows.
+
+## Results
+
+| | SF1 | SF10 |
+|---|---|---|
+| DB universe (nodes bound) | 2,850 | 22,617 (**8.0x**) |
+| KV universe (nodes in context) | 736 | 1,157 (1.6x) |
+| H0 Jaccard, full universes | 0.258 | 0.051 |
+| **H0 Jaccard, top-decile hot sets** | **0.226 — FAIL** | **0.050 — FAIL** |
+| Containment KV ⊆ DB | 1.000 | 1.000 |
+| H1 top-decile appearance share | 0.238 — FAIL | 0.283 — FAIL, rising |
+| MRC hit rate @1024 blocks (session/shuffled) | 57.6% / 28.8% | 36.0% / 19.9% |
+
+The working sets do not overlap and then drift — they **diverge**: the DB
+side grows with the graph while what reaches the LLM stays an anchor-centric
+slice bounded by row caps and aggregates. Containment 1.0 says the KV set is
+a small subset of the DB set, not an overlapping peer.
+
+The KV side has its own structure worth keeping: the WP0 simulator (#487)
+measures large shared-prefix block counts and a 2x hit-rate gap between
+session-clustered and shuffled arrivals — prefix reuse is real and
+exploitable without any joint budgeting.
+
+## Decision
+
+Per the plan's own Go/No-Go table (§4.2, "Jaccard 중첩 낮음 → 통합 계층
+폐기, 두 캐시 독립 최적화로 전환"):
+
+1. **Dropped**: WP3 joint budget allocation and cross-prefetch
+   (opportunities A and B). seocho-fix.5 stays open only pending an SF100
+   confirmation run; no work starts on it.
+2. **Kept**: WP4 derived-KV invalidation — a correctness property that never
+   depended on overlap; WP2 KV-side canonicalization/ordering — justified by
+   the measured prefix reuse; pattern-trace experiments (fix.11).
+3. **Narrowed**: the ADR-0155 Rust data plane invokes its own kill-criteria
+   clause — scope shrinks to the invalidation + observation proxy.
+4. **H1 is not closed**: the share rises with scale (0.238 → 0.283); rerun
+   at SF100 before deciding pin/quantization policy.
+
+## Consequences
+
+Engineering weight shifts to the product-feature track (observability, CLI,
+ontology import — seocho-5bg) and to the two surviving cache workstreams.
+The negative result itself is the WP0 characterization deliverable the plan
+pre-registered ("why text-RAG caching techniques do not transfer to graphs")
+and is written to stand alone.

--- a/docs/decisions/ADR-0156-h0-gate-verdict.json
+++ b/docs/decisions/ADR-0156-h0-gate-verdict.json
@@ -1,0 +1,207 @@
+{
+  "operationalization": "WP0 gate verdict: H0 (working-set overlap) and H1 (node-appearance skew).\n\nOperationalization, stated up front because it IS the result's fine print:\n\n- DB-side working set = nodes bound by each replayed call's MATCH..WHERE\n  (shadow elementId queries). This is a *lower bound* on the page working\n  set \u2014 DozerDB CE exposes no page identities (measured 2026-08-15), and\n  index pages / scanned-but-unbound entities are invisible. A lower bound\n  biases H0 *upward* (missing DB-only nodes would only shrink overlap), so\n  a FAIL verdict is robust; a PASS near the threshold is not.\n- KV-side working set = nodes whose identity survives into the serialized\n  context (RETURN-exposed variables outside aggregates, plus nothing else:\n  a count() row carries no node into the LLM's cache).\n- H0 metric: Jaccard of the two universes, plus Jaccard of the top-decile\n  (by episode-appearance frequency) hot sets. Threshold (set here, absent\n  from the plan): top-decile Jaccard >= 0.30 \u2014 below that the hot sets are\n  mostly disjoint and there is no shared working set to co-manage.\n- H1 metric: share of context-node appearances captured by the top 10% of\n  context nodes. Plan's own gate: < 30% -> reject pin/quantization.",
+  "h0_threshold_top_decile_jaccard": 0.3,
+  "h1_threshold_top_decile_share": 0.3,
+  "per_sf": [
+    {
+      "sf": 1,
+      "episodes": 234,
+      "episodes_with_read_set": 154,
+      "db_universe": 2850,
+      "kv_universe": 736,
+      "kv_in_db_containment": 1.0,
+      "h0_jaccard_full": 0.2582,
+      "h0_jaccard_top_decile": 0.226,
+      "h1_top_decile_appearance_share": 0.2382,
+      "db_top10": [
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:0",
+          130
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:223",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:36",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:252",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:1434",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:78",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:165",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:637",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:2",
+          120
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:298",
+          120
+        ]
+      ],
+      "kv_top10": [
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:165",
+          45
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:252",
+          39
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:223",
+          39
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:1434",
+          39
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:240",
+          36
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:81",
+          33
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:36",
+          33
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:139",
+          33
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:131",
+          33
+        ],
+        [
+          "4:c8ed0154-f366-494b-a4a0-e377c8e85a97:144",
+          33
+        ]
+      ]
+    },
+    {
+      "sf": 10,
+      "episodes": 234,
+      "episodes_with_read_set": 154,
+      "db_universe": 22617,
+      "kv_universe": 1157,
+      "kv_in_db_containment": 1.0,
+      "h0_jaccard_full": 0.0512,
+      "h0_jaccard_top_decile": 0.0504,
+      "h1_top_decile_appearance_share": 0.2832,
+      "db_top10": [
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:17",
+          130
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:51",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:424",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:3018",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:341",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:15",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:65",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:706",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:4267",
+          124
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:2",
+          124
+        ]
+      ],
+      "kv_top10": [
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:1210",
+          44
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:1916",
+          44
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:14280",
+          41
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:65",
+          38
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:162",
+          38
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:114",
+          38
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:733",
+          35
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:341",
+          35
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:517",
+          35
+        ],
+        [
+          "4:13522601-4740-4b59-b49d-d7a58a8c5b0c:17011",
+          35
+        ]
+      ]
+    }
+  ],
+  "verdicts": {
+    "sf1": {
+      "H0": "FAIL",
+      "H1": "FAIL"
+    },
+    "sf10": {
+      "H0": "FAIL",
+      "H1": "FAIL"
+    }
+  }
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -901,6 +901,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - keep seocho.tracing.record_metric as a legacy-name shim; uncataloged names are dropped
   - risk: legacy snake_case series end at the rename — none were referenced by any dashboard or rule
 
+## 2026-08-15
+
+- [Accepted] ADR-0156 h0-gate-verdict-working-sets-diverge
+  - measured on SF1/SF10 FinBench replay: DB and KV working sets diverge with scale (top-decile Jaccard 0.226 -> 0.050); KV is an anchor-centric subset (containment 1.0)
+  - per the plan's own gate: joint budget (WP3) and cross-prefetch dropped; WP4 invalidation and WP2 KV-side optimization kept; ADR-0155 data plane narrowed to invalidation+observation
+  - H1 left open (share rising with scale); rerun at SF100 before pin/quantization verdict
+  - caveat: read set is variable-binding based (CE exposes no page identities) — biases overlap up, so FAIL is robust
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/cache_sim/collect_finbench_traces.py
+++ b/scripts/cache_sim/collect_finbench_traces.py
@@ -1,0 +1,253 @@
+"""Replay FinBench agent episodes into trace-schema v1 + H0 node sets.
+
+The 702-episode agent_interaction run stored every call's Cypher, so the
+whole workload replays against a reloaded graph without a model in the loop:
+
+  KV side   the serialized context each episode actually shipped —
+            instructions prefix (reconstructed exactly via the harness's own
+            build_instructions) + question + the tool payload JSON per call.
+  DB side   per call, a shadow query returns elementIds of every node
+            variable the MATCH..WHERE clause binds (the read set — closer to
+            what pages must be resident than the returned rows alone), and a
+            second shadow restricted to variables the RETURN clause exposes
+            outside aggregates (the context-node set: what the LLM can see).
+
+Exclusions are counted, never silent: truncated call Cyphers (stored capped
+at 600 chars) fall back to the episode's settled query; shadow rewrites that
+fail scope analysis are logged per reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "src"))
+
+_spec = importlib.util.spec_from_file_location(
+    "fb_agent", REPO / "scripts" / "finbench" / "agent_interaction.py")
+fb = importlib.util.module_from_spec(_spec)
+sys.modules["fb_agent"] = fb
+_spec.loader.exec_module(fb)
+
+_tspec = importlib.util.spec_from_file_location(
+    "pattern_trace_schema", REPO / "scripts" / "pattern_traces" / "schema.py")
+tschema = importlib.util.module_from_spec(_tspec)
+sys.modules["pattern_trace_schema"] = tschema
+_tspec.loader.exec_module(tschema)
+
+NODE_VAR = re.compile(r"\(\s*(\w+)\s*:")
+PATH_VAR = re.compile(r"MATCH\s+(\w+)\s*=", re.I)
+AGG = re.compile(r"\b(count|sum|avg|min|max|collect|percentile\w*|stdev\w*)\s*\(", re.I)
+
+
+def instructions_for(arm: str, ontology_path: Path) -> str:
+    import yaml
+    from seocho.ontology import Ontology
+    from seocho.query.hybrid_planner import policy_from_ontology, schema_for_prompt
+
+    doc = yaml.safe_load(ontology_path.read_text())
+    onto = Ontology.from_dict(doc)
+    policy = policy_from_ontology(onto)
+    schema = fb.labels_only_schema(onto) if arm == "labels" else schema_for_prompt(onto, policy)
+    return fb.build_instructions(schema, arm=arm)
+
+
+def shadow_queries(cypher: str) -> tuple[str | None, str | None, list[str], list[str]]:
+    """(read_set_query, ctx_set_query, all_vars, ctx_vars) or Nones on failure."""
+    idx = cypher.rfind("RETURN")
+    if idx < 0:
+        return None, None, [], []
+    head, tail = cypher[:idx], cypher[idx:]
+    node_vars = list(dict.fromkeys(NODE_VAR.findall(cypher)))
+    path_vars = list(dict.fromkeys(PATH_VAR.findall(cypher)))
+    node_vars = [v for v in node_vars if v not in path_vars]
+    if not node_vars and not path_vars:
+        return None, None, [], []
+    # WITH clauses change scope; a shadow over the full head would reference
+    # out-of-scope vars. Refuse rather than guess.
+    if re.search(r"\bWITH\b", head, re.I):
+        return None, None, [], []
+
+    def id_exprs(variables: list[str], paths: list[str]) -> str:
+        parts = [f"elementId({v}) AS id_{v}" for v in variables]
+        parts += [f"[x IN nodes({p}) | elementId(x)] AS ids_{p}" for p in paths]
+        return ", ".join(parts)
+
+    read_q = head + "RETURN DISTINCT " + id_exprs(node_vars, path_vars) + "\nLIMIT 500000"
+
+    def mask_aggregates(text: str) -> str:
+        # Remove each aggregate CALL including its argument span, so a var
+        # that appears only inside count(...)/sum(...) does not count as
+        # context-exposed — an aggregate row carries no node into the LLM.
+        out = []
+        i = 0
+        while i < len(text):
+            m = AGG.search(text, i)
+            if not m:
+                out.append(text[i:])
+                break
+            out.append(text[i:m.start()])
+            depth, j = 1, m.end()
+            while j < len(text) and depth:
+                depth += text[j] == "("
+                depth -= text[j] == ")"
+                j += 1
+            i = j
+        return "".join(out)
+
+    exposed = mask_aggregates(tail)
+    ctx_vars = [v for v in node_vars + path_vars
+                if re.search(rf"\b{re.escape(v)}\b", exposed)]
+    ctx_q = None
+    if ctx_vars:
+        # The context receives only the first row_cap rows, so the context-node
+        # shadow is capped by the same $limit the original ran with. The read
+        # shadow stays uncapped: the DB touches what the pattern binds, and the
+        # gap between the two IS the asymmetry H0 is probing. (Caveat recorded:
+        # the shadow drops the original ORDER BY, so *which* row_cap rows is
+        # approximate for ordered queries.)
+        ctx_q = head + "RETURN DISTINCT " + id_exprs(
+            [v for v in ctx_vars if v in node_vars],
+            [p for p in ctx_vars if p in path_vars]) + "\nLIMIT $limit"
+    return read_q, ctx_q, node_vars + path_vars, ctx_vars
+
+
+def collect_ids(rows: list[dict]) -> set[str]:
+    out: set[str] = set()
+    for row in rows:
+        for value in row.values():
+            if isinstance(value, str):
+                out.add(value)
+            elif isinstance(value, list):
+                out.update(x for x in value if isinstance(x, str))
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run", default=str(REPO / "outputs/finbench/agent_interaction.json"))
+    parser.add_argument("--uri", default="bolt://localhost:17687")
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--databases", nargs="+", default=["finbenchl1", "finbenchl10"])
+    parser.add_argument("--ontology", default=str(REPO / "examples/finbench/finbench.ontology.yaml"))
+    parser.add_argument("--out-dir", required=True)
+    args = parser.parse_args()
+
+    from neo4j import GraphDatabase
+
+    run = json.loads(Path(args.run).read_text())
+    episodes = [e for e in run["episodes"] if e["database"] in set(args.databases)]
+    prefixes = {arm: instructions_for(arm, Path(args.ontology)) for arm in run["arms"]}
+    questions = {q["id"]: q for q in run["questions"]}
+
+    driver = GraphDatabase.driver(args.uri, auth=("neo4j", args.password))
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stats = Counter()
+    t0 = time.time()
+
+    trace_path = out_dir / "finbench_traces_v1.jsonl"
+    sets_path = out_dir / "h0_sets.jsonl"
+    trace_path.write_text("")
+    sets_path.write_text("")
+
+    for n, ep in enumerate(episodes):
+        db, arm, anchor = ep["database"], ep["arm"], ep.get("anchor")
+        row_cap = ep.get("row_cap") or run.get("row_cap", 50)
+        params = {"workspace_id": "default", "ws": "default", "limit": row_cap}
+        if anchor is not None:
+            params["a"] = anchor
+            params["acct_no"] = anchor
+
+        q = questions.get(ep["question_id"], {})
+        question_text = str(q.get("question", ep["question_id"])).replace(
+            "{a}", str(anchor if anchor is not None else ""))
+        context_parts = [prefixes[arm], "", "Question: " + question_text, ""]
+        read_ids: set[str] = set()
+        ctx_ids: set[str] = set()
+        episode_v1 = tschema.Episode(
+            pattern="single_agent", case_id=f"{db}:{ep['question_id']}:{arm}:{ep.get('repeat', 0)}",
+            model=run.get("model", ""), provider="replay")
+        episode_v1.workspace_id = "default"
+        episode_v1.ontology = "finbench"
+
+        with driver.session(database=db) as session:
+            for call in ep["calls"]:
+                if call.get("outcome") not in ("ok",):
+                    stats["call_skipped_" + str(call.get("outcome"))] += 1
+                    continue
+                cypher = call["cypher"]
+                if len(cypher) >= 600:
+                    cypher = ep.get("settled_cypher") or ""
+                    stats["call_truncated_fallback"] += 1
+                    if not cypher:
+                        stats["call_truncated_lost"] += 1
+                        continue
+                try:
+                    result = session.run(cypher, **params)
+                    rows = [dict(r) for _, r in zip(range(row_cap), result)]
+                    result.consume()
+                except Exception as exc:
+                    stats["call_replay_error"] += 1
+                    stats["err_" + type(exc).__name__] += 1
+                    continue
+                payload = json.dumps({"rows": rows, "row_count": len(rows),
+                                      "row_cap": row_cap}, default=str)
+                context_parts.append(payload)
+                episode_v1.steps.append(tschema.ToolStep(
+                    name="graph_query", rows=len(rows), db_hits=call.get("db_hits", 0),
+                    latency_ms=call.get("ms", 0.0)))
+
+                read_q, ctx_q, all_vars, ctx_vars = shadow_queries(cypher)
+                if read_q is None:
+                    stats["shadow_unsupported"] += 1
+                else:
+                    try:
+                        shadow_rows = [dict(r) for r in session.run(read_q, **params)]
+                        read_ids |= collect_ids(shadow_rows)
+                        stats["shadow_read_ok"] += 1
+                    except Exception:
+                        stats["shadow_read_error"] += 1
+                    if ctx_q is not None:
+                        try:
+                            shadow_rows = [dict(r) for r in session.run(ctx_q, **params)]
+                            ctx_ids |= collect_ids(shadow_rows)
+                            stats["shadow_ctx_ok"] += 1
+                        except Exception:
+                            stats["shadow_ctx_error"] += 1
+                    else:
+                        stats["ctx_aggregate_only"] += 1
+
+        context = "\n".join(context_parts)
+        episode_v1.outcome = {"round_trips": len(episode_v1.steps),
+                              "context_chars": len(context)}
+        record = episode_v1.to_dict()
+        record["context"] = context
+        record["sf"] = ep["sf"]
+        with trace_path.open("a") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+        with sets_path.open("a") as fh:
+            fh.write(json.dumps({
+                "case_id": episode_v1.case_id, "sf": ep["sf"], "arm": arm,
+                "question_id": ep["question_id"], "db": db,
+                "read_ids": sorted(read_ids), "ctx_ids": sorted(ctx_ids),
+            }) + "\n")
+        if (n + 1) % 50 == 0:
+            print(f"{n+1}/{len(episodes)} episodes, {time.time()-t0:.0f}s, {dict(stats)}",
+                  flush=True)
+
+    driver.close()
+    print(json.dumps({"episodes": len(episodes), "stats": dict(stats),
+                      "elapsed_s": round(time.time() - t0, 1)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cache_sim/h0_gate.py
+++ b/scripts/cache_sim/h0_gate.py
@@ -1,0 +1,122 @@
+"""WP0 gate verdict: H0 (working-set overlap) and H1 (node-appearance skew).
+
+Operationalization, stated up front because it IS the result's fine print:
+
+- DB-side working set = nodes bound by each replayed call's MATCH..WHERE
+  (shadow elementId queries). This is a *lower bound* on the page working
+  set — DozerDB CE exposes no page identities (measured 2026-08-15), and
+  index pages / scanned-but-unbound entities are invisible. A lower bound
+  biases H0 *upward* (missing DB-only nodes would only shrink overlap), so
+  a FAIL verdict is robust; a PASS near the threshold is not.
+- KV-side working set = nodes whose identity survives into the serialized
+  context (RETURN-exposed variables outside aggregates, plus nothing else:
+  a count() row carries no node into the LLM's cache).
+- H0 metric: Jaccard of the two universes, plus Jaccard of the top-decile
+  (by episode-appearance frequency) hot sets. Threshold (set here, absent
+  from the plan): top-decile Jaccard >= 0.30 — below that the hot sets are
+  mostly disjoint and there is no shared working set to co-manage.
+- H1 metric: share of context-node appearances captured by the top 10% of
+  context nodes. Plan's own gate: < 30% -> reject pin/quantization.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def load_sets(path: Path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def hot_set(counter: Counter, decile: float = 0.10) -> set:
+    if not counter:
+        return set()
+    k = max(1, int(len(counter) * decile))
+    return {node for node, _ in counter.most_common(k)}
+
+
+def jaccard(a: set, b: set) -> float:
+    if not a and not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def analyze(records, sf: int) -> dict:
+    rows = [r for r in records if r["sf"] == sf]
+    read_freq: Counter = Counter()
+    ctx_freq: Counter = Counter()
+    covered = 0
+    for r in rows:
+        if r["read_ids"]:
+            covered += 1
+        read_freq.update(set(r["read_ids"]))
+        ctx_freq.update(set(r["ctx_ids"]))
+
+    read_universe, ctx_universe = set(read_freq), set(ctx_freq)
+    top_read, top_ctx = hot_set(read_freq), hot_set(ctx_freq)
+
+    total_appearances = sum(ctx_freq.values())
+    top_ctx_appearances = sum(ctx_freq[n] for n in top_ctx)
+    h1_share = top_ctx_appearances / total_appearances if total_appearances else 0.0
+
+    return {
+        "sf": sf,
+        "episodes": len(rows),
+        "episodes_with_read_set": covered,
+        "db_universe": len(read_universe),
+        "kv_universe": len(ctx_universe),
+        "kv_in_db_containment": (len(ctx_universe & read_universe) / len(ctx_universe)
+                                 if ctx_universe else 0.0),
+        "h0_jaccard_full": round(jaccard(read_universe, ctx_universe), 4),
+        "h0_jaccard_top_decile": round(jaccard(top_read, top_ctx), 4),
+        "h1_top_decile_appearance_share": round(h1_share, 4),
+        "db_top10": read_freq.most_common(10),
+        "kv_top10": ctx_freq.most_common(10),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sets", nargs="+", required=True)
+    parser.add_argument("--h0-threshold", type=float, default=0.30)
+    parser.add_argument("--h1-threshold", type=float, default=0.30)
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    records = []
+    for path in args.sets:
+        records.extend(load_sets(Path(path)))
+    sfs = sorted({r["sf"] for r in records})
+
+    report = {"operationalization": __doc__.strip(),
+              "h0_threshold_top_decile_jaccard": args.h0_threshold,
+              "h1_threshold_top_decile_share": args.h1_threshold,
+              "per_sf": [analyze(records, sf) for sf in sfs]}
+
+    verdicts = {}
+    for row in report["per_sf"]:
+        verdicts[f"sf{row['sf']}"] = {
+            "H0": "PASS" if row["h0_jaccard_top_decile"] >= args.h0_threshold else "FAIL",
+            "H1": "PASS" if row["h1_top_decile_appearance_share"] >= args.h1_threshold else "FAIL",
+        }
+    report["verdicts"] = verdicts
+
+    rendered = json.dumps(report, indent=2, default=str)
+    if args.out:
+        Path(args.out).write_text(rendered)
+    for row in report["per_sf"]:
+        print(f"SF{row['sf']}: episodes={row['episodes']} (read-set coverage "
+              f"{row['episodes_with_read_set']}/{row['episodes']}) "
+              f"db_universe={row['db_universe']} kv_universe={row['kv_universe']}")
+        print(f"  H0 full-Jaccard={row['h0_jaccard_full']} "
+              f"top-decile-Jaccard={row['h0_jaccard_top_decile']} "
+              f"containment(KV⊆DB)={row['kv_in_db_containment']:.3f}")
+        print(f"  H1 top-decile appearance share={row['h1_top_decile_appearance_share']}")
+    print("verdicts:", json.dumps(verdicts))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The unified-cache-layer plan made its own survival conditional on H0 (working-set overlap), decided in WP0 before any joint-budget machinery got built. This lands the verdict, its data, and the tools that produced it.

**Verdict: FAIL, monotonically worse with scale.** On the replayed 702-episode FinBench workload: top-decile Jaccard **0.226 (SF1) → 0.050 (SF10)**; DB universe grows **8×** while the KV universe grows 1.6×; containment 1.0 — what reaches the LLM is an anchor-centric *slice* of what the DB reads, not an overlapping peer.

**Per the plan's own §4.2 Go/No-Go:** WP3 joint budget + cross-prefetch **dropped**; WP4 invalidation (correctness, overlap-independent) and WP2 KV-side optimization **kept** — the #487 simulator measures a 2× session-vs-shuffled hit-rate gap, so prefix reuse is real without joint budgeting; ADR-0155's data plane invokes its own kill-criteria clause and narrows to invalidation+observation. **H1 stays open** (skew rises with scale, 0.238→0.283): pin/quantization gets its verdict at SF100.

Tools: `scripts/cache_sim/collect_finbench_traces.py` (call replay → trace-schema v1 + shadow-elementId read/context node sets; WITH-scope refused rather than guessed, every exclusion counted) and `scripts/cache_sim/h0_gate.py` (verdict with operationalization in the docstring). Raw numbers in `ADR-0156-h0-gate-verdict.json`.

Honest limits, in the ADR: read sets are variable-binding based (DozerDB CE exposes no page identities — biases overlap **up**, so FAIL is robust); single-anchor workload; 66% call coverage.

Validation: `check-doc-contracts.sh` green; scripts compile+ruff clean; numbers reproduced twice.