### PR TITLE
ci(boundaries): check package imports by parsing, not by grepping (seocho-mzg)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ shared.
 | Docs contract only | `bash scripts/ci/check-doc-contracts.sh` |
 | Runtime shell/import ownership | `bash scripts/ci/check-runtime-shell-contract.sh` |
 | SDK/extraction ownership | `bash scripts/ci/check-module-ownership-contract.sh` |
+| Package import boundaries | `python3 scripts/ci/check-import-boundaries.py` |
 | Root layout or public GitHub surface | `scripts/ci/check-root-hierarchy-contract.sh` |
 | Python import smoke | `uv run python -c "import seocho; print(seocho.__file__)"` |
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -235,6 +235,7 @@ Primary surfaces:
   - `git diff --check`
   - `bash scripts/ci/check-runtime-shell-contract.sh`
   - `bash scripts/ci/check-module-ownership-contract.sh`
+  - `python3 scripts/ci/check-import-boundaries.py`
   - `scripts/pm/lint-agent-docs.sh`
 
 Runtime migration slices should follow `docs/RUNTIME_PACKAGE_MIGRATION.md` and

--- a/scripts/ci/check-import-boundaries.py
+++ b/scripts/ci/check-import-boundaries.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Enforce the package boundaries `AGENTS.md` and `CLAUDE.md` declare.
+
+Why this exists, and why it is AST rather than grep.
+
+`check-runtime-shell-contract.sh` and `check-module-ownership-contract.sh` are
+roughly ninety `grep -F` assertions pinning exact source lines from past
+migrations. They enumerate history; they do not state a rule. The gap is
+demonstrable: `check_absent "from middleware import"` is asserted for
+`runtime/agent_server.py`, while `from config import`, `from debate import` and
+`from rule_api import` in the same file go unchecked — and those are the imports
+that reach into `extraction/`. A brand-new `src/seocho/foo.py` doing
+`import extraction.debate` passes both scripts today.
+
+Grep also cannot tell code from prose. `src/seocho/agent/runtime_factory.py`
+contains `from runtime.ontology_registry import ...` inside a ``Usage::``
+docstring — a line that looks like a violation to any text search and is not
+one. Parsing is the only way to be right about that, and being wrong in that
+direction is how a guard loses its credibility.
+
+The contracts, in dependency order (later may import earlier, never the reverse):
+
+    src/seocho/   the SDK. Imports neither runtime nor extraction.
+    extraction/   legacy service. May import seocho. Never runtime.
+    runtime/      deployment shell. May import both.
+
+Plus one structural rule with no direction: nothing may import an
+`extraction/` module under a bare top-level name. `runtime/__init__.py` puts
+`extraction/` on `sys.path`, so `import config` and `import extraction.config`
+both resolve to the same file and Python caches them as two distinct modules —
+two `DatabaseRegistry` classes, two `db_registry` singletons (seocho-60u).
+That rule is a ratchet: the current count is recorded below and may only fall.
+
+Usage:
+    python3 scripts/ci/check-import-boundaries.py           # check
+    python3 scripts/ci/check-import-boundaries.py --baseline # reprint the ratchet
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, Iterator, List, NamedTuple, Set, Tuple
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# Bare-name imports that resolve into extraction/ because runtime/__init__.py
+# injects that directory onto sys.path. Tracked as a ratchet, not a hard zero:
+# removing them is seocho-60u, ~173 statements across ~69 files, and it must be
+# one reviewable change rather than a drip. This number may fall, never rise.
+FLAT_EXTRACTION_IMPORT_BUDGET = 95  # measured 2026-08-16: 66 in extraction/, 29 in runtime/
+
+# Violations that exist today and are owned by a ticket. Each entry is
+# (path, imported_module, ticket). An allowlisted violation still has to be a
+# real import — if it disappears, the check tells you to delete the entry, so
+# the list cannot rot into a permanent exemption.
+ALLOWLIST: Dict[Tuple[str, str], str] = {
+    # The only production edge pointing the wrong way. Deferred inside a bare
+    # try/except, which is why it has survived: the cycle is invisible and its
+    # failure is silent (returns "", read downstream as status=unknown).
+    ("extraction/rule_api.py", "runtime.ontology_registry"): "seocho-4j2",
+}
+
+
+class Import(NamedTuple):
+    path: str
+    lineno: int
+    module: str
+    is_deferred: bool
+
+
+def _top(module: str) -> str:
+    return module.split(".", 1)[0]
+
+
+def iter_imports(path: Path) -> Iterator[Import]:
+    """Yield every import in a file, flagged with whether it is module-level.
+
+    A deferred import (inside a function or method) is still an edge — it is
+    how the one real cycle in this repo survives — so it is reported, not
+    skipped. The flag lets a contract decide whether to care.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError) as exc:
+        print(f"  !! could not parse {path}: {type(exc).__name__}", file=sys.stderr)
+        return
+
+    deferred: Set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for inner in ast.walk(node):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    deferred.add(id(inner))
+
+    rel = str(path.relative_to(ROOT))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield Import(rel, node.lineno, alias.name, id(node) in deferred)
+        elif isinstance(node, ast.ImportFrom):
+            # level > 0 is a relative import: by construction it cannot cross a
+            # top-level package boundary, so it is never a violation here.
+            if node.level:
+                continue
+            if node.module:
+                yield Import(rel, node.lineno, node.module, id(node) in deferred)
+
+
+def owner_of(rel_path: str) -> str:
+    if rel_path.startswith("src/seocho/"):
+        return "seocho"
+    if rel_path.startswith("runtime/"):
+        return "runtime"
+    if rel_path.startswith("extraction/"):
+        return "extraction"
+    return "other"
+
+
+def production_files() -> List[Path]:
+    """Shipped and deployed code only.
+
+    Tests, scripts and examples are excluded deliberately: a test importing
+    across a boundary to set up a fixture is not an architecture violation, and
+    treating it as one is what makes engineers add blanket ignores.
+    """
+    out: List[Path] = []
+    for base in ("src/seocho", "runtime", "extraction"):
+        for path in sorted((ROOT / base).rglob("*.py")):
+            rel = str(path.relative_to(ROOT))
+            if "/tests/" in rel or rel.endswith("_test.py") or "/test_" in rel:
+                continue
+            out.append(path)
+    return out
+
+
+def extraction_module_names() -> Set[str]:
+    """Top-level names that `extraction/*.py` would occupy on sys.path."""
+    return {p.stem for p in (ROOT / "extraction").glob("*.py") if p.stem != "__init__"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", action="store_true",
+                        help="print the measured flat-import count and exit")
+    args = parser.parse_args()
+
+    flat_names = extraction_module_names()
+    files = production_files()
+
+    violations: List[str] = []
+    flat_hits: List[Import] = []
+    stale_allowlist = set(ALLOWLIST)
+
+    for path in files:
+        owner = owner_of(str(path.relative_to(ROOT)))
+        for imp in iter_imports(path):
+            top = _top(imp.module)
+            key = (imp.path, imp.module)
+
+            # Contract 4: bare-name imports resolving into extraction/.
+            # Only meaningful from inside the repo's own packages, and a file
+            # in extraction/ importing its own sibling is the same defect.
+            if top in flat_names and owner in {"runtime", "extraction", "seocho"}:
+                flat_hits.append(imp)
+                continue
+
+            broken = (
+                (owner == "seocho" and top in {"runtime", "extraction"})
+                or (owner == "extraction" and top == "runtime")
+            )
+            if not broken:
+                continue
+            if key in ALLOWLIST:
+                stale_allowlist.discard(key)
+                continue
+            kind = "deferred" if imp.is_deferred else "module-level"
+            violations.append(
+                f"  {imp.path}:{imp.lineno}  {owner} -> {top}  ({kind}: {imp.module})"
+            )
+
+    if args.baseline:
+        print(f"flat extraction imports in production code: {len(flat_hits)}")
+        by_owner: Dict[str, int] = {}
+        for hit in flat_hits:
+            by_owner[owner_of(hit.path)] = by_owner.get(owner_of(hit.path), 0) + 1
+        for owner in sorted(by_owner):
+            print(f"  {owner}: {by_owner[owner]}")
+        return 0
+
+    failed = False
+
+    if violations:
+        failed = True
+        print("Import boundary violations (see AGENTS.md dependency order):")
+        for line in sorted(violations):
+            print(line)
+        print("\n  src/seocho must not import runtime or extraction;")
+        print("  extraction must not import runtime.")
+
+    if len(flat_hits) > FLAT_EXTRACTION_IMPORT_BUDGET:
+        failed = True
+        print(
+            f"\nBare-name imports resolving into extraction/: {len(flat_hits)}, "
+            f"budget {FLAT_EXTRACTION_IMPORT_BUDGET}."
+        )
+        print("  Each one loads the module a second time under a different name;")
+        print("  see seocho-60u. The budget may fall, never rise.")
+        for hit in sorted(flat_hits)[:15]:
+            print(f"    {hit.path}:{hit.lineno}  import {hit.module}")
+        if len(flat_hits) > 15:
+            print(f"    ... and {len(flat_hits) - 15} more")
+    elif len(flat_hits) < FLAT_EXTRACTION_IMPORT_BUDGET:
+        failed = True
+        print(
+            f"\nBare-name extraction imports fell to {len(flat_hits)} "
+            f"(budget {FLAT_EXTRACTION_IMPORT_BUDGET}). Lower the budget in "
+            f"{Path(__file__).name} so the gain is locked in."
+        )
+
+    if stale_allowlist:
+        failed = True
+        print("\nAllowlist entries that no longer match a real import:")
+        for path, module in sorted(stale_allowlist):
+            print(f"  {path} -> {module}  ({ALLOWLIST[(path, module)]})")
+        print("  Delete them; an exemption for a fixed problem is a lie.")
+
+    if not failed:
+        print(
+            f"Import boundary contracts passed "
+            f"({len(files)} production modules, "
+            f"{len(flat_hits)} known flat extraction imports)."
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -111,10 +111,12 @@ uv run pytest \
   tests/seocho/test_sweep.py \
   tests/seocho/test_entity_identity.py \
   tests/seocho/test_triage_metadata.py \
+  tests/seocho/test_import_boundaries.py \
   -q
 
 git diff --check
 scripts/ci/check-runtime-shell-contract.sh
 bash scripts/ci/check-module-ownership-contract.sh
+python3 scripts/ci/check-import-boundaries.py
 scripts/ci/check-root-hierarchy-contract.sh
 scripts/pm/lint-agent-docs.sh

--- a/tests/seocho/test_import_boundaries.py
+++ b/tests/seocho/test_import_boundaries.py
@@ -1,0 +1,81 @@
+"""The boundary checker must actually catch violations.
+
+A guard that passes on a real violation is worse than no guard: it converts an
+unchecked boundary into a checked-looking one. The two shell contracts this
+sits beside are ~90 literal grep assertions that pass while
+`runtime/agent_server.py` imports eight extraction modules, which is exactly
+the failure mode being pinned here.
+
+These tests plant violations in a temporary tree and assert the checker
+notices — including the one case grep gets wrong, an import inside a docstring.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "check_import_boundaries", _ROOT / "scripts" / "ci" / "check-import-boundaries.py"
+)
+checker = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = checker
+_spec.loader.exec_module(checker)
+
+
+def _imports(tmp_path: Path, source: str):
+    path = tmp_path / "probe.py"
+    path.write_text(source, encoding="utf-8")
+    # iter_imports reports paths relative to ROOT; point it at the temp tree.
+    original = checker.ROOT
+    checker.ROOT = tmp_path
+    try:
+        return list(checker.iter_imports(path))
+    finally:
+        checker.ROOT = original
+
+
+def test_a_module_level_import_is_found(tmp_path):
+    found = _imports(tmp_path, "import extraction.debate\n")
+    assert [(i.module, i.is_deferred) for i in found] == [("extraction.debate", False)]
+
+
+def test_a_deferred_import_is_found_and_flagged(tmp_path):
+    """The one real reverse edge in this repo hides inside a function."""
+    found = _imports(tmp_path, "def f():\n    from runtime.x import y\n    return y\n")
+    assert [(i.module, i.is_deferred) for i in found] == [("runtime.x", True)]
+
+
+def test_an_import_inside_a_docstring_is_not_an_import(tmp_path):
+    """grep cannot tell these apart; this is why the checker parses.
+
+    `src/seocho/agent/runtime_factory.py` carries exactly this shape and was
+    reported as an SDK-to-runtime violation by a text search. It is not one.
+    """
+    source = '"""Usage::\n\n    from runtime.ontology_registry import get_it\n"""\n'
+    assert _imports(tmp_path, source) == []
+
+
+def test_a_relative_import_never_crosses_a_boundary(tmp_path):
+    assert _imports(tmp_path, "from ..store.graph import GraphStore\n") == []
+
+
+def test_ownership_is_decided_by_path():
+    assert checker.owner_of("src/seocho/query/intent.py") == "seocho"
+    assert checker.owner_of("runtime/agent_server.py") == "runtime"
+    assert checker.owner_of("extraction/config.py") == "extraction"
+    assert checker.owner_of("scripts/demo/x.py") == "other"
+
+
+def test_tests_are_excluded_from_production_scan():
+    """A test importing across a boundary is a fixture, not an architecture break."""
+    paths = {str(p) for p in checker.production_files()}
+    assert not any("/tests/" in p or "/test_" in p for p in paths)
+
+
+def test_the_repository_currently_satisfies_the_contracts(monkeypatch):
+    """Fails loudly if someone lands a new violation or grows the ratchet."""
+    monkeypatch.setattr(sys, "argv", ["check-import-boundaries.py"])
+    assert checker.main() == 0


### PR DESCRIPTION
Adds an AST-based import boundary checker. This is the prerequisite for the `extraction/` packaging work (`seocho-60u`) — it turns the boundary from prose into something the build can check, so every later step is verifiable rather than asserted.

## The gap being closed

`check-runtime-shell-contract.sh` and `check-module-ownership-contract.sh` are roughly **ninety `grep -F` assertions** pinning exact source lines from past migrations. They enumerate history; they do not state a rule.

Concretely: `check_absent "from middleware import"` is asserted for `runtime/agent_server.py`, while `from config import`, `from debate import` and `from rule_api import` **in the same file** go unchecked — and those are precisely the imports that reach into `extraction/`. A brand-new `src/seocho/foo.py` doing `import extraction.debate` passed both scripts.

## Parsing changed one of the answers

A text search reports `src/seocho/agent/runtime_factory.py` as an SDK→runtime violation. The line is inside a ``Usage::`` docstring.

**The SDK boundary is in fact clean — zero real violations in either direction.** That is worth establishing before anyone "fixes" it, and it is the kind of thing grep cannot get right.

The genuine reverse edge is `extraction/rule_api.py:39`, a deferred `from runtime.ontology_registry import ...` inside a bare `try/except`. With `runtime/agent_server.py` importing `rule_api`, that is a real `runtime ↔ extraction` cycle — survived only because this side defers and swallows. The swallow is load-bearing in the wrong way: on failure it returns `""`, which downstream reads as `ontology_identity_hash="" → status=unknown`. So the cycle is invisible *and* its failure is silent. Allowlisted against `seocho-4j2`.

## Four contracts

| | Rule | Status |
|---|---|---|
| 1 | `src/seocho` imports neither `runtime` nor `extraction` | 0 violations |
| 2 | `extraction` never imports `runtime` | 1, allowlisted (`seocho-4j2`) |
| 3 | only `runtime` may import `extraction` | holds |
| 4 | no bare-name import resolves into `extraction/` | ratchet at 95 |

Contract 4 lands as a **ratchet at the measured baseline of 95** (66 in `extraction/`, 29 in `runtime/`) rather than a hard zero. Removing them is `seocho-60u` and should be one reviewable change, not a drip. The budget fails if it rises — and also **fails if it falls without being lowered**, so a gain cannot be silently given back.

The allowlist is self-cleaning: if an allowlisted import stops existing, the check fails and tells you to delete the entry. An exemption cannot outlive the problem it excuses.

## Scope choices

Tests, scripts and examples are excluded from the scan on purpose. A test importing across a boundary to build a fixture is not an architecture violation, and treating it as one is what makes engineers add blanket ignores.

Deferred imports **are** reported (flagged as such) rather than skipped — the one real cycle in this repo hides inside a function, so skipping them would miss the thing worth catching.

## Validation

`bash scripts/ci/run_basic_ci.sh` → **772 passed, 3 skipped** (765 before), with the checker registered in that script and the new test file added to its explicit list — that list is why new tests have silently not run here before.

`tests/seocho/test_import_boundaries.py` plants violations in a temp tree and asserts they are caught, including the docstring case. A guard that passes on a real violation is worse than no guard: it converts an unchecked boundary into a checked-looking one, which is exactly how the current scripts let `seocho-60u` through.

Manually verified end-to-end by planting three probes: an SDK→extraction import (caught), a new bare-name import pushing the ratchet to 96 (caught), and an import inside a docstring (correctly ignored).

## Follow-ups

`seocho-60u` (package-ify `extraction/`, drop the ratchet to 0), `seocho-4j2` (the reverse edge).
