### PR TITLE
feat(guardrail): actionable rejection messages — how to fix, not just what failed

### DIFF
--- a/src/seocho/integrations/openai_agents.py
+++ b/src/seocho/integrations/openai_agents.py
@@ -37,7 +37,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +137,48 @@ class GuardrailLedger:
         }
 
 
+# Each deterministic violation gets a concrete repair instruction. A raw token
+# list ("result_limit_exceeded, missing_workspace_scope_expression") tells the
+# model WHAT failed but not HOW to fix it — the measured failure mode (ADR-0169)
+# was a model flailing for 6 turns rewriting the *query* when the fix was a
+# *params_json* field. The hint names the exact edit; ``{k}`` slots take the
+# violation payload (e.g. the offending label) or the policy's row cap.
+_VIOLATION_HINTS: Dict[str, str] = {
+    "forbidden_token": "remove write/DDL/procedure keywords — this is a "
+                       "read-only path ({k} is not allowed)",
+    "missing_return_clause": "add a RETURN clause",
+    "missing_parameterized_limit": "end the query with `LIMIT $limit` — the "
+                                   "literal token $limit, not a number",
+    "missing_parameter": "reference the parameter ${k} in the Cypher",
+    "missing_parameter_value": "{k} is supplied by the layer; do not set it "
+                               "yourself, but keep the reference in the query",
+    "unbounded_graph_path": "bound variable-length paths, e.g. [:REL*1..3]",
+    "graph_hop_limit_exceeded": "shorten the path — it exceeds the max hop limit",
+    "unknown_labels": "use only labels from the schema; {k} is not declared",
+    "unknown_relationships": "use only relationship types from the schema; "
+                             "{k} is not declared",
+    "unknown_properties": "use only properties from the schema; {k} is not "
+                          "declared",
+    "missing_workspace_scope_expression":
+        "scope every matched node inline: (n:Label {{_workspace_id: "
+        "$workspace_id}}) — a WHERE clause does not satisfy this check",
+    "result_limit_exceeded":
+        "set a `limit` value in params_json between 1 and {max_rows} "
+        "(e.g. {{\"limit\": 1}}) — `limit` is a params_json field, NOT written "
+        "in the Cypher; the query keeps `LIMIT $limit`",
+}
+
+
+def _actionable_reason(violation: str, *, max_rows: int) -> str:
+    """Turn a `kind:payload` violation into `kind — how to fix it`."""
+    kind, _, payload = str(violation).partition(":")
+    hint = _VIOLATION_HINTS.get(kind)
+    if not hint:
+        return violation
+    text = hint.format(k=payload or kind, max_rows=max_rows)
+    return f"{kind} — {text}"
+
+
 def make_ontology_guardrail(ontology: Any, *, ledger: Optional[GuardrailLedger] = None,
                             cypher_arg: str = "cypher"):
     """A tool-input guardrail that enforces the ontology on generated Cypher.
@@ -181,11 +223,16 @@ def make_ontology_guardrail(ontology: Any, *, ledger: Optional[GuardrailLedger] 
         violations = validate_text2cypher_fallback(cypher, params=params, policy=policy)
         ledger.record(violations)
         if violations:
+            max_rows = getattr(policy, "max_result_rows", 50)
+            reasons = "; ".join(
+                _actionable_reason(v, max_rows=max_rows) for v in violations)
+            # Actionable rejection: each violation carries HOW to fix it, so the
+            # repair loop converges in one turn instead of the model rewriting
+            # the query blindly (ADR-0169). The ledger keeps the raw kinds for
+            # the status tally.
             return ToolGuardrailFunctionOutput.reject_content(
-                "the query violates the graph schema and was not executed: "
-                + ", ".join(violations)
-                + ". Re-emit it using only the declared labels, relationship types and "
-                  "parameters.")
+                "the query was not executed — it violates the graph contract. "
+                "Fix each item and re-emit:\n- " + reasons.replace("; ", "\n- "))
         return ToolGuardrailFunctionOutput.allow()
 
     ontology_guardrail.ledger = ledger  # type: ignore[attr-defined]

--- a/tests/seocho/test_guardrail_actionable.py
+++ b/tests/seocho/test_guardrail_actionable.py
@@ -1,0 +1,53 @@
+"""Actionable guardrail rejections (ADR-0169 follow-up, seocho-6md).
+
+A rejection must tell the model HOW to fix the query, not just WHAT failed.
+The measured failure (ADR-0169) was a model flailing 6 turns rewriting the
+*query* when the fix was a *params_json* field it never saw named.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("agents", reason="openai-agents SDK not installed")
+
+from seocho.integrations.openai_agents import (  # noqa: E402
+    _VIOLATION_HINTS, _actionable_reason)
+
+
+def test_result_limit_hint_points_at_params_json():
+    """The flail's root cause: the fix is a params_json field, named explicitly."""
+    msg = _actionable_reason("result_limit_exceeded", max_rows=50)
+    assert "params_json" in msg
+    assert "limit" in msg
+    assert "50" in msg                       # the actual cap, not a placeholder
+
+
+def test_workspace_scope_hint_shows_the_inline_form():
+    msg = _actionable_reason("missing_workspace_scope_expression", max_rows=50)
+    assert "{_workspace_id: $workspace_id}" in msg
+    assert "WHERE" in msg                     # states the WHERE form does NOT satisfy it
+
+
+def test_payload_is_interpolated():
+    assert "Widget" in _actionable_reason("unknown_labels:Widget", max_rows=50)
+    assert "OWNS" in _actionable_reason("unknown_relationships:OWNS", max_rows=50)
+
+
+def test_unknown_violation_kind_falls_through_unchanged():
+    assert _actionable_reason("some_new_token:x", max_rows=50) == "some_new_token:x"
+
+
+@pytest.mark.parametrize("kind", [
+    "forbidden_token", "missing_return_clause", "missing_parameterized_limit",
+    "missing_parameter", "missing_parameter_value", "unbounded_graph_path",
+    "graph_hop_limit_exceeded", "unknown_labels", "unknown_relationships",
+    "unknown_properties", "missing_workspace_scope_expression",
+    "result_limit_exceeded",
+])
+def test_every_validator_violation_kind_has_a_hint(kind):
+    """Coverage: every deterministic violation the validator can emit maps to a
+    concrete instruction, so no rejection is left opaque."""
+    assert kind in _VIOLATION_HINTS
+    msg = _actionable_reason(kind, max_rows=50)
+    assert msg != kind and "—" in msg        # kind + a how-to-fix clause


### PR DESCRIPTION
The important follow-up to ADR-0169. The killer experiment caught a model **flailing 6 turns** rewriting the *query* (WITH LIMIT, CALL subquery, DISTINCT…) when the actual fix was a **params_json field** the opaque violation token never named — `result_limit_exceeded` fired only because `limit` defaulted to 0, but the message said nothing about params.

## Change
Every deterministic violation now maps to a concrete repair instruction (`_VIOLATION_HINTS`); the `tool_input_guardrail` rejection lists **"kind — how to fix"** per item instead of a raw token list.

- `result_limit_exceeded` → "set a `limit` value in params_json between 1 and 50 (e.g. {"limit": 1}) — `limit` is a params_json field, NOT written in the Cypher"
- `missing_workspace_scope_expression` → "scope every matched node inline: (n:Label {_workspace_id: $workspace_id}) — a WHERE clause does not satisfy this check"
- `unknown_labels:Widget` → "use only labels from the schema; Widget is not declared" (payload interpolated), etc.

## Safety / back-compat
- **Validator tokens unchanged** — okx + semantic-query tests that assert `result_limit_exceeded` / `missing_parameterized_limit` still pass.
- The **GuardrailLedger status** (allowed/rejected/by_reason/summary) is untouched — it already carries rejection reasons as the "improve-loop" status the model-drift tally reads.
- 30 tests pass incl. per-kind hint coverage (every violation the validator can emit has a hint). `run_basic_ci.sh` green.

## Follow-ups (added to seocho-6md)
- aggregate over-strictness: `count()` returns one row and needs no row budget, yet the policy requires `LIMIT $limit` — relax for pure-aggregate returns.
- KV prefill reuse across the repair-loop turns (seocho-40j).

🤖 Generated with [Claude Code](https://claude.com/claude-code)