### PR TITLE
docs(os): ADR-0163 control/data-plane split — where bolt-rs/OpenAI-API optimization belongs

### DIFF
--- a/docs/decisions/ADR-0163-control-data-plane-split.md
+++ b/docs/decisions/ADR-0163-control-data-plane-split.md
@@ -1,0 +1,66 @@
+# ADR-0163: the OS's I/O subsystem — control-plane / data-plane split
+
+Date: 2026-08-15 · Status: accepted (architecture) · relates to ADR-0155, ADR-0144
+
+## Context
+
+SEOCHO is being assembled as an agent OS (ADR-0157; unified surface PR #510).
+An OS mediates between processes and hardware via **drivers** behind a **syscall
+boundary**. SEOCHO-as-OS mediates between agents and two "devices": the graph
+database (Bolt / DozerDB) and the LLM (OpenAI-compatible API). hadry asked where
+the Bolt / OpenAI-API protocol optimization (neo4j-bolt-rs and friends) belongs
+now that this is an OS. It belongs to the OS's **I/O subsystem**, and that
+subsystem has two planes that must not be conflated.
+
+## Decision
+
+Split, explicitly, the operating layer into a control plane and a data plane,
+with a single named seam between them.
+
+**Control plane** — policy and decisions, low QPS, stays in Python:
+- admission / scheduling (`LaneScheduler`, `PriorityAdmission`)
+- tenancy pinning + fail-closed read enforcement
+- token-budget metering (RunHooks over the LLM path)
+- cost classification (per-cypher-hash EWMA)
+- observability (golden signals, decision receipts)
+
+**Data plane** — the actual I/O, high QPS, the optimization surface:
+- the Bolt round-trip + PackStream decode to DozerDB
+- the LLM token stream over the OpenAI-compatible API
+- connection pooling, batching, zero-copy hydration
+
+**The seam is one call.** `SeochoOS.execute_query` (control: classify → admit →
+pin → execute → release → observe) invokes `graph_store.query(...)` (data: the
+Bolt round-trip). The LLM seam is `RunHooks` (control: budget) over the SDK's
+model I/O (data). Optimizing the data plane must not require touching the control
+plane, and vice versa — that is the whole point of naming the split.
+
+## Where protocol optimization goes (and the gate before it)
+
+neo4j-bolt-rs / a native Rust driver is a **data-plane driver** swap beneath the
+control-plane gate. It replaces or accelerates `graph_store.query`'s transport +
+codec without changing admission, tenancy, or scheduling. There is already
+partial Rust on this plane: the neo4j 6.x driver's PackStream codec reports
+`rust-ext` vs `pure-python` (`graph.py:packstream_codec()`), and ADR-0144 already
+splits server time (ResultSummary) from client hydration at this boundary.
+
+**The gate (per ADR-0155's discipline — no Rust on speculation):** before
+investing in bolt-rs we measure the data plane's share of `execute_query` wall
+time — `server_share` = (Bolt round-trip + decode) / (total governed-query
+time). If the data plane dominates, bolt-rs pays; if LLM wait or control-plane
+overhead dominates, it does not. This is a measurement gate, not a belief. The
+OpenAI-API path is the other data-plane driver (token streaming); its
+control-plane counterpart is budget metering, already built.
+
+## Consequences
+
+- The Rust data-plane work (ADR-0155) has a precise home and a precise trigger:
+  data-plane driver, gated on `server_share`. A follow-up ticket owns the
+  measurement.
+- The control plane stays Python and framework-agnostic; it is where the OS's
+  policy value lives and where it must stay legible.
+- Design rule going forward: a change is control-plane XOR data-plane; if a PR
+  touches both, it is doing two things and should be split.
+- Observability must attribute wall time to the plane (server vs client vs
+  control-plane overhead), extending ADR-0144, so `server_share` is a standing
+  signal, not a one-off probe.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -965,6 +965,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - NEW insight: name-only out-recalls name+label (0.811>0.755) because models disagree on labels -> don't over-specify identity_keys with model-contested fields
   - real missed cases: Delta Air Lines/Delta, Pfizer Inc./Pfizer, Chipotle Mexican Grill Inc./CHIPOTLE, Enphase Energy Inc./ENPHASE
 
+## 2026-08-15 (OS I/O plane split)
+
+- [Accepted] ADR-0163 control-data-plane-split (the OS's I/O subsystem)
+  - control plane (admission/tenancy/budget/classification/observability) = Python, low QPS; data plane (Bolt round-trip + PackStream, LLM token stream) = high QPS optimization surface
+  - seam = SeochoOS.execute_query (control) -> graph_store.query (data); RunHooks (control) over LLM I/O (data)
+  - neo4j-bolt-rs = a DATA-PLANE driver swap beneath the gate; gated on server_share measurement (ADR-0155 discipline, no Rust on speculation)
+  - design rule: a change is control-plane XOR data-plane
+
 ## Template
 
 Use this block for new entries:


### PR DESCRIPTION
Answers hadry's Q2: now that SEOCHO is an OS, where does the data-plane/control-plane + Bolt/OpenAI-API protocol optimization (neo4j-bolt-rs) belong? → the OS's **I/O subsystem**, split into two planes.

- **Control plane** (Python, low QPS): admission/scheduling, tenancy pinning, budget metering, cost classification, observability.
- **Data plane** (high QPS, the optimization surface): Bolt round-trip + PackStream decode to DozerDB, LLM token stream over the OpenAI-compatible API, pooling/batching/zero-copy.
- **The seam is one call:** `execute_query` (control) → `graph_store.query` (data); `RunHooks` (control) over LLM I/O (data).

**neo4j-bolt-rs = a data-plane driver swap beneath the gate**, gated on a `server_share` measurement (ADR-0155 discipline — no Rust on speculation). Partial Rust already exists here (PackStream codec `rust-ext`; ADR-0144 already splits server vs client time). Design rule going forward: a change is control-plane XOR data-plane.

Follow-ups: **seocho-xju** (measure `server_share` = the bolt-rs go/no-go gate), **seocho-qus** (resolve() vs GraphRAG/LightRAG/NLP positioning, Q1). Companion design note (Q1) in the Obsidian vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)