### PR TITLE
feat(os): assemble the unified OS surface — every subsystem a method on one Session

### DIFF
--- a/examples/agent_designs/os_unified_surface.py
+++ b/examples/agent_designs/os_unified_surface.py
@@ -1,0 +1,100 @@
+"""The SEOCHO agent OS as one object.
+
+`from seocho import Seocho` gives a client; `client.session(...)` gives ONE
+Session that is the whole operating layer — every OS subsystem is a method on
+it, not a free function taking the session as an argument:
+
+    memory      sess.add(...) / sess.ask(...) / sess.resolve(mention)
+    scheduling  sess.query(...)         # shared admission gate
+    isolation   sess.query(...)         # workspace pinned server-side
+    execution   sess.agent()            # governed openai-agents Agent
+    resources   sess.budget / sess.priority
+    observ.     sess.os_stats()
+
+The governance knobs are opt-in on the constructor (all off by default). This
+script needs no live database — it shows the surface and the wiring; the
+`query`/`resolve` calls are what you would run against your DozerDB.
+
+Run:  python examples/agent_designs/os_unified_surface.py
+"""
+
+from __future__ import annotations
+
+from seocho import Seocho
+from seocho.ontology import NodeDef, Ontology, P
+
+
+def build_client() -> Seocho:
+    ontology = Ontology(
+        name="demo", graph_model="lpg",
+        nodes={"Company": NodeDef(
+            properties={"name": P(str), "sector": P(str)},
+            identity_keys=["name", "sector"])},
+        relationships={},
+    )
+    # Governance is opt-in: bound in-flight graph work, give one session a
+    # per-run token budget, keep the interactive class ahead of batch.
+    return Seocho(
+        ontology=ontology,
+        graph_store=_DemoStore(),          # your DozerDB GraphStore in real use
+        llm=object(),                      # your LLM backend in real use
+        workspace_id="acme",
+        max_inflight=8,                    # scheduling: bounded concurrency
+        reserved_for_high=1,               # scheduling: protect interactive
+        token_budget=100_000,              # resources: per-session budget
+        agent_row_cap=50,                  # memory: bounded, disclosed reads
+    )
+
+
+class _DemoStore:
+    """Stand-in graph store so the example runs offline. A real deployment
+    passes a DozerDB-backed GraphStore; the governed path is identical."""
+
+    def query(self, cypher, *, params=None, database=None,
+              enforce_workspace_filter=False):
+        # Pretend the workspace holds one Company node, addressed by its
+        # composite identity id (what the write-time interner would have set).
+        if "n.id = $addr" in cypher:
+            return [{"n": {"name": "Chipotle Mexican Grill, Inc.",
+                           "sector": "restaurant",
+                           "id": params.get("addr")}}]
+        return []
+
+
+def main() -> None:
+    client = build_client()
+
+    # ONE object, every subsystem a method on it.
+    with client.session("analyst", priority="high") as sess:
+        print("workspace :", sess.workspace_id)
+        print("priority  :", sess.priority)
+
+        # memory / interning: resolve a surface mention to its canonical node,
+        # reusing the exact write-time identity function (read-time interning).
+        hit = sess.resolve("Chipotle Mexican Grill, Inc.",
+                           label="Company", sector="restaurant")
+        print("resolve   :", hit["method"], "->", hit["address"])
+        print("            node:", hit["node"]["name"])
+
+        # scheduling + isolation: a governed read. The workspace is pinned
+        # server-side; the shared admission gate bounds concurrency.
+        rows = sess.query(
+            "MATCH (n:Company) WHERE n._workspace_id = $workspace_id "
+            "AND n.id = $addr RETURN n LIMIT 1",
+            addr=hit["address"])
+        print("query     :", len(rows), "row(s), workspace pinned by the layer")
+
+        # execution: an agent whose only graph access is this governed session.
+        agent = sess.agent(name="analyst_agent")
+        print("agent     :", agent.name, "tool:", agent.tools[0].name)
+        # In real use:
+        #   from agents import Runner
+        #   Runner.run(agent, "which sector is Chipotle in?",
+        #              session=sess.sdk_session, hooks=sess.hooks)
+
+        # observability: shared pool + this session's budget/priority.
+        print("os_stats  :", sess.os_stats())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1569,8 +1569,13 @@ class Seocho:
         # operating-layer handles. Hand ``sess.sdk_session`` and
         # ``sess.hooks`` to openai-agents ``Runner.run``; the shared
         # admission gate and per-session budget ride the layer.
-        os_session = self._os().session(sess.session_id, priority=priority,
-                                        user_id=self.user_id)
+        os_layer = self._os()
+        os_session = os_layer.session(sess.session_id, priority=priority,
+                                      user_id=self.user_id)
+        # Attach the layer + this session's handle so the Session object itself
+        # is the whole OS surface: sess.query()/resolve()/agent() delegate here.
+        sess._os = os_layer
+        sess._os_session = os_session
         sess.priority = os_session.priority
         sess.sdk_session = os_session.sdk_session
         sess.hooks = os_session.hooks

--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -183,6 +183,17 @@ class Session:
         self._trace = None
         self._closed = False
 
+        # Operating-layer handles, attached by ``Seocho.session()`` so this one
+        # Session object is the whole OS surface: memory (add/ask/resolve),
+        # scheduling+isolation (query), execution (agent), resources (budget).
+        # None until attached — the OS methods raise a clear error otherwise.
+        self._os = None            # the SeochoOS instance (shared admission pool)
+        self._os_session = None    # this session's OSSession handle
+        self.priority = "normal"
+        self.sdk_session = None
+        self.hooks = None
+        self.budget = None
+
         # Start session trace
         try:
             from .tracing import begin_session, is_tracing_enabled
@@ -902,6 +913,110 @@ class Session:
             logger.warning("Streaming failed, falling back: %s", exc)
             answer = self.ask(question, database=database)
             yield answer
+
+    # -- operating-layer surface ------------------------------------------
+    # These make one Session the coherent OS object: every subsystem is a
+    # method here, not a free function taking the session as its first arg.
+    # They require the handles attached by ``Seocho.session()`` (local mode).
+
+    def _require_os(self) -> None:
+        if self._os is None or self._os_session is None:
+            from .exceptions import SeochoError
+
+            raise SeochoError(
+                "operating-layer methods need a session created by "
+                "Seocho.session() in local mode (ontology + graph_store).")
+
+    def query(self, cypher: str, **params: Any) -> List[Dict[str, Any]]:
+        """Governed graph read — the scheduling + isolation + memory-read path.
+
+        Runs through the shared admission gate (scheduling), pins this
+        session's workspace server-side (isolation), and executes fail-closed
+        (``enforce_workspace_filter``). Named parameters pass through as
+        ``$name``. Returns the row list; raises on a structured error so
+        callers see admission rejection / query failure rather than a silent
+        empty result.
+        """
+        import json as _json
+
+        self._require_os()
+        payload = self._os.execute_query(
+            self._os_session, cypher, _json.dumps(params, default=str))
+        result = _json.loads(payload)
+        if "error" in result:
+            from .exceptions import SeochoError
+
+            raise SeochoError(
+                f"query failed [{result['error']}]: {result.get('message', '')}")
+        return result.get("rows", [])
+
+    def resolve(self, mention: str, *, label: Optional[str] = None,
+                **identity_props: Any) -> Optional[Dict[str, Any]]:
+        """Resolve a surface mention to the one canonical node it denotes.
+
+        Read-time interning: this reuses the exact write-time identity
+        function (``seocho.index.identity.compute_node_identity``), so the
+        resolution recall/precision are the interning collapse/collision
+        measured in ADR-0160/0161/0162 — guaranteed-precision, model-free,
+        O(1) address lookup, scoped to this session's workspace.
+
+        Give a ``label`` (and any disambiguating identity properties) to use
+        the composite key — the precise path. With no label it falls back to a
+        normalized-name match, whose miss on un-normalized surface forms
+        (e.g. legal suffixes) is the documented recall ceiling a semantic
+        fallback would close (seocho-6l8). Returns the node dict, or ``None``.
+        """
+        self._require_os()
+        from .index.identity import _normalize_segment, compute_node_identity
+
+        nodes = getattr(self.ontology, "nodes", {}) or {}
+        if label and label in nodes:
+            node_def = nodes[label]
+            keys = list(getattr(node_def, "effective_identity_keys", [])
+                        or getattr(node_def, "identity_keys", []) or ["name"])
+            props = dict(identity_props)
+            props.setdefault("name", mention)
+            addr = compute_node_identity(label, props, keys)
+            if addr:
+                # label is validated by membership in the ontology above.
+                rows = self.query(
+                    f"MATCH (n:`{label}`) WHERE n.id = $addr "
+                    "AND n._workspace_id = $workspace_id RETURN n LIMIT 1",
+                    addr=addr)
+                if rows:
+                    node = rows[0].get("n", rows[0])
+                    return {"node": node, "address": addr, "method": "intern"}
+        # Fallback: normalized-name equality (best-effort; recall-ceiling path).
+        norm = _normalize_segment(mention)
+        rows = self.query(
+            "MATCH (n) WHERE n.name IS NOT NULL "
+            "AND n._workspace_id = $workspace_id "
+            "AND toLower(trim(n.name)) = $norm RETURN n LIMIT 5",
+            norm=norm)
+        if rows:
+            node = rows[0].get("n", rows[0])
+            return {"node": node, "address": None, "method": "normalized_name",
+                    "candidates": len(rows)}
+        return None
+
+    def agent(self, *, name: str = "seocho_agent", model: Any = None,
+              extra_tools: Sequence[Any] = ()) -> Any:
+        """An openai-agents Agent whose only graph access is this governed
+        session — the execution subsystem. Hand it to ``Runner.run(agent,
+        msg, session=sess.sdk_session, hooks=sess.hooks)`` so memory,
+        budget, and admission all ride along."""
+        self._require_os()
+        return self._os.build_agent(
+            self._os_session, name=name, model=model, extra_tools=extra_tools)
+
+    def os_stats(self) -> Dict[str, Any]:
+        """Operating-layer observability: shared pool + this session's budget."""
+        self._require_os()
+        stats = dict(self._os.stats())
+        stats["priority"] = self.priority
+        if self.budget is not None:
+            stats["budget"] = getattr(self.budget, "budget", 0)
+        return stats
 
     def close(self) -> Dict[str, Any]:
         """Close the session and finalize traces.

--- a/tests/seocho/test_operating_layer.py
+++ b/tests/seocho/test_operating_layer.py
@@ -337,3 +337,80 @@ def test_operating_layer_refused_outside_local_mode():
     client = Seocho(base_url="http://localhost:9")   # HTTP mode
     with pytest.raises(Exception, match="local"):
         client.session("x")
+
+
+# -- the unified OS surface: every subsystem is a method on one Session --------
+
+@pytest.fixture
+def named_ontology() -> Ontology:
+    return Ontology(
+        name="unified_test", graph_model="lpg",
+        nodes={"Company": NodeDef(
+            properties={"name": P(str), "sector": P(str)},
+            identity_keys=["name", "sector"])},
+        relationships={},
+    )
+
+
+def test_session_query_goes_through_governed_path(named_ontology):
+    """sess.query() is the scheduling+isolation+read path — workspace pinned."""
+    from seocho import Seocho
+
+    store = RecordingStore(rows=[{"n": {"name": "X"}}])
+    client = Seocho(ontology=named_ontology, graph_store=store, llm=object(),
+                    workspace_id="acme", max_inflight=4)
+    sess = client.session("analyst", priority="high")
+    rows = sess.query(
+        "MATCH (n:Company) WHERE n._workspace_id = $workspace_id RETURN n", )
+    assert rows == [{"n": {"name": "X"}}]
+    # tenancy pinned server-side regardless of caller
+    assert store.calls[-1]["params"]["workspace_id"] == "acme"
+    assert store.calls[-1]["enforced"] is True
+
+
+def test_session_resolve_uses_the_intern_table(named_ontology):
+    """resolve() reuses compute_node_identity: the read-time interning primitive."""
+    from seocho import Seocho
+    from seocho.index.identity import compute_node_identity
+
+    store = RecordingStore(rows=[{"n": {"name": "Chipotle", "id": "x"}}])
+    client = Seocho(ontology=named_ontology, graph_store=store, llm=object(),
+                    workspace_id="acme", max_inflight=4)
+    sess = client.session("analyst")
+    hit = sess.resolve("Chipotle", label="Company", sector="restaurant")
+    expected_addr = compute_node_identity(
+        "Company", {"name": "Chipotle", "sector": "restaurant"},
+        ["name", "sector"])
+    assert hit is not None and hit["method"] == "intern"
+    assert hit["address"] == expected_addr == "company|chipotle|restaurant"
+    # the governed query looked up that exact composite address, workspace-scoped
+    assert store.calls[-1]["params"]["addr"] == expected_addr
+    assert store.calls[-1]["params"]["workspace_id"] == "acme"
+
+
+def test_session_resolve_falls_back_to_normalized_name(named_ontology):
+    """No label -> normalized-name match (the recall-ceiling fallback path)."""
+    from seocho import Seocho
+
+    store = RecordingStore(rows=[{"n": {"name": "Chipotle"}}])
+    client = Seocho(ontology=named_ontology, graph_store=store, llm=object(),
+                    workspace_id="acme")
+    sess = client.session("analyst")
+    hit = sess.resolve("  CHIPOTLE  ")
+    assert hit is not None and hit["method"] == "normalized_name"
+    assert store.calls[-1]["params"]["norm"] == "chipotle"   # normalized
+
+
+def test_session_agent_and_stats_on_one_object(named_ontology):
+    """execution (agent) and observability (os_stats) are methods on the session."""
+    from seocho import Seocho
+
+    store = RecordingStore()
+    client = Seocho(ontology=named_ontology, graph_store=store, llm=object(),
+                    workspace_id="acme", max_inflight=4, token_budget=1000)
+    sess = client.session("analyst", priority="high")
+    agent = sess.agent(name="t")
+    assert agent.tools[0].name == "graph_query"
+    stats = sess.os_stats()
+    assert stats["workspace_id"] == "acme" and stats["priority"] == "high"
+    assert stats["budget"] == 1000


### PR DESCRIPTION
Starts the "실제 OS로 조립" work (goal: SEOCHO usable as an agent OS). The operating layer's mechanisms existed but the surface was fragmented C-API (`os.execute_query(session, …)`, `client.build_agent(session, …)`). This makes **one `Session` the coherent OS object** — every subsystem is a method on it.

## The surface
```python
with client.session("analyst", priority="high") as sess:
    node = sess.resolve("Chipotle", label="Company", sector="restaurant")  # memory / interning
    rows = sess.query("MATCH (n:Company) WHERE n._workspace_id=$workspace_id RETURN n")  # scheduling + isolation
    agent = sess.agent()          # execution (governed openai-agents Agent)
    sess.os_stats()               # observability;  sess.budget / sess.priority = resources
```

| subsystem | method |
|---|---|
| memory | `add` / `ask` / **`resolve`** |
| scheduling | `query` (shared admission gate) |
| isolation | `query` (workspace pinned server-side, fail-closed) |
| execution | `agent` |
| resources | `budget` / `priority` |
| observability | `os_stats` |

## The new piece: `sess.resolve()` = read-time interning
It reuses the **exact write-time identity function** (`compute_node_identity`), so read-time resolution *is* the interning measured in ADR-0160/0161/0162 — guaranteed-precision, model-free, O(1), workspace-scoped. With a `label` it uses the composite key (precise path); without, a normalized-name fallback (the recall-ceiling residue a semantic fallback closes — seocho-6l8). This operationalizes the measurement work as a live OS primitive.

## Wiring
`Seocho.session()` attaches the `SeochoOS` + `OSSession` handles; the Session methods delegate to the governed paths (admission + workspace pinning + fail-closed reads all ride along). The old `client.execute_query(session, …)` C-API stays as back-compat.

## Validation
- 4 new unit tests (governed query pins workspace; resolve uses the intern address; normalized-name fallback; agent + stats on one object) — 20 pass in `test_operating_layer.py`.
- Runnable **offline** example: `examples/agent_designs/os_unified_surface.py` (prints resolve→intern address, governed query, agent tool, os_stats).
- Full `run_basic_ci.sh` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)