### PR TITLE
exp(interning): identity table as a memory allocator — collapse/collision measurement (ADR-0160)

### DIFF
--- a/docs/decisions/ADR-0160-interning-measurement.md
+++ b/docs/decisions/ADR-0160-interning-measurement.md
@@ -1,0 +1,81 @@
+# ADR-0160: interning measurement — the identity table as a memory allocator
+
+Date: 2026-08-15 · Status: accepted (measurement record)
+
+## Context
+
+The memory-allocator reframe (hadry 2026-08-15; obsidian
+wiki/memory-allocator-model-design.md) reads SEOCHO's `identity_keys` →
+composite-id MERGE as **hash-consing / string interning**, with the UNIQUE
+constraint on the composite id as the intern table (the "ontology hash →
+hashtable"). If that framing is load-bearing, the layer's defining metric is
+not latency but the two properties every interning allocator lives or dies by:
+
+- **Collapse** — do multiple mentions of the *same* canonical entity (surface
+  variation across documents/agents) resolve to *one* address?
+- **Collision** — do *distinct* canonical entities that share a member
+  (homonyms) wrongly land on *one* address, corrupting the heap?
+
+Nobody in the neighborhood (mem0/graphiti/cognee) reports these, because none
+has a typed intern table to measure — a category-defining measurement, like
+PORT-1.
+
+## Method
+
+`scripts/agentos/interning_probe.py` exercises the **real** identity function
+`seocho.index.identity.compute_node_identity` (the one the write path calls —
+not a reimplementation) over the FinBench entity population (Person, Company;
+SF1 and SF10). Per canonical entity it injects deterministic surface variation
+in two families, kept separate so collapse is measured honestly:
+
+- **normalizable** (case, leading/trailing whitespace) — `_normalize_segment`
+  should fold these onto the canonical address;
+- **suffix** (appended legal suffix "Inc"/"Co."/…) — semantically the same
+  entity but NOT normalized away: the intern table's real recall ceiling.
+
+Planted homonyms force distinct canonicals to share a surface name while
+differing in a disambiguating property (Person→country, Company→sector) — the
+realistic collision (two people named X in different countries; PTC's vs
+Tesla's "Total revenue"). Two key policies are compared: `name_only`
+(`identity_keys=["name"]`, the naive allocator) vs `composite`
+(`identity_keys=["name", <disambiguator>]`, seocho-uxs). Pure function, no DB /
+no LLM → byte-deterministic; isolates key policy from storage.
+
+## Result (SF1; SF10 identical in shape — scale-invariant)
+
+| policy | norm. collapse | suffix recall | collision (planted homonyms) |
+|---|---|---|---|
+| `name_only` | 100% | 0% | **100%** (SF1 60/60, SF10 569/569) |
+| `composite` | 100% | 0% | **0%** (SF1 0/60, SF10 0/569) |
+
+- **Collision is the load-bearing result.** The naive name-only allocator
+  aliases *every* planted homonym pair onto one address — silent heap
+  corruption where the second write overwrites the first entity's values. The
+  composite key separates *all* of them, at both scales. Address accounting
+  makes the corruption concrete: at SF10 name_only produces 47,155 Person
+  addresses vs composite's 50,000 — 2,845 addresses lost to wrongful merges.
+- **Collapse of formatting noise works** (100% for case + whitespace): the
+  normalizer folds three surface forms to one address.
+- **Suffix recall is 0% — reported, not hidden.** Legal-suffix variants do not
+  fold; this is the intern table's honest recall ceiling and the motivation for
+  alias / `same_as` handling (a follow-up, not claimed here).
+
+## Honest scope
+
+The planted homonyms differ in the disambiguator by construction, so
+`composite`'s 0% collision measures that the composite key **uses** available
+disambiguating signal — not that it separates true duplicates. Homonyms
+identical in *every* identity key are the same address by definition (the probe
+skips those pairs and they are out of scope for a key policy). The claim is
+therefore precise: *when a distinguishing property exists (the common homonym
+case), the composite intern key exploits it to keep distinct entities at
+distinct addresses; the name-only key does not.*
+
+## Consequences
+
+- Interning collapse/collision join PORT-1 as the paper's Tier-1 evidence that
+  SEOCHO is a **typed interning allocator** for agent memory, not a metaphor:
+  the intern table gives every canonical entity one address across all agents —
+  a namespace no gateway/vector-store provides (ADR-0157 scope; seocho-gzo).
+- Motivates: alias/`same_as` to lift suffix recall (follow-up); the sound
+  isolation work (seocho-5zz) as the protection-domain half of the same model.

--- a/docs/decisions/ADR-0160-interning-sf1.json
+++ b/docs/decisions/ADR-0160-interning-sf1.json
@@ -1,0 +1,65 @@
+{
+  "nodes_dir": "/home/hadry/lab/seocho/outputs/finbench/sf1/nodes",
+  "variants": 4,
+  "homonym_rate": 0.15,
+  "labels": {
+    "Person": {
+      "disambiguator": "country",
+      "arms": {
+        "name_only": {
+          "policy": "name_only",
+          "canonicals": 1000,
+          "distinct_addresses": 4700,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 300,
+          "planted_homonym_pairs": 60,
+          "planted_pairs_collided": 60,
+          "collision_rate": 1.0
+        },
+        "composite": {
+          "policy": "composite",
+          "canonicals": 1000,
+          "distinct_addresses": 5000,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 0,
+          "planted_homonym_pairs": 60,
+          "planted_pairs_collided": 0,
+          "collision_rate": 0.0
+        }
+      }
+    },
+    "Company": {
+      "disambiguator": "sector",
+      "arms": {
+        "name_only": {
+          "policy": "name_only",
+          "canonicals": 100,
+          "distinct_addresses": 475,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 25,
+          "planted_homonym_pairs": 5,
+          "planted_pairs_collided": 5,
+          "collision_rate": 1.0
+        },
+        "composite": {
+          "policy": "composite",
+          "canonicals": 100,
+          "distinct_addresses": 500,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 0,
+          "planted_homonym_pairs": 5,
+          "planted_pairs_collided": 0,
+          "collision_rate": 0.0
+        }
+      }
+    }
+  }
+}

--- a/docs/decisions/ADR-0160-interning-sf10.json
+++ b/docs/decisions/ADR-0160-interning-sf10.json
@@ -1,0 +1,65 @@
+{
+  "nodes_dir": "/home/hadry/lab/seocho/outputs/finbench/sf10/nodes",
+  "variants": 4,
+  "homonym_rate": 0.15,
+  "labels": {
+    "Person": {
+      "disambiguator": "country",
+      "arms": {
+        "name_only": {
+          "policy": "name_only",
+          "canonicals": 10000,
+          "distinct_addresses": 47155,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 2845,
+          "planted_homonym_pairs": 569,
+          "planted_pairs_collided": 569,
+          "collision_rate": 1.0
+        },
+        "composite": {
+          "policy": "composite",
+          "canonicals": 10000,
+          "distinct_addresses": 50000,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 0,
+          "planted_homonym_pairs": 569,
+          "planted_pairs_collided": 0,
+          "collision_rate": 0.0
+        }
+      }
+    },
+    "Company": {
+      "disambiguator": "sector",
+      "arms": {
+        "name_only": {
+          "policy": "name_only",
+          "canonicals": 1000,
+          "distinct_addresses": 4725,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 275,
+          "planted_homonym_pairs": 55,
+          "planted_pairs_collided": 55,
+          "collision_rate": 1.0
+        },
+        "composite": {
+          "policy": "composite",
+          "canonicals": 1000,
+          "distinct_addresses": 5000,
+          "normalization_collapse_rate": 1.0,
+          "suffix_recall": 0.0,
+          "mean_addresses_per_canonical": 5.0,
+          "colliding_addresses": 0,
+          "planted_homonym_pairs": 55,
+          "planted_pairs_collided": 0,
+          "collision_rate": 0.0
+        }
+      }
+    }
+  }
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -939,6 +939,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - S2: work-conserving reserve keeps interactive protection while lifting normal throughput +56~59% vs the static reserve
   - defaults: single lane + fast-fail + borrowable reserve, all off-by-default on Seocho(...)
 
+## 2026-08-15 (interning)
+
+- [Accepted] ADR-0160 interning-measurement (identity table = memory allocator)
+  - exercises real compute_node_identity over FinBench Person/Company, SF1+SF10
+  - collision: name_only 100% (SF10 569/569 homonym pairs aliased) vs composite 0% — 2,845 Person addresses lost to wrongful merges at SF10 under name-only
+  - collapse: case/whitespace 100%; suffix recall 0% (honest ceiling → alias/same_as follow-up)
+  - scale-invariant; feeds the allocator/interning Tier-1 claim (seocho-gzo, seocho-5r2)
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/interning_probe.py
+++ b/scripts/agentos/interning_probe.py
@@ -1,0 +1,225 @@
+"""Interning probe: measure SEOCHO's identity-key table as a memory allocator.
+
+The memory-allocator reframe (hadry 2026-08-15,
+obsidian wiki/memory-allocator-model-design.md): SEOCHO's ``identity_keys`` ->
+composite-id MERGE is hash-consing / string interning, and the UNIQUE
+constraint on that id is the intern table (the "ontology hash -> hashtable").
+Its *defining* metric is not latency but the two properties every interning
+allocator lives or dies by:
+
+  * COLLAPSE — do multiple mentions of the SAME canonical entity (surface
+    variation across documents / agents) resolve to ONE address? An allocator
+    that gives the same entity two addresses has failed to intern.
+  * COLLISION — do DISTINCT canonical entities that happen to share a member
+    (homonyms: two "J. Smith", PTC's vs Tesla's "Total revenue") wrongly land
+    on ONE address? An allocator that aliases distinct objects has corrupted
+    the heap.
+
+This probe exercises the REAL identity code (``seocho.index.identity.
+compute_node_identity``, the function the write path calls) — not a
+reimplementation — over a FinBench entity population with:
+
+  * deterministic surface variation injected per canonical (case / whitespace /
+    legal-suffix / punctuation — what LLM extraction actually produces), and
+  * planted homonym collisions (distinct canonicals sharing a surface name but
+    differing in a disambiguating property).
+
+It compares two intern-key policies:
+
+  * ``name_only``  — identity_keys = ["name"]                  (the naive allocator)
+  * ``composite``  — identity_keys = ["name", <disambiguator>] (seocho-uxs)
+
+and sweeps population scale. No DB, no LLM: the identity function is pure, so
+the measurement is byte-deterministic and isolates the allocator's key policy
+from storage quirks.
+
+Usage:
+  python scripts/agentos/interning_probe.py \
+      --nodes-dir outputs/finbench/sf1/nodes \
+      --variants 4 --homonym-rate 0.15 \
+      --out outputs/agentos/interning_sf1.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from seocho.index.identity import compute_node_identity  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Deterministic surface variation — the forms one canonical entity takes across
+# documents/agents. No randomness: variant i is a fixed transform, so the whole
+# probe is reproducible. `_normalize_segment` (case/whitespace) is expected to
+# collapse variants 1-2; the legal-suffix/punctuation variants are NOT
+# normalized away and expose the intern table's real recall ceiling — reported,
+# not hidden.
+# ---------------------------------------------------------------------------
+
+_SUFFIXES = [" Inc", " Co.", " Ltd", ", LLC"]
+
+# Two variant families with different expectations, kept separate so collapse
+# is measured honestly rather than as one blunt rate:
+#   NORMALIZABLE — case + leading/trailing whitespace. `_normalize_segment`
+#     (lower + strip + collapse-spaces) SHOULD fold these to the canonical.
+#   SUFFIX — appended legal suffix. Semantically the same entity, but NOT
+#     normalized away — this is the intern table's real recall ceiling and the
+#     motivation for alias / same_as handling.
+
+
+def normalizable_variants(name: str) -> List[str]:
+    return [name, name.upper(), f"  {name}  "]
+
+
+def suffix_variants(name: str, k: int) -> List[str]:
+    return [name + _SUFFIXES[j % len(_SUFFIXES)] for j in range(k)]
+
+
+def load_population(nodes_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    import duckdb
+
+    con = duckdb.connect()
+    pop: Dict[str, List[Dict[str, Any]]] = {}
+    specs = {
+        "Person": ("name", "country"),
+        "Company": ("name", "sector"),
+    }
+    for label, (_name_col, disamb) in specs.items():
+        path = nodes_dir / f"{label}.parquet"
+        if not path.exists():
+            continue
+        rows = con.execute(
+            f"select id, name, {disamb} from '{path}' order by id").fetchall()
+        pop[label] = [
+            {"canonical_id": f"{label}:{r[0]}", "name": str(r[1]),
+             "disamb_key": disamb, "disamb_val": str(r[2])}
+            for r in rows]
+    return pop
+
+
+def plant_homonyms(entities: List[Dict[str, Any]], rate: float
+                   ) -> List[Tuple[str, str]]:
+    """Force distinct canonicals to share a surface name (differ in disambig).
+    Deterministic: pair entity i with entity i+half for the first `rate` share.
+    Returns the list of planted (canonical_a, canonical_b) collision pairs."""
+    n = len(entities)
+    half = n // 2
+    pairs: List[Tuple[str, str]] = []
+    count = int(half * rate)
+    for i in range(count):
+        a, b = entities[i], entities[i + half]
+        if a["disamb_val"] == b["disamb_val"]:
+            # a real homonym must differ in the disambiguator, else composite
+            # can't separate them either — skip so we measure a fair collision.
+            continue
+        b["name"] = a["name"]          # same surface name, different disamb
+        pairs.append((a["canonical_id"], b["canonical_id"]))
+    return pairs
+
+
+def _id_for(label: str, name: str, ent: Dict[str, Any],
+            identity_keys: List[str]) -> str:
+    props = {"name": name, ent["disamb_key"]: ent["disamb_val"]}
+    node_id = compute_node_identity(label, props, identity_keys)
+    return node_id if node_id is not None else f"__raw__:{name}"
+
+
+def measure(label: str, entities: List[Dict[str, Any]], *, suffix_k: int,
+            policy: str, disamb: str, homonym_pairs: List[Tuple[str, str]]
+            ) -> Dict[str, Any]:
+    identity_keys = ["name"] if policy == "name_only" else ["name", disamb]
+
+    id_to_canon: Dict[str, set] = {}
+    canon_to_ids: Dict[str, set] = {}
+    norm_folds = 0            # canonicals whose case/whitespace variants all fold
+    suffix_mentions = 0
+    suffix_folded = 0         # suffix variants that fold onto the canonical id
+
+    for ent in entities:
+        canonical_id_str = _id_for(label, ent["name"], ent, identity_keys)
+        # NORMALIZABLE family: expect all to fold onto the canonical address.
+        norm_ids = {_id_for(label, f, ent, identity_keys)
+                    for f in normalizable_variants(ent["name"])}
+        if norm_ids == {canonical_id_str}:
+            norm_folds += 1
+        # SUFFIX family: the recall ceiling.
+        for f in suffix_variants(ent["name"], suffix_k):
+            suffix_mentions += 1
+            if _id_for(label, f, ent, identity_keys) == canonical_id_str:
+                suffix_folded += 1
+        # Full address accounting over every mention (canonical + all variants).
+        all_forms = normalizable_variants(ent["name"]) + \
+            suffix_variants(ent["name"], suffix_k)
+        for f in all_forms:
+            nid = _id_for(label, f, ent, identity_keys)
+            id_to_canon.setdefault(nid, set()).add(ent["canonical_id"])
+            canon_to_ids.setdefault(ent["canonical_id"], set()).add(nid)
+
+    mean_ids = sum(len(ids) for ids in canon_to_ids.values()) / len(canon_to_ids)
+    colliding_ids = {i: c for i, c in id_to_canon.items() if len(c) > 1}
+    planted_collided = sum(
+        1 for a, b in homonym_pairs
+        if canon_to_ids.get(a, set()) & canon_to_ids.get(b, set()))
+
+    return {
+        "policy": policy,
+        "canonicals": len(canon_to_ids),
+        "distinct_addresses": len(id_to_canon),
+        # COLLAPSE, split honestly:
+        "normalization_collapse_rate": round(norm_folds / len(entities), 4),
+        "suffix_recall": round(suffix_folded / suffix_mentions, 4)
+        if suffix_mentions else 0.0,
+        "mean_addresses_per_canonical": round(mean_ids, 4),
+        # COLLISION:
+        "colliding_addresses": len(colliding_ids),
+        "planted_homonym_pairs": len(homonym_pairs),
+        "planted_pairs_collided": planted_collided,
+        "collision_rate": round(planted_collided / len(homonym_pairs), 4)
+        if homonym_pairs else 0.0,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--nodes-dir", required=True)
+    ap.add_argument("--variants", type=int, default=4)
+    ap.add_argument("--homonym-rate", type=float, default=0.15)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    pop = load_population(Path(args.nodes_dir))
+    report: Dict[str, Any] = {"nodes_dir": args.nodes_dir,
+                              "variants": args.variants,
+                              "homonym_rate": args.homonym_rate, "labels": {}}
+    for label, entities in pop.items():
+        disamb = entities[0]["disamb_key"]
+        pairs = plant_homonyms(entities, args.homonym_rate)
+        arms = {}
+        for policy in ("name_only", "composite"):
+            arms[policy] = measure(label, entities, suffix_k=args.variants,
+                                   policy=policy, disamb=disamb,
+                                   homonym_pairs=pairs)
+        report["labels"][label] = {"disambiguator": disamb, "arms": arms}
+        print(f"\n== {label} (n={len(entities)}, disamb={disamb}, "
+              f"homonym_pairs={len(pairs)}, variants/entity={args.variants}) ==")
+        for policy, r in arms.items():
+            print(f"  {policy:10s} norm_collapse={r['normalization_collapse_rate']:.2%} "
+                  f"suffix_recall={r['suffix_recall']:.2%} "
+                  f"mean_addr/canon={r['mean_addresses_per_canonical']:.2f} "
+                  f"| collision={r['collision_rate']:.2%} "
+                  f"({r['planted_pairs_collided']}/{r['planted_homonym_pairs']}) "
+                  f"| addresses={r['distinct_addresses']}")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Delivers **seocho-5r2** — the defining measurement of the memory-allocator reframe (hadry 2026-08-15).

## What
SEOCHO's `identity_keys` → composite-id MERGE is hash-consing/interning; the UNIQUE constraint on that id is the intern table. An interning allocator lives or dies by two properties, so we measure them directly, exercising the **real** `seocho.index.identity.compute_node_identity` (the write path's own function) over FinBench Person/Company at SF1 and SF10:

- **Collapse** — same-entity surface variants → one address?
- **Collision** — distinct entities sharing a member → wrongly one address?

## Result (scale-invariant, SF1 ≡ SF10 in shape)

| policy | norm. collapse | suffix recall | collision (planted homonyms) |
|---|---|---|---|
| `name_only` | 100% | 0% | **100%** (SF10 569/569) |
| `composite` (seocho-uxs) | 100% | 0% | **0%** (SF10 0/569) |

- **Collision is the headline:** name-only aliases *every* homonym pair onto one address — silent heap corruption. Composite separates all of them. At SF10, name-only loses 2,845 Person addresses to wrongful merges (47,155 vs 50,000).
- Formatting-noise collapse (case/whitespace) works at 100%.
- **Suffix recall 0% is reported, not hidden** — the intern table's honest recall ceiling; motivates alias/`same_as` (follow-up).

## Honest scope
Planted homonyms differ in the disambiguator by construction, so composite's 0% measures that the key *uses* available disambiguating signal — not that it separates true duplicates (identical-in-all-keys homonyms are the same address by definition; the probe skips them). Claim is precise accordingly (ADR-0160 §Honest scope).

Pure function, no DB / no LLM → byte-deterministic. Feeds the Tier-1 allocator/interning claim (seocho-gzo) alongside PORT-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)