### PR TITLE
fix: five legacy silent-wrong-result bugs (#235 #240 #243 #246 #261)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -102,6 +102,9 @@ uv run pytest \
   tests/seocho/test_ontology_reasoner.py \
   tests/seocho/test_ontology_iso704_cq.py \
   tests/seocho/test_relationship_direction.py \
+  tests/seocho/test_faiss_delete.py \
+  tests/seocho/test_dedup_scope.py \
+  tests/seocho/test_financial_delta_direction.py \
   tests/seocho/test_prompt_prefix_stability.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -1429,6 +1429,19 @@ class IndexingPipeline:
 
         Returns
         -------
-        Summary with ``nodes_deleted``, ``relationships_deleted``.
+        Summary with ``nodes_deleted``, ``relationships_deleted`` (and
+        ``vectors_deleted`` when a vector store is attached).
         """
-        return self.graph_store.delete_by_source(source_id, database=database)
+        summary = self.graph_store.delete_by_source(source_id, database=database)
+        # Also drop the source's vectors so the vector store stays consistent
+        # with the graph; otherwise stale vectors keep surfacing as top-k hits
+        # pointing at deleted nodes (issue #123). reindex() goes through here.
+        if self.vector_store is not None:
+            try:
+                removed = self.vector_store.delete_by_source(source_id)
+                summary = {**summary, "vectors_deleted": int(removed or 0)}
+            except Exception as exc:
+                logger.warning(
+                    "Vector delete for source_id=%s failed: %s", source_id, exc
+                )
+        return summary

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -254,7 +254,6 @@ class IndexingPipeline:
         self.enable_dedup = enable_dedup
         self.enable_rule_constraints = enable_rule_constraints
         self.vector_store = vector_store
-        self._seen_hashes: set = set()
         self.extraction_prompt = extraction_prompt
         self.ontology_profile = str(ontology_profile or "default")
 
@@ -699,6 +698,7 @@ class IndexingPipeline:
         metadata: Optional[Dict[str, Any]] = None,
         on_chunk: Optional[Callable[[int, int], None]] = None,
         source_id: Optional[str] = None,
+        _seen_hashes: Optional[set] = None,
     ) -> IndexingResult:
         """Index a single document (with automatic chunking).
 
@@ -729,15 +729,18 @@ class IndexingPipeline:
         )
         result.ontology_context = ontology_context.metadata(usage="indexing")
 
-        # Dedup check
-        if self.enable_dedup:
+        # Dedup check — scoped to a single batch ingest via _seen_hashes.
+        # Standalone index() calls pass None and are never deduplicated against
+        # earlier, independent calls (issue #133: a process-lifetime instance
+        # set silently dropped legitimately re-submitted documents).
+        if self.enable_dedup and _seen_hashes is not None:
             h = content_hash(content)
-            if h in self._seen_hashes:
+            if h in _seen_hashes:
                 result.deduplicated = True
                 result.skipped_chunks = 1
-                logger.info("Skipping duplicate content (hash=%s)", h)
+                logger.info("Skipping duplicate content within batch (hash=%s)", h)
                 return result
-            self._seen_hashes.add(h)
+            _seen_hashes.add(h)
 
         # Chunk
         import time as _time
@@ -1270,6 +1273,9 @@ class IndexingPipeline:
         BatchIndexingResult with per-document results.
         """
         batch = BatchIndexingResult(total_documents=len(documents))
+        # Dedup is scoped to THIS batch only — a later batch (or a standalone
+        # index() call) re-submitting the same text indexes it again (#133).
+        seen_hashes: set = set()
 
         for i, doc in enumerate(documents):
             if on_document:
@@ -1278,6 +1284,7 @@ class IndexingPipeline:
             result = self.index(
                 doc, database=database,
                 category=category, metadata=metadata,
+                _seen_hashes=seen_hashes,
             )
 
             batch.results.append(result)
@@ -1398,11 +1405,8 @@ class IndexingPipeline:
             source_id,
         )
 
-        # 2. Remove from dedup cache (allow re-indexing same content)
-        h = content_hash(content)
-        self._seen_hashes.discard(h)
-
-        # 3. Index fresh
+        # 2. Index fresh. Dedup is per-batch now, so a standalone index() call
+        #    is never blocked by an earlier ingest — no dedup cache to clear.
         result = self.index(
             content,
             database=database,

--- a/src/seocho/query/answering.py
+++ b/src/seocho/query/answering.py
@@ -185,14 +185,24 @@ class QueryAnswerSynthesizer:
                 return f"For {company}, {metric_label} was {series}."
 
         if intent == "financial_metric_delta":
-            target_years = self._ordered_years(years or [row["year"] for row in selected_rows])
-            if len(target_years) < 2:
-                return self._direct_answer(
-                    question,
-                    supporting_fact,
-                    priority_terms=intent_data.get("metric_aliases", ()),
-                ) or None
-            start_year, end_year = target_years[0], target_years[-1]
+            # Follow the order the years were stated in the question: "change
+            # from 2023 to 2021" must report 2023 -> 2021 (a decrease), not the
+            # chronological 2021 -> 2023. Fall back to chronological order only
+            # when the question did not name the years (issue #131).
+            phrased_years = self._dedupe_years(years)
+            if len(phrased_years) >= 2:
+                start_year, end_year = phrased_years[0], phrased_years[-1]
+            else:
+                target_years = self._ordered_years(
+                    years or [row["year"] for row in selected_rows]
+                )
+                if len(target_years) < 2:
+                    return self._direct_answer(
+                        question,
+                        supporting_fact,
+                        priority_terms=intent_data.get("metric_aliases", ()),
+                    ) or None
+                start_year, end_year = target_years[0], target_years[-1]
             by_year = {row["year"]: row for row in selected_rows if row.get("year")}
             start_row = by_year.get(start_year)
             end_row = by_year.get(end_year)
@@ -703,13 +713,20 @@ class QueryAnswerSynthesizer:
                 return match.group(1)
         return ""
 
-    def _ordered_years(self, years: Sequence[Any]) -> List[str]:
+    def _dedupe_years(self, years: Sequence[Any]) -> List[str]:
+        """Dedupe years preserving the order they were given (e.g. as phrased in
+        the question). Use this where stated order carries meaning, such as a
+        delta's start/end; use :meth:`_ordered_years` where chronological order
+        is wanted."""
         deduped: List[str] = []
         for year in years:
             text = str(year).strip()
             if text and text not in deduped:
                 deduped.append(text)
-        return sorted(deduped)
+        return deduped
+
+    def _ordered_years(self, years: Sequence[Any]) -> List[str]:
+        return sorted(self._dedupe_years(years))
 
     def _humanize_metric_label(self, intent_data: Dict[str, Any]) -> str:
         metric_name = str(intent_data.get("metric_name", "")).strip()

--- a/src/seocho/store/vector.py
+++ b/src/seocho/store/vector.py
@@ -21,12 +21,19 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class VectorSearchResult:
-    """A single similarity search result."""
+    """A single similarity search result.
+
+    ``score`` is always a similarity where higher means a better match, regardless
+    of backend: FAISS inner-product and LanceDB L2 distance are normalized to the
+    same higher-is-better convention so scores are comparable across stores.
+    ``metric`` records the score semantic for callers.
+    """
 
     id: str
     text: str
     score: float
     metadata: Dict[str, Any] = field(default_factory=dict)
+    metric: str = "similarity"
 
 
 class VectorStore(ABC):
@@ -167,8 +174,9 @@ class FAISSVectorStore(VectorStore):
                 VectorSearchResult(
                     id=str(doc["id"]),
                     text=str(doc["text"]),
-                    score=float(score),
+                    score=float(score),  # inner product on normalized vectors: higher = better
                     metadata=dict(doc.get("metadata", {})),
+                    metric="similarity",
                 )
             )
 
@@ -327,13 +335,17 @@ class LanceDBVectorStore(VectorStore):
                 metadata = raw_metadata
             else:
                 metadata = {}
-            score = row.get("_distance", row.get("score", 0.0))
+            # LanceDB returns L2 distance (lower = closer); convert to a similarity
+            # (higher = better) so scores are comparable with the FAISS backend.
+            raw_distance = float(row.get("_distance", row.get("score", 0.0)))
+            score = 1.0 / (1.0 + raw_distance)
             results.append(
                 VectorSearchResult(
                     id=str(row.get("id", "")),
                     text=str(row.get("text", "")),
-                    score=float(score),
+                    score=score,
                     metadata=metadata,
+                    metric="similarity",
                 )
             )
         return results

--- a/src/seocho/store/vector.py
+++ b/src/seocho/store/vector.py
@@ -108,6 +108,10 @@ class FAISSVectorStore(VectorStore):
         self._index = faiss.IndexFlatIP(dimension)
         self._docs: List[Dict[str, Any]] = []
         self._id_to_idx: Dict[str, int] = {}
+        # IndexFlatIP cannot remove a single vector, so delete() tombstones the
+        # doc and search() over-fetches by this count to still return `limit`
+        # live results (issue #122).
+        self._tombstones = 0
 
     def _embed(self, texts: Sequence[str]) -> Any:
         return _normalize_vectors(self._embedding_backend.embed(texts, model=self._model))
@@ -160,7 +164,10 @@ class FAISSVectorStore(VectorStore):
             return []
 
         query_vec = self._embed([query])
-        k = min(limit, self._index.ntotal)
+        # Over-fetch by the tombstone count: deleted vectors still occupy
+        # top-k slots, so fetching only `limit` could drop live results behind
+        # them. Bounded by ntotal (issue #122).
+        k = min(limit + self._tombstones, self._index.ntotal)
         scores, indices = self._index.search(query_vec, k)
 
         results: List[VectorSearchResult] = []
@@ -179,6 +186,8 @@ class FAISSVectorStore(VectorStore):
                     metric="similarity",
                 )
             )
+            if len(results) >= limit:
+                break
 
         return results
 
@@ -192,6 +201,7 @@ class FAISSVectorStore(VectorStore):
             "metadata": {},
             "_deleted": True,
         }
+        self._tombstones += 1
         return True
 
     def count(self) -> int:

--- a/src/seocho/store/vector.py
+++ b/src/seocho/store/vector.py
@@ -61,6 +61,17 @@ class VectorStore(ABC):
     def delete(self, doc_id: str) -> bool:
         """Remove a document from the index."""
 
+    def delete_by_source(self, source_id: str) -> int:
+        """Delete every vector belonging to ``source_id`` and return the count.
+
+        The indexing pipeline keys vectors by ``{source_id}_chunk_{ordinal}``,
+        so deleting a source's vectors keeps the vector store consistent with
+        the graph on delete_source/reindex (issue #123). Default is a no-op for
+        custom stores that don't track source provenance; the built-in backends
+        override it.
+        """
+        return 0
+
     @abstractmethod
     def count(self) -> int:
         """Return the number of active documents in the index."""
@@ -203,6 +214,21 @@ class FAISSVectorStore(VectorStore):
         }
         self._tombstones += 1
         return True
+
+    def delete_by_source(self, source_id: str) -> int:
+        prefix = f"{source_id}_chunk_"
+        ids = [
+            str(doc["id"])
+            for doc in self._docs
+            if not doc.get("_deleted")
+            and (
+                str(doc.get("metadata", {}).get("source_id", "")) == source_id
+                or str(doc["id"]).startswith(prefix)
+            )
+        ]
+        for doc_id in ids:
+            self.delete(doc_id)
+        return len(ids)
 
     def count(self) -> int:
         return len(self._id_to_idx)
@@ -369,6 +395,19 @@ class LanceDBVectorStore(VectorStore):
         except Exception:
             return False
         return True
+
+    def delete_by_source(self, source_id: str) -> int:
+        # Vectors are keyed by ``{source_id}_chunk_{ordinal}``; metadata is a
+        # JSON string here, so match on the id prefix (issue #123).
+        if self._table is None:
+            return 0
+        before = self.count()
+        safe = str(source_id).replace("'", "''")
+        try:
+            self._table.delete(f"id LIKE '{safe}_chunk_%'")
+        except Exception:
+            return 0
+        return max(0, before - self.count())
 
     def count(self) -> int:
         if self._table is None:

--- a/tests/seocho/test_dedup_scope.py
+++ b/tests/seocho/test_dedup_scope.py
@@ -1,0 +1,60 @@
+"""Regression for #133 — content dedup must be scoped to a single batch ingest,
+not a process-lifetime instance set. The shared `_seen_hashes` set silently
+dropped a document re-submitted in a separate add()/index() call.
+"""
+
+from __future__ import annotations
+
+from seocho.index.pipeline import IndexingPipeline
+from seocho.indexing import IndexingResult, content_hash
+from seocho.ontology import NodeDef, Ontology, P
+
+
+def _pipeline() -> IndexingPipeline:
+    onto = Ontology(name="t", nodes={"Doc": NodeDef(properties={"name": P(str)})})
+    # graph_store/llm are unused on the paths under test.
+    return IndexingPipeline(ontology=onto, graph_store=object(), llm=object())
+
+
+def test_no_process_lifetime_dedup_state() -> None:
+    # The cross-call leak was the instance set itself; it must be gone.
+    assert not hasattr(_pipeline(), "_seen_hashes")
+
+
+def test_duplicate_within_batch_set_is_skipped_early() -> None:
+    # Second occurrence within one batch (its hash already in the batch set)
+    # short-circuits to deduplicated without touching the graph/llm.
+    pipeline = _pipeline()
+    text = "hello world"
+    result = pipeline.index(text, _seen_hashes={content_hash(text)})
+    assert result.deduplicated is True
+    assert result.skipped_chunks == 1
+
+
+def test_standalone_index_has_no_dedup_set() -> None:
+    # No _seen_hashes passed -> dedup gate is never consulted, so a standalone
+    # re-submission is not dropped. The duplicate branch needs a set to fire;
+    # with None it cannot, which is the fix.
+    pipeline = _pipeline()
+    # Pre-"seeing" the hash is impossible because there is no shared set; assert
+    # the signature default keeps standalone calls independent.
+    import inspect
+
+    assert inspect.signature(pipeline.index).parameters["_seen_hashes"].default is None
+
+
+def test_each_batch_gets_a_fresh_dedup_set(monkeypatch) -> None:
+    pipeline = _pipeline()
+    seen_sets = []
+
+    def fake_index(doc, *, _seen_hashes=None, **kwargs):
+        seen_sets.append(_seen_hashes)
+        return IndexingResult(source_id="x", chunks_processed=1, total_nodes=0)
+
+    monkeypatch.setattr(pipeline, "index", fake_index)
+    pipeline.index_batch(["a", "a"])  # two docs, one batch
+    pipeline.index_batch(["a"])       # a separate batch
+
+    assert seen_sets[0] is seen_sets[1]        # same batch -> same dedup set
+    assert seen_sets[0] is not seen_sets[2]    # new batch -> fresh set
+    assert isinstance(seen_sets[0], set)

--- a/tests/seocho/test_delete_source_vectors.py
+++ b/tests/seocho/test_delete_source_vectors.py
@@ -1,0 +1,77 @@
+"""Regression for #123 — delete_source/reindex must also drop the source's
+vectors. Previously they removed graph nodes only, leaving orphan vectors that
+kept surfacing as top-k hits pointing at deleted/stale graph nodes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.index.chunk import build_chunk_id
+from seocho.index.pipeline import IndexingPipeline
+from seocho.ontology import NodeDef, Ontology, P
+
+
+class _FakeGraphStore:
+    def delete_by_source(self, source_id, *, database="neo4j"):
+        return {"nodes_deleted": 1, "relationships_deleted": 0}
+
+
+class _SpyVectorStore:
+    def __init__(self):
+        self.deleted = []
+
+    def delete_by_source(self, source_id):
+        self.deleted.append(source_id)
+        return 3
+
+
+def _pipeline(vector_store):
+    onto = Ontology(name="t", nodes={"Doc": NodeDef(properties={"name": P(str)})})
+    return IndexingPipeline(
+        ontology=onto, graph_store=_FakeGraphStore(), llm=object(),
+        vector_store=vector_store,
+    )
+
+
+def test_delete_source_also_deletes_vectors():
+    spy = _SpyVectorStore()
+    summary = _pipeline(spy).delete_source("src-1")
+    assert spy.deleted == ["src-1"]
+    assert summary["vectors_deleted"] == 3
+    assert summary["nodes_deleted"] == 1
+
+
+def test_delete_source_without_vector_store_is_unaffected():
+    summary = _pipeline(None).delete_source("src-1")
+    assert "vectors_deleted" not in summary
+    assert summary["nodes_deleted"] == 1
+
+
+# --- FAISS backend end-to-end (requires faiss-cpu) ---
+
+faiss = pytest.importorskip("faiss")
+pytest.importorskip("numpy")
+
+from seocho.store.vector import FAISSVectorStore
+
+
+class _Embed:
+    def embed(self, texts, *, model=None):
+        return [[float(abs(hash(str(t))) % 97) / 97.0, 1.0] for t in texts]
+
+
+def test_faiss_delete_by_source_removes_only_that_source():
+    store = FAISSVectorStore(embedding_backend=_Embed(), dimension=2)
+    for src in ("srcA", "srcB"):
+        for ordinal in range(3):
+            cid = build_chunk_id(src, ordinal)
+            store.add(cid, f"text {cid}", metadata={"source_id": src})
+    assert store.count() == 6
+
+    removed = store.delete_by_source("srcA")
+    assert removed == 3
+    assert store.count() == 3
+    # only srcB vectors remain
+    remaining = {r.metadata["source_id"] for r in store.search("text", limit=10)}
+    assert remaining == {"srcB"}

--- a/tests/seocho/test_faiss_delete.py
+++ b/tests/seocho/test_faiss_delete.py
@@ -1,0 +1,70 @@
+"""FAISSVectorStore delete behavior (requires faiss-cpu).
+
+#122 — a deleted (tombstoned) vector must not consume a top-k slot: search
+over-fetches by the tombstone count so it still returns up to `limit` live
+results, and the deleted doc never appears.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("faiss")
+pytest.importorskip("numpy")
+
+from seocho.store.vector import FAISSVectorStore
+
+
+class _AngleBackend:
+    """Maps known texts to fixed 2-D vectors for deterministic ranking."""
+
+    _VECS = {
+        "q": [1.0, 0.0],
+        "near": [0.99, 0.14],
+        "mid": [0.70, 0.71],
+        "far": [0.0, 1.0],
+    }
+
+    def embed(self, texts, *, model=None):
+        return [self._VECS.get(str(t), [0.5, 0.5]) for t in texts]
+
+
+def _store() -> FAISSVectorStore:
+    return FAISSVectorStore(embedding_backend=_AngleBackend(), dimension=2)
+
+
+def test_deleted_doc_not_in_results() -> None:
+    store = _store()
+    store.add("near", "near")
+    store.add("far", "far")
+    assert store.delete("near") is True
+    ids = [r.id for r in store.search("q", limit=5)]
+    assert "near" not in ids
+    assert ids == ["far"]
+
+
+def test_delete_still_returns_full_limit_of_live_results() -> None:
+    # The deleted doc ranks at the very top; a limit=2 search with 3 live docs
+    # remaining must return 2 live results, not 1 (the tombstone must not eat a
+    # top-k slot). On main, search fetched only `limit` and returned 1.
+    store = _store()
+    store.add("dead", "near")  # top-ranked, then deleted
+    store.add("near", "near")
+    store.add("mid", "mid")
+    store.add("far", "far")
+
+    assert store.delete("dead") is True
+    results = store.search("q", limit=2)
+    ids = [r.id for r in results]
+
+    assert "dead" not in ids
+    assert len(ids) == 2          # full limit of live results
+    assert ids[0] in {"near", "dead"} and ids[0] == "near"
+
+
+def test_count_reflects_live_docs_after_delete() -> None:
+    store = _store()
+    store.add("a", "near")
+    store.add("b", "far")
+    store.delete("a")
+    assert store.count() == 1

--- a/tests/seocho/test_financial_delta_direction.py
+++ b/tests/seocho/test_financial_delta_direction.py
@@ -1,0 +1,64 @@
+"""Regression for #131 — a delta must follow the year order stated in the
+question. `financial_metric_delta` derived start/end from `_ordered_years`,
+which always sorts chronologically, so "change from 2023 to 2021" was answered
+as 2021 -> 2023 with the sign and increased/decreased direction reversed.
+"""
+
+from __future__ import annotations
+
+from seocho.query.answering import QueryAnswerSynthesizer
+
+
+def _synth() -> QueryAnswerSynthesizer:
+    # No llm / strategy needed: the delta branch is fully deterministic.
+    return QueryAnswerSynthesizer.__new__(QueryAnswerSynthesizer)
+
+
+_RECORDS = [
+    {"company": "ACME", "metric_name": "revenue", "year": "2021", "value": 100},
+    {"company": "ACME", "metric_name": "revenue", "year": "2023", "value": 150},
+]
+
+
+def _intent(years: list[str]) -> dict:
+    return {
+        "intent": "financial_metric_delta",
+        "years": years,
+        "anchor_entity": "ACME",
+        "metric_name": "revenue",
+        "metric_aliases": ["revenue"],
+    }
+
+
+def test_delta_follows_descending_question_phrasing() -> None:
+    answer = _synth()._build_financial_answer(
+        "how did revenue change from 2023 to 2021",
+        _RECORDS,
+        _intent(["2023", "2021"]),
+    )
+    # 2023 (150) -> 2021 (100): a decrease of 50, reported in the stated order.
+    assert "decreased" in answer
+    assert "from 2023 to 2021" in answer
+    assert "increased" not in answer
+
+
+def test_delta_follows_ascending_question_phrasing() -> None:
+    answer = _synth()._build_financial_answer(
+        "how did revenue change from 2021 to 2023",
+        _RECORDS,
+        _intent(["2021", "2023"]),
+    )
+    assert "increased" in answer
+    assert "from 2021 to 2023" in answer
+    assert "decreased" not in answer
+
+
+def test_delta_without_stated_years_defaults_to_chronological() -> None:
+    # No years named in the question → fall back to chronological order.
+    answer = _synth()._build_financial_answer(
+        "how did revenue change",
+        _RECORDS,
+        _intent([]),
+    )
+    assert "increased" in answer
+    assert "from 2021 to 2023" in answer

--- a/tests/seocho/test_vector_store.py
+++ b/tests/seocho/test_vector_store.py
@@ -40,13 +40,14 @@ class _FakeQuery:
         return self
 
     def to_arrow(self):
-        def score(row):
+        # Real LanceDB returns L2 distance (lower = closer), ordered ascending.
+        def distance(row):
             vector = row["vector"]
-            return sum(left * right for left, right in zip(self._query_vector, vector))
+            return sum((left - right) ** 2 for left, right in zip(self._query_vector, vector)) ** 0.5
 
-        rows = sorted(self._rows, key=score, reverse=True)[: self._limit]
+        rows = sorted(self._rows, key=distance)[: self._limit]
         return _FakeArrowTable(
-            [{**row, "_distance": float(score(row))} for row in rows]
+            [{**row, "_distance": float(distance(row))} for row in rows]
         )
 
 
@@ -105,6 +106,33 @@ def test_lancedb_vector_store_round_trip(monkeypatch):
     assert store.count() == 2
     assert store.delete("doc-alpha") is True
     assert store.count() == 1
+
+
+def test_lancedb_scores_are_similarity_higher_is_better(monkeypatch):
+    module = ModuleType("lancedb")
+    module.connect = lambda uri, **kwargs: _FakeLanceDB()
+    monkeypatch.setitem(sys.modules, "lancedb", module)
+
+    store = LanceDBVectorStore(
+        uri="/tmp/fake-lancedb",
+        table_name="docs",
+        embedding_backend=_FakeEmbeddingBackend(),
+        model="fake-embed",
+    )
+    store.add("doc-alpha", "alpha report")  # vector [1, 0]
+    store.add("doc-other", "gamma report")  # vector [0.5, 0.5]
+    store.add("doc-beta", "beta report")    # vector [0, 1]
+
+    results = store.search("alpha question", limit=3)  # query vector [1, 0]
+
+    # Raw L2 distance is lower-is-better; after conversion the score is a
+    # similarity (higher-is-better), so it is comparable with the FAISS backend.
+    assert [r.id for r in results] == ["doc-alpha", "doc-other", "doc-beta"]
+    scores = [r.score for r in results]
+    assert scores == sorted(scores, reverse=True)        # higher = better, monotonic with closeness
+    assert all(0.0 < s <= 1.0 for s in scores)           # bounded similarity
+    assert results[0].score == 1.0                       # exact match: distance 0 -> similarity 1.0
+    assert all(r.metric == "similarity" for r in results)
 
 
 def test_create_vector_store_supports_lancedb(monkeypatch):


### PR DESCRIPTION
Five more single-commit fixes rescued from the `piso7/seocho` fork. Unlike #508 (crashes), **every one of these fails silently** — no exception, no log line, just a wrong answer or missing data. Each was verified as still present on `main` before rescuing; all five cherry-picked without conflict.

| PR | What goes wrong, silently | Where |
|---|---|---|
| **#243** | `_seen_hashes` is **instance** state, so a genuinely distinct document whose normalized text collides with an earlier one returns `deduplicated=True` and **writes nothing**. Behaviour depends on process lifetime — the same two documents index differently depending on whether they arrived in one run or two. | `index/pipeline.py` |
| **#240** | `financial_metric_delta` takes its endpoints from `_ordered_years`, which always sorts chronologically. *"How did revenue change from 2023 to 2021"* is answered as 2021→2023 — **sign inverted, increased/decreased flipped**. | `query/answering.py` |
| **#235** | `VectorSearchResult.score` is FAISS inner-product (higher is better) but LanceDB `_distance` (lower is better) — the same field means **opposite things** by backend. Any `sort(reverse=True)` consumer ranks LanceDB results **worst-first**. | `store/vector.py` |
| **#246** | `k = min(limit, ntotal)`, then deleted docs are filtered **after** the search, so `search(limit=k)` returns fewer than `k` live results even when more exist. Amplified because `add()` tombstones on re-add. | `store/vector.py` |
| **#261** | `delete_source()` only calls `graph_store.delete_by_source(...)`; `reindex()` goes through it. Old vectors survive and keep surfacing as top-k hits that resolve to deleted or stale graph nodes. | `index/pipeline.py`, `store/vector.py` |

## On #240 specifically

The fix does not simply reverse the sort. It follows the order the years were **stated in the question**, and falls back to chronological order only when the question named no years:

```python
phrased_years = self._dedupe_years(years)
if len(phrased_years) >= 2:
    start_year, end_year = phrased_years[0], phrased_years[-1]
else:
    target_years = self._ordered_years(years or [row["year"] for row in selected_rows])
```

## On #235 specifically

Distance is mapped to similarity with `1.0 / (1.0 + raw_distance)`, so both backends now put "better" at the high end and the field is comparable across stores. Note this is a **monotonic re-mapping, not a calibration** — absolute scores still are not comparable between FAISS and LanceDB, only their ordering is.

## Validation

- five cherry-picks clean against current `main`
- `bash scripts/ci/run_basic_ci.sh` — **771 passed**, 3 skipped
- final commit registers `test_faiss_delete.py`, `test_dedup_scope.py` and `test_financial_delta_direction.py` in `run_basic_ci.sh`, which takes an explicit file list rather than a directory

## Review note

These change behaviour, not just error paths, so they deserve more scrutiny than #508. In particular: #243 changes when a second identical-text document is written, and #261 adds a vector deletion that did not previously happen. If anything downstream relied on the old dedup being process-wide, this will surface there.

Closes #235. Closes #240. Closes #243. Closes #246. Closes #261.