### PR TITLE
fix(query): read relationship direction off the edge, not from binding order

### DIFF
--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -672,12 +672,36 @@ class CypherBuilder:
             params.update(target_params)
 
         where = " AND ".join(where_parts)
+        # Two defects lived here, both invisible until the endpoints share a label
+        # (Account -TRANSFER-> Account), which is every payments/ownership schema.
+        #
+        # 1. The projection named the ANCHOR `source` and the neighbour `target`
+        #    regardless of which way the arrow pointed. Matching undirected then
+        #    labelling by binding order inverts every incoming edge: asked "which
+        #    accounts transferred to B2", it returned B2 as the source of A1's
+        #    transfer and the model answered the exact opposite of the graph, with
+        #    no error raised. Read the direction off the edge instead (seocho-k5n).
+        # 2. The pattern stayed undirected even when the ontology declared which end
+        #    the anchor sits on, so recall ignored the question's direction. Honour
+        #    `anchor_role` — the same flip `_count` (seocho-k2v) and `_list_all`
+        #    (seocho-pl1) already apply.
+        #
+        # `target_labels` / `target_properties` / `supporting_fact` stay bound to
+        # `b`, the anchor's counterpart, which is what an answer needs; only the
+        # source/target naming was ever a claim about direction.
+        role = getattr(self, "anchor_role", "")
+        if role == "source":
+            pattern = f"MATCH (a{a_label})-[r{rel_clause}]->(b{t_label})"
+        elif role == "target":
+            pattern = f"MATCH (a{a_label})<-[r{rel_clause}]-(b{t_label})"
+        else:
+            pattern = f"MATCH (a{a_label})-[r{rel_clause}]-(b{t_label})"
         return (
-            f"MATCH (a{a_label})-[r{rel_clause}]-(b{t_label})\n"
+            f"{pattern}\n"
             f"WHERE {where}\n"
-            "RETURN coalesce(a.name, a.uri) AS source,\n"
+            "RETURN coalesce(startNode(r).name, startNode(r).uri) AS source,\n"
             "       type(r) AS relationship,\n"
-            "       coalesce(b.name, b.uri) AS target,\n"
+            "       coalesce(endNode(r).name, endNode(r).uri) AS target,\n"
             "       labels(b) AS target_labels,\n"
             "       properties(b) AS target_properties,\n"
             "       coalesce(b.content_preview, b.description, b.content, '') AS supporting_fact\n"

--- a/src/seocho/query/semantic_agents.py
+++ b/src/seocho/query/semantic_agents.py
@@ -1667,9 +1667,17 @@ class LPGAgent:
         OPTIONAL MATCH (n)-[r{relation_clause}]-(m)
         WHERE $target_hint = ''
            OR toLower(coalesce(m.name, m.title, m.id, m.uri, elementId(m))) CONTAINS toLower($target_hint)
-        RETURN coalesce(n.name, n.title, n.id, n.uri, elementId(n)) AS source_entity,
+        RETURN CASE WHEN r IS NULL
+                    THEN coalesce(n.name, n.title, n.id, n.uri, elementId(n))
+                    ELSE coalesce(startNode(r).name, startNode(r).title,
+                                  startNode(r).id, startNode(r).uri,
+                                  elementId(startNode(r))) END AS source_entity,
                type(r) AS relation_type,
-               coalesce(m.name, m.title, m.id, m.uri, elementId(m)) AS target_entity,
+               CASE WHEN r IS NULL
+                    THEN coalesce(m.name, m.title, m.id, m.uri, elementId(m))
+                    ELSE coalesce(endNode(r).name, endNode(r).title,
+                                  endNode(r).id, endNode(r).uri,
+                                  elementId(endNode(r))) END AS target_entity,
                labels(m) AS target_labels,
                coalesce(m.content_preview, m.description, '') AS supporting_fact
         ORDER BY target_entity

--- a/tests/seocho/test_relationship_direction.py
+++ b/tests/seocho/test_relationship_direction.py
@@ -1,0 +1,101 @@
+"""Direction survives the projection for same-label relationships (seocho-k5n).
+
+`_relationship_lookup` matched undirected and then named the *anchor* `source`
+and the neighbour `target`, discarding the arrow. When both endpoints carry the
+same label — every payments, ownership or transfer schema — that inverts each
+incoming edge. Asked "which accounts transferred to B2" against a graph holding
+`A1 -TRANSFER-> B2`, it returned `source=B2, target=A1` and the model answered
+the exact opposite of the graph, confidently, with no error raised.
+
+The ontology already declared the fix: `TRANSFER` carries
+`sourceRole: sender` / `targetRole: beneficiary`, and the planner infers
+`anchor_role` correctly. Two of five templates honoured it; this one did not.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from seocho.ontology import Ontology  # noqa: E402
+from seocho.query.cypher_builder import CypherBuilder  # noqa: E402
+
+_SAME_LABEL_ONTOLOGY = {
+    "name": "directiontest",
+    "nodes": {
+        "Account": {"properties": {"name": "string"}},
+        "Institution": {"properties": {"name": "string"}},
+    },
+    "relationships": {
+        # Both endpoints share a label, so the arrow — not the label — carries
+        # the direction. This is the shape the bug was invisible outside of.
+        "TRANSFER": {
+            "source": "Account",
+            "target": "Account",
+            "source_role": "sender",
+            "target_role": "beneficiary",
+        },
+        "HELD_AT": {"source": "Account", "target": "Institution"},
+    },
+}
+
+
+def _build(role: str) -> str:
+    """Build the relationship_lookup Cypher with the declared anchor role.
+
+    ``anchor_role`` reaches the builder through ``schema_hints`` — that is the
+    channel the planner fills from the intent payload.
+    """
+    builder = CypherBuilder(Ontology.from_dict(_SAME_LABEL_ONTOLOGY))
+    cypher, _params = builder.build(
+        intent="relationship_lookup",
+        anchor_entity="B2",
+        anchor_label="Account",
+        relationship_type="TRANSFER",
+        workspace_id="default",
+        schema_hints={"anchor_role": role} if role else {},
+    )
+    return cypher
+
+
+@pytest.mark.parametrize("role", ["", "source", "target"])
+def test_source_and_target_are_read_off_the_edge(role):
+    """Never label the anchor `source`; the arrow decides, at every role."""
+    cypher = _build(role)
+    assert "startNode(r)" in cypher, "source must come from the edge, not binding order"
+    assert "endNode(r)" in cypher, "target must come from the edge, not binding order"
+    assert "coalesce(a.name, a.uri) AS source" not in cypher
+    assert "coalesce(b.name, b.uri) AS target" not in cypher
+
+
+def test_declared_anchor_role_constrains_the_pattern():
+    """A question that names a direction must not match the other one."""
+    incoming = _build("target")
+    outgoing = _build("source")
+
+    # anchor is the beneficiary -> edges point INTO it
+    assert "<-[r" in incoming
+    assert "]->(b" not in incoming
+    # anchor is the sender -> edges point OUT of it
+    assert "]->(b" in outgoing
+    assert "<-[r" not in outgoing
+
+
+def test_unknown_role_stays_undirected():
+    """With no declared role, recall must not silently halve."""
+    cypher = _build("")
+    assert "<-[r" not in cypher
+    assert "]->(b" not in cypher
+    assert "-[r" in cypher
+
+
+def test_neighbour_columns_still_describe_the_counterpart():
+    """The direction fix must not move what the answer synthesiser reads."""
+    cypher = _build("target")
+    assert "labels(b) AS target_labels" in cypher
+    assert "properties(b) AS target_properties" in cypher
+    assert "AS supporting_fact" in cypher


### PR DESCRIPTION
Fixes **seocho-k5n**. Found during the serve-track investigation; kept out of PR #497 so it lands small with its own test.

## The failure

`_relationship_lookup` matched undirected and then named the **anchor** `source` and the neighbour `target`, discarding the arrow. Where both endpoints carry the same label — every payments, ownership or transfer schema — that inverts each incoming edge.

Graph holds `A1 -TRANSFER-> B2`. Asked *"which accounts transferred money to B2"*:

> "no accounts transferred money to B2. B2 transferred to A1 and C3"

The exact inverse of the graph, stated confidently, **no error raised**. The rows were there; the projection overwrote their direction.

| | reported_source | reported_target | actual edge |
|---|---|---|---|
| row 1 | B2 | A1 | **A1 → B2** |
| row 2 | B2 | C3 | B2 → C3 |

## The ontology already declared the fix

`TRANSFER` carries `sourceRole: sender` / `targetRole: beneficiary`, `CypherBuilder` populates `self.anchor_role`, and the planner infers it correctly (verified: `anchor_role='target'`, 2/2 runs). Two of five templates honoured it — `_count` (seocho-k2v) and `_list_all` (seocho-pl1) — and this one did not.

That is the uncomfortable part: **a schema each call site must separately remember to read is not type safety.** The information was correct, declared, and reached the builder; one template ignored it and the answer came out backwards.

## Changes

Two, both narrow:

1. Project `startNode(r)` / `endNode(r)` as source/target — direction read off the edge at **every** role, including when none is declared.
2. Constrain the pattern from `anchor_role` when the ontology declares it, using the same flip the other two templates already use.

`target_labels` / `target_properties` / `supporting_fact` stay bound to `b`, the anchor's counterpart, which is what the synthesiser reads — only source/target was ever a claim about direction. The undirected match is kept when no role is declared, so recall does not silently halve.

The same defect was duplicated in `semantic_agents._relationship_query` and is fixed there too, guarded so an `OPTIONAL MATCH` with no relationship still yields the row shape it did before.

## Validation

- `tests/seocho/test_relationship_direction.py` — 6 passed. **4 of them fail against the pre-fix builder** (verified by stashing), so the guard bites rather than documents.
- `bash scripts/ci/run_basic_ci.sh` — 751 passed, 3 skipped.
- Live against DozerDB + MiniMax-M2.7, same question, same graph:
  `MATCH (a:Account)<-[r:TRANSFER]-(b:Account)` → *"Account **A1** transferred money to B2 — Source: A1, Target: B2"* ✓
- `ruff` clean on both files. Two pre-existing unused imports in `semantic_agents.py` confirmed present on `main` and left alone.

## Not in scope

`_responsibility_query` and `_entity_summary_query` also match undirected, but their column names (`owner_or_operator`, `neighbors[].target`) do not claim arrow direction the way `source`/`target` does. Worth a look, not the same defect.