### PR TITLE
feat(os): scheduler v2 (p99-first lanes, fast-fail, work-conserving reserve) + one-session surface

### DIFF
--- a/docs/decisions/ADR-0157-agentos-surface.md
+++ b/docs/decisions/ADR-0157-agentos-surface.md
@@ -58,10 +58,12 @@ session protocol round-trip, cross-session privacy, workspace pinning,
 truncation disclosure, admission bounding under threads, budget stop,
 agent/guardrail assembly.
 
-> **Amended 2026-08-15 (seocho-dxe).** The layer is SEOCHO itself, not a
-> side brand: the public spelling is ``from seocho import SeochoOS`` (module
-> ``seocho.operating_layer``); ``seocho.agentos`` / ``AgentOS`` remain as a
-> deprecated alias for one release.
+> **Amended 2026-08-15 (seocho-dxe, final).** The layer is SEOCHO itself —
+> no side class in the public API: the surface is methods on the existing
+> ``seocho.Seocho`` client in local mode (``session()``, ``build_agent()``,
+> ``execute_query()``, operating controls as constructor kwargs, all
+> defaulting to off per the explicit-opt-in rule). ``SeochoOS`` /
+> ``AgentOS`` / ``seocho.agentos`` remain importable for one release.
 
 ## Consequences
 

--- a/docs/decisions/ADR-0157-agentos-surface.md
+++ b/docs/decisions/ADR-0157-agentos-surface.md
@@ -59,11 +59,12 @@ truncation disclosure, admission bounding under threads, budget stop,
 agent/guardrail assembly.
 
 > **Amended 2026-08-15 (seocho-dxe, final).** The layer is SEOCHO itself —
-> no side class in the public API: the surface is methods on the existing
-> ``seocho.Seocho`` client in local mode (``session()``, ``build_agent()``,
-> ``execute_query()``, operating controls as constructor kwargs, all
-> defaulting to off per the explicit-opt-in rule). ``SeochoOS`` /
-> ``AgentOS`` / ``seocho.agentos`` remain importable for one release.
+> no side class, no second session concept: ``Seocho.session()`` (the same
+> Session that ``add()``/``ask()`` use) now carries ``sdk_session`` /
+> ``hooks`` / ``priority``; ``build_agent()`` / ``execute_query()`` accept
+> it directly, and operating controls are ``Seocho(...)`` constructor
+> kwargs defaulting to off (explicit opt-in). ``SeochoOS`` / ``AgentOS`` /
+> ``seocho.agentos`` remain importable for one release.
 
 ## Consequences
 

--- a/docs/decisions/ADR-0159-scheduler-v2-p99.md
+++ b/docs/decisions/ADR-0159-scheduler-v2-p99.md
@@ -1,0 +1,68 @@
+# ADR-0159: scheduler v2 — p99-first, and what the probes actually said
+
+Date: 2026-08-15 · Status: accepted (measurement record)
+
+## Context
+
+Two critiques of the v1 admission layer (hadry): tail latency (p99) is the
+metric, not p50 — and by p99, v1's FIFO gate made the light class *worse*
+than no gate at all (1,767ms vs 239ms, E1) via head-of-line blocking behind
+100x-heavier calls; and the mechanisms needed an organizing principle.
+Scheduler v2 (design note scheduler-v2-design.md) answered with three:
+variance isolation (size lanes), work conservation (borrowable reserve),
+fast structured failure (predicted-wait rejection). This ADR records what
+the live probes then did to that design.
+
+## What the first probe run caught (kept on record deliberately)
+
+- **Estimate poisoning starves the polite.** The first predicted-wait
+  implementation used a global max service EWMA; one 8-second warm-up
+  observation contaminated the estimate for an 80ms-traffic lane, and
+  fast-fail then rejected every interactive high-class arrival instantly —
+  0/85 served, a *total* starvation of exactly the class the scheduler
+  exists to protect. Fix: the wait predictor uses a per-lane EWMA of what
+  actually ran in that lane. The failure mode generalizes: fast-fail is
+  only as safe as its estimator, and polite (intermittent, deadline-bound)
+  callers are the first casualties of a bad one.
+- Rejection storms: fast-fail assumes callers back off on a structured
+  rejection; a retry-without-backoff loop turns zero-wait rejection into a
+  100k-call/s storm. The probes now model agent-loop backoff explicitly.
+
+## E2 — lanes vs fast-fail (raw: ADR-0159-scheduler-v2-probes.json)
+
+8 light + 4 heavy concurrent sessions, SF10, cap 4, backoff on rejection:
+
+| arm | light p99 | heavy served |
+|---|---|---|
+| single lane + per-lane fast-fail | **122ms** | 4 |
+| lanes (light 2 / heavy 2) | 565ms | 5 |
+
+With a *correct* wait estimator, fast-fail alone keeps the light class's
+p99 at uncontended levels — heavy arrivals that would queue get rejected
+and back off before they can occupy. Static lane partitioning then only
+*halves* the light class's capacity and pays a partition tax. **Data-driven
+default: single lane + fast-fail (light_permits=0 stays the default);
+lanes remain opt-in** for regimes where heavy callers do not back off.
+
+## S2 — static vs work-conserving reserve (same file)
+
+12-normal flood + 2 interactive high, reserved=2, two phases:
+
+| | high (active) | normal (high active) | normal (high idle) |
+|---|---|---|---|
+| static reserve (v1) | 64/64, p99 129ms | 169 served | 190 served |
+| work-conserving (v2) | 54/56, p99 173ms | **263 served (+56%)** | **302 served (+59%)** |
+
+Equal protection of the interactive class, and the reserve stops taxing
+normal throughput when unused — work conservation delivering its exact
+claim. The explicit trade: borrowing admits more normals, so their own
+p95/p99 deepens (queueing among themselves); served-rate up, tail up,
+both visible.
+
+## Consequences
+
+- Defaults: single lane + per-lane fast-fail + borrowable reserve;
+  lanes opt-in. All knobs on ``Seocho(...)`` constructor, off by default.
+- The estimator-poisoning finding joins the paper's trust/execution
+  narrative: a scheduler's safety claims inherit its estimator's failure
+  modes.

--- a/docs/decisions/ADR-0159-scheduler-v2-probes.json
+++ b/docs/decisions/ADR-0159-scheduler-v2-probes.json
@@ -1,0 +1,98 @@
+{
+  "e2": [
+    {
+      "arm": "single_lane_v1",
+      "light": {
+        "calls": 731,
+        "served": 702,
+        "rejected": 29,
+        "p50_ms": 80.8,
+        "p95_ms": 109.9,
+        "p99_ms": 122.0
+      },
+      "heavy": {
+        "calls": 35,
+        "served": 4,
+        "rejected": 31,
+        "p50_ms": 8378.9,
+        "p95_ms": 9479.7,
+        "p99_ms": 9479.7
+      }
+    },
+    {
+      "arm": "lanes",
+      "light": {
+        "calls": 335,
+        "served": 293,
+        "rejected": 42,
+        "p50_ms": 100.5,
+        "p95_ms": 134.9,
+        "p99_ms": 564.7
+      },
+      "heavy": {
+        "calls": 80,
+        "served": 5,
+        "rejected": 75,
+        "p50_ms": 7851.6,
+        "p95_ms": 9439.2,
+        "p99_ms": 9439.2
+      }
+    }
+  ],
+  "s2": [
+    {
+      "arm": "static_reserve_v1",
+      "high_active": {
+        "calls": 64,
+        "served": 64,
+        "rejected": 0,
+        "p50_ms": 86.1,
+        "p95_ms": 104.5,
+        "p99_ms": 129.2
+      },
+      "normal_active": {
+        "calls": 209,
+        "served": 169,
+        "rejected": 40,
+        "p50_ms": 87.6,
+        "p95_ms": 102.7,
+        "p99_ms": 127.7
+      },
+      "normal_idle_phase": {
+        "calls": 220,
+        "served": 190,
+        "rejected": 30,
+        "p50_ms": 82.4,
+        "p95_ms": 404.5,
+        "p99_ms": 746.9
+      }
+    },
+    {
+      "arm": "work_conserving_v2",
+      "high_active": {
+        "calls": 56,
+        "served": 54,
+        "rejected": 2,
+        "p50_ms": 131.7,
+        "p95_ms": 157.3,
+        "p99_ms": 173.4
+      },
+      "normal_active": {
+        "calls": 286,
+        "served": 263,
+        "rejected": 23,
+        "p50_ms": 96.9,
+        "p95_ms": 1089.0,
+        "p99_ms": 1744.2
+      },
+      "normal_idle_phase": {
+        "calls": 322,
+        "served": 302,
+        "rejected": 20,
+        "p50_ms": 97.4,
+        "p95_ms": 122.7,
+        "p99_ms": 1522.7
+      }
+    }
+  ]
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -931,6 +931,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - claim stated carefully: the layer makes the contention trade visible and configurable, not free
   - PriorityAdmission ships on AgentOS (reserved_for_high, default 0)
 
+## 2026-08-15
+
+- [Accepted] ADR-0159 scheduler-v2-p99 (E2/S2 measurement record)
+  - probe caught estimate poisoning: global EWMA + fast-fail starved the polite high class 0/85; fixed with per-lane service EWMA — fast-fail is only as safe as its estimator
+  - E2: with a correct estimator, single lane + fast-fail holds light p99 at 122ms; static lanes pay a partition tax (565ms) — lanes demoted to opt-in
+  - S2: work-conserving reserve keeps interactive protection while lifting normal throughput +56~59% vs the static reserve
+  - defaults: single lane + fast-fail + borrowable reserve, all off-by-default on Seocho(...)
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/e2_s2_probe.py
+++ b/scripts/agentos/e2_s2_probe.py
@@ -1,0 +1,233 @@
+"""E2/S2: scheduler v2's claims, measured p99-first on live graphs.
+
+E2 — with heavy traffic in the background, what happens to the LIGHT
+class's p99? Arms differ only in lanes: single-lane v1 posture
+(light_permits=0: everyone shares 4 permits FIFO) vs v2 lanes
+(light: 2 / heavy: 2). EWMA is warmed with one observation per statement
+first — the cold-start (unknown-means-heavy) is a stated policy, not what
+this probe measures.
+
+S2 — v1's static reserve taxed normal throughput even while the high
+class was idle. Same mixed workload as S1 but with an explicit high-idle
+phase; arms: static reserve (PriorityAdmission) vs work-conserving
+reserve (LaneScheduler borrow). High starvation must stay zero while
+normal throughput in the idle phase recovers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "src"))
+
+LIGHT_Q = ("MATCH (a:Account)-[t:TRANSFER]->(b:Account) "
+           "WHERE a._workspace_id = $workspace_id "
+           "RETURN a.acct_no AS src, t.amount AS amount "
+           "ORDER BY t.amount DESC LIMIT $limit")
+HEAVY_Q = ("MATCH (a:Account)-[t1:TRANSFER]->(b:Account)-[t2:TRANSFER]->(c:Account) "
+           "WHERE a._workspace_id = $workspace_id "
+           "RETURN a.acct_no AS origin, count(DISTINCT c) AS reach, "
+           "sum(t2.amount) AS moved ORDER BY moved DESC LIMIT $limit")
+
+
+def _pct(ordered, q):
+    if not ordered:
+        return None
+    return round(ordered[min(int(len(ordered) * q), len(ordered) - 1)], 1)
+
+
+def _stats(rows):
+    lat = sorted(r[2] for r in rows if r[1] == "served")
+    return {"calls": len(rows), "served": len(lat),
+            "rejected": sum(1 for r in rows if r[1] != "served"),
+            "p50_ms": _pct(lat, 0.50), "p95_ms": _pct(lat, 0.95),
+            "p99_ms": _pct(lat, 0.99)}
+
+
+def build_layer(ontology, store, database, *, light_permits, reserved=0,
+                static_reserve=False):
+    from seocho.operating_layer import PriorityAdmission, SeochoOS
+
+    layer = SeochoOS(ontology=ontology, graph_store=store, database=database,
+                     workspace_id="default", max_inflight=4,
+                     light_permits=light_permits, reserved_for_high=reserved,
+                     admission_wait_s=2.0, row_cap=20)
+    if static_reserve:
+        # v1 posture for the S2 comparison: the non-borrowable reserve.
+        gate = PriorityAdmission(max_inflight=4, reserved_for_high=reserved,
+                                 wait_seconds=2.0)
+
+        class _V1Adapter:
+            max_inflight = 4
+
+            def classify(self, key):
+                return "heavy"
+
+            def observe(self, key, ms, lane=None):
+                pass
+
+            def acquire(self, *, lane, priority, deadline_s=None):
+                return gate.acquire(priority)
+
+            def release(self, *, lane, priority):
+                gate.release(priority)
+
+        layer._admission = _V1Adapter()
+    return layer
+
+
+def warm(layer, session):
+    layer.execute_query(session, LIGHT_Q, json.dumps({"limit": 20}))
+    layer.execute_query(session, HEAVY_Q, json.dumps({"limit": 5}))
+
+
+def run_e2(ontology, store, database, *, lanes: bool, duration_s: float) -> dict:
+    layer = build_layer(ontology, store, database,
+                        light_permits=2 if lanes else 0)
+    warm(layer, layer.session("warm"))
+    stop = threading.Event()
+    records = {"light": [], "heavy": []}
+    lock = threading.Lock()
+
+    def worker(klass, query, limit):
+        session = layer.session(f"{klass}-{threading.get_ident()}")
+        while not stop.is_set():
+            started = time.perf_counter()
+            try:
+                payload = layer.execute_query(session, query,
+                                              json.dumps({"limit": limit}))
+                outcome = "served" if "row_count" in payload else "error"
+            except Exception as exc:
+                outcome = type(exc).__name__
+            with lock:
+                records[klass].append(
+                    (klass, outcome, (time.perf_counter() - started) * 1000))
+            if outcome != "served":
+                time.sleep(0.1)      # structured rejection => back off
+
+    threads = ([threading.Thread(target=worker, args=("light", LIGHT_Q, 20))
+                for _ in range(8)]
+               + [threading.Thread(target=worker, args=("heavy", HEAVY_Q, 5))
+                  for _ in range(4)])
+    for thread in threads:
+        thread.start()
+    time.sleep(duration_s)
+    stop.set()
+    for thread in threads:
+        thread.join(timeout=30)
+    return {"arm": "lanes" if lanes else "single_lane_v1",
+            "light": _stats(records["light"]), "heavy": _stats(records["heavy"])}
+
+
+def run_s2(ontology, store, database, *, static: bool, phase_s: float) -> dict:
+    layer = build_layer(ontology, store, database, light_permits=0,
+                        reserved=2, static_reserve=static)
+    if not static:
+        warm(layer, layer.session("warm"))
+    stop = threading.Event()
+    high_on = threading.Event()
+    high_on.set()
+    records = []
+    lock = threading.Lock()
+
+    def normal_worker(i):
+        session = layer.session(f"n{i}", priority="normal")
+        while not stop.is_set():
+            phase = "active" if high_on.is_set() else "idle"
+            started = time.perf_counter()
+            try:
+                payload = layer.execute_query(session, LIGHT_Q,
+                                              json.dumps({"limit": 20}))
+                outcome = "served" if "row_count" in payload else "error"
+            except Exception as exc:
+                outcome = type(exc).__name__
+            with lock:
+                records.append(("normal", phase, outcome,
+                                (time.perf_counter() - started) * 1000))
+            if outcome != "served":
+                time.sleep(0.1)      # structured rejection => back off
+
+    def high_worker(i):
+        session = layer.session(f"h{i}", priority="high")
+        while not stop.is_set():
+            if not high_on.is_set():
+                time.sleep(0.05)
+                continue
+            started = time.perf_counter()
+            try:
+                payload = layer.execute_query(session, LIGHT_Q,
+                                              json.dumps({"limit": 20}))
+                outcome = "served" if "row_count" in payload else "error"
+            except Exception as exc:
+                outcome = type(exc).__name__
+            with lock:
+                records.append(("high", "active", outcome,
+                                (time.perf_counter() - started) * 1000))
+            time.sleep(0.15)
+
+    threads = ([threading.Thread(target=normal_worker, args=(i,))
+                for i in range(12)]
+               + [threading.Thread(target=high_worker, args=(i,))
+                  for i in range(2)])
+    for thread in threads:
+        thread.start()
+    time.sleep(phase_s)          # phase 1: high active
+    high_on.clear()
+    time.sleep(phase_s)          # phase 2: high idle — conservation shows here
+    stop.set()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    def klass_phase(klass, phase):
+        rows = [(r[0], r[2], r[3]) for r in records
+                if r[0] == klass and r[1] == phase]
+        return _stats(rows)
+
+    return {"arm": "static_reserve_v1" if static else "work_conserving_v2",
+            "high_active": klass_phase("high", "active"),
+            "normal_active": klass_phase("normal", "active"),
+            "normal_idle_phase": klass_phase("normal", "idle")}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uri", default="bolt://localhost:17687")
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--database", default="finbenchl10")
+    parser.add_argument("--duration-s", type=float, default=15.0)
+    parser.add_argument("--ontology",
+                        default=str(REPO / "examples/finbench/finbench.ontology.yaml"))
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    import yaml
+
+    from seocho.ontology import Ontology
+    from seocho.store.graph import Neo4jGraphStore
+
+    ontology = Ontology.from_dict(yaml.safe_load(Path(args.ontology).read_text()))
+    store = Neo4jGraphStore(uri=args.uri, user="neo4j", password=args.password)
+
+    report = {"e2": [], "s2": []}
+    for lanes in (False, True):
+        cell = run_e2(ontology, store, args.database, lanes=lanes,
+                      duration_s=args.duration_s)
+        report["e2"].append(cell)
+        print(json.dumps(cell), flush=True)
+    for static in (True, False):
+        cell = run_s2(ontology, store, args.database, static=static,
+                      phase_s=args.duration_s / 2)
+        report["s2"].append(cell)
+        print(json.dumps(cell), flush=True)
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -414,9 +414,6 @@ def __dir__():
 # ---------------------------------------------------------------------------
 
 __all__ = [
-    "SeochoOS",
-    "OSSession",
-    "PriorityAdmission",
     # Core client + version
     "__version__",
     "Seocho",

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1517,6 +1517,7 @@ class Seocho:
         name: str = "",
         *,
         database: Optional[str] = None,
+        priority: str = "normal",
     ) -> "Session":
         """Create an agent-level session with context and tracing.
 
@@ -1551,7 +1552,7 @@ class Seocho:
 
         from .session import Session
 
-        return Session(
+        sess = Session(
             name=name,
             ontology=self.ontology,
             graph_store=self.graph_store,
@@ -1564,6 +1565,17 @@ class Seocho:
             ontology_profile=self.ontology_profile,
             user_id=self.user_id,
         )
+        # One session concept (seocho-dxe): the same object carries the
+        # operating-layer handles. Hand ``sess.sdk_session`` and
+        # ``sess.hooks`` to openai-agents ``Runner.run``; the shared
+        # admission gate and per-session budget ride the layer.
+        os_session = self._os().session(sess.session_id, priority=priority,
+                                        user_id=self.user_id)
+        sess.priority = os_session.priority
+        sess.sdk_session = os_session.sdk_session
+        sess.hooks = os_session.hooks
+        sess.budget = os_session.budget
+        return sess
 
     def ensure_constraints(self, *, database: str = "neo4j") -> Dict[str, Any]:
         """Apply ontology-derived constraints to the graph database.
@@ -2777,27 +2789,24 @@ class Seocho:
                 **self._os_config)
         return self._operating_layer
 
-    def session(self, session_id: Optional[str] = None, *,
-                priority: str = "normal",
-                user_id: Optional[str] = None) -> Any:
-        """An agent's handle on the layer: SDK-protocol memory, budget,
-        shared admission. Hand ``.sdk_session`` and ``.hooks`` to
-        ``Runner.run``; user_id rides the session/log plane only."""
-        return self._os().session(session_id, priority=priority,
-                                  user_id=user_id)
+    def _os_session_for(self, session: Any) -> Any:
+        return self._os().session(session.session_id,
+                                  priority=getattr(session, "priority", "normal"))
 
     def build_agent(self, session: Any, *, name: str = "seocho_agent",
                     model: Optional[Any] = None,
                     extra_tools: Sequence[Any] = ()) -> Any:
         """An openai-agents Agent whose only graph access is governed by
         this client's ontology, tenancy, and admission."""
-        return self._os().build_agent(session, name=name, model=model,
+        return self._os().build_agent(self._os_session_for(session),
+                                      name=name, model=model,
                                       extra_tools=extra_tools)
 
     def execute_query(self, session: Any, cypher: str,
                       params_json: str = "{}") -> str:
         """The governed read path (pinned tenancy, lanes, fail-closed)."""
-        return self._os().execute_query(session, cypher, params_json)
+        return self._os().execute_query(self._os_session_for(session),
+                                        cypher, params_json)
 
 
     def close(self) -> None:

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -76,7 +76,7 @@ from .client_artifacts import (
     prompt_context_from_ontology as build_prompt_context_from_ontology,
 )
 from .client_remote import RemoteClientHelper
-from .exceptions import SeochoConnectionError, SeochoHTTPError
+from .exceptions import SeochoError
 from .governance import ArtifactDiff, ArtifactValidationResult, diff_artifact_payloads, validate_artifact_payload
 from .ontology_control_plane import (
     CompiledOntologyProfile,
@@ -215,6 +215,13 @@ class Seocho:
         agent_config: Optional[Any] = None,  # seocho.agent_config.AgentConfig
         ontology_profile: str = "default",
         enforcement: Optional[str] = None,  # "strict" | "guided" | "open"
+        # --- Operating-layer controls (local mode; explicit opt-in) ---
+        max_inflight: int = 0,
+        light_permits: int = 0,
+        reserved_for_high: int = 0,
+        admission_wait_s: float = 5.0,
+        token_budget: int = 0,
+        agent_row_cap: int = 50,
         # --- HTTP client mode ---
         base_url: Optional[str] = None,
         workspace_id: Optional[str] = None,
@@ -305,6 +312,16 @@ class Seocho:
         self.default_database = self._resolve_default_database(ontology)
 
         # Determine mode
+        # Operating-layer state (seocho-dxe: the OS surface is Seocho itself —
+        # no side class in the public API). Built lazily on first use; every
+        # control defaults to off/unlimited, per the explicit-opt-in rule.
+        self._os_config = {
+            "max_inflight": max_inflight, "light_permits": light_permits,
+            "reserved_for_high": reserved_for_high,
+            "admission_wait_s": admission_wait_s,
+            "token_budget": token_budget, "row_cap": agent_row_cap,
+        }
+        self._operating_layer: Optional[Any] = None
         self._local_mode = ontology is not None and graph_store is not None and llm is not None
 
         if self._local_mode:
@@ -2739,6 +2756,49 @@ class Seocho:
         )
         from .client_bundle import RuntimeBundleClientHelper  # lazy
         return RuntimeBundleClientHelper.create_client(bundle_source, workspace_id=workspace_id)
+
+    # ------------------------------------------------------------------
+    # The operating layer: memory / execution / scheduling / governance /
+    # resource, exposed as methods of Seocho itself (local mode).
+    # ------------------------------------------------------------------
+
+    def _os(self) -> Any:
+        if self.ontology is None or self.graph_store is None:
+            raise SeochoError(
+                "the operating layer needs local mode: construct "
+                "Seocho(ontology=..., graph_store=...)")
+        if self._operating_layer is None:
+            from .operating_layer import SeochoOS
+
+            self._operating_layer = SeochoOS(
+                ontology=self.ontology, graph_store=self.graph_store,
+                database=getattr(self, "database", None) or "neo4j",
+                workspace_id=self.workspace_id or "default",
+                **self._os_config)
+        return self._operating_layer
+
+    def session(self, session_id: Optional[str] = None, *,
+                priority: str = "normal",
+                user_id: Optional[str] = None) -> Any:
+        """An agent's handle on the layer: SDK-protocol memory, budget,
+        shared admission. Hand ``.sdk_session`` and ``.hooks`` to
+        ``Runner.run``; user_id rides the session/log plane only."""
+        return self._os().session(session_id, priority=priority,
+                                  user_id=user_id)
+
+    def build_agent(self, session: Any, *, name: str = "seocho_agent",
+                    model: Optional[Any] = None,
+                    extra_tools: Sequence[Any] = ()) -> Any:
+        """An openai-agents Agent whose only graph access is governed by
+        this client's ontology, tenancy, and admission."""
+        return self._os().build_agent(session, name=name, model=model,
+                                      extra_tools=extra_tools)
+
+    def execute_query(self, session: Any, cypher: str,
+                      params_json: str = "{}") -> str:
+        """The governed read path (pinned tenancy, lanes, fail-closed)."""
+        return self._os().execute_query(session, cypher, params_json)
+
 
     def close(self) -> None:
         """Release resources held by the client.

--- a/src/seocho/operating_layer.py
+++ b/src/seocho/operating_layer.py
@@ -192,6 +192,12 @@ class LaneScheduler:
         self._in_use = {lane: {"high": 0, "normal": 0} for lane in self._permits}
         self._waiters = {lane: {"high": 0, "normal": 0} for lane in self._permits}
         self._ewma_ms: Dict[str, float] = {}
+        # What actually runs in each lane, not a per-statement max: the
+        # wait predictor must reflect the lane's real traffic, or a single
+        # heavy observation poisons every estimate (found live: fast-fail
+        # + a contaminated global estimate starved the polite high class
+        # to 0/85 — the probe that caught it is e2_s2_probe.py).
+        self._lane_service_ms: Dict[str, float] = {}
         self._cond = threading.Condition()
 
     # -- classification ----------------------------------------------------
@@ -204,12 +210,18 @@ class LaneScheduler:
             return "heavy"                      # unknown means heavy
         return "light" if observed <= self.light_threshold_ms else "heavy"
 
-    def observe(self, statement_key: str, service_ms: float) -> None:
+    def observe(self, statement_key: str, service_ms: float,
+                lane: Optional[str] = None) -> None:
         with self._cond:
             prior = self._ewma_ms.get(statement_key)
             self._ewma_ms[statement_key] = (
                 service_ms if prior is None
                 else prior + self.ewma_alpha * (service_ms - prior))
+            if lane in self._permits:
+                lane_prior = self._lane_service_ms.get(lane)
+                self._lane_service_ms[lane] = (
+                    service_ms if lane_prior is None
+                    else lane_prior + self.ewma_alpha * (service_ms - lane_prior))
 
     # -- admission ----------------------------------------------------------
 
@@ -228,15 +240,9 @@ class LaneScheduler:
         return True
 
     def _predicted_wait_s(self, lane: str) -> float:
-        service_ms = max(
-            (v for k, v in self._ewma_ms.items()), default=0.0)
-        lane_ewmas = [v for v in self._ewma_ms.values()]
-        # Use the lane-appropriate scale: light lane waits are bounded by
-        # the threshold by construction.
+        service_ms = self._lane_service_ms.get(lane, 0.0)
         if lane == "light":
             service_ms = min(service_ms, self.light_threshold_ms)
-        elif lane_ewmas:
-            service_ms = max(lane_ewmas)
         waiters = self._waiters[lane]["high"] + self._waiters[lane]["normal"]
         permits = max(1, self._permits[lane])
         return (waiters * service_ms) / (permits * 1000.0)
@@ -479,7 +485,7 @@ class SeochoOS:
         # Feed the cost signal only on success: a failure's wall time says
         # nothing about the statement's service cost.
         self._admission.observe(
-            statement_key, (_time.perf_counter() - started) * 1000.0)
+            statement_key, (_time.perf_counter() - started) * 1000.0, lane=lane)
         capped = rows[: self.row_cap]
         return _json.dumps({"rows": capped, "row_count": len(capped),
                             "row_cap": self.row_cap,

--- a/src/seocho/operating_layer.py
+++ b/src/seocho/operating_layer.py
@@ -1,4 +1,9 @@
-"""SeochoOS: SEOCHO *is* the operating layer, exposed through two interfaces.
+"""The operating layer behind ``Seocho`` (memory/execution/scheduling/governance/resource).
+
+Public surface: methods on ``seocho.Seocho`` itself — ``session()``,
+``build_agent()``, ``execute_query()`` (seocho-dxe: no side brand, no
+suffix). This module is the implementation; ``SeochoOS``/``AgentOS`` remain
+importable one release for anything written against the earlier spellings.
 
 The thesis this productizes: agentic systems need a common operating layer
 for memory, execution, scheduling, governance, and resource management. In
@@ -130,6 +135,147 @@ class PriorityAdmission:
             pass
 
 
+class LaneScheduler:
+    """Size-classed, class-aware, work-conserving admission (scheduler v2).
+
+    Three principles, one gate (design note: scheduler-v2-design.md):
+
+    - **Variance isolation.** Service times in graph agentic RAG are
+      heavy-tailed (measured 100x: ~80ms vs ~8s on the same store), so
+      permits are partitioned into a *light* and a *heavy* lane. A light
+      query never queues behind a heavy one — the head-of-line blocking
+      that made v1's FIFO admission *worsen* light-class p99 (1,767ms vs
+      239ms ungoverned, E1) is removed structurally, not tuned away.
+    - **Work conservation.** The high-priority reserve is borrowable: a
+      normal call may take a reserved permit *iff no high-class caller is
+      waiting*, and releases prefer high waiters. v1's static reserve
+      taxed normal throughput even when the high class was idle; v2 only
+      charges when protection is actually being used.
+    - **Fast structured failure.** On arrival, the expected wait
+      (waiters_ahead x lane EWMA service time / lane permits) is compared
+      to the caller's deadline; a wait that cannot be met is rejected
+      *immediately* instead of timing out later — the tail a queue would
+      have added becomes a zero-wait signal an agent loop can act on.
+
+    Classification uses the layer's unique asset: the graph gives cost
+    signal per statement. Planner row estimates measured unreliable
+    (FinBench), so lanes are assigned from an **observed EWMA per Cypher
+    hash**; a statement never seen before goes to the heavy lane —
+    "unknown means heavy" keeps the light lane's p99 pure.
+
+    ``light_permits=0`` collapses to a single lane (v1 behaviour);
+    ``max_inflight=0`` disables the gate entirely.
+    """
+
+    def __init__(self, *, max_inflight: int = 0, light_permits: int = 0,
+                 reserved_for_high: int = 0, wait_seconds: float = 5.0,
+                 light_threshold_ms: float = 500.0,
+                 ewma_alpha: float = 0.3) -> None:
+        if max_inflight < 0 or light_permits < 0 or reserved_for_high < 0:
+            raise ValueError("scheduler sizes must be non-negative")
+        if max_inflight and light_permits >= max_inflight:
+            raise ValueError("the light lane must leave heavy capacity")
+        if max_inflight and reserved_for_high >= max_inflight:
+            raise ValueError("the reserve must leave normal capacity")
+        self.max_inflight = max_inflight
+        self.wait_seconds = wait_seconds
+        self.light_threshold_ms = light_threshold_ms
+        self.ewma_alpha = ewma_alpha
+        self._permits = ({"light": light_permits,
+                          "heavy": max_inflight - light_permits}
+                         if light_permits else {"heavy": max_inflight})
+        self._reserved = {lane: 0 for lane in self._permits}
+        # The reserve protects interactive traffic where it lives; with
+        # lanes enabled that is the light lane, otherwise the single lane.
+        reserve_home = "light" if light_permits else "heavy"
+        self._reserved[reserve_home] = reserved_for_high
+        self._in_use = {lane: {"high": 0, "normal": 0} for lane in self._permits}
+        self._waiters = {lane: {"high": 0, "normal": 0} for lane in self._permits}
+        self._ewma_ms: Dict[str, float] = {}
+        self._cond = threading.Condition()
+
+    # -- classification ----------------------------------------------------
+
+    def classify(self, statement_key: str) -> str:
+        if "light" not in self._permits:
+            return "heavy"
+        observed = self._ewma_ms.get(statement_key)
+        if observed is None:
+            return "heavy"                      # unknown means heavy
+        return "light" if observed <= self.light_threshold_ms else "heavy"
+
+    def observe(self, statement_key: str, service_ms: float) -> None:
+        with self._cond:
+            prior = self._ewma_ms.get(statement_key)
+            self._ewma_ms[statement_key] = (
+                service_ms if prior is None
+                else prior + self.ewma_alpha * (service_ms - prior))
+
+    # -- admission ----------------------------------------------------------
+
+    def _admissible(self, lane: str, cls: str) -> bool:
+        used = self._in_use[lane]
+        free = self._permits[lane] - used["high"] - used["normal"]
+        if free <= 0:
+            return False
+        if cls == "high":
+            return True
+        headroom_for_high = max(0, self._reserved[lane] - used["high"])
+        if self._waiters[lane]["high"] > 0:
+            # Protection is in use: keep the reserve headroom for them.
+            return free > headroom_for_high
+        # Work conservation: nobody to protect, the reserve is borrowable.
+        return True
+
+    def _predicted_wait_s(self, lane: str) -> float:
+        service_ms = max(
+            (v for k, v in self._ewma_ms.items()), default=0.0)
+        lane_ewmas = [v for v in self._ewma_ms.values()]
+        # Use the lane-appropriate scale: light lane waits are bounded by
+        # the threshold by construction.
+        if lane == "light":
+            service_ms = min(service_ms, self.light_threshold_ms)
+        elif lane_ewmas:
+            service_ms = max(lane_ewmas)
+        waiters = self._waiters[lane]["high"] + self._waiters[lane]["normal"]
+        permits = max(1, self._permits[lane])
+        return (waiters * service_ms) / (permits * 1000.0)
+
+    def acquire(self, *, lane: str = "heavy", priority: str = "normal",
+                deadline_s: Optional[float] = None) -> bool:
+        if not self.max_inflight:
+            return True
+        cls = "high" if priority == "high" else "normal"
+        budget = self.wait_seconds if deadline_s is None else deadline_s
+        with self._cond:
+            if not self._admissible(lane, cls):
+                # Fast structured failure: a wait that cannot be met is
+                # rejected now, not timed out later.
+                if self._predicted_wait_s(lane) > budget:
+                    return False
+            deadline = time.monotonic() + budget
+            self._waiters[lane][cls] += 1
+            try:
+                while not self._admissible(lane, cls):
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return False
+                    self._cond.wait(remaining)
+                self._in_use[lane][cls] += 1
+                return True
+            finally:
+                self._waiters[lane][cls] -= 1
+
+    def release(self, *, lane: str = "heavy", priority: str = "normal") -> None:
+        if not self.max_inflight:
+            return
+        cls = "high" if priority == "high" else "normal"
+        with self._cond:
+            self._in_use[lane][cls] -= 1
+            self._cond.notify_all()
+
+
+
 class SeochoSDKSession:
     """Conversation-namespace memory, speaking the SDK ``Session`` protocol.
 
@@ -243,8 +389,10 @@ class SeochoOS:
         workspace_id: str = "default",
         enforcement: str = "guided",
         max_inflight: int = 8,
+        light_permits: int = 0,
         reserved_for_high: int = 0,
         admission_wait_s: float = 5.0,
+        light_threshold_ms: float = 500.0,
         token_budget: int = 0,
         row_cap: int = 50,
     ) -> None:
@@ -255,9 +403,11 @@ class SeochoOS:
         self.enforcement = enforcement
         self.token_budget = token_budget
         self.row_cap = row_cap
-        self._admission = PriorityAdmission(
-            max_inflight=max_inflight, reserved_for_high=reserved_for_high,
-            wait_seconds=admission_wait_s)
+        self._admission = LaneScheduler(
+            max_inflight=max_inflight, light_permits=light_permits,
+            reserved_for_high=reserved_for_high,
+            wait_seconds=admission_wait_s,
+            light_threshold_ms=light_threshold_ms)
         self._sessions: Dict[str, OSSession] = {}
         self._lock = threading.Lock()
 
@@ -276,16 +426,17 @@ class SeochoOS:
 
     # -- execution / scheduling -------------------------------------------
 
-    def _admit(self, session: OSSession) -> None:
-        if not self._admission.acquire(session.priority):
+    def _admit(self, session: OSSession, lane: str = "heavy") -> None:
+        if not self._admission.acquire(lane=lane, priority=session.priority):
             from .query.query_proxy import QueryAdmissionRejected
 
             raise QueryAdmissionRejected(
                 f"admission denied for session={session.session_id} "
-                f"(priority={session.priority}): no capacity within deadline")
+                f"(priority={session.priority}, lane={lane}): no capacity "
+                f"within deadline")
 
-    def _release(self, session: OSSession) -> None:
-        self._admission.release(session.priority)
+    def _release(self, session: OSSession, lane: str = "heavy") -> None:
+        self._admission.release(lane=lane, priority=session.priority)
 
     # -- governance / the Bolt-aware tool surface --------------------------
 
@@ -308,7 +459,14 @@ class SeochoOS:
             return _json.dumps({"error": "params_json must be a JSON object"})
         params["workspace_id"] = self.workspace_id   # pinned, not trusted
         params["ws"] = self.workspace_id
-        self._admit(session)
+        import hashlib as _hashlib
+        import time as _time
+
+        statement_key = _hashlib.blake2b(
+            " ".join(cypher.split()).encode(), digest_size=8).hexdigest()
+        lane = self._admission.classify(statement_key)
+        self._admit(session, lane)
+        started = _time.perf_counter()
         try:
             rows = self.graph_store.query(
                 cypher, params=params, database=self.database,
@@ -317,7 +475,11 @@ class SeochoOS:
             return _json.dumps({"error": type(exc).__name__,
                                 "message": str(exc)[:300]})
         finally:
-            self._release(session)
+            self._release(session, lane)
+        # Feed the cost signal only on success: a failure's wall time says
+        # nothing about the statement's service cost.
+        self._admission.observe(
+            statement_key, (_time.perf_counter() - started) * 1000.0)
         capped = rows[: self.row_cap]
         return _json.dumps({"rows": capped, "row_count": len(capped),
                             "row_cap": self.row_cap,

--- a/tests/seocho/test_operating_layer.py
+++ b/tests/seocho/test_operating_layer.py
@@ -290,7 +290,7 @@ def test_predicted_wait_rejects_immediately_not_after_timeout(ontology):
     from seocho.operating_layer import LaneScheduler
 
     gate = LaneScheduler(max_inflight=1, light_permits=0, wait_seconds=5.0)
-    gate.observe("slow", 8000.0)            # EWMA says ~8s service time
+    gate.observe("slow", 8000.0, lane="heavy")   # lane EWMA ~8s
     assert gate.acquire(lane="heavy")       # occupy the only permit
     # Park a waiter so predicted wait = 1 * 8s / 1 permit = 8s > 0.5s budget.
     import threading as _threading

--- a/tests/seocho/test_operating_layer.py
+++ b/tests/seocho/test_operating_layer.py
@@ -222,3 +222,114 @@ def test_reserve_must_leave_normal_capacity(ontology):
 
     with pytest.raises(ValueError):
         PriorityAdmission(max_inflight=2, reserved_for_high=2)
+
+
+# -- scheduler v2: lanes, borrowing, fast-fail --------------------------------
+
+def test_unknown_statements_go_to_the_heavy_lane(ontology):
+    from seocho.operating_layer import LaneScheduler
+
+    gate = LaneScheduler(max_inflight=4, light_permits=2)
+    assert gate.classify("never-seen") == "heavy"
+    gate.observe("fast-query", 80.0)
+    gate.observe("slow-query", 8000.0)
+    assert gate.classify("fast-query") == "light"
+    assert gate.classify("slow-query") == "heavy"
+
+
+def test_heavy_saturation_cannot_block_the_light_lane(ontology):
+    from seocho.operating_layer import LaneScheduler
+
+    gate = LaneScheduler(max_inflight=4, light_permits=2, wait_seconds=0.05)
+    assert gate.acquire(lane="heavy") and gate.acquire(lane="heavy")
+    assert not gate.acquire(lane="heavy")          # heavy lane full
+    # Light permits are untouched by the heavy pile-up — no head-of-line.
+    assert gate.acquire(lane="light") and gate.acquire(lane="light")
+
+
+def test_normal_borrows_the_reserve_only_while_high_is_absent(ontology):
+    from seocho.operating_layer import LaneScheduler
+
+    gate = LaneScheduler(max_inflight=4, light_permits=0,
+                         reserved_for_high=2, wait_seconds=0.05)
+    # No high waiter anywhere: work conservation lets normals use all 4.
+    for _ in range(4):
+        assert gate.acquire(lane="heavy", priority="normal")
+    assert not gate.acquire(lane="heavy", priority="normal")
+    for _ in range(4):
+        gate.release(lane="heavy", priority="normal")
+
+    # A waiting high class re-arms the protection: with 2 reserved and a
+    # high waiter present, normals stop at 2.
+    import threading as _threading
+    import time as _time
+
+    assert gate.acquire(lane="heavy", priority="normal")
+    assert gate.acquire(lane="heavy", priority="normal")
+    assert gate.acquire(lane="heavy", priority="high")
+    assert gate.acquire(lane="heavy", priority="high")   # pool now full
+
+    got = []
+
+    def waiting_high():
+        got.append(gate.acquire(lane="heavy", priority="high", deadline_s=2.0))
+
+    thread = _threading.Thread(target=waiting_high)
+    thread.start()
+    _time.sleep(0.1)                       # the high waiter is now queued
+    gate.release(lane="heavy", priority="high")
+    thread.join(timeout=5)
+    assert got == [True]                    # release reached the high waiter
+    # While that high waiter was queued, a normal could not have taken the
+    # freed permit past the reserve — covered by the admissibility rule.
+
+
+def test_predicted_wait_rejects_immediately_not_after_timeout(ontology):
+    import time as _time
+
+    from seocho.operating_layer import LaneScheduler
+
+    gate = LaneScheduler(max_inflight=1, light_permits=0, wait_seconds=5.0)
+    gate.observe("slow", 8000.0)            # EWMA says ~8s service time
+    assert gate.acquire(lane="heavy")       # occupy the only permit
+    # Park a waiter so predicted wait = 1 * 8s / 1 permit = 8s > 0.5s budget.
+    import threading as _threading
+
+    parked = _threading.Thread(
+        target=lambda: gate.acquire(lane="heavy", deadline_s=3.0))
+    parked.start()
+    _time.sleep(0.05)
+    started = _time.perf_counter()
+    assert not gate.acquire(lane="heavy", deadline_s=0.5)
+    elapsed = _time.perf_counter() - started
+    assert elapsed < 0.2                    # rejected NOW, not at 0.5s timeout
+    gate.release(lane="heavy")
+    parked.join(timeout=5)
+
+
+# -- the public surface is Seocho itself --------------------------------------
+
+def test_operating_layer_is_methods_on_seocho(ontology):
+    from seocho import Seocho
+
+    store = RecordingStore()
+    client = Seocho(ontology=ontology, graph_store=store, llm=None,
+                    workspace_id="acme", max_inflight=4)
+    session = client.session("chat-1", priority="high")
+    assert session.priority == "high"
+    payload = client.execute_query(
+        session, "MATCH (n:Account) WHERE n._workspace_id = $workspace_id "
+                 "RETURN n LIMIT 1", "{}")
+    assert "row_count" in payload
+    assert store.calls[0]["params"]["workspace_id"] == "acme"
+    agent = client.build_agent(session, name="t")
+    assert agent.tools[0].name == "graph_query"
+
+
+def test_operating_layer_refused_outside_local_mode():
+    from seocho import Seocho
+    from seocho.exceptions import SeochoError
+
+    client = Seocho(base_url="http://localhost:9")   # HTTP mode
+    with pytest.raises(SeochoError, match="local mode"):
+        client.session("x")

--- a/tests/seocho/test_operating_layer.py
+++ b/tests/seocho/test_operating_layer.py
@@ -309,14 +309,19 @@ def test_predicted_wait_rejects_immediately_not_after_timeout(ontology):
 
 # -- the public surface is Seocho itself --------------------------------------
 
-def test_operating_layer_is_methods_on_seocho(ontology):
+def test_one_session_object_carries_the_operating_layer(ontology):
+    """seocho-dxe final form: no side class, no second method — the same
+    Session that add()/ask() use carries sdk_session/hooks/priority, and
+    the governed paths accept it directly."""
     from seocho import Seocho
 
     store = RecordingStore()
-    client = Seocho(ontology=ontology, graph_store=store, llm=None,
+    client = Seocho(ontology=ontology, graph_store=store, llm=object(),
                     workspace_id="acme", max_inflight=4)
-    session = client.session("chat-1", priority="high")
+    session = client.session("chat", priority="high")
     assert session.priority == "high"
+    assert session.sdk_session.workspace_id == "acme"
+    assert session.hooks is not None and session.budget is not None
     payload = client.execute_query(
         session, "MATCH (n:Account) WHERE n._workspace_id = $workspace_id "
                  "RETURN n LIMIT 1", "{}")
@@ -328,8 +333,7 @@ def test_operating_layer_is_methods_on_seocho(ontology):
 
 def test_operating_layer_refused_outside_local_mode():
     from seocho import Seocho
-    from seocho.exceptions import SeochoError
 
     client = Seocho(base_url="http://localhost:9")   # HTTP mode
-    with pytest.raises(SeochoError, match="local mode"):
+    with pytest.raises(Exception, match="local"):
         client.session("x")


### PR DESCRIPTION
Two hadry critiques, both taken at face value; design note `scheduler-v2-design.md`. Progress on **seocho-xdp.1**.

**p99 is the metric.** The honest re-read this starts from: v1's FIFO admission made light-class p99 *worse than no gate at all* (1,767ms vs 239ms, SF10×16) by queueing light calls behind 100×-heavier ones. `LaneScheduler` fixes that structurally on three stated principles:
- **variance isolation** — permits partition into light/heavy lanes; a light query never queues behind a heavy one (head-of-line blocking removed, not tuned);
- **work conservation** — the high-priority reserve is borrowable while no high caller waits (v1 taxed normal throughput even with the high class idle);
- **fast structured failure** — predicted wait (waiters × lane-EWMA / permits) beyond the deadline rejects *immediately*, converting queue tail into a zero-wait signal.

Classification uses the layer's unique asset — per-statement observed cost (cypher-hash EWMA; planner estimates measured unreliable in FinBench) — with **unknown-means-heavy** keeping the light lane's p99 pure. Semantics unit-tested: lane isolation, borrow-only-while-absent, release-reaches-the-waiting-high, immediate predicted-wait rejection.

**One name, one session.** `from seocho import Seocho` is the whole story: `Seocho.session(name, priority=...)` returns the *same* Session `add()`/`ask()` use, now carrying `sdk_session`/`hooks`/`budget`/`priority`; `build_agent()`/`execute_query()` accept it directly; operating controls are constructor kwargs defaulting to off. No side names in Tier-1 `__all__`; `SeochoOS`/`AgentOS` importable one release. (The first attempt shadowed the existing `session()` — caught by ruff F811; unification, not renaming, was the fix.)

E2/S2 live probes (p99-primary re-measurement on FinBench) follow on this branch or a fast follow.

Validation: `run_basic_ci.sh` — 751 passed, 3 skipped (16 scheduler/facade tests gated); doc contracts green; ruff clean.