### PR TITLE
feat(ontology): P2 import converters + curated template pack — seocho ontology clone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,3 +192,4 @@ namespaces = false
 [tool.setuptools.package-data]
 seocho = ["py.typed"]
 "seocho.semantic_layer" = ["cik_table.json"]
+"seocho.ontology_templates" = ["*.yaml"]

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -144,6 +144,19 @@ def register(subparsers) -> None:
         "--json", dest="output_json", action="store_true", help="JSON output")
 
 
+    ontology_subparsers.add_parser(
+        "templates", help="List curated starter ontologies for `ontology clone`")
+
+    ontology_clone_parser = ontology_subparsers.add_parser(
+        "clone", help="Copy a curated starter ontology as an editable draft — "
+                      "prints unless --output is given",
+    )
+    ontology_clone_parser.add_argument("template", help="Template name (see `ontology templates`)")
+    ontology_clone_parser.add_argument("--output", default=None, help="Write the draft YAML here")
+    ontology_clone_parser.add_argument(
+        "--json", dest="output_json", action="store_true", help="JSON output")
+
+
 def handle(args: argparse.Namespace) -> int:
     from ..ontology_governance import (
         build_ontology_governance_report,
@@ -452,5 +465,33 @@ def handle(args: argparse.Namespace) -> int:
                     print(rendered)
         # A draft with no document is an unusable import; say so in the exit code.
         return 0 if result.document is not None else 1
+
+    if args.ontology_command == "templates":
+        from ..ontology_templates import list_templates
+
+        for template in list_templates():
+            print(f"{template['name']:22s} {template['description']}")
+        return 0
+
+    if args.ontology_command == "clone":
+        import yaml
+
+        from ..ontology_templates import load_template
+
+        try:
+            document = load_template(args.template)
+        except KeyError as exc:
+            raise SeochoError(str(exc)) from exc
+        if getattr(args, "output_json", False):
+            print(json.dumps(document, indent=2, ensure_ascii=False))
+            return 0
+        rendered = yaml.safe_dump(document, sort_keys=False, allow_unicode=True)
+        if args.output:
+            Path(args.output).write_text(rendered, encoding="utf-8")
+            print(f"template {args.template!r} written to {args.output} — edit, "
+                  f"then validate with: seocho ontology check --schema {args.output}")
+        else:
+            print(rendered)
+        return 0
 
     raise SeochoError(f"Unknown ontology command: {args.ontology_command}")

--- a/src/seocho/ontology_import.py
+++ b/src/seocho/ontology_import.py
@@ -15,11 +15,11 @@ draft. Two rules shape everything here:
    warning instead of silently defaulted — the draft is a starting point,
    and the warnings are its review checklist.
 
-Formats (P1 slice): ``arrows`` (Arrows.app JSON), ``cypher`` (DDL —
-CREATE CONSTRAINT / CREATE INDEX statements), ``native`` (this library's
-own JSON/YAML), ``auto`` (content sniffing). GraphQL SDL / LinkML /
-Data Importer are detected and reported as not-yet-supported rather than
-mis-parsed.
+Formats: ``arrows`` (Arrows.app JSON), ``cypher`` (DDL as SHOW INDEXES /
+SHOW CONSTRAINTS dump it), ``graphql`` (SDL object types), ``linkml``
+(classes/attributes; ``is_a`` becomes the native ``broader`` taxonomy),
+``data-importer`` (Neo4j Data Importer model JSON, tolerantly walked),
+``native`` (this library's own JSON/YAML), ``auto`` (content sniffing).
 """
 
 from __future__ import annotations
@@ -31,8 +31,8 @@ from typing import Any, Dict, List, Optional
 
 from .ontology import NodeDef, Ontology, P, RelDef
 
-SUPPORTED_FORMATS = ("arrows", "cypher", "native", "auto")
-DETECT_ONLY_FORMATS = ("graphql", "linkml", "data-importer")
+SUPPORTED_FORMATS = ("arrows", "cypher", "native", "graphql", "linkml", "data-importer", "auto")
+DETECT_ONLY_FORMATS: tuple = ()
 
 
 @dataclass(slots=True)
@@ -337,3 +337,227 @@ __all__ = [
     "import_document",
     "import_native",
 ]
+
+
+# ---------------------------------------------------------------------------
+# GraphQL SDL — object types as labels, object-typed fields as relationships
+# ---------------------------------------------------------------------------
+
+_GQL_TYPE = re.compile(r"\btype\s+(\w+)[^{]*\{([^}]*)\}", re.S)
+# No line anchor: SDL allows several fields per line, and arguments in
+# parentheses are stripped before matching so `field(arg: X): Y` keeps Y.
+_GQL_FIELD = re.compile(r"(\w+)\s*:\s*(\[?)\s*(\w+)\s*\]?\s*(!?)")
+_GQL_SCALARS = {
+    "String": str, "ID": str, "Int": int, "Float": float, "Boolean": bool,
+    "DateTime": "DATETIME", "Date": "DATE",
+}
+_GQL_ROOTS = {"Query", "Mutation", "Subscription"}
+
+
+def import_graphql(content: str) -> OntologyImportResult:
+    result = OntologyImportResult(detected_format="graphql")
+    type_blocks = {name: body for name, body in _GQL_TYPE.findall(content)
+                   if name not in _GQL_ROOTS}
+    if not type_blocks:
+        result.warnings.append("no object type definitions found (Query/Mutation "
+                               "roots are intentionally skipped)")
+        return result
+    if re.search(r"\b(interface|union)\s+\w+", content):
+        result.warnings.append(
+            "interface/union definitions have no native equivalent; skipped — "
+            "model shared fields on each concrete type")
+
+    node_defs: Dict[str, NodeDef] = {}
+    rel_defs: Dict[str, RelDef] = {}
+    for name, body in type_blocks.items():
+        props: Dict[str, P] = {}
+        body = re.sub(r"\([^)]*\)", "", body)  # drop argument lists
+        for field_name, is_list, field_type, required in _GQL_FIELD.findall(body):
+            if field_type in _GQL_SCALARS:
+                props[field_name] = P(_GQL_SCALARS[field_type],
+                                      required=required == "!",
+                                      unique=field_type == "ID")
+            elif field_type in type_blocks:
+                rtype = re.sub(r"(?<!^)(?=[A-Z])", "_", field_name).upper()
+                existing = rel_defs.get(rtype)
+                if existing and (existing.source, existing.target) != (name, field_type):
+                    result.warnings.append(
+                        f"relationship {rtype} (field {field_name!r}) maps to two "
+                        f"endpoint pairs; kept the first — rename one field")
+                    continue
+                rel_defs[rtype] = RelDef(source=name, target=field_type)
+                if is_list != "[":
+                    result.warnings.append(
+                        f"{name}.{field_name} is single-valued; cardinality "
+                        f"defaulted to MANY_TO_MANY — tighten it manually")
+            else:
+                result.warnings.append(
+                    f"{name}.{field_name}: unknown type {field_type!r} "
+                    f"(enum or missing definition); property skipped")
+        node_defs[name] = NodeDef(properties=props)
+
+    onto = Ontology(name="imported_graphql", graph_model="lpg",
+                    nodes=node_defs, relationships=rel_defs)
+    result.document = onto.to_dict()
+    result.suggested_name = "imported_graphql"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# LinkML — classes/attributes; is_a becomes the native `broader` taxonomy
+# ---------------------------------------------------------------------------
+
+_LINKML_SCALARS = {
+    "string": str, "str": str, "uri": str, "uriorcurie": str,
+    "integer": int, "int": int, "float": float, "double": float,
+    "decimal": float, "boolean": bool, "date": "DATE", "datetime": "DATETIME",
+}
+
+
+def import_linkml(content: str) -> OntologyImportResult:
+    import yaml
+
+    result = OntologyImportResult(detected_format="linkml")
+    payload = yaml.safe_load(content)
+    if not isinstance(payload, dict) or not isinstance(payload.get("classes"), dict):
+        result.warnings.append("no `classes:` mapping found; not a LinkML schema?")
+        return result
+    classes: Dict[str, Any] = payload["classes"]
+    slot_index: Dict[str, Any] = payload.get("slots") or {}
+
+    def norm(name: str) -> str:
+        return "".join(part.capitalize() for part in re.split(r"[\s_-]+", name))
+
+    node_defs: Dict[str, NodeDef] = {}
+    rel_defs: Dict[str, RelDef] = {}
+    class_names = {norm(c) for c in classes}
+    for raw_name, spec in classes.items():
+        spec = spec or {}
+        label = norm(raw_name)
+        props: Dict[str, P] = {}
+        attrs: Dict[str, Any] = dict(spec.get("attributes") or {})
+        for slot in spec.get("slots") or []:
+            attrs.setdefault(slot, slot_index.get(slot) or {})
+        for attr_name, attr_spec in attrs.items():
+            attr_spec = attr_spec or {}
+            rng = str(attr_spec.get("range", "string")).strip()
+            if norm(rng) in class_names:
+                rtype = attr_name.upper().replace("-", "_").replace(" ", "_")
+                rel_defs[rtype] = RelDef(source=label, target=norm(rng))
+            elif rng.lower() in _LINKML_SCALARS:
+                props[attr_name] = P(
+                    _LINKML_SCALARS[rng.lower()],
+                    required=bool(attr_spec.get("required")),
+                    unique=bool(attr_spec.get("identifier")))
+            else:
+                result.warnings.append(
+                    f"{raw_name}.{attr_name}: range {rng!r} is neither a scalar "
+                    f"nor a class in this schema; property skipped")
+        broader = []
+        if spec.get("is_a"):
+            parent = norm(str(spec["is_a"]))
+            if parent in class_names:
+                broader = [parent]
+            else:
+                result.warnings.append(
+                    f"{raw_name}: is_a {spec['is_a']!r} not defined here; "
+                    f"hierarchy link dropped")
+        node_defs[label] = NodeDef(properties=props, broader=broader)
+
+    name = re.sub(r"[^a-z0-9_]+", "_", str(payload.get("name", "imported_linkml")).lower())
+    onto = Ontology(name=name or "imported_linkml", graph_model="lpg",
+                    nodes=node_defs, relationships=rel_defs)
+    result.document = onto.to_dict()
+    result.suggested_name = name or "imported_linkml"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Neo4j Data Importer — tolerant walk over its versioned model JSON
+# ---------------------------------------------------------------------------
+
+_DI_TYPES = {"string": str, "integer": int, "float": float, "boolean": bool,
+             "datetime": "DATETIME", "date": "DATE"}
+
+
+def import_data_importer(content: str) -> OntologyImportResult:
+    result = OntologyImportResult(detected_format="data-importer")
+    payload = json.loads(content)
+    model = payload.get("dataModel") or payload
+    graph = (model.get("graphSchema") or model.get("graphModel") or model)
+
+    def walk_collect(obj: Any, key_names: tuple) -> List[Dict[str, Any]]:
+        found: List[Dict[str, Any]] = []
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key in key_names and isinstance(value, (list, dict)):
+                    found.extend(value.values() if isinstance(value, dict) else value)
+                else:
+                    found.extend(walk_collect(value, key_names))
+        elif isinstance(obj, list):
+            for item in obj:
+                found.extend(walk_collect(item, key_names))
+        return found
+
+    node_specs = walk_collect(graph, ("nodeLabels", "nodeSchemas", "nodeObjectTypes"))
+    rel_specs = walk_collect(graph, ("relationshipTypes", "relationshipSchemas",
+                                     "relationshipObjectTypes"))
+    if not node_specs:
+        result.warnings.append("no node label definitions recognized in the model "
+                               "JSON; the Data Importer export format may have "
+                               "changed — file an issue with the file attached")
+        return result
+
+    label_by_ref: Dict[str, str] = {}
+    node_defs: Dict[str, NodeDef] = {}
+    for spec in node_specs:
+        token = str(spec.get("token") or spec.get("label")
+                    or (spec.get("labels") or [""])[0] or "").strip()
+        if not token:
+            continue
+        if ref := spec.get("$id") or spec.get("id"):
+            label_by_ref[str(ref)] = token
+        props: Dict[str, P] = {}
+        for prop in spec.get("properties") or []:
+            pname = str(prop.get("token") or prop.get("name") or "").strip()
+            ptype = str(prop.get("type", {}).get("type")
+                        if isinstance(prop.get("type"), dict)
+                        else prop.get("type", "string")).lower()
+            if pname:
+                props[pname] = P(_DI_TYPES.get(ptype, str))
+        node_defs[token] = NodeDef(properties=props)
+
+    def endpoint(spec: Dict[str, Any], side: str) -> str:
+        value = spec.get(side) or spec.get(f"{side}NodeLabel") or {}
+        if isinstance(value, dict):
+            value = value.get("$ref") or value.get("nodeSchema") or value.get("label") or ""
+        label = label_by_ref.get(str(value).lstrip("#"), str(value).lstrip("#"))
+        return label if label in node_defs else "Any"
+
+    rel_defs: Dict[str, RelDef] = {}
+    for spec in rel_specs:
+        token = str(spec.get("token") or spec.get("type") or "").strip()
+        if not token:
+            continue
+        source, target = endpoint(spec, "from"), endpoint(spec, "to")
+        if "Any" in (source, target):
+            result.warnings.append(
+                f"relationship {token}: endpoint reference not resolved; "
+                f"left as 'Any' — edit before use")
+        rel_defs[token] = RelDef(source=source, target=target)
+
+    onto = Ontology(name="imported_data_importer", graph_model="lpg",
+                    nodes=node_defs, relationships=rel_defs)
+    result.document = onto.to_dict()
+    result.suggested_name = "imported_data_importer"
+    result.warnings.append(
+        "Data Importer models vary by app version; verify every property type "
+        "against your source data")
+    return result
+
+
+_IMPORTERS.update({
+    "graphql": import_graphql,
+    "linkml": import_linkml,
+    "data-importer": import_data_importer,
+})

--- a/src/seocho/ontology_templates/__init__.py
+++ b/src/seocho/ontology_templates/__init__.py
@@ -1,0 +1,50 @@
+"""Curated starter ontologies, shipped as package data.
+
+``seocho ontology clone <template>`` hands the user a reviewed, working
+schema instead of a blank page. Templates are ordinary native documents —
+cloning returns a draft (never persists on its own), and the draft flows
+into ``ontology check`` / ``create`` like any import.
+
+Curation rule: a template only enters this registry once it has carried a
+real workload in this repository — these are not speculative domain packs.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import Any, Dict, List
+
+TEMPLATES: Dict[str, str] = {
+    # name -> one-line description shown by `seocho ontology templates`
+    "quickstart": "Minimal company/person/product schema (the seocho run quickstart).",
+    "finance-aml": "FinBench-style AML graph: accounts, transfers, ownership, "
+                   "channels — the schema behind the agent<->database study.",
+    "finance-compliance": "Regulators, regulations, incidents, controls, policies "
+                          "— the finance-compliance example's schema.",
+}
+
+_FILES = {
+    "quickstart": "quickstart.yaml",
+    "finance-aml": "finance_aml.yaml",
+    "finance-compliance": "finance_compliance.yaml",
+}
+
+
+def list_templates() -> List[Dict[str, str]]:
+    return [{"name": name, "description": description}
+            for name, description in TEMPLATES.items()]
+
+
+def load_template(name: str) -> Dict[str, Any]:
+    """Return the template's native document. Raises KeyError on unknown names."""
+    import yaml
+
+    filename = _FILES.get(name)
+    if filename is None:
+        raise KeyError(
+            f"unknown template {name!r}; available: {', '.join(sorted(TEMPLATES))}")
+    content = resources.files(__package__).joinpath(filename).read_text("utf-8")
+    return yaml.safe_load(content)
+
+
+__all__ = ["TEMPLATES", "list_templates", "load_template"]

--- a/src/seocho/ontology_templates/finance_aml.yaml
+++ b/src/seocho/ontology_templates/finance_aml.yaml
@@ -1,0 +1,251 @@
+name: finbench
+description: 'Synthetic LDBC-FinBench-style financial AML schema (Account / Person / Company / Loan +
+  transfer/own/deposit/repay). Declaring the schema lets the guardrail (allowed labels/relationship types,
+  hop/row bounds) constrain agent-generated Cypher at scale.
+
+  '
+nodes:
+  Account:
+    description: A financial account that sends and receives transfers
+    identity_keys:
+    - acct_no
+    - id
+    properties:
+      id:
+        type: STRING
+        constraint: UNIQUE
+      acct_no:
+        type: INTEGER
+        description: The account number used to refer to this account
+      iban:
+        type: STRING
+      flagged:
+        type: BOOLEAN
+      risk_tier:
+        type: INTEGER
+      acct_type:
+        type: INTEGER
+  Person:
+    description: An individual who may own accounts
+    properties:
+      id:
+        type: STRING
+        constraint: UNIQUE
+      name:
+        type: STRING
+      country:
+        type: STRING
+  Company:
+    description: A company or organization that may own accounts
+    properties:
+      id:
+        type: STRING
+        constraint: UNIQUE
+      name:
+        type: STRING
+      sector:
+        type: STRING
+  Loan:
+    description: A loan disbursed to and repaid from accounts
+    properties:
+      id:
+        type: STRING
+        constraint: UNIQUE
+      principal:
+        type: INTEGER
+  Channel:
+    description: 'The means by which money moved (전자금융거래법 §2 channel inventory plus FATF-recognized high-risk
+      rails). Channel choice carries most of the AML signal because channels differ in traceability, limits,
+      and supervision. Anchored on fibo:Payment; FIBO defines no PaymentMethod taxonomy upstream.
+
+      '
+    properties:
+      code:
+        type: STRING
+        constraint: UNIQUE
+        description: Channel code such as WIRE_CROSSBORDER, ATM_CD, OPEN_BANKING
+      label:
+        type: STRING
+        description: Human-readable channel name (Korean / English)
+      risk_weight:
+        type: INTEGER
+        description: Ordinal AML risk hint, 1 (low) to 5 (high)
+  Medium:
+    description: >
+      A login device or terminal a session came from — FinBench's `Medium`. Distinct from
+      Channel: Channel is the payment rail money rode (전자금융거래법 §2 + FATF), Medium is
+      the device the session originated on. Conflating them would lose the strongest
+      multi-layer signal available, which is two accounts sharing a login device.
+    properties:
+      id:
+        type: STRING
+        constraint: UNIQUE
+      type:
+        type: STRING
+        description: Device class such as mobile_app, web_browser, atm_terminal
+      risk_level:
+        type: INTEGER
+        description: Ordinal device risk, 1 (low) to 5 (high)
+relationships:
+  TRANSFER:
+    source: Account
+    target: Account
+    description: 'A money transfer from one account to another.
+
+      '
+    # Declared, not only described. The prose above named these properties from the start, but
+    # `policy_from_ontology` builds `allowed_properties` from the `properties:` block alone, so
+    # the guardrail rejected `t.amount` — the single most-used property in the graph — as an
+    # unknown identifier. The model's repair was to return `null AS total_amount` and answer the
+    # question with a hole in it. A guardrail that blocks the correct query is worse than none,
+    # and prose the validator cannot read is not a declaration.
+    properties:
+      amount:
+        type: INTEGER
+        description: Transferred amount in KRW; the ₩10,000,000 CTR threshold applies to it
+      ts:
+        type: INTEGER
+        description: Transfer timestamp
+      channel:
+        type: STRING
+        description: Channel code the transfer rode, matching Channel.code
+      channel_risk:
+        type: INTEGER
+        description: Ordinal AML risk of that channel, 1 (low) to 5 (high), denormalised
+          onto the transfer so a channel filter needs no join
+      cross_border:
+        type: BOOLEAN
+    # Both endpoints are Accounts, so source/target alone cannot tell "sent to" from
+    # "received from" — and query construction defaulted to treating the anchor as the
+    # arrow's target, answering every outgoing question with an in-degree. Naming the
+    # roles is what makes the direction recoverable; the phrase lists below are only a
+    # deterministic fast path (they scored 0 of 6 on paraphrases on their own), and the
+    # general case is the model mapping arbitrary wording onto these role names.
+    sourceRole: sender
+    targetRole: beneficiary
+    sourcePhrases:
+    - transfer money to
+    - transferred money to
+    - transfer to
+    - transferred to
+    - sent to
+    - sent money to
+    - send to
+    - remitted to
+    - wired to
+    - paid to
+    - outgoing
+    - reachable within
+    - reachable from
+    - downstream of
+    targetPhrases:
+    - transfers into
+    - transferred into
+    - transfer from
+    - transferred from
+    - received from
+    - sent transfers into
+    - sent into
+    - credited by
+    - incoming
+    - upstream of
+    - paid by
+    # Measured, not asserted — written by scripts/finbench/annotate_ontology_degrees.py
+    # from the snapshot named in measured_from. A schema of labels and endpoint types
+    # cannot say that one account carries tens of thousands of edges while the median
+    # carries three, so a planner had no basis for preferring a bounded shape; an
+    # aggregate anchored on a hub does not return at all. Re-run the annotator when the
+    # snapshot changes: a hint carried over from a differently-shaped dataset is worse
+    # than none.
+    degreeHint:
+      median_out: 3
+      p99_out: 41
+      max_out: 77036
+      mean_out: 5.62
+      median_in: 3
+      max_in: 77810
+      max_over_median_out: 25678.7
+      heavy_tailed: true
+      measured_from: "outputs/finbench/sf1000-real"
+  USES_CHANNEL:
+    source: Account
+    target: Channel
+    description: 'An account moved money over this channel. Makes the channel dimension
+      traversable structure rather than only an edge property.
+
+      '
+    properties:
+      tx_count:
+        type: INTEGER
+        description: How many transactions this account put through this channel
+  # `Any` was not a neutral placeholder. Measured on the SF100 graph, GUARANTEE runs
+  # Person/Company -> Person/Company 40,001 times and touches an Account zero times — yet with
+  # `source: Any, target: Any` in the schema, every agent design wrote
+  # `(a:Account)-[:GUARANTEE]-(b:Account)` on the three-layer question and returned nothing.
+  # The model does not read `Any` as "not yet known"; it reads it as "anything is permitted".
+  # An under-specified endpoint costs as much as a missing one, and costs it silently.
+  OWN:
+    source: Person|Company
+    target: Account
+    description: A person or company owns an account. Accounts never own accounts.
+  DEPOSIT:
+    source: Loan
+    target: Account
+    description: A loan is disbursed into an account
+    properties:
+      amount:
+        type: INTEGER
+  REPAY:
+    source: Account
+    target: Loan
+    description: An account makes a repayment toward a loan
+    properties:
+      amount:
+        type: INTEGER
+  # The party and device layers. Until these existed, four of FinBench's nine edge types
+  # were declared and every question was confined to the account layer — a query could not
+  # reach the parties behind the accounts, so "are these two accounts under common control"
+  # could not be *expressed*, let alone answered.
+  APPLY:
+    source: Person|Company
+    target: Loan
+    description: >
+      A person or company applied for a loan. Connects the loan layer to the party layer,
+      so a loan can be traced to a human rather than floating unattached.
+    sourceRole: applicant
+    targetRole: facility
+  INVEST:
+    source: Person|Company
+    target: Company
+    description: >
+      A person or company holds an ownership stake in a company (ratio). The corporate
+      ownership layer, where control is concealed behind nominally separate entities.
+    sourceRole: investor
+    targetRole: investee
+  GUARANTEE:
+    source: Person|Company
+    target: Person|Company
+    description: >
+      A person or company guarantees another *party*. Never an account: guarantees are given
+      by the people and companies behind accounts, so reaching this layer from an account
+      requires going through OWN first. Ordinary between family or business partners, which is
+      precisely why it only becomes a signal in conjunction with other layers.
+    sourceRole: guarantor
+    targetRole: guaranteed
+  WITHDRAW:
+    source: Account
+    target: Account
+    description: >
+      Cash withdrawal. Kept separate from TRANSFER because FinBench separates it: a
+      withdrawal is money leaving the traceable system, which is the terminal step of most
+      typologies and a different thing to reason about.
+    sourceRole: withdrawer
+    targetRole: destination
+  SIGN_IN:
+    source: Medium
+    target: Account
+    description: >
+      A device signed in to an account. Shared-device access by nominally unrelated parties
+      is a first-order concealment red flag, and it is invisible to an account-only graph.
+    sourceRole: device
+    targetRole: session_account

--- a/src/seocho/ontology_templates/finance_compliance.yaml
+++ b/src/seocho/ontology_templates/finance_compliance.yaml
@@ -1,0 +1,95 @@
+graph_type: finance_compliance
+package_id: finance_compliance
+version: 1.0.0
+description: Starter ontology for finance compliance knowledge graphs.
+graph_model: lpg
+nodes:
+  Company:
+    description: A regulated financial entity.
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+      ticker:
+        type: STRING
+      jurisdiction:
+        type: STRING
+  Regulator:
+    description: A government or industry body that enforces regulations.
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+      jurisdiction:
+        type: STRING
+  Regulation:
+    description: A specific rule or statute that governs company behavior.
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+      code:
+        type: STRING
+      jurisdiction:
+        type: STRING
+  ComplianceIncident:
+    description: A reported breach, near-miss, or anomaly.
+    properties:
+      summary:
+        type: STRING
+        constraint: UNIQUE
+      date:
+        type: STRING
+      severity:
+        type: STRING
+  ControlEvidence:
+    description: Evidence that a control is operating (attestation, test, log).
+    properties:
+      summary:
+        type: STRING
+        constraint: UNIQUE
+      date:
+        type: STRING
+      status:
+        type: STRING
+  Policy:
+    description: An internal policy that governs company behavior.
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+      version:
+        type: STRING
+      effective_date:
+        type: STRING
+relationships:
+  SUBJECT_TO:
+    source: Company
+    target: Regulation
+    description: ''
+    cardinality: MANY_TO_MANY
+  ENFORCED_BY:
+    source: Regulation
+    target: Regulator
+    description: ''
+    cardinality: MANY_TO_MANY
+  REPORTED:
+    source: Company
+    target: ComplianceIncident
+    description: ''
+    cardinality: MANY_TO_MANY
+  RELATES_TO:
+    source: ComplianceIncident
+    target: Regulation
+    description: ''
+    cardinality: MANY_TO_MANY
+  MITIGATED_BY:
+    source: ComplianceIncident
+    target: ControlEvidence
+    description: ''
+    cardinality: MANY_TO_MANY
+  GOVERNED_BY:
+    source: Company
+    target: Policy
+    description: ''
+    cardinality: MANY_TO_MANY

--- a/src/seocho/ontology_templates/quickstart.yaml
+++ b/src/seocho/ontology_templates/quickstart.yaml
@@ -1,0 +1,34 @@
+name: quickstart
+description: Minimal company/person/product schema for the seocho run quickstart.
+nodes:
+  Company:
+    description: A business organization
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+  Person:
+    description: A person such as an executive or founder
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+  Product:
+    description: A product or service offered by a company
+    properties:
+      name:
+        type: STRING
+        constraint: UNIQUE
+relationships:
+  CEO_OF:
+    source: Person
+    target: Company
+    description: Person leads the company as chief executive
+  ACQUIRED:
+    source: Company
+    target: Company
+    description: Company acquired another company
+  OFFERS:
+    source: Company
+    target: Product
+    description: Company offers a product or service

--- a/tests/seocho/test_cli_parser_contract.py
+++ b/tests/seocho/test_cli_parser_contract.py
@@ -25,6 +25,7 @@ EXPECTED_COMMANDS = {
 EXPECTED_ONTOLOGY_SUBCOMMANDS = {
     "check", "export", "diff", "report", "inspect-owl", "review",
     "datahub", "select-guardrail", "datahub-apply", "eval-answers", "import",
+    "templates", "clone",
 }
 
 

--- a/tests/seocho/test_ontology_import.py
+++ b/tests/seocho/test_ontology_import.py
@@ -91,11 +91,76 @@ def test_unknown_content_asks_for_explicit_format():
     assert any("--format" in w for w in result.warnings)
 
 
-def test_detected_but_unsupported_format_is_reported_not_misparsed():
-    result = import_document("type Account { id: ID! }", format="auto")
-    assert result.document is None
+GRAPHQL_SDL = """
+type Account { id: ID!  balance: Float  owner: Company  transfers: [Transfer] }
+type Company { name: String! }
+type Transfer { amount: Float! }
+"""
+
+LINKML = """
+name: aml-mini
+classes:
+  account:
+    attributes:
+      acct_no: {range: integer, identifier: true}
+      owner: {range: company}
+  company:
+    attributes:
+      name: {range: string, required: true}
+  shell company:
+    is_a: company
+"""
+
+DATA_IMPORTER = """
+{"dataModel": {"graphSchema": {
+  "nodeLabels": [
+    {"$id": "n0", "token": "Account",
+     "properties": [{"token": "acct_no", "type": {"type": "integer"}}]},
+    {"$id": "n1", "token": "Company",
+     "properties": [{"token": "name", "type": {"type": "string"}}]}
+  ],
+  "relationshipTypes": [
+    {"token": "OWNS", "from": {"$ref": "#n1"}, "to": {"$ref": "#n0"}}
+  ]}}}
+"""
+
+
+def test_graphql_object_types_become_labels_and_relationships():
+    result = import_document(GRAPHQL_SDL, format="auto")
     assert result.detected_format == "graphql"
-    assert any("not yet supported" in w for w in result.warnings)
+    doc = result.document
+    assert doc["nodes"]["Account"]["properties"]["id"]["constraint"] == "UNIQUE"
+    assert doc["nodes"]["Account"]["properties"]["balance"]["type"] == "FLOAT"
+    assert doc["relationships"]["OWNER"]["target"] == "Company"
+    assert doc["relationships"]["TRANSFERS"]["target"] == "Transfer"
+    Ontology.from_dict(doc)
+
+
+def test_linkml_classes_map_and_is_a_becomes_broader():
+    result = import_document(LINKML, format="linkml")
+    doc = result.document
+    assert doc["nodes"]["Account"]["properties"]["acct_no"]["type"] == "INTEGER"
+    assert doc["relationships"]["OWNER"]["target"] == "Company"
+    assert doc["nodes"]["ShellCompany"]["broader"] == ["Company"]
+    Ontology.from_dict(doc)
+
+
+def test_data_importer_model_resolves_endpoint_refs():
+    result = import_document(DATA_IMPORTER, format="auto")
+    assert result.detected_format == "data-importer"
+    doc = result.document
+    assert doc["relationships"]["OWNS"]["source"] == "Company"
+    assert doc["relationships"]["OWNS"]["target"] == "Account"
+    Ontology.from_dict(doc)
+
+
+def test_every_template_clones_into_a_valid_ontology():
+    from seocho.ontology_templates import list_templates, load_template
+
+    names = [t["name"] for t in list_templates()]
+    assert {"quickstart", "finance-aml", "finance-compliance"} <= set(names)
+    for name in names:
+        Ontology.from_dict(load_template(name))
 
 
 def test_import_never_persists(tmp_path, monkeypatch):


### PR DESCRIPTION
Completes **seocho-5bg**'s converter coverage and adds the starter-template surface, same contract as P1 (#493): drafts never persist, warnings carry the lossy parts.

**Converters:** `graphql` (SDL object types → labels, ID→UNIQUE, object-typed fields → relationships, roots skipped, interface/union warned — field regex handles several fields per line and strips argument lists), `linkml` (identifier→UNIQUE, required honored, class-ranged attributes → relationships, **`is_a` maps onto the native `broader` taxonomy** instead of being dropped), `data-importer` (tolerant walk over versioned model JSON, $ref endpoint resolution, unresolved endpoints → 'Any'+warning, version-drift warning always).

**Template pack** (`seocho.ontology_templates`, package data): `quickstart`, `finance-aml` (the FinBench study schema), `finance-compliance` (generated from the example's `build_ontology()`). Curation rule in the module docstring: a template enters only after carrying a real workload in this repo — no speculative domain packs. CLI: `seocho ontology templates` / `seocho ontology clone <name> [--output]`; a clone flows into `ontology check` like any import. Every template round-trip-validates in tests.

Remaining on 5bg: nothing converter-side; REST/activate lifecycle folds into seocho-aed as planned.

Validation: `run_basic_ci.sh` — 729 passed, 3 skipped; ruff clean on touched files.