### PR TITLE
exp(interning): real-data validation on the live MDM golden master (ADR-0162)

### DIFF
--- a/docs/decisions/ADR-0162-interning-real-mdm.json
+++ b/docs/decisions/ADR-0162-interning-real-mdm.json
@@ -41,7 +41,201 @@
       "precision": 1.0,
       "recall": 0.8962,
       "f1": 0.9453,
-      "note": "best-F1 over swept threshold = oracle ceiling for semantic fallback"
+      "false_merges": 0,
+      "note": "best-F1 over swept threshold = oracle ceiling (see full sweep)",
+      "sweep": [
+        {
+          "threshold": 0.5,
+          "precision": 0.0165,
+          "recall": 1.0,
+          "f1": 0.0324,
+          "false_merges": 6335
+        },
+        {
+          "threshold": 0.52,
+          "precision": 0.0165,
+          "recall": 1.0,
+          "f1": 0.0324,
+          "false_merges": 6335
+        },
+        {
+          "threshold": 0.54,
+          "precision": 0.0165,
+          "recall": 1.0,
+          "f1": 0.0324,
+          "false_merges": 6335
+        },
+        {
+          "threshold": 0.56,
+          "precision": 0.0165,
+          "recall": 1.0,
+          "f1": 0.0324,
+          "false_merges": 6335
+        },
+        {
+          "threshold": 0.58,
+          "precision": 0.0165,
+          "recall": 1.0,
+          "f1": 0.0324,
+          "false_merges": 6335
+        },
+        {
+          "threshold": 0.6,
+          "precision": 0.0165,
+          "recall": 1.0,
+          "f1": 0.0324,
+          "false_merges": 6335
+        },
+        {
+          "threshold": 0.62,
+          "precision": 0.0203,
+          "recall": 1.0,
+          "f1": 0.0398,
+          "false_merges": 5111
+        },
+        {
+          "threshold": 0.64,
+          "precision": 0.028,
+          "recall": 1.0,
+          "f1": 0.0544,
+          "false_merges": 3683
+        },
+        {
+          "threshold": 0.66,
+          "precision": 0.0763,
+          "recall": 1.0,
+          "f1": 0.1417,
+          "false_merges": 1284
+        },
+        {
+          "threshold": 0.68,
+          "precision": 0.1016,
+          "recall": 1.0,
+          "f1": 0.1845,
+          "false_merges": 937
+        },
+        {
+          "threshold": 0.7,
+          "precision": 0.1117,
+          "recall": 1.0,
+          "f1": 0.2009,
+          "false_merges": 843
+        },
+        {
+          "threshold": 0.72,
+          "precision": 0.1434,
+          "recall": 1.0,
+          "f1": 0.2509,
+          "false_merges": 633
+        },
+        {
+          "threshold": 0.74,
+          "precision": 0.3212,
+          "recall": 1.0,
+          "f1": 0.4862,
+          "false_merges": 224
+        },
+        {
+          "threshold": 0.76,
+          "precision": 0.3292,
+          "recall": 1.0,
+          "f1": 0.4953,
+          "false_merges": 216
+        },
+        {
+          "threshold": 0.78,
+          "precision": 0.4898,
+          "recall": 0.9057,
+          "f1": 0.6358,
+          "false_merges": 100
+        },
+        {
+          "threshold": 0.8,
+          "precision": 0.5053,
+          "recall": 0.9057,
+          "f1": 0.6486,
+          "false_merges": 94
+        },
+        {
+          "threshold": 0.82,
+          "precision": 1.0,
+          "recall": 0.8962,
+          "f1": 0.9453,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.84,
+          "precision": 1.0,
+          "recall": 0.8962,
+          "f1": 0.9453,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.86,
+          "precision": 1.0,
+          "recall": 0.8962,
+          "f1": 0.9453,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.88,
+          "precision": 1.0,
+          "recall": 0.8774,
+          "f1": 0.9347,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.9,
+          "precision": 1.0,
+          "recall": 0.8774,
+          "f1": 0.9347,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.92,
+          "precision": 1.0,
+          "recall": 0.8208,
+          "f1": 0.9016,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.94,
+          "precision": 1.0,
+          "recall": 0.8208,
+          "f1": 0.9016,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.96,
+          "precision": 1.0,
+          "recall": 0.8113,
+          "f1": 0.8958,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.98,
+          "precision": 1.0,
+          "recall": 0.8113,
+          "f1": 0.8958,
+          "false_merges": 0
+        }
+      ],
+      "precision_just_below_peak": [
+        {
+          "threshold": 0.78,
+          "precision": 0.4898,
+          "recall": 0.9057,
+          "f1": 0.6358,
+          "false_merges": 100
+        },
+        {
+          "threshold": 0.8,
+          "precision": 0.5053,
+          "recall": 0.9057,
+          "f1": 0.6486,
+          "false_merges": 94
+        }
+      ]
     }
   },
   "multisource_only": {
@@ -77,7 +271,201 @@
       "precision": 1.0,
       "recall": 0.8962,
       "f1": 0.9453,
-      "note": "best-F1 over swept threshold = oracle ceiling for semantic fallback"
+      "false_merges": 0,
+      "note": "best-F1 over swept threshold = oracle ceiling (see full sweep)",
+      "sweep": [
+        {
+          "threshold": 0.5,
+          "precision": 0.0206,
+          "recall": 1.0,
+          "f1": 0.0403,
+          "false_merges": 5045
+        },
+        {
+          "threshold": 0.52,
+          "precision": 0.0206,
+          "recall": 1.0,
+          "f1": 0.0403,
+          "false_merges": 5045
+        },
+        {
+          "threshold": 0.54,
+          "precision": 0.0206,
+          "recall": 1.0,
+          "f1": 0.0403,
+          "false_merges": 5045
+        },
+        {
+          "threshold": 0.56,
+          "precision": 0.0206,
+          "recall": 1.0,
+          "f1": 0.0403,
+          "false_merges": 5045
+        },
+        {
+          "threshold": 0.58,
+          "precision": 0.0206,
+          "recall": 1.0,
+          "f1": 0.0403,
+          "false_merges": 5045
+        },
+        {
+          "threshold": 0.6,
+          "precision": 0.0214,
+          "recall": 1.0,
+          "f1": 0.0419,
+          "false_merges": 4845
+        },
+        {
+          "threshold": 0.62,
+          "precision": 0.0267,
+          "recall": 1.0,
+          "f1": 0.052,
+          "false_merges": 3866
+        },
+        {
+          "threshold": 0.64,
+          "precision": 0.0669,
+          "recall": 1.0,
+          "f1": 0.1254,
+          "false_merges": 1478
+        },
+        {
+          "threshold": 0.66,
+          "precision": 0.0962,
+          "recall": 1.0,
+          "f1": 0.1755,
+          "false_merges": 996
+        },
+        {
+          "threshold": 0.68,
+          "precision": 0.1115,
+          "recall": 1.0,
+          "f1": 0.2006,
+          "false_merges": 845
+        },
+        {
+          "threshold": 0.7,
+          "precision": 0.1122,
+          "recall": 1.0,
+          "f1": 0.2017,
+          "false_merges": 839
+        },
+        {
+          "threshold": 0.72,
+          "precision": 0.144,
+          "recall": 1.0,
+          "f1": 0.2518,
+          "false_merges": 630
+        },
+        {
+          "threshold": 0.74,
+          "precision": 0.3242,
+          "recall": 1.0,
+          "f1": 0.4896,
+          "false_merges": 221
+        },
+        {
+          "threshold": 0.76,
+          "precision": 0.3323,
+          "recall": 1.0,
+          "f1": 0.4988,
+          "false_merges": 213
+        },
+        {
+          "threshold": 0.78,
+          "precision": 0.4948,
+          "recall": 0.9057,
+          "f1": 0.64,
+          "false_merges": 98
+        },
+        {
+          "threshold": 0.8,
+          "precision": 0.5053,
+          "recall": 0.9057,
+          "f1": 0.6486,
+          "false_merges": 94
+        },
+        {
+          "threshold": 0.82,
+          "precision": 1.0,
+          "recall": 0.8962,
+          "f1": 0.9453,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.84,
+          "precision": 1.0,
+          "recall": 0.8962,
+          "f1": 0.9453,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.86,
+          "precision": 1.0,
+          "recall": 0.8962,
+          "f1": 0.9453,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.88,
+          "precision": 1.0,
+          "recall": 0.8774,
+          "f1": 0.9347,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.9,
+          "precision": 1.0,
+          "recall": 0.8774,
+          "f1": 0.9347,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.92,
+          "precision": 1.0,
+          "recall": 0.8208,
+          "f1": 0.9016,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.94,
+          "precision": 1.0,
+          "recall": 0.8208,
+          "f1": 0.9016,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.96,
+          "precision": 1.0,
+          "recall": 0.8113,
+          "f1": 0.8958,
+          "false_merges": 0
+        },
+        {
+          "threshold": 0.98,
+          "precision": 1.0,
+          "recall": 0.8113,
+          "f1": 0.8958,
+          "false_merges": 0
+        }
+      ],
+      "precision_just_below_peak": [
+        {
+          "threshold": 0.78,
+          "precision": 0.4948,
+          "recall": 0.9057,
+          "f1": 0.64,
+          "false_merges": 98
+        },
+        {
+          "threshold": 0.8,
+          "precision": 0.5053,
+          "recall": 0.9057,
+          "f1": 0.6486,
+          "false_merges": 94
+        }
+      ]
     }
   }
 }

--- a/docs/decisions/ADR-0162-interning-real-mdm.json
+++ b/docs/decisions/ADR-0162-interning-real-mdm.json
@@ -1,0 +1,83 @@
+{
+  "database": "mdmmaster",
+  "n_sourcerefs": 114,
+  "n_golden_clusters": 48,
+  "n_multisource_clusters": 36,
+  "models": [
+    "DeepSeek-V3.1",
+    "MiniMax-M2.5",
+    "gpt-oss-120b"
+  ],
+  "all": {
+    "intern_name": {
+      "precision": 1.0,
+      "recall": 0.8113,
+      "f1": 0.8958,
+      "tp": 86,
+      "fp": 0,
+      "fn": 20,
+      "distinct_keys": 55
+    },
+    "intern_name_label": {
+      "precision": 1.0,
+      "recall": 0.7547,
+      "f1": 0.8602,
+      "tp": 80,
+      "fp": 0,
+      "fn": 26,
+      "distinct_keys": 59
+    },
+    "business_key": {
+      "precision": 1.0,
+      "recall": 0.7642,
+      "f1": 0.8663,
+      "tp": 81,
+      "fp": 0,
+      "fn": 25,
+      "distinct_keys": 58
+    },
+    "vector_bge": {
+      "threshold": 0.82,
+      "precision": 1.0,
+      "recall": 0.8962,
+      "f1": 0.9453,
+      "note": "best-F1 over swept threshold = oracle ceiling for semantic fallback"
+    }
+  },
+  "multisource_only": {
+    "intern_name": {
+      "precision": 1.0,
+      "recall": 0.8113,
+      "f1": 0.8958,
+      "tp": 86,
+      "fp": 0,
+      "fn": 20,
+      "distinct_keys": 43
+    },
+    "intern_name_label": {
+      "precision": 1.0,
+      "recall": 0.7547,
+      "f1": 0.8602,
+      "tp": 80,
+      "fp": 0,
+      "fn": 26,
+      "distinct_keys": 47
+    },
+    "business_key": {
+      "precision": 1.0,
+      "recall": 0.7642,
+      "f1": 0.8663,
+      "tp": 81,
+      "fp": 0,
+      "fn": 25,
+      "distinct_keys": 46
+    },
+    "vector_bge": {
+      "threshold": 0.82,
+      "precision": 1.0,
+      "recall": 0.8962,
+      "f1": 0.9453,
+      "note": "best-F1 over swept threshold = oracle ceiling for semantic fallback"
+    }
+  }
+}

--- a/docs/decisions/ADR-0162-interning-real-mdm.md
+++ b/docs/decisions/ADR-0162-interning-real-mdm.md
@@ -32,7 +32,42 @@ best-F1 threshold = an oracle ceiling for the semantic fallback).
 | **intern_name** (compute_node_identity) | **1.000** | 0.811 | 0.896 |
 | intern_name_label | 1.000 | 0.755 | 0.860 |
 | business_key (MDM's own key) | 1.000 | 0.764 | 0.866 |
-| vector_bge @thr=0.82 (oracle) | 1.000 | 0.896 | 0.945 |
+| vector_bge @thr=0.82 (**oracle** — see caveat) | 1.000 | 0.896 | 0.945 |
+
+## The vector number is an oracle, not a win — the threshold sweep
+
+`vector_bge`'s 1.000 precision is **not** an operational result. It is the
+best-F1 point of a swept similarity threshold, and its precision **collapses**
+just below that point (full sweep in the JSON):
+
+| threshold | precision | recall | F1 | false merges |
+|---|---|---|---|---|
+| 0.70 | 0.112 | 1.000 | 0.201 | 843 |
+| 0.75 | 0.329 | 1.000 | 0.495 | 216 |
+| 0.80 | 0.505 | 0.906 | 0.649 | 94 |
+| **0.82** | **1.000** | 0.896 | 0.945 | 0 |
+| 0.90 | 1.000 | 0.877 | 0.935 | 0 |
+
+Two things this exposes:
+
+- **The 1.000 precision lives in a razor-thin band (0.82–0.90).** Two hundredths
+  lower and precision is 0.505 (94 false merges). There is no robust operating
+  point; the peak was *selected with the answer key*.
+- **Why the band is thin:** distinct entities embed as close as true duplicates.
+  "American Airlines" vs "Alaska Airlines" — two different airlines — have cosine
+  **0.820**, the same neighborhood as the true duplicate "Delta" vs "Delta Air
+  Lines". The threshold that separates them barely exists on these 114 clean
+  names and would not survive more entities or noisier surface forms, where the
+  true-duplicate and distinct-but-similar similarity distributions overlap and no
+  threshold yields P=1.000.
+
+So vector did **not** beat exact interning on precision. Its only real advantage
+is **recall** (it recovers abbreviations/suffixes exact keys miss), and it buys
+that recall with a tuned, fragile, model-dependent threshold. Exact interning's
+1.000 precision needs **no** threshold, **no** model, **no** tuning — it is a
+by-construction guarantee, identical at any scale. This is precisely why the
+hybrid is **intern-first** (guaranteed-precision bulk) **with vector fallback**
+(recall on the residue), not vector-first.
 
 ## What it confirms (the synthetic findings hold on real cross-model data)
 
@@ -51,10 +86,15 @@ best-F1 threshold = an oracle ceiling for the semantic fallback).
    This is ADR-0161's suffix recall ceiling, reproduced on real surface
    variation — and independently confirmed by the fact that MDM needed a
    fuzzy/semantic layer *on top of* its exact key to reach the golden truth.
-3. **The semantic fallback recovers what exact keys miss** (vector_bge R=0.896,
-   F1=0.945 at P=1.000). This validates the ADR-0161 **hybrid** (intern for
-   guaranteed precision, vector to lift recall) on real data — it is, in effect,
-   what the production MDM pipeline already had to do.
+3. **The semantic fallback recovers what exact keys miss — on recall only.**
+   vector_bge lifts recall to 0.896 by folding abbreviations/suffixes; its 1.000
+   precision, however, is an oracle-threshold artifact that collapses to 0.505 a
+   hundredth below the peak (see the sweep section). So the finding is not
+   "vector wins" but "vector adds recall at the cost of a fragile threshold" —
+   which is exactly why the ADR-0161 **hybrid** is intern-first (guaranteed
+   precision) with vector as a recall *fallback*. It is, in effect, what the
+   production MDM pipeline already had to do (its exact business_key alone
+   reached only R=0.764).
 
 ## New real-data insight (synthetic data could not show this)
 

--- a/docs/decisions/ADR-0162-interning-real-mdm.md
+++ b/docs/decisions/ADR-0162-interning-real-mdm.md
@@ -1,0 +1,80 @@
+# ADR-0162: real-data interning validation against the MDM golden master
+
+Date: 2026-08-15 · Status: accepted (measurement record)
+
+## Context
+
+ADR-0160/0161 measured interning on FinBench with *planted synthetic*
+duplicates. hadry: validate on the real DozerDB where multiple models and
+categories produced overlapping entities. The `mdmmaster` database provides both
+the real duplicates and a ground truth: `SourceRef` nodes (raw extractions from
+DeepSeek-V3.1 / gpt-oss-120b / MiniMax-M2.5 across categories risk/research/
+compliance/…) each `DERIVED_FROM` a `GoldenEntity` (the MDM-consolidated
+canonical). The golden clustering is the ground truth; `SourceRef.business_key`
+is the MDM pipeline's own identity key.
+
+## Method
+
+`scripts/agentos/interning_real_mdm.py` (read-only, via the live `graphrag-neo4j`
+container). Cluster the 114 SourceRefs by each policy's key and score against the
+48 golden clusters (36 multi-source) with **pairwise** precision/recall/F1:
+recall = of co-golden pairs, fraction sharing a key (does exact interning
+collapse real duplicates?); precision = of key-sharing pairs, fraction co-golden
+(does it avoid merging distinct entities?). Arms: `intern_name`
+(`compute_node_identity`, name only — the real function), `intern_name_label`
+(name+label), `business_key` (MDM's own key), `vector_bge` (bge single-link at
+best-F1 threshold = an oracle ceiling for the semantic fallback).
+
+## Result (114 SourceRefs, 48 golden clusters, 3 models)
+
+| arm | precision | recall | F1 |
+|---|---|---|---|
+| **intern_name** (compute_node_identity) | **1.000** | 0.811 | 0.896 |
+| intern_name_label | 1.000 | 0.755 | 0.860 |
+| business_key (MDM's own key) | 1.000 | 0.764 | 0.866 |
+| vector_bge @thr=0.82 (oracle) | 1.000 | 0.896 | 0.945 |
+
+## What it confirms (the synthetic findings hold on real cross-model data)
+
+1. **Exact interning = perfect precision on real duplicates.** `intern_name`
+   never merges two distinct golden entities (P=1.000) across 114 real
+   cross-model extractions. The collision-resistance claim (ADR-0160) holds on
+   real data, not just planted homonyms.
+2. **Exact interning has a real recall ceiling (~0.81), and so does the
+   production MDM key (0.764).** The intern function misses ~1/5 of real
+   duplicate pairs — and MDM's *own* `business_key` misses even more. Real
+   missed cases (different models, same company):
+   - "Delta Air Lines" vs "Delta"; "Pfizer Inc." vs "Pfizer";
+     "Catalent, Inc." vs "Catalent" (legal-suffix / abbreviation)
+   - "Chipotle Mexican Grill, Inc." vs "CHIPOTLE";
+     "Enphase Energy, Inc." vs "ENPHASE" vs "ENPHASE ENERGY, INC."
+   This is ADR-0161's suffix recall ceiling, reproduced on real surface
+   variation — and independently confirmed by the fact that MDM needed a
+   fuzzy/semantic layer *on top of* its exact key to reach the golden truth.
+3. **The semantic fallback recovers what exact keys miss** (vector_bge R=0.896,
+   F1=0.945 at P=1.000). This validates the ADR-0161 **hybrid** (intern for
+   guaranteed precision, vector to lift recall) on real data — it is, in effect,
+   what the production MDM pipeline already had to do.
+
+## New real-data insight (synthetic data could not show this)
+
+**Name-only interning out-recalls name+label across heterogeneous models**
+(0.811 vs 0.755). Models disagree on the label — the same "CHIPOTLE" is a
+`LegalEntity` for one model and an `Entity` for another — so adding the label to
+the identity key *splits* real duplicates that the golden truth merged. Lesson
+for the intern key over multi-model output: **do not over-specify the composite
+key with fields models disagree on**; the label is not a reliable identity
+component across heterogeneous extractors. (Precision stays 1.000 for name-only
+here because the real entities have distinct names — no homonyms in this set.)
+
+## Consequences
+
+- Interning collapse/collision now has real-data backing (this ADR) alongside
+  the scale-invariant synthetic result (ADR-0160) and the end-to-end retrieval
+  effect (ADR-0161). The Tier-1 allocator claim (seocho-gzo) cites all three.
+- Confirms the hybrid resolver (seocho-6l8): exact-key first (P=1.000),
+  semantic fallback for the recall ceiling. The MDM golden pipeline is an
+  existence proof that the hybrid is what real consolidation requires.
+- Key-design guidance for `identity_keys` over multi-model output: prefer the
+  stable, model-agnostic fields (name, normalized); avoid model-contested fields
+  (label) — recorded for the ontology/import guidance.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -956,6 +956,15 @@ Each entry must link to a full ADR when impact is non-trivial.
   - HONEST weakness: intern 100% miss on suffix variants (normalizer recall ceiling, closeable by alias/same_as)
   - design = intern-first + vector fallback (hybrid); stronger than 'we beat vector'
 
+## 2026-08-15 (real-data interning)
+
+- [Accepted] ADR-0162 interning-real-mdm (validation on live DozerDB golden master)
+  - real cross-model duplicates (DeepSeek/gpt-oss/MiniMax x categories), MDM GoldenEntity = ground truth; 114 SourceRefs / 48 golden clusters
+  - CONFIRMS synthetic: exact intern_name P=1.000 (never merges distinct golden entities) with recall ceiling 0.811; MDM's own business_key also ceilinged (0.764) -> production needed a fuzzy layer
+  - semantic fallback vector_bge R=0.896/F1=0.945 recovers the miss -> validates the hybrid (seocho-6l8) on real data
+  - NEW insight: name-only out-recalls name+label (0.811>0.755) because models disagree on labels -> don't over-specify identity_keys with model-contested fields
+  - real missed cases: Delta Air Lines/Delta, Pfizer Inc./Pfizer, Chipotle Mexican Grill Inc./CHIPOTLE, Enphase Energy Inc./ENPHASE
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/interning_real_mdm.py
+++ b/scripts/agentos/interning_real_mdm.py
@@ -125,6 +125,7 @@ def _vector_best_f1(items, golden_fn) -> Dict[str, Any]:
 
     n = len(items)
     sims = {(a, b): cos(vecs[a], vecs[b]) for a, b in itertools.combinations(range(n), 2)}
+    sweep = []
     best = {"f1": -1.0}
     for thr_i in range(50, 100, 2):
         thr = thr_i / 100.0
@@ -149,10 +150,20 @@ def _vector_best_f1(items, golden_fn) -> Dict[str, Any]:
         prec = tp / (tp + fp) if (tp + fp) else 1.0
         rec = tp / (tp + fn) if (tp + fn) else 1.0
         f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+        point = {"threshold": thr, "precision": round(prec, 4),
+                 "recall": round(rec, 4), "f1": round(f1, 4), "false_merges": fp}
+        sweep.append(point)
         if f1 > best["f1"]:
-            best = {"threshold": thr, "precision": round(prec, 4),
-                    "recall": round(rec, 4), "f1": round(f1, 4)}
-    best["note"] = "best-F1 over swept threshold = oracle ceiling for semantic fallback"
+            best = dict(point)
+    # The whole sweep is kept, not just the peak: vector's precision is
+    # threshold-dependent and collapses just below the best-F1 point, so the
+    # best-F1 number is an ORACLE ceiling, not an operational result.
+    best["note"] = "best-F1 over swept threshold = oracle ceiling (see full sweep)"
+    best["sweep"] = sweep
+    # precision at the operational thresholds just below the peak — the honesty
+    # check: how fragile is that 1.000?
+    below = [p for p in sweep if p["threshold"] in (0.78, 0.80)]
+    best["precision_just_below_peak"] = below
     return best
 
 

--- a/scripts/agentos/interning_real_mdm.py
+++ b/scripts/agentos/interning_real_mdm.py
@@ -1,0 +1,221 @@
+"""Real-data interning validation against the MDM golden master (mdmmaster).
+
+FinBench (ADR-0160/0161) used planted synthetic duplicates. This validates the
+same intern function on REAL entities that multiple models (DeepSeek-V3.1,
+gpt-oss-120b, MiniMax-M2.5) and categories (risk, research, compliance, …)
+extracted from SEC filings — and where a human/rule MDM pipeline already built
+the ground-truth consolidation:
+
+  * GoldenEntity  — the consolidated canonical entities (the golden intern table)
+  * SourceRef -[:DERIVED_FROM]-> GoldenEntity — each raw model/category extraction
+    and the golden entity it was merged into. THIS IS THE GROUND TRUTH.
+  * SourceRef.business_key — the MDM pipeline's OWN identity key (name|label).
+
+Question: does ``seocho.index.identity.compute_node_identity`` reproduce the
+golden clustering? We cluster SourceRefs by each policy's key and score the
+clustering against the golden clusters with pairwise precision/recall/F1:
+
+  * recall  = of SourceRef pairs that ARE co-golden, fraction sharing a key
+              (does exact interning collapse real duplicates?)
+  * precision = of pairs sharing a key, fraction actually co-golden
+              (does exact interning avoid merging distinct entities?)
+
+Arms: ``intern_name`` (compute_node_identity, name only), ``intern_name_label``
+(name+label), ``business_key`` (MDM's own key — a real baseline), and
+``vector_bge`` (semantic single-link at its best-F1 threshold — an oracle
+ceiling for the fuzzy fallback the ADR-0161 hybrid recommends).
+
+Usage:
+  python scripts/agentos/interning_real_mdm.py --container graphrag-neo4j \
+      --database mdmmaster --out outputs/agentos/interning_real_mdm.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from seocho.index.identity import compute_node_identity  # noqa: E402
+
+
+def auth_of(container: str) -> Tuple[str, str]:
+    out = subprocess.check_output(
+        ["docker", "inspect", container, "--format",
+         "{{range .Config.Env}}{{println .}}{{end}}"]).decode()
+    for line in out.splitlines():
+        if line.startswith("NEO4J_AUTH="):
+            u, p = line[len("NEO4J_AUTH="):].split("/", 1)
+            return u, p
+    raise SystemExit(f"no NEO4J_AUTH on {container}")
+
+
+def load_sourcerefs(container: str, uri: str, database: str) -> List[Dict[str, Any]]:
+    from neo4j import GraphDatabase
+
+    u, p = auth_of(container)
+    drv = GraphDatabase.driver(uri, auth=(u, p))
+    try:
+        with drv.session(database=database, default_access_mode="READ") as s:
+            rows = s.run(
+                "MATCH (sr:SourceRef)-[:DERIVED_FROM]-(g:GoldenEntity) "
+                "RETURN sr.name AS name, sr.business_key AS bk, sr.model AS model, "
+                "sr.src_db AS src_db, elementId(g) AS golden, g.name AS golden_name, "
+                "labels(sr) AS labels, sr.business_key AS raw_bk "
+                "ORDER BY golden").data()
+    finally:
+        drv.close()
+    out = []
+    for r in rows:
+        # label for name+label key: prefer the business_key's label suffix, else
+        # the node's non-SourceRef label.
+        bk = r.get("bk") or ""
+        label = bk.split("|")[-1] if "|" in bk else (
+            next((l for l in (r.get("labels") or []) if l != "SourceRef"), "Entity"))
+        out.append({
+            "name": r["name"] or "",
+            "label": label,
+            "business_key": bk,
+            "model": r.get("model"),
+            "src_db": r.get("src_db"),
+            "golden": r["golden"],
+        })
+    return out
+
+
+def _pairwise_prf(items: List[Dict[str, Any]], key_fn, golden_fn) -> Dict[str, float]:
+    tp = fp = fn = 0
+    for a, b in itertools.combinations(range(len(items)), 2):
+        same_key = key_fn(items[a]) is not None and key_fn(items[a]) == key_fn(items[b])
+        same_gold = golden_fn(items[a]) == golden_fn(items[b])
+        if same_key and same_gold:
+            tp += 1
+        elif same_key and not same_gold:
+            fp += 1
+        elif not same_key and same_gold:
+            fn += 1
+    precision = tp / (tp + fp) if (tp + fp) else 1.0
+    recall = tp / (tp + fn) if (tp + fn) else 1.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {"precision": round(precision, 4), "recall": round(recall, 4),
+            "f1": round(f1, 4), "tp": tp, "fp": fp, "fn": fn,
+            "distinct_keys": len({key_fn(i) for i in items if key_fn(i) is not None})}
+
+
+def _vector_best_f1(items, golden_fn) -> Dict[str, Any]:
+    """Single-link clustering over bge name similarity, swept threshold, best F1
+    (an oracle-threshold ceiling for the semantic fallback — labeled as such)."""
+    from seocho.store.fastembed_backend import make_fastembed_backend
+    backend = make_fastembed_backend()
+    if backend is None:
+        return {"unavailable": True}
+    import math
+    vecs = backend.embed([i["name"] for i in items])
+
+    def cos(a, b):
+        d = sum(x * y for x, y in zip(a, b))
+        na = math.sqrt(sum(x * x for x in a)) or 1.0
+        nb = math.sqrt(sum(y * y for y in b)) or 1.0
+        return d / (na * nb)
+
+    n = len(items)
+    sims = {(a, b): cos(vecs[a], vecs[b]) for a, b in itertools.combinations(range(n), 2)}
+    best = {"f1": -1.0}
+    for thr_i in range(50, 100, 2):
+        thr = thr_i / 100.0
+        parent = list(range(n))
+
+        def find(x):
+            while parent[x] != x:
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            return x
+        for (a, b), sc in sims.items():
+            if sc >= thr:
+                parent[find(a)] = find(b)
+        comp = [find(i) for i in range(n)]
+        tp = fp = fn = 0
+        for a, b in itertools.combinations(range(n), 2):
+            sk = comp[a] == comp[b]
+            sg = golden_fn(items[a]) == golden_fn(items[b])
+            tp += sk and sg
+            fp += sk and not sg
+            fn += (not sk) and sg
+        prec = tp / (tp + fp) if (tp + fp) else 1.0
+        rec = tp / (tp + fn) if (tp + fn) else 1.0
+        f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+        if f1 > best["f1"]:
+            best = {"threshold": thr, "precision": round(prec, 4),
+                    "recall": round(rec, 4), "f1": round(f1, 4)}
+    best["note"] = "best-F1 over swept threshold = oracle ceiling for semantic fallback"
+    return best
+
+
+def evaluate(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    golden_fn = lambda i: i["golden"]
+
+    def intern_name(i):
+        return compute_node_identity("Entity", {"name": i["name"]}, ["name"])
+
+    def intern_name_label(i):
+        return compute_node_identity(i["label"], {"name": i["name"]}, ["name"])
+
+    def biz_key(i):
+        return i["business_key"] or None
+
+    return {
+        "intern_name": _pairwise_prf(items, intern_name, golden_fn),
+        "intern_name_label": _pairwise_prf(items, intern_name_label, golden_fn),
+        "business_key": _pairwise_prf(items, biz_key, golden_fn),
+        "vector_bge": _vector_best_f1(items, golden_fn),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--container", default="graphrag-neo4j")
+    ap.add_argument("--uri", default="bolt://localhost:7687")
+    ap.add_argument("--database", default="mdmmaster")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    items = load_sourcerefs(args.container, args.uri, args.database)
+    golden_clusters = {}
+    for i in items:
+        golden_clusters.setdefault(i["golden"], []).append(i)
+    multi = {g: v for g, v in golden_clusters.items() if len(v) > 1}
+    models = sorted({i["model"] for i in items if i["model"]})
+    print(f"{args.database}: {len(items)} SourceRefs, {len(golden_clusters)} golden "
+          f"clusters ({len(multi)} multi-source), models={models}")
+
+    report = {"database": args.database, "n_sourcerefs": len(items),
+              "n_golden_clusters": len(golden_clusters),
+              "n_multisource_clusters": len(multi), "models": models}
+    report["all"] = evaluate(items)
+    # multi-source-only: the real duplicates (drop singletons that trivially match)
+    multi_items = [i for g, v in multi.items() for i in v]
+    report["multisource_only"] = evaluate(multi_items) if multi_items else {}
+
+    print("\n=== clustering vs MDM golden ground truth (pairwise P / R / F1) ===")
+    for scope in ("all", "multisource_only"):
+        print(f"\n-- {scope} ({len(items) if scope=='all' else len(multi_items)} refs) --")
+        for arm, r in report[scope].items():
+            if r.get("unavailable"):
+                print(f"  {arm:18s} (fastembed unavailable)"); continue
+            extra = f" @thr={r['threshold']}" if "threshold" in r else ""
+            print(f"  {arm:18s} P={r['precision']:.3f} R={r['recall']:.3f} "
+                  f"F1={r['f1']:.3f}{extra}")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Validates the intern function on **real cross-model duplicates** in the live DozerDB — hadry's request to test beyond synthetic FinBench.

## Setup
`mdmmaster` has `SourceRef` (raw extractions from DeepSeek-V3.1 / gpt-oss-120b / MiniMax-M2.5 across categories) each `DERIVED_FROM` a `GoldenEntity` (the MDM-consolidated canonical). The golden clustering is **ground truth**; `SourceRef.business_key` is the MDM pipeline's own key. We cluster 114 SourceRefs by each policy's key and score against 48 golden clusters with pairwise P/R/F1. Read-only via the live `graphrag-neo4j` container; real `compute_node_identity`.

## Result (114 SourceRefs, 48 golden clusters, 3 models)

| arm | precision | recall | F1 |
|---|---|---|---|
| **intern_name** (compute_node_identity) | **1.000** | 0.811 | 0.896 |
| intern_name_label | 1.000 | 0.755 | 0.860 |
| business_key (MDM's own) | 1.000 | 0.764 | 0.866 |
| vector_bge @0.82 (oracle) | 1.000 | 0.896 | 0.945 |

## Confirms the synthetic findings on real data
- **Exact interning = perfect precision (1.000)** — never merges two distinct golden entities across 114 real cross-model extractions.
- **Real recall ceiling (~0.81)**, and MDM's own `business_key` hits it too (0.764) → the production pipeline needed a fuzzy layer on top. Real missed cases: `Delta Air Lines`/`Delta`, `Pfizer Inc.`/`Pfizer`, `Chipotle Mexican Grill, Inc.`/`CHIPOTLE`, `Enphase Energy, Inc.`/`ENPHASE`.
- **Semantic fallback recovers the miss** (R=0.896, F1=0.945) → validates the ADR-0161 **hybrid** (seocho-6l8) on real data.

## New real-data insight (synthetic couldn't show it)
**Name-only out-recalls name+label (0.811 > 0.755)** because models disagree on the label (same `CHIPOTLE` is `LegalEntity` for one, `Entity` for another) → don't over-specify `identity_keys` with model-contested fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)