### PR TITLE
docs: make the operating layer visible in README + ARCHITECTURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,39 @@ is a drop-in if you are not on uv.
 This is the core SEOCHO idea: one schema contract should govern what gets
 written, what gets retrieved, and what an agent is allowed to claim.
 
+## The Operating Layer (Governed Agents)
+
+When an agent uses SEOCHO, the schema contract becomes an operating layer: one
+`Session` object through which every subsystem an agent needs is a method, on one
+governed path. The economics is the OS one — pay for rigor once at write time
+(the ontology fixes each entity's canonical address), so every read is a cheap,
+guaranteed, governed lookup.
+
+```python
+with client.session("analyst", priority="high") as sess:
+    node = sess.resolve("Chipotle", label="Company", sector="restaurant")  # memory: read-time interning
+    rows = sess.query("MATCH (n:Company) WHERE n._workspace_id = $workspace_id RETURN n")  # scheduling + isolation
+    agent = sess.agent()          # execution: a governed openai-agents Agent
+    sess.os_stats()               # observability;  sess.budget / sess.priority = resources
+```
+
+| Subsystem | Method / handle | What the governed path guarantees |
+|---|---|---|
+| Memory | `sess.resolve()` / `add` / `ask` | Read-time interning reuses the write-time identity function — an exact, model-free, workspace-scoped address lookup. |
+| Scheduling | `sess.query()` | A shared admission gate bounds concurrency across all sessions of one layer. |
+| Isolation | `sess.query()` | The model's `workspace_id` is pinned server-side; reads that forget the tenant scope fail closed. |
+| Execution | `sess.agent()` | The agent's only graph access is this governed tool. |
+| Resources | `sess.budget` / `sess.priority` | A per-session token budget stops a run with a structured error, never a clipped answer. |
+
+Every control is opt-in on the `Seocho(...)` constructor and off by default
+(`max_inflight`, `token_budget`, `reserved_for_high`, …). Because all graph
+access funnels through one call, the safety is structural — a prompt-injected
+agent cannot route around it. Runnable offline walkthrough:
+[`examples/agent_designs/os_unified_surface.py`](examples/agent_designs/os_unified_surface.py).
+Design: [ADR-0157](docs/decisions/ADR-0157-agentos-surface.md) (surface),
+[ADR-0163](docs/decisions/ADR-0163-control-data-plane-split.md) (control/data
+plane split — where Bolt/LLM protocol optimization lives).
+
 ## Runtime Stack
 
 Run the local platform:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,8 +30,24 @@ Internally, it is split into planes so graph behavior stays reviewable.
 | Ontology plane | schema contract, context hash, JSON-LD, offline governance | `src/seocho/ontology*.py` |
 | Indexing plane | document ingest, extraction, linking, rule assessment, graph writes | `src/seocho/index/`, `src/seocho/rules.py` |
 | Query plane | intent, retrieval, Cypher validation, evidence, answer synthesis | `src/seocho/query/` |
+| Operating layer | the agent-facing OS surface: one `Session` binds memory (interning resolve), scheduling (admission), isolation (tenancy pin + binding verification), execution (governed agent), resources (budget) | `src/seocho/operating_layer.py`, `src/seocho/session.py` |
 | Runtime shell | HTTP routes, policy, readiness, workspace/database scope | `runtime/` |
 | Compatibility shell | legacy imports and batch compatibility while migration continues | `extraction/` |
+
+The operating layer itself splits into two planes (ADR-0163), and the split is
+the seam where protocol optimization belongs:
+
+- **Control plane** (policy, low QPS): admission/scheduling, tenancy pinning,
+  read-safety, budget metering, cost classification, observability.
+- **Data plane** (I/O, high QPS): the Bolt round-trip + PackStream decode to
+  DozerDB, the LLM token stream. This is where a Rust driver (neo4j-bolt-rs)
+  pays — gated on a `server_share` measurement, never on speculation.
+
+The seam is one call: `execute_query` (control) invokes `graph_store.query`
+(data). In OS terms the governed call is a syscall — the single guarded boundary
+every agent graph access must pass, where tenancy, read-safety, admission, and
+budget are enforced. Because access cannot route around it, agent safety is
+structural, like process isolation.
 
 The invariant is simple:
 


### PR DESCRIPTION
The OS surface shipped (#498/#500/#510) but was invisible in the docs — README had zero mention of it (the product review's finding). This doc-only pass makes it discoverable and ties the write-time/read-time economics and the syscall-safety framing into the architecture.

- **README** — new 'The Operating Layer (Governed Agents)' section: the one-`Session` surface (`resolve`/`query`/`agent`/`os_stats`), a subsystem→guarantee table, the write-time economics one-liner, the opt-in knobs, and a pointer to the runnable offline example.
- **ARCHITECTURE** — the operating layer as a plane; the control/data-plane split (ADR-0163) and where bolt-rs belongs; the governed call as a syscall (structural agent safety).

No code change; everything references shipped code and ADR-0157/0163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)