### PR TITLE
fix(extraction): make it a real package, so config stops loading twice (seocho-60u)

### DIFF
--- a/examples/finance-compliance/quickstart.py
+++ b/examples/finance-compliance/quickstart.py
@@ -18,7 +18,7 @@ from pathlib import Path
 # Make `ontology.py` importable when running this file from any cwd.
 sys.path.insert(0, str(Path(__file__).parent))
 
-from ontology import build_ontology  # noqa: E402
+from extraction.ontology import build_ontology  # noqa: E402
 
 from seocho import Seocho  # noqa: E402
 

--- a/extraction/Dockerfile
+++ b/extraction/Dockerfile
@@ -8,10 +8,14 @@ WORKDIR /app
 COPY extraction/requirements.txt /tmp/extraction-requirements.txt
 RUN uv pip install --system --no-cache -r /tmp/extraction-requirements.txt
 
-COPY extraction/ /app/
+# extraction/ is a real package (seocho-60u), so it must land under its own
+# directory rather than being flattened into /app. Flattening is what let
+# `import config` and `import extraction.config` both resolve, loading the
+# module twice as two objects with two DatabaseRegistry singletons.
+COPY extraction/ /app/extraction/
 COPY runtime/ /app/runtime/
 COPY src/seocho/ /app/seocho/
 
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/extraction/entrypoint.sh
 
-CMD ["/bin/bash", "./entrypoint.sh"]
+CMD ["/bin/bash", "./extraction/entrypoint.sh"]

--- a/extraction/__init__.py
+++ b/extraction/__init__.py
@@ -1,0 +1,24 @@
+"""Legacy extraction service.
+
+This is a real package now. It was not one before: there was no `__init__.py`,
+and `runtime/__init__.py` put this directory on `sys.path` so every module here
+was importable under a bare top-level name. The consequence was not cosmetic —
+`extraction/config.py` loaded twice, as `config` and as `extraction.config`,
+which Python caches as two distinct module objects:
+
+    flat.__file__ == pkg.__file__                   -> True
+    flat is pkg                                     -> False
+    flat.db_registry is pkg.db_registry             -> False
+    flat.DatabaseRegistry is pkg.DatabaseRegistry   -> False
+
+Two `DatabaseRegistry` classes and two `db_registry` singletons, so any process
+touching both spellings got two connection registries and cross-registry
+`isinstance` failures. Both spellings were in tracked code (seocho-60u).
+
+Making it a package also makes the dependency graph legible: five `runtime/`
+modules import twenty-eight modules from here, and under bare names none of
+those edges were visible to grep or to an AST tool.
+
+Per `CLAUDE.md` this stays a compatibility surface — legacy service behaviour
+lives here, new canonical logic does not.
+"""

--- a/extraction/agent_factory.py
+++ b/extraction/agent_factory.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from agents import Agent, function_tool, RunContextWrapper
 
-from config import GraphTarget, graph_registry
+from .config import GraphTarget, graph_registry
 from seocho.ontology_context import (
     _clean_distinct_strings,
     build_ontology_context_summary_query,

--- a/extraction/agent_readiness.py
+++ b/extraction/agent_readiness.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.agent_readiness")

--- a/extraction/agent_server.py
+++ b/extraction/agent_server.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.agent_server")

--- a/extraction/config.py
+++ b/extraction/config.py
@@ -364,7 +364,7 @@ def validate_config() -> None:
     Raises:
         MissingAPIKeyError: If OPENAI_API_KEY is missing or empty.
     """
-    from exceptions import MissingAPIKeyError
+    from .exceptions import MissingAPIKeyError
 
     api_key = os.getenv("OPENAI_API_KEY", "")
     if not api_key:

--- a/extraction/database_manager.py
+++ b/extraction/database_manager.py
@@ -11,7 +11,7 @@ from typing import Optional
 from neo4j import GraphDatabase
 from neo4j.exceptions import ServiceUnavailable, SessionExpired
 
-from config import (
+from .config import (
     NEO4J_URI,
     NEO4J_USER,
     NEO4J_PASSWORD,
@@ -19,10 +19,10 @@ from config import (
     db_registry,
     graph_registry,
 )
-from graph_loader import GraphLoader
-from ontology.base import Ontology
-from exceptions import InvalidDatabaseNameError, Neo4jConnectionError
-from retry_utils import neo4j_retry
+from .graph_loader import GraphLoader
+from .ontology.base import Ontology
+from .exceptions import InvalidDatabaseNameError, Neo4jConnectionError
+from .retry_utils import neo4j_retry
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/debate.py
+++ b/extraction/debate.py
@@ -15,9 +15,9 @@ from typing import Any, Dict, List, Optional
 
 from agents import Agent
 
-from agents_runtime import get_agents_runtime
-from shared_memory import SharedMemory
-from tracing import track, update_current_span, update_current_trace
+from .agents_runtime import get_agents_runtime
+from .shared_memory import SharedMemory
+from .tracing import track, update_current_span, update_current_trace
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/deduplicator.py
+++ b/extraction/deduplicator.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 
-from vector_store import VectorStoreBase as VectorStore
+from .vector_store import VectorStoreBase as VectorStore
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/dependencies.py
+++ b/extraction/dependencies.py
@@ -10,21 +10,21 @@ import functools
 @functools.lru_cache(maxsize=1)
 def get_neo4j_connector():
     """Singleton Neo4jConnector provider."""
-    from graph_connector import MultiGraphConnector
+    from .graph_connector import MultiGraphConnector
     return MultiGraphConnector()
 
 
 @functools.lru_cache(maxsize=1)
 def get_database_manager():
     """Singleton DatabaseManager provider."""
-    from database_manager import DatabaseManager
+    from .database_manager import DatabaseManager
     return DatabaseManager()
 
 
 @functools.lru_cache(maxsize=1)
 def get_agent_factory():
     """Singleton AgentFactory provider."""
-    from agent_factory import AgentFactory
+    from .agent_factory import AgentFactory
     connector = get_neo4j_connector()
     return AgentFactory(connector)
 
@@ -32,11 +32,11 @@ def get_agent_factory():
 @functools.lru_cache(maxsize=1)
 def get_vector_store():
     """Singleton VectorStore provider."""
-    from vector_store import VectorStore
+    from .vector_store import VectorStore
     return VectorStore(api_key=os.getenv("OPENAI_API_KEY", ""))
 
 
 def get_shared_memory():
     """Request-scoped SharedMemory provider (new instance per request)."""
-    from shared_memory import SharedMemory
+    from .shared_memory import SharedMemory
     return SharedMemory()

--- a/extraction/entrypoint.sh
+++ b/extraction/entrypoint.sh
@@ -8,17 +8,17 @@ jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root --NotebookApp.tok
 # Start Agent Server (Uvicorn)
 echo "Starting Agent Server..."
 echo "Starting Agent Server..."
-uvicorn agent_server:app --host 0.0.0.0 --port 8001 &
+uvicorn extraction.agent_server:app --host 0.0.0.0 --port 8001 &
 
 BATCH_STATUS_FILE="${SEOCHO_BATCH_STATUS_FILE:-/tmp/seocho_batch_status}"
 echo "running" > "${BATCH_STATUS_FILE}"
 
-echo "Running Pipeline (main.py)..."
-if python main.py; then
+echo "Running Pipeline (extraction.main)..."
+if python -m extraction.main; then
   echo "success" > "${BATCH_STATUS_FILE}"
 else
   echo "failed" > "${BATCH_STATUS_FILE}"
-  echo "main.py failed or finished"
+  echo "extraction.main failed or finished"
 fi
 
 # Keep the container alive (if main.py finishes, we still want Jupyter running)

--- a/extraction/extractor.py
+++ b/extraction/extractor.py
@@ -3,10 +3,10 @@ import logging
 import time
 from typing import Optional, Dict, Any
 from openai import OpenAI
-from prompt_manager import PromptManager
-from tracing import wrap_openai_client
-from exceptions import OpenAIAPIError, ExtractionError
-from retry_utils import openai_retry
+from .prompt_manager import PromptManager
+from .tracing import wrap_openai_client
+from .exceptions import OpenAIAPIError, ExtractionError
+from .retry_utils import openai_retry
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/graph_connector.py
+++ b/extraction/graph_connector.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, Tuple
 from neo4j import GraphDatabase
 from seocho.query.query_proxy import coerce_query_records
 
-from config import (
+from .config import (
     GraphTarget,
     NEO4J_PASSWORD,
     NEO4J_URI,

--- a/extraction/graph_loader.py
+++ b/extraction/graph_loader.py
@@ -4,8 +4,8 @@ import re
 from typing import Any, Dict
 from neo4j import GraphDatabase
 from neo4j.exceptions import ServiceUnavailable, SessionExpired
-from exceptions import Neo4jConnectionError, InvalidLabelError, LoadError
-from retry_utils import neo4j_retry
+from .exceptions import Neo4jConnectionError, InvalidLabelError, LoadError
+from .retry_utils import neo4j_retry
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/ingest_finance_corpus.py
+++ b/extraction/ingest_finance_corpus.py
@@ -9,9 +9,9 @@ import pandas as pd
 import yaml
 from openai import OpenAI
 
-from graph_loader import GraphLoader
-from tracing import wrap_openai_client
-from vector_store import VectorStore
+from .graph_loader import GraphLoader
+from .tracing import wrap_openai_client
+from .vector_store import VectorStore
 
 # Initialize generic client, will set API key in main or environment
 client = None

--- a/extraction/linker.py
+++ b/extraction/linker.py
@@ -5,10 +5,10 @@ from typing import Any, Dict, Optional
 
 from openai import OpenAI
 
-from prompt_manager import PromptManager
-from tracing import wrap_openai_client
-from exceptions import OpenAIAPIError, LinkingError
-from retry_utils import openai_retry
+from .prompt_manager import PromptManager
+from .tracing import wrap_openai_client
+from .exceptions import OpenAIAPIError, LinkingError
+from .retry_utils import openai_retry
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/main.py
+++ b/extraction/main.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-from pipeline import ExtractionPipeline
-from config import configure_logging, load_pipeline_runtime_config
+from .pipeline import ExtractionPipeline
+from .config import configure_logging, load_pipeline_runtime_config
 
 
 logger = logging.getLogger(__name__)

--- a/extraction/manage_databases.py
+++ b/extraction/manage_databases.py
@@ -10,7 +10,7 @@ import logging
 
 from neo4j import GraphDatabase
 
-from config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD, _VALID_DB_NAME_RE, db_registry
+from .config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD, _VALID_DB_NAME_RE, db_registry
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     create_databases(target_dbs)
 
     # --- Schema Application ---
-    from schema_manager import SchemaManager
+    from .schema_manager import SchemaManager
 
     sm = SchemaManager(NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD)
 

--- a/extraction/memory_service.py
+++ b/extraction/memory_service.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.memory_service")

--- a/extraction/middleware.py
+++ b/extraction/middleware.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.middleware")

--- a/extraction/ontology_control_plane_api.py
+++ b/extraction/ontology_control_plane_api.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
-from ontology_control_plane_store import (
+from .ontology_control_plane_store import (
     compile_ontology_profile,
     evaluate_ontology_profile,
     get_ontology_profile,

--- a/extraction/pipeline.py
+++ b/extraction/pipeline.py
@@ -4,15 +4,15 @@ import logging
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 
-from collector import DataCollector
-from data_source import DataSource
-from graph_loader import GraphLoader
-from vector_store import VectorStore
-from deduplicator import EntityDeduplicator
-from rule_constraints import infer_rules_from_graph, apply_rules_to_graph
-from config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
-from exceptions import PipelineError
-from tracing import track
+from .collector import DataCollector
+from .data_source import DataSource
+from .graph_loader import GraphLoader
+from .vector_store import VectorStore
+from .deduplicator import EntityDeduplicator
+from .rule_constraints import infer_rules_from_graph, apply_rules_to_graph
+from .config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
+from .exceptions import PipelineError
+from .tracing import track
 from seocho.index import CanonicalExtractionEngine
 from seocho.store.llm import create_llm_backend
 
@@ -85,7 +85,7 @@ class ExtractionPipeline:
         self.deduplicator = EntityDeduplicator(vector_store=self.vector_store)
 
         # Schema Manager — reuse across items instead of creating per-item
-        from schema_manager import SchemaManager
+        from .schema_manager import SchemaManager
 
         self._schema_manager = SchemaManager(NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD)
 

--- a/extraction/policy.py
+++ b/extraction/policy.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.policy")

--- a/extraction/public_memory_api.py
+++ b/extraction/public_memory_api.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.public_memory_api")

--- a/extraction/retry_utils.py
+++ b/extraction/retry_utils.py
@@ -14,7 +14,7 @@ from tenacity import (
     before_sleep_log,
 )
 
-from exceptions import OpenAIAPIError, Neo4jConnectionError
+from .exceptions import OpenAIAPIError, Neo4jConnectionError
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/rule_api.py
+++ b/extraction/rule_api.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field
 
-from rule_constraints import RuleSet, apply_rules_to_graph, infer_rules_from_graph
-from rule_export import export_ruleset_to_cypher, export_ruleset_to_shacl
-from rule_profile_store import get_rule_profile, list_rule_profiles, save_rule_profile
+from .rule_constraints import RuleSet, apply_rules_to_graph, infer_rules_from_graph
+from .rule_export import export_ruleset_to_cypher, export_ruleset_to_shacl
+from .rule_profile_store import get_rule_profile, list_rule_profiles, save_rule_profile
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/rule_export.py
+++ b/extraction/rule_export.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List
 
-from rule_constraints import RuleSet
+from .rule_constraints import RuleSet
 
 
 def export_ruleset_to_cypher(rule_profile: Dict[str, Any]) -> Dict[str, Any]:

--- a/extraction/runtime_ingest.py
+++ b/extraction/runtime_ingest.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.runtime_ingest")

--- a/extraction/schema_manager.py
+++ b/extraction/schema_manager.py
@@ -3,9 +3,9 @@ import yaml
 import os
 from neo4j import GraphDatabase
 from neo4j.exceptions import ServiceUnavailable, SessionExpired
-from config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
-from exceptions import Neo4jConnectionError
-from retry_utils import neo4j_retry
+from .config import NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
+from .exceptions import Neo4jConnectionError
+from .retry_utils import neo4j_retry
 from seocho.cypher_ident import is_valid_identifier
 
 logger = logging.getLogger(__name__)

--- a/extraction/semantic_artifact_api.py
+++ b/extraction/semantic_artifact_api.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 
-from semantic_artifact_store import (
+from .semantic_artifact_store import (
     approve_semantic_artifact,
     deprecate_semantic_artifact,
     get_semantic_artifact,

--- a/extraction/semantic_pass_orchestrator.py
+++ b/extraction/semantic_pass_orchestrator.py
@@ -12,9 +12,9 @@ import json
 import logging
 from typing import Any, Callable, Dict, Optional
 
-from retry_utils import openai_retry
-from semantic_context import build_dynamic_prompt_context
-from tracing import track, wrap_openai_client
+from .retry_utils import openai_retry
+from .semantic_context import build_dynamic_prompt_context
+from .tracing import track, wrap_openai_client
 
 logger = logging.getLogger(__name__)
 

--- a/extraction/semantic_vocabulary.py
+++ b/extraction/semantic_vocabulary.py
@@ -15,7 +15,7 @@ import os
 import re
 from typing import Any, Dict, List, Tuple
 
-from semantic_artifact_store import (
+from .semantic_artifact_store import (
     DEFAULT_SEMANTIC_ARTIFACT_DIR,
     get_semantic_artifact,
     list_semantic_artifacts,

--- a/extraction/server_runtime.py
+++ b/extraction/server_runtime.py
@@ -3,7 +3,7 @@
 try:
     from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 except ImportError:
-    from _runtime_alias import alias_runtime_module as _alias_runtime_module
+    from ._runtime_alias import alias_runtime_module as _alias_runtime_module
 
 
 _alias_runtime_module(__name__, "runtime.server_runtime")

--- a/extraction/tests/test_agent_factory.py
+++ b/extraction/tests/test_agent_factory.py
@@ -18,7 +18,7 @@ fake_agents = types.SimpleNamespace(
 )
 sys.modules["agents"] = fake_agents
 
-import agent_factory
+from .. import agent_factory
 
 
 def teardown_module(module):

--- a/extraction/tests/test_agents_runtime.py
+++ b/extraction/tests/test_agents_runtime.py
@@ -35,7 +35,7 @@ fake_agents = types.SimpleNamespace(
 )
 sys.modules["agents"] = fake_agents
 
-import agents_runtime
+from .. import agents_runtime
 
 
 def teardown_module(module):

--- a/extraction/tests/test_approve_governance_gate.py
+++ b/extraction/tests/test_approve_governance_gate.py
@@ -15,7 +15,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from semantic_artifact_store import (  # noqa: E402
+from ..semantic_artifact_store import (  # noqa: E402
     approve_semantic_artifact,
     get_semantic_artifact,
     save_semantic_artifact,

--- a/extraction/tests/test_basic.py
+++ b/extraction/tests/test_basic.py
@@ -1,5 +1,5 @@
 import pytest
-from collector import DataCollector
+from ..collector import DataCollector
 
 def test_data_collector():
     collector = DataCollector()

--- a/extraction/tests/test_config_validation.py
+++ b/extraction/tests/test_config_validation.py
@@ -8,19 +8,19 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import pytest
 from unittest.mock import patch
 
-from exceptions import MissingAPIKeyError
+from ..exceptions import MissingAPIKeyError
 
 
 class TestValidateConfig:
     def test_missing_api_key_raises(self):
         with patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=False):
-            from config import validate_config
+            from ..config import validate_config
             with pytest.raises(MissingAPIKeyError, match="OPENAI_API_KEY"):
                 validate_config()
 
     def test_valid_config_passes(self):
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test123"}, clear=False):
-            from config import validate_config
+            from ..config import validate_config
             # Should not raise
             validate_config()
 
@@ -28,6 +28,6 @@ class TestValidateConfig:
         env = os.environ.copy()
         env.pop("OPENAI_API_KEY", None)
         with patch.dict(os.environ, env, clear=True):
-            from config import validate_config
+            from ..config import validate_config
             with pytest.raises(MissingAPIKeyError):
                 validate_config()

--- a/extraction/tests/test_debate.py
+++ b/extraction/tests/test_debate.py
@@ -32,7 +32,7 @@ fake_agents = types.SimpleNamespace(
 )
 sys.modules["agents"] = fake_agents
 
-import debate
+from .. import debate
 
 
 def teardown_module(module):

--- a/extraction/tests/test_deduplicator.py
+++ b/extraction/tests/test_deduplicator.py
@@ -13,7 +13,7 @@ for mod in ["faiss", "openai", "opik", "opik.integrations", "opik.integrations.o
     sys.modules.setdefault(mod, MagicMock())
 
 import numpy as np
-from deduplicator import EntityDeduplicator, MAX_CANONICAL_EMBEDDINGS
+from ..deduplicator import EntityDeduplicator, MAX_CANONICAL_EMBEDDINGS
 
 
 class TestEntityDeduplicatorBoundedCache:

--- a/extraction/tests/test_error_responses.py
+++ b/extraction/tests/test_error_responses.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
-from exceptions import (
+from ..exceptions import (
     SeochoError,
     ConfigurationError,
     InfrastructureError,

--- a/extraction/tests/test_exceptions.py
+++ b/extraction/tests/test_exceptions.py
@@ -5,7 +5,7 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from exceptions import (
+from ..exceptions import (
     SeochoError,
     InfrastructureError,
     OpenAIAPIError,

--- a/extraction/tests/test_fulltext_index.py
+++ b/extraction/tests/test_fulltext_index.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from fulltext_index import FulltextIndexManager
+from ..fulltext_index import FulltextIndexManager
 
 
 class FakeConnector:

--- a/extraction/tests/test_graph_connector.py
+++ b/extraction/tests/test_graph_connector.py
@@ -1,19 +1,42 @@
 """Tests for graph-scoped multi-instance connector behavior."""
 
 import json
-import os
-import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from types import SimpleNamespace
 
-import graph_connector
-from config import GraphTarget
+from .. import graph_connector
+from ..config import GraphTarget
 
+
+def _patch_registry(monkeypatch, get_graph):
+    """Swap the module's registry reference instead of mutating the singleton.
+
+    `graph_registry` is one object shared with `runtime/server_runtime.py`. Until
+    seocho-60u it was not — `extraction/config.py` loaded twice, so patching the
+    method here reached a different object than the runtime used, and the leak
+    was invisible. With one module there is one registry, and mutating its
+    method during a test made the runtime resolve
+    `bolt://finance:7687 / password="secret"`, failing later integration tests
+    with Neo.ClientError.Security.Unauthorized.
+
+    Rebinding the module attribute keeps the fake local to this module and
+    leaves the shared object untouched.
+    """
+    monkeypatch.setattr(
+        graph_connector,
+        "graph_registry",
+        SimpleNamespace(
+            get_graph=get_graph,
+            list_graph_ids=lambda: ["finance"],
+            # Returning None keeps resolve_target on its explicit-override path,
+            # which is what these tests exercise.
+            find_by_database=lambda database: None,
+        ),
+    )
 
 def test_resolve_target_from_graph_registry(monkeypatch):
-    monkeypatch.setattr(
-        graph_connector.graph_registry,
-        "get_graph",
+    _patch_registry(
+        monkeypatch,
         lambda graph_id: GraphTarget(
             graph_id=graph_id,
             database="kgfibo",
@@ -71,9 +94,8 @@ def test_run_cypher_uses_graph_bound_driver(monkeypatch):
         def close(self):
             return None
 
-    monkeypatch.setattr(
-        graph_connector.graph_registry,
-        "get_graph",
+    _patch_registry(
+        monkeypatch,
         lambda graph_id: GraphTarget(
             graph_id=graph_id,
             database="kgfibo",
@@ -83,10 +105,14 @@ def test_run_cypher_uses_graph_bound_driver(monkeypatch):
             ontology_id="fibo",
         ),
     )
+    # Replace the module's reference, not neo4j's GraphDatabase class. Patching
+    # the class mutates global state shared with every other test in the
+    # session; until seocho-60u that leak was hidden because extraction/ loaded
+    # twice and the runtime held a different module object.
     monkeypatch.setattr(
-        graph_connector.GraphDatabase,
-        "driver",
-        lambda uri, auth: _Driver(uri, auth),
+        graph_connector,
+        "GraphDatabase",
+        SimpleNamespace(driver=lambda uri, auth: _Driver(uri, auth)),
     )
     connector = graph_connector.MultiGraphConnector()
 
@@ -132,9 +158,8 @@ def test_query_normalizes_graph_bound_driver_rows(monkeypatch):
         def close(self):
             return None
 
-    monkeypatch.setattr(
-        graph_connector.graph_registry,
-        "get_graph",
+    _patch_registry(
+        monkeypatch,
         lambda graph_id: GraphTarget(
             graph_id=graph_id,
             database="kgfibo",
@@ -144,10 +169,14 @@ def test_query_normalizes_graph_bound_driver_rows(monkeypatch):
             ontology_id="fibo",
         ),
     )
+    # Replace the module's reference, not neo4j's GraphDatabase class. Patching
+    # the class mutates global state shared with every other test in the
+    # session; until seocho-60u that leak was hidden because extraction/ loaded
+    # twice and the runtime held a different module object.
     monkeypatch.setattr(
-        graph_connector.GraphDatabase,
-        "driver",
-        lambda uri, auth: _Driver(uri, auth),
+        graph_connector,
+        "GraphDatabase",
+        SimpleNamespace(driver=lambda uri, auth: _Driver(uri, auth)),
     )
     connector = graph_connector.MultiGraphConnector()
 

--- a/extraction/tests/test_graph_loader.py
+++ b/extraction/tests/test_graph_loader.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock, patch
 sys.modules.setdefault("neo4j", MagicMock())
 sys.modules.setdefault("neo4j.exceptions", MagicMock())
 
-from exceptions import InvalidLabelError
-from graph_loader import _normalize_label, _sanitize_properties, _validate_label
+from ..exceptions import InvalidLabelError
+from ..graph_loader import _normalize_label, _sanitize_properties, _validate_label
 
 
 class TestValidateLabel:
@@ -74,18 +74,18 @@ class TestPropertySanitization:
 
 class TestGraphLoaderLoadGraph:
     def test_load_empty_data(self):
-        from graph_loader import GraphLoader
+        from ..graph_loader import GraphLoader
 
-        with patch("graph_loader.GraphDatabase") as mock_gdb:
+        with patch("extraction.graph_loader.GraphDatabase") as mock_gdb:
             loader = GraphLoader("bolt://test:7687", "user", "pass")
             # Should not raise or call session
             loader.load_graph({}, "src_1")
             loader.load_graph(None, "src_1")
 
     def test_load_valid_data(self):
-        from graph_loader import GraphLoader
+        from ..graph_loader import GraphLoader
 
-        with patch("graph_loader.GraphDatabase") as mock_gdb:
+        with patch("extraction.graph_loader.GraphDatabase") as mock_gdb:
             mock_session = MagicMock()
             mock_driver = MagicMock()
             mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
@@ -106,7 +106,7 @@ class TestGraphLoaderLoadGraph:
             assert mock_session.execute_write.call_count == 2
 
     def test_create_node_normalizes_label_and_nested_properties(self):
-        from graph_loader import GraphLoader
+        from ..graph_loader import GraphLoader
 
         tx = MagicMock()
         GraphLoader._create_node(
@@ -128,7 +128,7 @@ class TestGraphLoaderLoadGraph:
         assert kwargs["props"]["workspace_id"] == "default"
 
     def test_create_relationship_sanitizes_nested_properties(self):
-        from graph_loader import GraphLoader
+        from ..graph_loader import GraphLoader
 
         tx = MagicMock()
         GraphLoader._create_relationship(

--- a/extraction/tests/test_ontology_hints_builder.py
+++ b/extraction/tests/test_ontology_hints_builder.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from ontology_hints_builder import build_hints_from_records
+from ..ontology_hints_builder import build_hints_from_records
 
 
 def test_build_hints_from_records_merges_aliases_and_keywords():

--- a/extraction/tests/test_phase5_artifact_ontology_binding.py
+++ b/extraction/tests/test_phase5_artifact_ontology_binding.py
@@ -80,7 +80,7 @@ def test_infer_rules_default_hash_is_empty_string():
 
 
 def test_save_semantic_artifact_stamps_ontology_identity_hash(tmp_path):
-    import semantic_artifact_store as sas
+    from .. import semantic_artifact_store as sas
 
     payload = sas.save_semantic_artifact(
         workspace_id="acme",
@@ -96,7 +96,7 @@ def test_save_semantic_artifact_stamps_ontology_identity_hash(tmp_path):
 
 
 def test_get_semantic_artifact_match(tmp_path):
-    import semantic_artifact_store as sas
+    from .. import semantic_artifact_store as sas
 
     payload = sas.save_semantic_artifact(
         workspace_id="acme",
@@ -118,7 +118,7 @@ def test_get_semantic_artifact_match(tmp_path):
 
 
 def test_get_semantic_artifact_drift(tmp_path):
-    import semantic_artifact_store as sas
+    from .. import semantic_artifact_store as sas
 
     payload = sas.save_semantic_artifact(
         workspace_id="acme",
@@ -149,7 +149,7 @@ def test_get_semantic_artifact_legacy_unknown(tmp_path):
     parity gap to the operator."""
 
     import json as _json
-    import semantic_artifact_store as sas
+    from .. import semantic_artifact_store as sas
 
     payload = sas.save_semantic_artifact(
         workspace_id="acme",
@@ -178,7 +178,7 @@ def test_get_semantic_artifact_no_expected_hash_skips_drift_block(tmp_path):
     """Backward compat: callers that don't pass expected_ontology_hash get
     the legacy payload without the artifact_ontology_mismatch block."""
 
-    import semantic_artifact_store as sas
+    from .. import semantic_artifact_store as sas
 
     payload = sas.save_semantic_artifact(
         workspace_id="acme",
@@ -197,7 +197,7 @@ def test_get_semantic_artifact_no_expected_hash_skips_drift_block(tmp_path):
 
 
 def test_rule_profile_save_and_get_round_trip_hash(tmp_path):
-    import rule_profile_store as rps
+    from .. import rule_profile_store as rps
 
     out = rps.save_rule_profile(
         "acme",
@@ -213,7 +213,7 @@ def test_rule_profile_save_and_get_round_trip_hash(tmp_path):
 
 
 def test_rule_profile_drift_detection(tmp_path):
-    import rule_profile_store as rps
+    from .. import rule_profile_store as rps
 
     out = rps.save_rule_profile(
         "acme",
@@ -235,7 +235,7 @@ def test_rule_profile_migration_adds_column_to_legacy_db(tmp_path):
     """Pre-Phase-5 sqlite DBs lack ontology_identity_hash. Connecting via
     the Phase 5 _connect must ALTER the table without dropping data."""
 
-    import rule_profile_store as rps
+    from .. import rule_profile_store as rps
 
     db_path = tmp_path / "rule_profiles.db"
     legacy = sqlite3.connect(str(db_path))
@@ -280,7 +280,7 @@ def test_rule_profile_migration_adds_column_to_legacy_db(tmp_path):
 def test_rule_profile_legacy_row_reads_unknown_status(tmp_path):
     """Drift detection on a pre-Phase-5 row reports status=unknown, not drift."""
 
-    import rule_profile_store as rps
+    from .. import rule_profile_store as rps
 
     db_path = tmp_path / "rule_profiles.db"
     legacy = sqlite3.connect(str(db_path))
@@ -320,7 +320,7 @@ def test_rule_profile_save_propagates_hash_into_stored_json(tmp_path):
     """The hash is also stamped into the JSON blob, so a profile reconstructed
     from JSON alone (e.g. read by a different tool) still carries it."""
 
-    import rule_profile_store as rps
+    from .. import rule_profile_store as rps
 
     out = rps.save_rule_profile(
         "acme",
@@ -334,7 +334,7 @@ def test_rule_profile_save_propagates_hash_into_stored_json(tmp_path):
 
 
 def test_rule_profile_no_expected_hash_skips_drift_block(tmp_path):
-    import rule_profile_store as rps
+    from .. import rule_profile_store as rps
 
     out = rps.save_rule_profile(
         "acme",

--- a/extraction/tests/test_phase6_rule_api_promotion_gates.py
+++ b/extraction/tests/test_phase6_rule_api_promotion_gates.py
@@ -66,14 +66,14 @@ def _register(workspace_id: str, graph_id: str, database: str, ontology) -> str:
 
 
 def test_helper_returns_hash_for_single_ontology_workspace():
-    import rule_api
+    from .. import rule_api
 
     expected = _register("acme", "finance", "kgnormal", _ontology("finance"))
     assert rule_api._active_ontology_hash("acme") == expected
 
 
 def test_helper_returns_empty_when_workspace_unknown():
-    import rule_api
+    from .. import rule_api
 
     _register("acme", "finance", "kgnormal", _ontology("finance"))
     assert rule_api._active_ontology_hash("other") == ""
@@ -84,7 +84,7 @@ def test_helper_returns_empty_for_multi_ontology_workspace():
     active hash from a workspace_id-only request — returns empty,
     consistent with Phase 5's `unknown` trichotomy."""
 
-    import rule_api
+    from .. import rule_api
 
     _register("acme", "finance", "kgnormal", _ontology("finance"))
     _register("acme", "legal", "kglegal", _ontology("legal"))
@@ -92,7 +92,7 @@ def test_helper_returns_empty_for_multi_ontology_workspace():
 
 
 def test_helper_returns_empty_for_empty_registry():
-    import rule_api
+    from .. import rule_api
 
     assert rule_api._active_ontology_hash("acme") == ""
 
@@ -103,7 +103,7 @@ def test_helper_returns_empty_for_empty_registry():
 
 
 def test_infer_stamps_active_ontology_hash():
-    import rule_api
+    from .. import rule_api
 
     expected = _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -118,7 +118,7 @@ def test_infer_stamps_active_ontology_hash():
 
 
 def test_infer_leaves_hash_empty_when_registry_inactive():
-    import rule_api
+    from .. import rule_api
 
     response = rule_api.infer_rule_profile(
         rule_api.RuleInferRequest(
@@ -135,7 +135,7 @@ def test_infer_leaves_hash_empty_when_registry_inactive():
 
 
 def test_create_stamps_active_hash_when_caller_omits_one():
-    import rule_api
+    from .. import rule_api
 
     expected = _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -155,7 +155,7 @@ def test_create_preserves_caller_supplied_hash_through_round_trip():
     the active hash takes precedence — but they should match for fresh
     inference, which is the common path."""
 
-    import rule_api
+    from .. import rule_api
 
     expected = _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -180,7 +180,7 @@ def test_create_preserves_caller_supplied_hash_through_round_trip():
 
 
 def test_read_returns_match_when_stored_equals_active():
-    import rule_api
+    from .. import rule_api
 
     active = _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -201,7 +201,7 @@ def test_read_returns_drift_after_ontology_changes():
     """The structural promise: re-registering the ontology under a new
     version makes the previously-saved profile read as drift."""
 
-    import rule_api
+    from .. import rule_api
 
     _register("acme", "finance", "kgnormal", _ontology("finance", version="1.0.0"))
 
@@ -229,7 +229,7 @@ def test_read_omits_drift_block_when_registry_inactive():
     """Backward compat: workspaces without registered ontologies see no
     drift block; the legacy endpoint shape is preserved."""
 
-    import rule_api
+    from .. import rule_api
 
     saved = rule_api.create_rule_profile(
         rule_api.RuleProfileCreateRequest(
@@ -248,7 +248,7 @@ def test_read_omits_drift_block_when_registry_inactive():
 
 
 def test_assess_with_supplied_profile_surfaces_drift():
-    import rule_api
+    from .. import rule_api
 
     active = _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -270,7 +270,7 @@ def test_assess_with_supplied_profile_surfaces_drift():
 
 
 def test_assess_with_inferred_profile_returns_match():
-    import rule_api
+    from .. import rule_api
 
     _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -289,7 +289,7 @@ def test_assess_with_legacy_supplied_profile_returns_unknown():
     active workspace hash must report status=unknown rather than drift,
     so legacy assessment paths keep working until profiles are re-saved."""
 
-    import rule_api
+    from .. import rule_api
 
     _register("acme", "finance", "kgnormal", _ontology("finance"))
 
@@ -305,7 +305,7 @@ def test_assess_with_legacy_supplied_profile_returns_unknown():
 
 
 def test_assess_with_no_active_hash_reports_no_drift_block():
-    import rule_api
+    from .. import rule_api
 
     response = rule_api.assess_rule_profile(
         rule_api.RuleAssessRequest(

--- a/extraction/tests/test_pipeline_canonical_engine.py
+++ b/extraction/tests/test_pipeline_canonical_engine.py
@@ -20,8 +20,8 @@ fake_neo4j_exceptions.SessionExpired = RuntimeError
 sys.modules.setdefault("neo4j", fake_neo4j)
 sys.modules.setdefault("neo4j.exceptions", fake_neo4j_exceptions)
 
-import schema_manager  # noqa: E402
-import pipeline as pipeline_module  # noqa: E402
+from .. import schema_manager  # noqa: E402
+from .. import pipeline as pipeline_module  # noqa: E402
 from seocho import NodeDef, Ontology, P, RelDef  # noqa: E402
 
 

--- a/extraction/tests/test_pipeline_runtime_config.py
+++ b/extraction/tests/test_pipeline_runtime_config.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from config import load_pipeline_runtime_config
+from ..config import load_pipeline_runtime_config
 
 
 def test_load_pipeline_runtime_config_from_prompt_files(tmp_path, monkeypatch):

--- a/extraction/tests/test_platform_agents.py
+++ b/extraction/tests/test_platform_agents.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from platform_agents import PlatformSessionStore, BackendSpecialistAgent, FrontendSpecialistAgent
+from ..platform_agents import PlatformSessionStore, BackendSpecialistAgent, FrontendSpecialistAgent
 
 
 def test_session_store_append_and_clear():

--- a/extraction/tests/test_raw_material_parser.py
+++ b/extraction/tests/test_raw_material_parser.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-import raw_material_parser
-from raw_material_parser import MaterialParseError, parse_raw_material_record
+from .. import raw_material_parser
+from ..raw_material_parser import MaterialParseError, parse_raw_material_record
 
 
 def test_parse_text_material():

--- a/extraction/tests/test_retry.py
+++ b/extraction/tests/test_retry.py
@@ -8,8 +8,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import pytest
 from unittest.mock import MagicMock
 
-from exceptions import OpenAIAPIError, Neo4jConnectionError
-from retry_utils import openai_retry, neo4j_retry
+from ..exceptions import OpenAIAPIError, Neo4jConnectionError
+from ..retry_utils import openai_retry, neo4j_retry
 
 
 class TestOpenAIRetry:

--- a/extraction/tests/test_rule_api.py
+++ b/extraction/tests/test_rule_api.py
@@ -1,4 +1,4 @@
-from rule_api import (
+from ..rule_api import (
     RuleInferRequest,
     RuleAssessRequest,
     RuleExportCypherRequest,

--- a/extraction/tests/test_rule_constraints.py
+++ b/extraction/tests/test_rule_constraints.py
@@ -1,4 +1,4 @@
-from rule_constraints import (
+from ..rule_constraints import (
     apply_rules_to_graph,
     infer_rules_from_graph,
 )

--- a/extraction/tests/test_rule_export.py
+++ b/extraction/tests/test_rule_export.py
@@ -1,4 +1,4 @@
-from rule_export import export_ruleset_to_cypher, export_ruleset_to_shacl
+from ..rule_export import export_ruleset_to_cypher, export_ruleset_to_shacl
 
 
 def test_export_required_rule_to_cypher():

--- a/extraction/tests/test_rule_profile_store.py
+++ b/extraction/tests/test_rule_profile_store.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from rule_profile_store import get_rule_profile, list_rule_profiles, save_rule_profile
+from ..rule_profile_store import get_rule_profile, list_rule_profiles, save_rule_profile
 
 
 def _profile(rule_name: str) -> dict:

--- a/extraction/tests/test_runtime_package_aliases.py
+++ b/extraction/tests/test_runtime_package_aliases.py
@@ -9,62 +9,102 @@ if ROOT_DIR not in sys.path:
 
 
 def test_policy_alias_points_to_runtime_module() -> None:
-    import policy
+    from .. import policy
     import runtime.policy as runtime_policy
 
     assert policy is runtime_policy
 
 
 def test_public_memory_alias_points_to_runtime_module() -> None:
-    import public_memory_api
+    from .. import public_memory_api
     import runtime.public_memory_api as runtime_public_memory_api
 
     assert public_memory_api is runtime_public_memory_api
 
 
 def test_server_runtime_alias_points_to_runtime_module() -> None:
-    import server_runtime
+    from .. import server_runtime
     import runtime.server_runtime as runtime_server_runtime
 
     assert server_runtime is runtime_server_runtime
 
 
 def test_runtime_ingest_alias_points_to_runtime_module() -> None:
-    import runtime_ingest
+    from .. import runtime_ingest
     import runtime.runtime_ingest as runtime_runtime_ingest
 
     assert runtime_ingest is runtime_runtime_ingest
 
 
 def test_agent_readiness_alias_points_to_runtime_module() -> None:
-    import agent_readiness
+    from .. import agent_readiness
     import runtime.agent_readiness as runtime_agent_readiness
 
     assert agent_readiness is runtime_agent_readiness
 
 
 def test_middleware_alias_points_to_runtime_module() -> None:
-    import middleware
+    from .. import middleware
     import runtime.middleware as runtime_middleware
 
     assert middleware is runtime_middleware
 
 
 def test_memory_service_alias_points_to_runtime_module() -> None:
-    import memory_service
+    from .. import memory_service
     import runtime.memory_service as runtime_memory_service
 
     assert memory_service is runtime_memory_service
 
 
-def test_extraction_cwd_flat_alias_can_resolve_runtime_module() -> None:
+def test_extraction_modules_do_not_resolve_under_a_bare_flat_name() -> None:
+    """The replacement for the old flat-alias guarantee, inverted on purpose.
+
+    This test used to assert that `import policy`, run with cwd=extraction/,
+    was the same object as `runtime.policy`. That alias was a symptom, not a
+    feature: `runtime/__init__.py` put extraction/ on sys.path, so every module
+    here answered to two names and Python cached each spelling separately.
+    `extraction/config.py` therefore loaded twice, yielding two
+    `DatabaseRegistry` classes and two `db_registry` singletons (seocho-60u).
+
+    extraction/ is a package now, so the bare name must not resolve at all.
+    Run in a subprocess from the repository root because sys.modules in this
+    process is already populated.
+    """
     result = subprocess.run(
         [
             sys.executable,
             "-c",
-            "import policy; import runtime.policy as rp; assert policy is rp",
+            "import runtime\n"
+            "import extraction.config as pkg\n"
+            "try:\n"
+            "    import config\n"
+            "except ModuleNotFoundError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise AssertionError('flat name still resolves: %s' % config.__file__)\n",
         ],
-        cwd=os.path.join(ROOT_DIR, "extraction"),
+        cwd=os.path.abspath(ROOT_DIR),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_importing_a_module_twice_yields_one_object() -> None:
+    """The defect itself, pinned. Two spellings must never mean two modules."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import extraction.config as a\n"
+            "import extraction.config as b\n"
+            "assert a is b\n"
+            "assert a.db_registry is b.db_registry\n"
+            "assert a.DatabaseRegistry is b.DatabaseRegistry\n",
+        ],
+        cwd=os.path.abspath(ROOT_DIR),
         capture_output=True,
         text=True,
     )

--- a/extraction/tests/test_semantic_artifact_api.py
+++ b/extraction/tests/test_semantic_artifact_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from semantic_artifact_api import (
+from ..semantic_artifact_api import (
     SemanticArtifactApproveRequest,
     SemanticArtifactDeprecateRequest,
     SemanticArtifactDraftCreateRequest,

--- a/extraction/tests/test_semantic_context.py
+++ b/extraction/tests/test_semantic_context.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from semantic_context import build_dynamic_prompt_context
+from ..semantic_context import build_dynamic_prompt_context
 
 
 def test_build_dynamic_prompt_context_merges_graph_artifacts_and_developer_overrides():

--- a/extraction/tests/test_semantic_pass_orchestrator.py
+++ b/extraction/tests/test_semantic_pass_orchestrator.py
@@ -1,4 +1,4 @@
-from semantic_pass_orchestrator import SemanticPassOrchestrator
+from ..semantic_pass_orchestrator import SemanticPassOrchestrator
 
 
 class _FakeExtractor:

--- a/extraction/tests/test_semantic_query_flow.py
+++ b/extraction/tests/test_semantic_query_flow.py
@@ -5,13 +5,13 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from semantic_query_flow import (
+from ..semantic_query_flow import (
     QueryRouterAgent,
     SemanticAgentFlow,
     SemanticEntityResolver,
 )
-from semantic_artifact_store import approve_semantic_artifact, save_semantic_artifact
-from semantic_run_store import get_semantic_run, list_semantic_runs
+from ..semantic_artifact_store import approve_semantic_artifact, save_semantic_artifact
+from ..semantic_run_store import get_semantic_run, list_semantic_runs
 
 
 class FakeConnector:

--- a/extraction/tests/test_semantic_run_store.py
+++ b/extraction/tests/test_semantic_run_store.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from semantic_run_store import get_semantic_run, list_semantic_runs, save_semantic_run
+from ..semantic_run_store import get_semantic_run, list_semantic_runs, save_semantic_run
 
 
 def test_semantic_run_store_roundtrip(tmp_path):

--- a/extraction/tests/test_semantic_vocabulary.py
+++ b/extraction/tests/test_semantic_vocabulary.py
@@ -4,8 +4,8 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from semantic_artifact_store import approve_semantic_artifact, save_semantic_artifact
-from semantic_vocabulary import ManagedVocabularyResolver
+from ..semantic_artifact_store import approve_semantic_artifact, save_semantic_artifact
+from ..semantic_vocabulary import ManagedVocabularyResolver
 
 
 def test_managed_vocabulary_resolver_uses_global_fallback(tmp_path):

--- a/extraction/tests/test_shared_memory.py
+++ b/extraction/tests/test_shared_memory.py
@@ -5,7 +5,7 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared_memory import SharedMemory, MAX_QUERY_CACHE_SIZE
+from ..shared_memory import SharedMemory, MAX_QUERY_CACHE_SIZE
 
 
 class TestSharedMemoryBasic:

--- a/extraction/tracing.py
+++ b/extraction/tracing.py
@@ -12,7 +12,7 @@ and simply disable Opik-specific instrumentation.
 import logging
 import inspect
 
-from config import (
+from .config import (
     OPIK_API_KEY,
     OPIK_ENABLED,
     OPIK_MODE,

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -1,24 +1,18 @@
 """Canonical runtime deployment shell package.
 
 This package is the long-term replacement for the historically overloaded
-``extraction/`` shell. During the staged migration, most runtime modules still
-depend on flat modules that live under ``extraction/``. Bootstrap the known
-legacy helper locations here so ``runtime.*`` modules can import those
-remaining helpers without requiring every downstream caller to mutate
-``sys.path`` first.
+``extraction/`` shell. Runtime modules still depend on modules that live under
+``extraction/``, and they now import them as ``extraction.<name>``.
+
+This module used to insert both the repository root and ``extraction/`` onto
+``sys.path`` so those helpers could be imported under bare top-level names.
+That is gone (seocho-60u). It made ``extraction/config.py`` load twice — once
+as ``config`` and once as ``extraction.config`` — which Python caches as two
+distinct module objects, producing two ``DatabaseRegistry`` classes and two
+``db_registry`` singletons. It also hid twenty-eight ``runtime`` →
+``extraction`` edges from every static tool, including the boundary checks that
+were supposed to police exactly this direction.
+
+Nothing replaced it: ``import runtime`` already requires the repository root on
+``sys.path``, which is the same condition ``import extraction`` needs.
 """
-
-from __future__ import annotations
-
-import sys
-from pathlib import Path
-
-
-_ROOT_DIR = Path(__file__).resolve().parent.parent
-
-for _helper_dir in (_ROOT_DIR, _ROOT_DIR / "extraction"):
-    if not _helper_dir.exists():
-        continue
-    _helper_dir_str = str(_helper_dir)
-    if _helper_dir_str not in sys.path:
-        sys.path.insert(0, _helper_dir_str)

--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -14,11 +14,11 @@ from pydantic import BaseModel, Field
 # OpenAI Agent SDK Imports (Local Shim)
 from agents import Agent, function_tool, RunContextWrapper
 
-from config import db_registry, graph_registry, validate_config
+from extraction.config import db_registry, graph_registry, validate_config
 from runtime.agent_readiness import summarize_readiness
-from agents_runtime import get_agents_runtime
-from shared_memory import SharedMemory
-from exceptions import (
+from extraction.agents_runtime import get_agents_runtime
+from extraction.shared_memory import SharedMemory
+from extraction.exceptions import (
     SeochoError,
     ConfigurationError,
     InfrastructureError,
@@ -29,7 +29,7 @@ from exceptions import (
 from runtime.middleware import RequestIDMiddleware, RequestMetricsMiddleware
 from runtime.identity import PrincipalMiddleware
 from seocho.metrics import enable_metrics, get_metrics
-from tracing import configure_opik, track, update_current_span, update_current_trace
+from extraction.tracing import configure_opik, track, update_current_span, update_current_trace
 from runtime.policy import require_runtime_permission
 from seocho.runtime_contract import (
     DATABASE_NAME_PATTERN,
@@ -38,7 +38,7 @@ from seocho.runtime_contract import (
     RuntimePath,
     WORKSPACE_ID_PATTERN,
 )
-from rule_api import (
+from extraction.rule_api import (
     RuleInferRequest,
     RuleInferResponse,
     RuleAssessRequest,
@@ -63,7 +63,7 @@ from rule_api import (
     validate_rule_profile,
 )
 from runtime.public_memory_api import build_public_memory_router
-from debate import DebateOrchestrator
+from extraction.debate import DebateOrchestrator
 from runtime.server_runtime import (
     ServerContext,
     batch_status_file_path,
@@ -84,7 +84,7 @@ from runtime.server_runtime import (
     invalidate_semantic_vocabulary_cache,
     utc_now_iso,
 )
-from semantic_artifact_api import (
+from extraction.semantic_artifact_api import (
     SemanticArtifactApproveRequest,
     SemanticArtifactDeprecateRequest,
     SemanticArtifactListResponse,
@@ -97,7 +97,7 @@ from semantic_artifact_api import (
     read_semantic_artifacts,
     resolve_approved_artifact_payload,
 )
-from ontology_control_plane_api import (
+from extraction.ontology_control_plane_api import (
     OntologyCompiledProfileResponse,
     OntologyProfileEvaluateRequest,
     OntologyProfileEvaluationResponse,
@@ -120,7 +120,7 @@ from ontology_control_plane_api import (
     select_ontology_profile_request,
     upsert_ontology_profile,
 )
-from semantic_run_store import get_semantic_run, list_semantic_runs
+from extraction.semantic_run_store import get_semantic_run, list_semantic_runs
 from seocho.query.query_proxy import QueryRequest as GraphQueryRequest
 
 logger = logging.getLogger(__name__)

--- a/runtime/memory_service.py
+++ b/runtime/memory_service.py
@@ -8,9 +8,9 @@ from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 from uuid import uuid4
 
-from config import db_registry, graph_registry
+from extraction.config import db_registry, graph_registry
 from runtime.runtime_ingest import RuntimeRawIngestor
-from semantic_query_flow import SemanticAgentFlow
+from extraction.semantic_query_flow import SemanticAgentFlow
 from seocho.ontology_context import (
     _clean_distinct_strings,
     assess_graph_ontology_context_status,

--- a/runtime/public_memory_api.py
+++ b/runtime/public_memory_api.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from config import graph_registry
+from extraction.config import graph_registry
 from runtime.middleware import get_request_id
 from runtime.policy import require_runtime_permission
 from seocho.runtime_contract import (

--- a/runtime/runtime_ingest.py
+++ b/runtime/runtime_ingest.py
@@ -17,10 +17,10 @@ import threading
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from config import graph_registry, load_pipeline_runtime_config
-from database_manager import DatabaseManager
-from exceptions import InvalidDatabaseNameError
-from raw_material_parser import MaterialParseError, parse_raw_material_record
+from extraction.config import graph_registry, load_pipeline_runtime_config
+from extraction.database_manager import DatabaseManager
+from extraction.exceptions import InvalidDatabaseNameError
+from extraction.raw_material_parser import MaterialParseError, parse_raw_material_record
 from seocho.index import CanonicalExtractionEngine
 from seocho.index.runtime_artifacts import (
     build_vocabulary_candidate,
@@ -106,7 +106,7 @@ class RuntimeRawIngestor:
         self._embedding_cache_lock = threading.Lock()
 
         try:
-            from semantic_pass_orchestrator import SemanticPassOrchestrator
+            from extraction.semantic_pass_orchestrator import SemanticPassOrchestrator
 
             cfg = load_pipeline_runtime_config()
             api_key = cfg.openai_api_key
@@ -136,7 +136,7 @@ class RuntimeRawIngestor:
             )
             if self._embedding_enabled:
                 from openai import OpenAI
-                from tracing import wrap_openai_client
+                from extraction.tracing import wrap_openai_client
 
                 self._embedding_client = wrap_openai_client(OpenAI(api_key=api_key))
             self._llm_stack_ready = True
@@ -177,7 +177,7 @@ class RuntimeRawIngestor:
         Raises:
             InvalidDatabaseNameError: If *target_database* fails name validation.
         """
-        from rule_constraints import RuleSet, apply_rules_to_graph, infer_rules_from_graph
+        from extraction.rule_constraints import RuleSet, apply_rules_to_graph, infer_rules_from_graph
 
         if not _DB_NAME_RE.match(target_database):
             raise InvalidDatabaseNameError(

--- a/runtime/server_runtime.py
+++ b/runtime/server_runtime.py
@@ -6,20 +6,20 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
-from agent_factory import AgentFactory as DebateAgentFactory
-from config import db_registry, graph_registry
-from database_manager import DatabaseManager
-from fulltext_index import FulltextIndexManager
-from graph_connector import MultiGraphConnector
+from extraction.agent_factory import AgentFactory as DebateAgentFactory
+from extraction.config import db_registry, graph_registry
+from extraction.database_manager import DatabaseManager
+from extraction.fulltext_index import FulltextIndexManager
+from extraction.graph_connector import MultiGraphConnector
 from runtime.memory_service import GraphMemoryService
-from platform_agents import (
+from extraction.platform_agents import (
     BackendSpecialistAgent,
     FrontendSpecialistAgent,
     PlatformSessionStore,
 )
 from runtime.runtime_ingest import RuntimeRawIngestor
-from semantic_query_flow import SemanticAgentFlow
-from shared_memory import SharedMemory
+from extraction.semantic_query_flow import SemanticAgentFlow
+from extraction.shared_memory import SharedMemory
 from seocho.query.agent_factory import (
     AgentConfig as SemanticFlowAgentConfig,
     AgentFactory as SemanticFlowAgentFactory,
@@ -111,7 +111,7 @@ def get_semantic_flow_factory_service() -> SemanticFlowAgentFactory:
 def get_vector_store_service():
     global _vector_store
     if _vector_store is None:
-        from vector_store import VectorStore
+        from extraction.vector_store import VectorStore
 
         _vector_store = VectorStore(api_key=os.getenv("OPENAI_API_KEY", ""))
     return _vector_store

--- a/scripts/ci/check-import-boundaries.py
+++ b/scripts/ci/check-import-boundaries.py
@@ -46,11 +46,14 @@ from typing import Dict, Iterator, List, NamedTuple, Set, Tuple
 
 ROOT = Path(__file__).resolve().parents[2]
 
-# Bare-name imports that resolve into extraction/ because runtime/__init__.py
-# injects that directory onto sys.path. Tracked as a ratchet, not a hard zero:
-# removing them is seocho-60u, ~173 statements across ~69 files, and it must be
-# one reviewable change rather than a drip. This number may fall, never rise.
-FLAT_EXTRACTION_IMPORT_BUDGET = 95  # measured 2026-08-16: 66 in extraction/, 29 in runtime/
+# Bare-name imports that resolve into extraction/ because that directory used to
+# be injected onto sys.path. seocho-60u removed the injection and rewrote all
+# 176 statements, so this is now a hard zero: extraction/ is a package and the
+# bare names do not resolve at all. The ratchet is kept rather than deleted
+# because it is what caught the regression risk in the first place -- and it
+# fires in both directions, so a reintroduced flat import fails here rather
+# than silently reviving the duplicate-module defect.
+FLAT_EXTRACTION_IMPORT_BUDGET = 0
 
 # Violations that exist today and are owned by a ticket. Each entry is
 # (path, imported_module, ticket). An allowlisted violation still has to be a

--- a/scripts/ci/check-runtime-shell-contract.sh
+++ b/scripts/ci/check-runtime-shell-contract.sh
@@ -82,7 +82,11 @@ check_present "_alias_runtime_module(__name__, \"runtime.runtime_ingest\")" \
   extraction/runtime_ingest.py
 check_present "_alias_runtime_module(__name__, \"runtime.server_runtime\")" \
   extraction/server_runtime.py
-check_present "cwd=os.path.join(ROOT_DIR, \"extraction\")" \
+# extraction/ is a package (seocho-60u); the flat-name alias it used to pin is
+# gone, and the test now asserts the bare name does NOT resolve. Structural
+# enforcement lives in scripts/ci/check-import-boundaries.py, which parses
+# rather than greps.
+check_present "def test_extraction_modules_do_not_resolve_under_a_bare_flat_name" \
   extraction/tests/test_runtime_package_aliases.py
 check_present "import runtime.agent_readiness as runtime_agent_readiness" \
   extraction/tests/test_runtime_package_aliases.py

--- a/scripts/ontology/build_ontology_hints.py
+++ b/scripts/ontology/build_ontology_hints.py
@@ -19,7 +19,7 @@ from typing import Dict, Iterable, List, Sequence
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "extraction"))
 
-from ontology_hints_builder import build_hints_from_records, keyword_tokens  # noqa: E402
+from extraction.ontology_hints_builder import build_hints_from_records, keyword_tokens  # noqa: E402
 
 
 ANNOTATION_FIELDS = (

--- a/scripts/rules/shacl_practical_demo.py
+++ b/scripts/rules/shacl_practical_demo.py
@@ -20,7 +20,7 @@ from typing import Any, Dict
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "extraction"))
 
-from rule_api import RuleAssessRequest, RuleInferRequest, assess_rule_profile, infer_rule_profile
+from extraction.rule_api import RuleAssessRequest, RuleInferRequest, assess_rule_profile, infer_rule_profile
 
 logger = logging.getLogger("shacl_practical_demo")
 


### PR DESCRIPTION
Depends on #519 (the boundary checker), which lands the ratchet this PR drives to zero.

## The defect, reproduced

`extraction/` had no `__init__.py`, and `runtime/__init__.py` inserted both the repo root and `extraction/` onto `sys.path`. Every module answered to two names, and Python caches each spelling separately:

```
import runtime; import config as flat; import extraction.config as pkg
flat.__file__ == pkg.__file__                    -> True
flat is pkg                                      -> False
flat.db_registry is pkg.db_registry              -> False
flat.DatabaseRegistry is pkg.DatabaseRegistry    -> False
```

**Two `DatabaseRegistry` classes and two `db_registry` singletons.** Both spellings were in tracked code — 15 files used the flat form, `examples/mdm/*.py` used `extraction.config` — so any process touching both got two connection registries and cross-registry `isinstance` failures.

## The change

`extraction/__init__.py`, plus **176 flat imports rewritten across 71 files** (144 inside `extraction/` → relative, 32 elsewhere → `extraction.<name>`), and the `sys.path` block deleted. A repo-wide AST sweep now finds **zero** flat imports, and the bare name no longer resolves at all — the duplicate load is structurally impossible rather than merely avoided.

## The estimate was wrong about one thing, and it matters

The review called this "mechanical, no logic changes." It is not. **The container flattens `extraction/` into `/app`** (`COPY extraction/ /app/`) and boots `uvicorn agent_server:app` + `python main.py` — both depend on the flat layout that is being removed. Without the coupled change this would have built fine and failed at runtime.

So: `COPY extraction/ /app/extraction/`, and the entrypoint now uses `extraction.agent_server` and `python -m extraction.main`.

**Docker is unavailable in this environment.** The container was verified by reproducing its layout on disk (`/app/{extraction,runtime,seocho}`) and importing every entrypoint target from that root — `extraction.agent_server`, `extraction.main`, `extraction.config`, `runtime.server_runtime` all resolve and import. **The image build itself was not run** and should be before merge.

## Test-isolation defects the fix surfaced

Two are fixed here. `test_graph_connector` mutated the **shared** `graph_registry` singleton's method, and patched **neo4j's `GraphDatabase` class globally**; both now rebind the module attribute, which never touches shared state. `test_graph_loader` patched `"graph_loader.GraphDatabase"` by flat string — invisible to any AST sweep — and now targets `extraction.graph_loader`.

The old flat-alias test is **inverted rather than deleted**. It asserted `import policy` *was* `runtime.policy`; that alias was the symptom, not a feature. It now asserts the bare name does not resolve, plus that two imports of `extraction.config` yield one object with one `db_registry`.

`check-runtime-shell-contract.sh` pinned the exact line this PR deletes and had to be updated — a live illustration of why #519 replaced that style of assertion with a parser.

## Validation

`bash scripts/ci/run_basic_ci.sh` → **766 passed, 3 skipped**. `git diff --check` clean.

### Known failure — please read before merging

Two live-Neo4j tests in `test_integration_runtime_flow.py` pass alone but fail after `test_graph_connector`, with `Neo.ClientError.Security.Unauthorized`. Ticketed as **`seocho-6s9`**.

Measured rather than assumed: origin/main's full `extraction/tests` suite fails **9**; this branch fails **11**; the delta is isolated to exactly those two. They are **not** in `run_basic_ci.sh`'s list.

They were green before because the two module copies held *different* registries, so a patch applied through one never reached the other. Removing the duplication made a pre-existing leak observable. The two isolation fixes above were necessary and not sufficient; the residual vector is unidentified and I did not want to guess at it inside this PR.

## Follow-ups

`seocho-6s9` (the exposed leak), `seocho-4j2` (the one remaining reverse edge, `extraction/rule_api.py` → `runtime.ontology_registry`).
