### PR TITLE
feat(agentos): the operating layer behind two interfaces — Bolt-aware, OpenAI Agents SDK compatible

### DIFF
--- a/docs/decisions/ADR-0157-agentos-surface.md
+++ b/docs/decisions/ADR-0157-agentos-surface.md
@@ -1,0 +1,69 @@
+# ADR-0157: AgentOS — the operating layer behind two interfaces
+
+Date: 2026-08-15 · Status: accepted
+
+## Context
+
+The thesis this repository has been testing states that agentic systems
+need a common operating layer for memory, execution, scheduling,
+governance, and resource management. Every pillar's *mechanism* already
+existed in SEOCHO — the workspace guardrail and Cypher validation at the
+store layer, the ontology guardrail, admission control, token budgets, the
+two-namespace memory contract (#494) — but an agent runtime had no single
+object to plug into, and the adapter tool executed model-supplied
+parameters directly, including the tenancy value.
+
+## Decision
+
+1. **One facade, two interfaces.** `seocho.agentos.AgentOS` binds the five
+   pillars to the interfaces agents actually use: *Bolt-aware* — every tool
+   it hands out reads through the governed store path (workspace pinning,
+   ontology validation, `enforce_workspace_filter=True` fail-closed reads);
+   *OpenAI-compatible* — memory as the Agents SDK `Session` protocol,
+   resource control as `RunHooks`, governance as `tool_input_guardrail`
+   (verified injection points on openai-agents 0.10.3:
+   `Runner.run(session=..., hooks=...)`).
+2. **Tenancy is pinned, never trusted.** The layer overwrites the model's
+   `workspace_id`/`ws` parameters with its own before execution — the
+   FinBench harness's "parameters the model must not be trusted with" rule
+   becomes a product property. A prompt-injected workspace value cannot
+   cross the boundary (held by test).
+3. **One gate, inside the tool.** Admission lives in `execute_query`, not
+   in hooks, so the bound holds for hook-less callers and permits are never
+   double-counted. All sessions of one AgentOS share the pool — that shared
+   pool is the process-local scheduling substrate; per-session `priority`
+   is recorded for the fairness work (S1/vdw.11).
+4. **Budget exhaustion is structured, truncation is disclosed.** Token
+   budgets raise `BudgetExceededError` at turn boundaries (ADR-0153
+   semantics); row caps always ship `truncated: true/false` (the FinBench
+   disclosure study's lesson, #478).
+5. **user_id stays out of the graph** — carried on the session for the
+   log/trace plane only, per the #494 contract decision.
+
+## Validation
+
+Scalability is the acceptance axis. `scripts/agentos/scale_probe.py` drives
+the governed path across SF × concurrency on live FinBench graphs
+(graphstack/dozerdb 5.26.3.0, measured 2026-08-15):
+
+| database | sessions | served | p50 | p95 | store max-concurrency (cap 4) |
+|---|---|---|---|---|---|
+| finbenchl1 | 1 / 4 / 16 | 8 / 32 / 128 | ~9–10ms | 9–174ms | 1 / 4 / 4 |
+| finbenchl10 | 1 / 4 / 16 | 8 / 32 / 128 | ~75–79ms | 78–1349ms | 1 / 4 / 4 |
+
+Zero bound violations, zero rejections, zero errors across 336 calls; the
+p95 tail under 16-way contention (1.35s on SF10) is the queueing signal the
+scheduling pillar will optimize. Unit contracts (7 tests, CI-gated): SDK
+session protocol round-trip, cross-session privacy, workspace pinning,
+truncation disclosure, admission bounding under threads, budget stop,
+agent/guardrail assembly.
+
+## Consequences
+
+- The OS surface is additive: `Session`, the runtime API, and the adapter
+  keep working; AgentOS composes existing parts and adds no second
+  rulebook.
+- Durable conversation backends (the PG authoritative-memory path) plug in
+  behind the same `Session` protocol later without touching callers.
+- Fairness (S1), model routing exposure, and the streaming path are the
+  epic's remaining children (seocho-xdp).

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -915,6 +915,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - H1 left open (share rising with scale); rerun at SF100 before pin/quantization verdict
   - caveat: read set is variable-binding based (CE exposes no page identities) — biases overlap up, so FAIL is robust
 
+## 2026-08-15
+
+- [Accepted] ADR-0157 agentos-surface
+  - one facade (seocho.agentos.AgentOS) binds the five pillars to two interfaces: Bolt-aware governed store path, OpenAI Agents SDK (Session protocol memory, RunHooks, tool_input_guardrail)
+  - tenancy pinned never trusted (model-supplied workspace params overwritten); one admission gate inside the tool; budget exhaustion structured; truncation always disclosed
+  - scalability validated live: SF1/SF10 x N in {1,4,16}, 336 calls, zero bound violations at the Bolt boundary
+  - remaining on epic seocho-xdp: fairness (S1), routing exposure, durable PG session backend
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/scale_probe.py
+++ b/scripts/agentos/scale_probe.py
@@ -1,0 +1,158 @@
+"""AgentOS scalability probe: N concurrent sessions, one layer, real graphs.
+
+Scalability is this feature's acceptance test, so the probe drives the exact
+governed path an SDK agent uses (``AgentOS.execute_query``) — pinning,
+admission, fail-closed reads — with no model in the loop, across:
+
+  - the SF axis: FinBench graphs (finbenchl1 / finbenchl10)
+  - the concurrency axis: N sessions in {1, 4, 16}
+  - the contention axis: max_inflight below N, so the shared gate binds
+
+Reported per cell: served/rejected counts, p50/p95 wall latency of served
+calls, and the store-side max concurrency actually observed (must never
+exceed max_inflight — that single number is the execution pillar holding).
+
+Usage:
+  python scripts/agentos/scale_probe.py --password ... \
+      --databases finbenchl1 finbenchl10 --sessions 1 4 16
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "src"))
+
+QUERY = (
+    "MATCH (a:Account)-[t:TRANSFER]->(b:Account) "
+    "WHERE a._workspace_id = $workspace_id "
+    "RETURN a.acct_no AS src, b.acct_no AS dst, t.amount AS amount "
+    "ORDER BY t.amount DESC LIMIT $limit"
+)
+
+
+class CountingStore:
+    """Wrap the real store to observe true concurrency at the Bolt boundary."""
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+        self.inflight = 0
+        self.max_seen = 0
+        self._lock = threading.Lock()
+
+    def query(self, *args, **kwargs):
+        with self._lock:
+            self.inflight += 1
+            self.max_seen = max(self.max_seen, self.inflight)
+        try:
+            return self._inner.query(*args, **kwargs)
+        finally:
+            with self._lock:
+                self.inflight -= 1
+
+
+def run_cell(*, ontology, store, database: str, sessions: int,
+             calls_per_session: int, max_inflight: int) -> dict:
+    from seocho.agentos import AgentOS
+
+    counting = CountingStore(store)
+    os_layer = AgentOS(ontology=ontology, graph_store=counting,
+                       database=database, workspace_id="default",
+                       max_inflight=max_inflight, admission_wait_s=2.0,
+                       row_cap=50)
+    latencies: list[float] = []
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        session = os_layer.session(f"probe-{index}")
+        for _ in range(calls_per_session):
+            started = time.perf_counter()
+            try:
+                payload = os_layer.execute_query(
+                    session, QUERY, json.dumps({"limit": 50}))
+                outcome = "served" if "row_count" in payload else "error"
+            except Exception as exc:
+                outcome = type(exc).__name__
+            elapsed = (time.perf_counter() - started) * 1000
+            with lock:
+                outcomes.append(outcome)
+                if outcome == "served":
+                    latencies.append(elapsed)
+
+    threads = [threading.Thread(target=worker, args=(i,))
+               for i in range(sessions)]
+    started = time.perf_counter()
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    wall_s = time.perf_counter() - started
+
+    served = outcomes.count("served")
+    ordered = sorted(latencies)
+    return {
+        "database": database, "sessions": sessions,
+        "max_inflight": max_inflight,
+        "served": served,
+        "rejected": outcomes.count("QueryAdmissionRejected"),
+        "errors": len(outcomes) - served - outcomes.count("QueryAdmissionRejected"),
+        "p50_ms": round(ordered[len(ordered) // 2], 1) if ordered else None,
+        "p95_ms": round(ordered[int(len(ordered) * 0.95) - 1], 1) if ordered else None,
+        "store_max_concurrency": counting.max_seen,
+        "bound_held": counting.max_seen <= max_inflight,
+        "wall_s": round(wall_s, 2),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uri", default="bolt://localhost:17687")
+    parser.add_argument("--user", default="neo4j")
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--databases", nargs="+",
+                        default=["finbenchl1", "finbenchl10"])
+    parser.add_argument("--sessions", nargs="+", type=int, default=[1, 4, 16])
+    parser.add_argument("--calls-per-session", type=int, default=8)
+    parser.add_argument("--max-inflight", type=int, default=4)
+    parser.add_argument("--ontology",
+                        default=str(REPO / "examples/finbench/finbench.ontology.yaml"))
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    import yaml
+
+    from seocho.ontology import Ontology
+    from seocho.store.graph import Neo4jGraphStore
+
+    ontology = Ontology.from_dict(yaml.safe_load(Path(args.ontology).read_text()))
+    store = Neo4jGraphStore(uri=args.uri, user=args.user, password=args.password)
+
+    report = []
+    for database in args.databases:
+        for sessions in args.sessions:
+            cell = run_cell(ontology=ontology, store=store, database=database,
+                            sessions=sessions,
+                            calls_per_session=args.calls_per_session,
+                            max_inflight=args.max_inflight)
+            report.append(cell)
+            print(json.dumps(cell), flush=True)
+
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(report, indent=2))
+    violations = [c for c in report if not c["bound_held"]]
+    print(f"\ncells={len(report)} bound_violations={len(violations)}")
+    if violations:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agentos/scale_probe.py
+++ b/scripts/agentos/scale_probe.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import statistics
 import sys
 import threading
 import time

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -66,6 +66,7 @@ uv run pytest \
   tests/seocho/test_cache_simulator.py \
   tests/seocho/test_ontology_import.py \
   tests/seocho/test_memory_sharing_contract.py \
+  tests/seocho/test_agentos.py \
   tests/seocho/test_semantic_query_phase_a.py \
   extraction/tests/test_sdk_evaluation.py \
   tests/seocho/test_agent_design.py \

--- a/src/seocho/agentos.py
+++ b/src/seocho/agentos.py
@@ -1,0 +1,340 @@
+"""AgentOS: the common operating layer, exposed through two interfaces.
+
+The thesis this productizes: agentic systems need a common operating layer
+for memory, execution, scheduling, governance, and resource management. In
+SEOCHO every pillar's *mechanism* already exists — the workspace guardrail
+and Cypher validation on the Bolt side, the ontology guardrail, admission
+control, token budgets, the two-namespace memory contract. What agents
+lacked was one object that binds them to the interfaces agents actually use:
+
+- **Bolt-aware**: every tool an ``AgentOS`` hands out reads the graph
+  through the governed store path — workspace scoping, ontology validation,
+  fail-closed queries. The agent cannot reach the database around the layer.
+- **OpenAI-compatible**: the layer speaks the OpenAI Agents SDK's own
+  extension points (verified on openai-agents 0.10.3) — memory as the
+  ``Session`` protocol, execution/resource control as ``RunHooks``,
+  governance as ``tool_input_guardrail`` (via the existing adapter).
+  ``Runner.run(agent, msg, session=os_session.sdk_session,
+  hooks=os_session.hooks)`` is the whole integration.
+
+Pillars → components:
+
+| pillar     | component                                                    |
+|------------|--------------------------------------------------------------|
+| memory     | ``AgentOSSession.sdk_session`` — conversation namespace per   |
+|            | the #494 contract (private per session); shared knowledge     |
+|            | flows only through the governed graph tools                   |
+| governance | ontology guardrail + enforcement mode (existing adapter)      |
+| execution  | shared ``QueryAdmissionController`` gating every tool call;   |
+|            | over-budget runs stop with ``BudgetExceededError`` — the      |
+|            | structured-unknown semantics of ADR-0153, never a silent      |
+|            | truncation                                                    |
+| resource   | ``TokenBudgetTracker`` per session, fed from ``on_llm_end``   |
+| scheduling | admission permits are shared across *all* sessions of one     |
+|            | AgentOS — the process-local contention point; ``priority``    |
+|            | is recorded per session for the fairness work (S1/vdw.11)     |
+
+Scale is the design constraint, not an afterthought: nothing here holds
+per-request state beyond the session objects, admission is O(1) per call,
+and the scalability probe (scripts/agentos/scale_probe.py) exercises the
+layer across the FinBench SF axis under concurrent sessions.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+from .budget import BudgetExceededError, TokenBudgetTracker
+from .query.query_proxy import QueryAdmissionController
+
+__all__ = [
+    "AgentOS",
+    "AgentOSSession",
+    "BudgetExceededError",
+    "SeochoSDKSession",
+]
+
+
+class SeochoSDKSession:
+    """Conversation-namespace memory, speaking the SDK ``Session`` protocol.
+
+    Implements ``agents.memory.Session`` (add_items/get_items/pop_item/
+    clear_session) so ``Runner.run(..., session=...)`` persists turns here.
+    Items live per (workspace_id, session_id) and are reachable only through
+    this object — the private half of the two-namespace contract
+    (docs/MEMORY_SHARING.md). Shared knowledge never travels this channel;
+    it goes through the governed graph tools.
+
+    v1 keeps items in process memory behind a lock (correct under the
+    SDK's asyncio concurrency and our threaded probes). Durable backends
+    (the PG authoritative-memory path) plug in behind the same protocol
+    without touching callers.
+    """
+
+    def __init__(self, session_id: str, workspace_id: str) -> None:
+        self.session_id = session_id
+        self.workspace_id = workspace_id
+        self._items: List[Any] = []
+        self._lock = threading.Lock()
+
+    async def add_items(self, items: List[Any]) -> None:
+        with self._lock:
+            self._items.extend(items)
+
+    async def get_items(self, limit: Optional[int] = None) -> List[Any]:
+        with self._lock:
+            if limit is None or limit <= 0:
+                return list(self._items)
+            return list(self._items[-limit:])
+
+    async def pop_item(self) -> Optional[Any]:
+        with self._lock:
+            return self._items.pop() if self._items else None
+
+    async def clear_session(self) -> None:
+        with self._lock:
+            self._items.clear()
+
+
+def _usage_tokens(usage: Any) -> int:
+    for name in ("total_tokens",):
+        value = getattr(usage, name, None)
+        if isinstance(value, int):
+            return value
+    input_tokens = getattr(usage, "input_tokens", 0) or 0
+    output_tokens = getattr(usage, "output_tokens", 0) or 0
+    return int(input_tokens) + int(output_tokens)
+
+
+@dataclass
+class AgentOSSession:
+    """One agent's handle on the operating layer.
+
+    Hand ``sdk_session`` and ``hooks`` to ``Runner.run``; build tools/agents
+    through the parent ``AgentOS`` so every graph access stays governed.
+    """
+
+    os: "AgentOS"
+    session_id: str
+    priority: str = "normal"
+    user_id: Optional[str] = None          # session/log plane only — never
+    #                                        persisted into the graph (#494)
+    sdk_session: SeochoSDKSession = field(init=False)
+    budget: TokenBudgetTracker = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.sdk_session = SeochoSDKSession(self.session_id, self.os.workspace_id)
+        self.budget = TokenBudgetTracker(
+            budget=self.os.token_budget, scope=f"session={self.session_id}")
+
+    @property
+    def hooks(self) -> Any:
+        """RunHooks wiring execution + resource control into the SDK loop."""
+        from agents import RunHooks
+
+        session = self
+
+        class _OSHooks(RunHooks):
+            async def on_llm_end(self, context: Any, agent: Any, response: Any) -> None:
+                usage = getattr(response, "usage", None)
+                if usage is not None:
+                    # Raising here stops the run at a turn boundary: the
+                    # ADR-0153 posture — a budget exhaustion is a structured
+                    # outcome the caller sees, never a silently clipped answer.
+                    session.budget.charge(completion=_usage_tokens(usage))
+
+            # Admission is deliberately NOT taken here: the gate lives
+            # inside the governed tool itself, so it holds even for callers
+            # that bypass hooks — and a second acquisition here would double-
+            # count permits per tool call.
+
+        return _OSHooks()
+
+
+class AgentOS:
+    """The operating layer: one instance per (workspace, database) pair.
+
+    All sessions created from one ``AgentOS`` share its admission permits —
+    that shared pool *is* the scheduling substrate: N agents contending for
+    the same graph go through one gate, whatever framework each runs on.
+    """
+
+    def __init__(
+        self,
+        *,
+        ontology: Any,
+        graph_store: Any,
+        database: str,
+        workspace_id: str = "default",
+        enforcement: str = "guided",
+        max_inflight: int = 8,
+        admission_wait_s: float = 5.0,
+        token_budget: int = 0,
+        row_cap: int = 50,
+    ) -> None:
+        self.ontology = ontology
+        self.graph_store = graph_store
+        self.database = database
+        self.workspace_id = workspace_id
+        self.enforcement = enforcement
+        self.token_budget = token_budget
+        self.row_cap = row_cap
+        self._admission = QueryAdmissionController(
+            max_inflight=max_inflight, wait_seconds=admission_wait_s)
+        self._sessions: Dict[str, AgentOSSession] = {}
+        self._lock = threading.Lock()
+
+    # -- memory -----------------------------------------------------------
+
+    def session(self, session_id: Optional[str] = None, *,
+                priority: str = "normal",
+                user_id: Optional[str] = None) -> AgentOSSession:
+        session_id = session_id or uuid.uuid4().hex[:12]
+        with self._lock:
+            if session_id not in self._sessions:
+                self._sessions[session_id] = AgentOSSession(
+                    os=self, session_id=session_id,
+                    priority=priority, user_id=user_id)
+            return self._sessions[session_id]
+
+    # -- execution / scheduling -------------------------------------------
+
+    def _admit(self, session: AgentOSSession) -> None:
+        if not self._admission.acquire():
+            from .query.query_proxy import QueryAdmissionRejected
+
+            raise QueryAdmissionRejected(
+                f"admission denied for session={session.session_id} "
+                f"(priority={session.priority}): no capacity within deadline")
+
+    def _release(self) -> None:
+        self._admission.release()
+
+    # -- governance / the Bolt-aware tool surface --------------------------
+
+    def execute_query(self, session: AgentOSSession, cypher: str,
+                      params_json: str = "{}") -> str:
+        """The governed read path every AgentOS tool call funnels through.
+
+        Order matters and is part of the contract: parse, pin tenancy,
+        admit, execute fail-closed, release, cap-and-disclose. Admission
+        rejection propagates (the SDK reports it as a tool failure the model
+        sees); execution errors return as structured error payloads.
+        """
+        import json as _json
+
+        try:
+            params = _json.loads(params_json or "{}")
+        except (TypeError, ValueError):
+            return _json.dumps({"error": "params_json was not valid JSON"})
+        if not isinstance(params, dict):
+            return _json.dumps({"error": "params_json must be a JSON object"})
+        params["workspace_id"] = self.workspace_id   # pinned, not trusted
+        params["ws"] = self.workspace_id
+        self._admit(session)
+        try:
+            rows = self.graph_store.query(
+                cypher, params=params, database=self.database,
+                enforce_workspace_filter=True)
+        except Exception as exc:
+            return _json.dumps({"error": type(exc).__name__,
+                                "message": str(exc)[:300]})
+        finally:
+            self._release()
+        capped = rows[: self.row_cap]
+        return _json.dumps({"rows": capped, "row_count": len(capped),
+                            "row_cap": self.row_cap,
+                            "truncated": len(rows) > self.row_cap},
+                           default=str)
+
+    def make_graph_tool(self, session: AgentOSSession) -> Any:
+        """The governed graph tool: pinned tenancy, gated execution.
+
+        Two properties the plain adapter tool does not have, and which are
+        exactly what an operating layer owes its tenants:
+
+        - **Workspace pinning.** The model's ``workspace_id``/``ws``
+          parameters are overwritten with this AgentOS's workspace before
+          execution — the same "parameters the model must not be trusted
+          with" rule the FinBench harness enforced. A prompt-injected
+          workspace value cannot cross the boundary.
+        - **Admission inside the call.** The shared permit is taken around
+          the actual query, so the gate holds even for callers that skip
+          the RunHooks path.
+
+        Reads go through ``graph_store.query(..., enforce_workspace_filter=
+        True)`` — fail-closed: Cypher that forgets the tenant scope is
+        refused, not leaked.
+        """
+
+        from agents import function_tool
+
+        os_layer = self
+
+        @function_tool(
+            name_override="graph_query",
+            description_override=(
+                "Run a read-only Cypher query against the governed graph. "
+                "Pass values as named parameters ($name) via params_json. "
+                "Include a LIMIT. The tenant scope is enforced by the layer."),
+        )
+        def graph_query(cypher: str, params_json: str = "{}") -> str:
+            return os_layer.execute_query(session, cypher, params_json)
+
+        from .integrations.openai_agents import make_ontology_guardrail
+
+        graph_query.tool_input_guardrails = [
+            make_ontology_guardrail(self.ontology)]
+        return graph_query
+
+    def build_agent(self, session: AgentOSSession, *,
+                    name: str = "seocho_agent",
+                    model: Optional[Any] = None,
+                    extra_tools: Sequence[Any] = ()) -> Any:
+        """An openai-agents Agent whose only graph access is this layer.
+
+        Instructions carry the same schema block the deterministic planner
+        uses (one rulebook), plus the truncation-honesty rule the FinBench
+        disclosure study motivated.
+        """
+        import json as _json
+
+        from agents import Agent
+
+        from .query.hybrid_planner import policy_from_ontology, schema_for_prompt
+
+        policy = policy_from_ontology(self.ontology)
+        schema = schema_for_prompt(self.ontology, policy)
+        instructions = (
+            "You are an analyst querying a graph database with Cypher.\n\n"
+            "Schema (use only these labels, relationship types and parameters):\n"
+            + _json.dumps(schema, indent=2, default=str)
+            + "\n\nRules:\n"
+            "- Every matched node must carry the tenant scope shown in the schema.\n"
+            "- Include a LIMIT; the tool caps rows regardless.\n"
+            "- If the tool reports `truncated: true`, say so instead of presenting "
+            "a partial result as complete.\n"
+            "- If the schema cannot express the question, say what is missing "
+            "instead of inventing labels.")
+        tools = [self.make_graph_tool(session), *extra_tools]
+        agent_kwargs: Dict[str, Any] = {"name": name,
+                                        "instructions": instructions,
+                                        "tools": tools}
+        if model is not None:
+            agent_kwargs["model"] = model
+        return Agent(**agent_kwargs)
+
+    # -- observability ------------------------------------------------------
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "workspace_id": self.workspace_id,
+                "database": self.database,
+                "sessions": len(self._sessions),
+                "max_inflight": self._admission.max_inflight,
+                "token_budget": self.token_budget,
+            }

--- a/tests/seocho/test_agentos.py
+++ b/tests/seocho/test_agentos.py
@@ -1,0 +1,191 @@
+"""AgentOS: the five pillars, held as unit contracts.
+
+Scalability is the design constraint, so the tests that matter most here
+are the concurrent ones: N sessions sharing one layer must stay isolated
+(memory), bounded (execution/scheduling), and individually budgeted
+(resource) — with tenancy pinned no matter what the model sends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from seocho.agentos import AgentOS, BudgetExceededError
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+
+pytest.importorskip("agents", reason="openai-agents SDK not installed")
+
+
+@pytest.fixture
+def ontology() -> Ontology:
+    return Ontology(
+        name="agentos_test", graph_model="lpg",
+        nodes={"Account": NodeDef(properties={"acct_no": P(int, unique=True)})},
+        relationships={"TRANSFER": RelDef(source="Account", target="Account")},
+    )
+
+
+class RecordingStore:
+    """Fake governed store: records params, optionally blocks to hold permits."""
+
+    def __init__(self, rows=None, gate: threading.Event | None = None):
+        self.rows = rows if rows is not None else [{"n": 1}]
+        self.calls: list[dict] = []
+        self.gate = gate
+        self.inflight = 0
+        self.max_seen = 0
+        self._lock = threading.Lock()
+
+    def query(self, cypher, *, params=None, database=None,
+              enforce_workspace_filter=False):
+        with self._lock:
+            self.inflight += 1
+            self.max_seen = max(self.max_seen, self.inflight)
+        try:
+            self.calls.append({"cypher": cypher, "params": dict(params or {}),
+                               "enforced": enforce_workspace_filter,
+                               "database": database})
+            if self.gate is not None:
+                self.gate.wait(timeout=5)
+            return list(self.rows)
+        finally:
+            with self._lock:
+                self.inflight -= 1
+
+
+def make_os(ontology, store, **kw):
+    defaults = dict(database="testdb", workspace_id="acme")
+    defaults.update(kw)
+    return AgentOS(ontology=ontology, graph_store=store, **defaults)
+
+
+# -- memory: conversation namespace ---------------------------------------
+
+def test_sdk_session_protocol_round_trip(ontology):
+    os_layer = make_os(ontology, RecordingStore())
+    session = os_layer.session("s1")
+
+    async def scenario():
+        await session.sdk_session.add_items([{"role": "user", "content": "hi"}])
+        await session.sdk_session.add_items([{"role": "assistant", "content": "yo"}])
+        items = await session.sdk_session.get_items()
+        assert [i["role"] for i in items] == ["user", "assistant"]
+        assert (await session.sdk_session.pop_item())["role"] == "assistant"
+        await session.sdk_session.clear_session()
+        assert await session.sdk_session.get_items() == []
+
+    asyncio.run(scenario())
+
+
+def test_sessions_are_private_to_each_other(ontology):
+    os_layer = make_os(ontology, RecordingStore())
+    a, b = os_layer.session("a"), os_layer.session("b")
+
+    async def scenario():
+        await a.sdk_session.add_items([{"role": "user", "content": "secret"}])
+        assert await b.sdk_session.get_items() == []
+
+    asyncio.run(scenario())
+    assert os_layer.session("a") is a          # stable handle per id
+
+
+# -- governance/tenancy: pinning ------------------------------------------
+
+def test_workspace_params_are_pinned_not_trusted(ontology):
+    store = RecordingStore()
+    os_layer = make_os(ontology, store)
+    session = os_layer.session("s")
+    payload = os_layer.execute_query(
+        session, "MATCH (n:Account) WHERE n._workspace_id = $workspace_id "
+                 "RETURN n LIMIT 1",
+        json.dumps({"workspace_id": "SOMEONE_ELSE", "ws": "SOMEONE_ELSE",
+                    "acct": 7}))
+    call = store.calls[0]
+    assert call["params"]["workspace_id"] == "acme"      # injected value lost
+    assert call["params"]["ws"] == "acme"
+    assert call["params"]["acct"] == 7                   # benign params kept
+    assert call["enforced"] is True                      # fail-closed reads
+    assert json.loads(payload)["row_count"] == 1
+
+
+def test_row_cap_disclosed_as_truncation(ontology):
+    store = RecordingStore(rows=[{"n": i} for i in range(80)])
+    os_layer = make_os(ontology, store, row_cap=50)
+    payload = json.loads(os_layer.execute_query(
+        os_layer.session("s"), "MATCH ... RETURN n LIMIT 100"))
+    assert payload["row_count"] == 50
+    assert payload["truncated"] is True                  # never silent
+
+
+# -- execution/scheduling: one shared gate ---------------------------------
+
+def test_admission_bounds_concurrent_sessions(ontology):
+    gate = threading.Event()
+    store = RecordingStore(gate=gate)
+    os_layer = make_os(ontology, store, max_inflight=2, admission_wait_s=0.2)
+    results: list[str] = []
+
+    def worker(i: int) -> None:
+        session = os_layer.session(f"s{i}")
+        try:
+            results.append(os_layer.execute_query(session, "MATCH n RETURN n"))
+        except Exception as exc:
+            # Admission rejection PROPAGATES out of the tool by design — the
+            # SDK surfaces it to the model as a tool failure, not a payload.
+            results.append(type(exc).__name__)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for thread in threads:
+        thread.start()
+    # Let the two admitted calls park on the gate, the rest hit the deadline.
+    import time
+
+    time.sleep(0.6)
+    gate.set()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert store.max_seen <= 2                           # the bound held
+    rejected = [r for r in results if "QueryAdmissionRejected" in r]
+    served = [r for r in results if "row_count" in r]
+    assert len(served) == 2 and len(rejected) == 3
+
+
+# -- resource: per-session budget -------------------------------------------
+
+def test_budget_stops_the_run_with_a_structured_error(ontology):
+    os_layer = make_os(ontology, RecordingStore(), token_budget=100)
+    session = os_layer.session("s")
+
+    class Usage:
+        total_tokens = 60
+
+    class Response:
+        usage = Usage()
+
+    hooks = session.hooks
+
+    async def scenario():
+        await hooks.on_llm_end(None, None, Response())      # 60 — fine
+        with pytest.raises(BudgetExceededError):
+            await hooks.on_llm_end(None, None, Response())  # 120 > 100
+
+    asyncio.run(scenario())
+
+
+# -- the SDK-facing assembly -------------------------------------------------
+
+def test_build_agent_wires_governed_tool_and_guardrail(ontology):
+    os_layer = make_os(ontology, RecordingStore())
+    session = os_layer.session("s")
+    agent = os_layer.build_agent(session, name="t")
+    assert agent.name == "t"
+    assert len(agent.tools) == 1
+    tool = agent.tools[0]
+    assert tool.name == "graph_query"
+    assert tool.tool_input_guardrails            # ontology guardrail attached
+    assert "truncated: true" in agent.instructions


### PR DESCRIPTION
**The thesis becomes a feature** (seocho-xdp, hadry direction: 5-pillar common layer, bolt-aware + openai-agent-sdk compatible, scalability-first tests). Every pillar's mechanism already existed; this lands the one object agents plug into — the whole SDK integration is one line:

```python
os = AgentOS(ontology=onto, graph_store=store, database="finbenchl1", workspace_id="acme", max_inflight=8, token_budget=200_000)
s = os.session("chat-1", priority="normal")
result = await Runner.run(os.build_agent(s), question, session=s.sdk_session, hooks=s.hooks)
```

**Bolt-aware** — the agent cannot reach the database around the layer: the governed tool **pins tenancy** (model-supplied `workspace_id`/`ws` are overwritten; a prompt-injected workspace cannot cross — held by test), reads are **fail-closed** (`enforce_workspace_filter=True`), the ontology guardrail rides `tool_input_guardrails` — one rulebook with the deterministic path.

**OpenAI-compatible** — the SDK's own extension points (verified on openai-agents 0.10.3): `Session` protocol memory = the private conversation namespace of the #494 contract (cross-session privacy held by test); `RunHooks` carry the per-session token budget, raising `BudgetExceededError` at turn boundaries (ADR-0153 structured-unknown). **One admission gate, inside the tool** — no double-counted permits, holds for hook-less callers; all sessions share the pool = the process-local scheduling substrate (priority recorded for S1). Row caps always disclose `truncated` (#478).

**Scalability, measured live** (dozerdb 5.26.3.0, FinBench SF1/SF10 × N∈{1,4,16}, cap 4): 336 calls, **zero bound violations at the Bolt boundary**, zero errors; SF10 p50 ~79ms with the 16-way p95 tail at 1,349ms — exactly the queueing signal S1 optimizes. `scripts/agentos/scale_probe.py` reproduces the table; ADR-0157 records the architecture; 7 unit contracts CI-gated.

Remaining on the epic: fairness/S1, model-routing exposure, durable PG session backend.

Validation: `run_basic_ci.sh` — 742 passed, 3 skipped; doc contracts green; live probe 6/6 cells; ruff clean.