### PR TITLE
exp(ablation): A4 budget + A5 truncation honesty, OFF vs ON (ADR-0165)

### DIFF
--- a/docs/decisions/ADR-0165-ablation-a4-a5.md
+++ b/docs/decisions/ADR-0165-ablation-a4-a5.md
@@ -1,0 +1,51 @@
+# ADR-0165: ablation A4 (resources) + A5 (execution honesty), OFF vs ON
+
+Date: 2026-08-15 · Status: accepted (measurement record) · seocho-4rb, seocho-2ay
+
+Two more Level-2 rows of the OS ablation study (wiki/os-ablation-study-design.md),
+each an OFF/ON on the real shipped mechanism.
+
+## A4 — resources: token-budget containment
+
+The resource subsystem's axis: does a runaway agent chain stop, and how far past
+the cap? Same multi-turn chain through the real `TokenBudgetTracker` (wired via
+RunHooks, ADR-0153) with the budget OFF (0 = unlimited, a bare agent) vs ON (a
+per-session cap). `scripts/agentos/ablation_a4_budget.py`.
+
+Chain: 40 turns × 800 tok (would spend 32,000 unchecked); cap = 10,000.
+
+| arm | halted | turns run | tokens spent | overshoot |
+|---|---|---|---|---|
+| OFF (no budget) | no | 40 | **32,000** | — (unbounded) |
+| ON (cap 10,000) | yes | 13 | **10,400** | **400** (< one turn = 800) |
+
+Budget OFF lets the chain spend everything (3.2× the cap here; unbounded in a
+real loop). ON halts at a turn boundary and is bounded by cap + at most one
+turn's spend — a structured stop, not a clipped answer.
+
+## A5 — execution honesty: truncation disclosure
+
+The execution subsystem's honesty axis: when a result is capped, does the tool
+SIGNAL it, so a partial result cannot be presented as complete? Bare raw tool
+(OFF — rows, no truncation metadata) vs the OS's governed `execute_query` (ON —
+caps at `row_cap`, always ships `truncated: true/false`, the #478 lesson).
+Metric = disclosure rate over over-cap results. `scripts/agentos/ablation_a5_honesty.py`,
+using the real `SeochoOS.execute_query`; cap = 50.
+
+| result size | over cap | ON rows | ON discloses | OFF discloses |
+|---|---|---|---|---|
+| 10 / 40 | no | 10 / 40 | yes (truncated:false) | no |
+| 80 / 200 / 500 | yes | 50 | **yes (truncated:true)** | **no** |
+
+Over-cap disclosure rate: **ON = 1.0, OFF = 0.0**. The governed path always
+carries the signal; the bare tool never does, so a capped result looks complete
+to the caller. (The stronger "does the agent actually say so" is Level-1's judge.)
+
+## Consequences
+
+- A4 and A5 join A2 (ADR-0164) as measured Level-2 rows; A1 (ADR-0160/0161/0162)
+  and A3 (ADR-0158/0159) are the reframed earlier work. Ablation coverage is now
+  A1–A5 measured, A6 (server_share) planned (seocho-xju), Level-1 integrated next
+  (seocho-41a). Feeds the F2 ablation-grid figure.
+- Both are OFF/ON on shipped mechanisms with the axis each subsystem owns — the
+  "each part, before/after" the study requires.

--- a/docs/decisions/ADR-0165-ablation-a4-budget.json
+++ b/docs/decisions/ADR-0165-ablation-a4-budget.json
@@ -1,0 +1,21 @@
+{
+  "turns": 40,
+  "per_turn": 800,
+  "cap": 10000,
+  "off": {
+    "budget": 0,
+    "halted": false,
+    "halted_at_turn": null,
+    "turns_run": 40,
+    "tokens_spent": 32000,
+    "overshoot": null
+  },
+  "on": {
+    "budget": 10000,
+    "halted": true,
+    "halted_at_turn": 13,
+    "turns_run": 13,
+    "tokens_spent": 10400,
+    "overshoot": 400
+  }
+}

--- a/docs/decisions/ADR-0165-ablation-a5-honesty.json
+++ b/docs/decisions/ADR-0165-ablation-a5-honesty.json
@@ -1,0 +1,53 @@
+{
+  "row_cap": 50,
+  "cases": [
+    {
+      "result_size": 10,
+      "over_cap": false,
+      "on_rows": 10,
+      "on_discloses": true,
+      "on_truncated_flag": false,
+      "off_rows": 10,
+      "off_discloses": false
+    },
+    {
+      "result_size": 40,
+      "over_cap": false,
+      "on_rows": 40,
+      "on_discloses": true,
+      "on_truncated_flag": false,
+      "off_rows": 40,
+      "off_discloses": false
+    },
+    {
+      "result_size": 80,
+      "over_cap": true,
+      "on_rows": 50,
+      "on_discloses": true,
+      "on_truncated_flag": true,
+      "off_rows": 80,
+      "off_discloses": false
+    },
+    {
+      "result_size": 200,
+      "over_cap": true,
+      "on_rows": 50,
+      "on_discloses": true,
+      "on_truncated_flag": true,
+      "off_rows": 200,
+      "off_discloses": false
+    },
+    {
+      "result_size": 500,
+      "over_cap": true,
+      "on_rows": 50,
+      "on_discloses": true,
+      "on_truncated_flag": true,
+      "off_rows": 500,
+      "off_discloses": false
+    }
+  ],
+  "over_cap_cases": 3,
+  "on_disclosure_rate": 1.0,
+  "off_disclosure_rate": 0.0
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -980,6 +980,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - properly_scoped control passes both arms (3 acme rows, 0 leak) => gate blocks attacks without over-blocking
   - first Level-2 ablation row measured; validates shipped defense-in-depth (per-workspace-DB endgame would make it structural)
 
+## 2026-08-15 (ablation A4+A5)
+
+- [Accepted] ADR-0165 ablation-a4-a5 (resources + execution honesty)
+  - A4 budget (seocho-4rb): OFF spends 32000/40 turns unbounded; ON halts turn 13 at 10400, overshoot 400 (< one turn) — structured stop
+  - A5 honesty (seocho-2ay): over-cap disclosure ON=1.0 (truncated flag always) vs OFF=0.0 (silent, partial looks complete)
+  - Level-2 rows A1-A5 now measured; A6=seocho-xju, L1 integrated=seocho-41a next
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/ablation_a4_budget.py
+++ b/scripts/agentos/ablation_a4_budget.py
@@ -1,0 +1,80 @@
+"""Ablation A4 — resources: token-budget containment, OFF vs ON.
+
+Ablation row A4 of the OS study (wiki/os-ablation-study-design.md, seocho-4rb).
+The resource subsystem's axis: does a runaway agent chain stop, and how far past
+the cap does it get? We run the same multi-turn chain through the real
+``TokenBudgetTracker`` (the one wired into the OS via RunHooks, ADR-0153) with
+the budget OFF (0 = unlimited, a bare agent) vs ON (a per-session cap). Metrics:
+tokens spent, whether the run halted, and overshoot past the cap.
+
+Usage:
+  python scripts/agentos/ablation_a4_budget.py \
+      --turns 40 --per-turn 800 --budget 10000 \
+      --out outputs/agentos/ablation_a4_budget.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from seocho.budget import BudgetExceededError, TokenBudgetTracker  # noqa: E402
+
+
+def run_chain(*, budget: int, turns: int, per_turn: int) -> Dict[str, Any]:
+    """Simulate a chain of turns, each charging `per_turn` completion tokens,
+    exactly as the OS's on_llm_end hook charges the tracker per turn."""
+    tracker = TokenBudgetTracker(budget=budget, scope="ablation-a4")
+    halted_at = None
+    for turn in range(1, turns + 1):
+        try:
+            tracker.charge(completion=per_turn)
+        except BudgetExceededError:
+            halted_at = turn
+            break
+    spent = tracker.total
+    return {
+        "budget": budget,
+        "halted": halted_at is not None,
+        "halted_at_turn": halted_at,
+        "turns_run": halted_at if halted_at is not None else turns,
+        "tokens_spent": spent,
+        # Overshoot: how far past the cap the last charged turn pushed us.
+        "overshoot": max(0, spent - budget) if budget > 0 else None,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--turns", type=int, default=40)
+    ap.add_argument("--per-turn", type=int, default=800)
+    ap.add_argument("--budget", type=int, default=10000)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    off = run_chain(budget=0, turns=args.turns, per_turn=args.per_turn)
+    on = run_chain(budget=args.budget, turns=args.turns, per_turn=args.per_turn)
+    report = {"turns": args.turns, "per_turn": args.per_turn,
+              "cap": args.budget, "off": off, "on": on}
+
+    print("=== A4 budget containment: OFF (no budget) vs ON (cap) ===")
+    print(f"  chain: {args.turns} turns x {args.per_turn} tok "
+          f"(would spend {args.turns * args.per_turn} unchecked); cap = {args.budget}")
+    print(f"  OFF  halted={off['halted']!s:5s} turns={off['turns_run']:2d} "
+          f"spent={off['tokens_spent']}")
+    print(f"  ON   halted={on['halted']!s:5s} turns={on['turns_run']:2d} "
+          f"spent={on['tokens_spent']}  overshoot={on['overshoot']} "
+          f"(<= one turn = {args.per_turn})")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agentos/ablation_a5_honesty.py
+++ b/scripts/agentos/ablation_a5_honesty.py
@@ -1,0 +1,118 @@
+"""Ablation A5 — execution honesty: truncation disclosure, OFF vs ON.
+
+Ablation row A5 of the OS study (wiki/os-ablation-study-design.md, seocho-2ay).
+The execution subsystem's honesty axis: when a result is capped, does the tool
+SIGNAL it, so a consumer (or the agent) cannot present a partial result as
+complete? We compare a bare raw tool (OFF — returns rows, no truncation
+metadata, silent) to the OS's governed ``execute_query`` (ON — caps at
+``row_cap`` and always ships ``truncated: true/false``, the #478 disclosure
+lesson).
+
+Metric = disclosure rate over OVER-CAP results: the fraction that carry a
+truncation signal a consumer can act on. Structural, no LLM judge — the judge
+version (does the agent actually say so) is Level-1's job. Uses the real
+``SeochoOS.execute_query`` for ON.
+
+Usage:
+  python scripts/agentos/ablation_a5_honesty.py \
+      --out outputs/agentos/ablation_a5_honesty.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+
+class _Store:
+    """Fake governed store returning `n_rows` scoped rows."""
+
+    def __init__(self, n_rows: int) -> None:
+        self.rows = [{"n": {"id": i, "_workspace_id": "acme"}} for i in range(n_rows)]
+
+    def query(self, cypher, *, params=None, database=None,
+              enforce_workspace_filter=False):
+        return list(self.rows)
+
+
+def _off_raw(store, cypher) -> Dict[str, Any]:
+    """A bare tool: hand the rows back as-is, no truncation metadata."""
+    rows = store.query(cypher, params={"workspace_id": "acme"})
+    return {"rows": rows, "row_count": len(rows)}   # note: no `truncated` key
+
+
+def _has_disclosure(payload: Dict[str, Any]) -> bool:
+    return "truncated" in payload
+
+
+def run(cap: int, sizes: List[int]) -> Dict[str, Any]:
+    from seocho.operating_layer import SeochoOS
+    from seocho.ontology import NodeDef, Ontology, P
+
+    onto = Ontology(name="a5", graph_model="lpg",
+                    nodes={"N": NodeDef(properties={"id": P(int)})},
+                    relationships={})
+    results = []
+    for size in sizes:
+        store = _Store(size)
+        os_layer = SeochoOS(ontology=onto, graph_store=store, database="neo4j",
+                            workspace_id="acme", row_cap=cap)
+        session = os_layer.session("s")
+        over_cap = size > cap
+        # ON: the governed path.
+        on_payload = json.loads(os_layer.execute_query(
+            session, "MATCH (n:N) WHERE n._workspace_id = $workspace_id RETURN n"))
+        # OFF: the bare tool over the same rows.
+        off_payload = _off_raw(store, "MATCH (n:N) RETURN n")
+        results.append({
+            "result_size": size, "over_cap": over_cap,
+            "on_rows": on_payload["row_count"],
+            "on_discloses": _has_disclosure(on_payload),
+            "on_truncated_flag": on_payload.get("truncated"),
+            "off_rows": off_payload["row_count"],
+            "off_discloses": _has_disclosure(off_payload),
+        })
+
+    over = [r for r in results if r["over_cap"]]
+    return {
+        "row_cap": cap, "cases": results,
+        "over_cap_cases": len(over),
+        "on_disclosure_rate": round(
+            sum(1 for r in over if r["on_discloses"]) / len(over), 3) if over else None,
+        "off_disclosure_rate": round(
+            sum(1 for r in over if r["off_discloses"]) / len(over), 3) if over else None,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cap", type=int, default=50)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    report = run(args.cap, sizes=[10, 40, 80, 200, 500])
+    print("=== A5 truncation honesty: disclosure OFF vs ON ===")
+    print(f"  row_cap = {args.cap}")
+    print(f"  {'result_size':>11s} {'over_cap':>8s} {'ON rows':>8s} "
+          f"{'ON discloses':>13s} {'OFF discloses':>14s}")
+    for r in report["cases"]:
+        print(f"  {r['result_size']:>11d} {str(r['over_cap']):>8s} "
+              f"{r['on_rows']:>8d} {str(r['on_discloses'])+' ('+str(r['on_truncated_flag'])+')':>13s} "
+              f"{str(r['off_discloses']):>14s}")
+    print(f"\n  over-cap cases: {report['over_cap_cases']}")
+    print(f"  ON  disclosure rate: {report['on_disclosure_rate']}  (signals truncation)")
+    print(f"  OFF disclosure rate: {report['off_disclosure_rate']}  (silent — partial looks complete)")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two more **Level-2 ablation rows** of the OS study, each OFF/ON on a shipped mechanism, on the axis its subsystem owns.

## A4 — resources: token-budget containment (seocho-4rb)
Same 40-turn × 800-tok chain (32,000 unchecked) through the real `TokenBudgetTracker`.

| arm | halted | turns | tokens spent | overshoot |
|---|---|---|---|---|
| OFF (no budget) | no | 40 | **32,000** | unbounded |
| ON (cap 10,000) | yes | 13 | **10,400** | **400** (< one turn) |

Budget OFF spends everything; ON halts at a turn boundary, bounded by cap + ≤ one turn — a structured stop, not a clipped answer.

## A5 — execution honesty: truncation disclosure (seocho-2ay)
Bare raw tool vs the real `SeochoOS.execute_query`; cap 50, result sizes 10…500. Metric = disclosure rate over over-cap results.

| result size | over cap | ON discloses | OFF discloses |
|---|---|---|---|
| 10 / 40 | no | yes (truncated:false) | no |
| 80 / 200 / 500 | yes | **yes (truncated:true)** | **no** |

Over-cap disclosure: **ON = 1.0, OFF = 0.0** — the governed path always carries the signal; the bare tool never does, so a capped result looks complete. (The "does the agent actually say so" judge is Level-1.)

Ablation coverage now A1–A5 measured (A1/A3 = reframed ADR-0160/0161/0162 + 0158/0159); A6 = seocho-xju, Level-1 integrated = seocho-41a next. Feeds the F2 ablation-grid figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)