### PR TITLE
fix(query): put question-scoped hints last so the ontology body stays cacheable

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -101,6 +101,8 @@ uv run pytest \
   tests/seocho/test_ontology_subclass_ttl.py \
   tests/seocho/test_ontology_reasoner.py \
   tests/seocho/test_ontology_iso704_cq.py \
+  tests/seocho/test_relationship_direction.py \
+  tests/seocho/test_prompt_prefix_stability.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \
   tests/seocho/test_scaffold.py \

--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -294,7 +294,17 @@ class CypherBuilder:
             node_descriptions.append(f"  - {label}: {desc} (properties: {props})")
         node_block = "\n".join(node_descriptions)
         hint_block = self.render_schema_hints(schema_hints)
-        hint_prefix = f"Question-scoped schema hints:\n{hint_block}\n\n" if hint_block else ""
+        # Question-scoped hints are the only part of this prompt that changes
+        # between questions on one ontology, so they go LAST (ADR-0148: stable
+        # sections precede volatile ones). They used to sit just after the
+        # invariant header, which truncated the reusable KV prefix at ~112
+        # tokens and forced the ~2.7 KB ontology body — byte-identical across
+        # questions — to be re-prefilled on every planning call.
+        hint_suffix = (
+            f"\nQuestion-scoped schema hints (specific to this question):\n{hint_block}\n"
+            if hint_block
+            else ""
+        )
 
         return (
             "You are a question analyzer for a knowledge graph.\n"
@@ -308,7 +318,6 @@ class CypherBuilder:
             f"- Ontology query profile: package_id={profile['package_id']}, "
             f"version={profile['version']}, graph_model={profile['graph_model']}.\n"
             f"- Deterministic intents supported: {', '.join(profile['deterministic_intents'])}.\n\n"
-            f"{hint_prefix}"
             f"Node types:\n{node_block}\n\n"
             f"Relationship types (ONLY these exist in the graph):\n{rel_block}\n\n"
             f"{role_block}"
@@ -353,6 +362,7 @@ class CypherBuilder:
             '  "How many accounts sent transfers into account 42?" → {"intent": "count", "anchor_entity": "42", '
             '"anchor_label": "Account", "target_label": "Account", "relationship_type": "TRANSFER"}\n'
             '  "Delta in CBOE Data & Access Solutions rev from 2021-23." → {"intent": "financial_metric_delta", "anchor_entity": "CBOE", "anchor_label": "Company", "metric_name": "Data & Access Solutions revenue", "years": ["2021", "2023"]}\n'
+            + hint_suffix
         )
 
     def derive_schema_hints(

--- a/tests/seocho/test_prompt_prefix_stability.py
+++ b/tests/seocho/test_prompt_prefix_stability.py
@@ -1,0 +1,117 @@
+"""The intent-extraction system prompt must be byte-stable up to its volatile tail.
+
+ADR-0148 requires stable prompt sections to precede volatile ones, because a KV
+prefix is reusable only as far as the prompt is byte-identical. This was not
+enforced anywhere, and it had regressed: question-scoped schema hints sat just
+after the invariant header, so the ~2.7 KB ontology body — identical for every
+question on one ontology — fell *after* the first divergence and was re-prefilled
+on every call.
+
+Measured on vLLM 0.27.1 / Qwen3-0.6B before the fix: the `plan` stage reported
+`stable_prefix_chars = 0` and 8-14% cross-question prefix-cache hits, against 99%
+when the same question repeated.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from seocho import Ontology  # noqa: E402
+from seocho.query.cypher_builder import CypherBuilder  # noqa: E402
+
+HINT_MARKER = "Question-scoped schema hints"
+
+_QUESTIONS = [
+    "Which accounts transferred money to B2?",
+    "Which institution holds account C3?",
+    "Which accounts form a transfer cycle?",
+    "How many accounts are held at Northbank?",
+]
+
+
+@pytest.fixture
+def builder() -> CypherBuilder:
+    return CypherBuilder(
+        Ontology.from_dict(
+            {
+                "name": "prefixtest",
+                "nodes": {
+                    "Account": {"properties": {"name": "string", "balance": "float"}},
+                    "Institution": {"properties": {"name": "string"}},
+                },
+                "relationships": {
+                    "TRANSFER": {"source": "Account", "target": "Account"},
+                    "HELD_AT": {"source": "Account", "target": "Institution"},
+                },
+            }
+        )
+    )
+
+
+def _prompts(builder: CypherBuilder) -> list[str]:
+    return [
+        builder.intent_extraction_prompt(schema_hints=builder.derive_schema_hints(q))
+        for q in _QUESTIONS
+    ]
+
+
+def _common_prefix_len(a: str, b: str) -> int:
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+def test_everything_before_the_hint_section_is_identical(builder):
+    """The reusable prefix is everything up to the question-scoped hints."""
+    prompts = _prompts(builder)
+    heads = []
+    for prompt in prompts:
+        assert HINT_MARKER in prompt, "hint section missing; the fixture must produce hints"
+        heads.append(prompt[: prompt.index(HINT_MARKER)])
+
+    assert len(set(heads)) == 1, (
+        "the system prompt diverges before its volatile tail, so the ontology body "
+        "cannot be cached; put question-derived content last (ADR-0148)"
+    )
+
+
+def test_hints_are_the_last_section(builder):
+    """Nothing stable may follow the hints, or it lands past the divergence."""
+    for prompt in _prompts(builder):
+        tail = prompt[prompt.index(HINT_MARKER) :]
+        # The hint block is a run of "- " lines and nothing else.
+        body = [line for line in tail.splitlines()[1:] if line.strip()]
+        assert body, "hint section rendered empty"
+        assert all(line.startswith("- ") for line in body), (
+            f"content after the hint section would be uncacheable: {body}"
+        )
+
+
+def test_stable_prefix_dominates_the_prompt(builder):
+    """Guards against the hints growing until caching stops paying off."""
+    prompts = _prompts(builder)
+    shortest = min(len(p) for p in prompts)
+    for other in prompts[1:]:
+        shared = _common_prefix_len(prompts[0], other)
+        assert shared / shortest > 0.75, (
+            f"only {shared}/{shortest} chars shared across questions"
+        )
+
+
+def test_repeating_one_question_is_byte_identical(builder):
+    """Hint derivation must be deterministic, or even a repeat cannot reuse."""
+    once = builder.intent_extraction_prompt(
+        schema_hints=builder.derive_schema_hints(_QUESTIONS[0])
+    )
+    twice = builder.intent_extraction_prompt(
+        schema_hints=builder.derive_schema_hints(_QUESTIONS[0])
+    )
+    assert once == twice


### PR DESCRIPTION
Two files, split out of #497 so it can merge on its own. Adversarial review of that branch recommended landing exactly this piece separately — it is hardware-independent, model-independent, and a real defect in SEOCHO's own prompt assembly, currently trapped behind 2,257 lines of instrumentation.

## The defect

`intent_extraction_prompt` inlined question-derived schema hints **right after the invariant header**. Everything following them — node types, relationship types, roles, cardinality, constraints, output format, examples: ~2.7 KB that is byte-identical for every question on one ontology — therefore landed *after* the first divergence and was re-prefilled on every planning call.

`ADR-0148` already required stable sections to precede volatile ones. Nothing enforced it, and this prompt had drifted the other way.

## The change

Hints move to the tail. Same content, same wording, same section. Hint rendering was already deterministic (fixed field order, append-built lists), so a repeated question still produces byte-identical text.

Measured on a four-question demo ontology:

| | before | after |
|---|---:|---:|
| shared prefix across questions | ~500 chars | **2,690 chars** (83% of prompt) |

## Scope note — read this before quoting a number

The end-to-end latency this buys is **small**. A planning call is dominated by reasoning-token decode, not prefill; on MiniMax-M2.7 the measured split is ~94% reasoning tokens for a 43-character JSON output. The prefill share is low single digits, and the saving sits well inside run-to-run variance.

So this lands as a **prompt-assembly correctness fix and an enforced ADR-0148 contract**, not a performance claim. The real planning-cost lever is model selection for intent classification, which is a separate change.

## Validation

- `tests/seocho/test_prompt_prefix_stability.py` — 4 passed. **2 of them fail against the pre-fix prompt** (verified by stashing), so the guard bites rather than documents: everything before the hint marker must be byte-identical across questions, nothing stable may follow the hints, the stable prefix must dominate, and repeating one question must be byte-identical.
- `bash scripts/ci/run_basic_ci.sh` — 751 passed, 3 skipped.
- `ruff` clean.

Related: #497 (the rig, stays on its branch), #502 (direction fix, also split out of the same investigation).