### PR TITLE
feat(os): governed agent ships worked examples, not just a schema (ADR-0169)

### DIFF
--- a/src/seocho/operating_layer.py
+++ b/src/seocho/operating_layer.py
@@ -532,6 +532,42 @@ class SeochoOS:
             make_ontology_guardrail(self.ontology)]
         return graph_query
 
+    def _worked_examples(self, policy: Any) -> str:
+        """Two worked, contract-conformant examples derived from THIS ontology.
+
+        ADR-0169: describing the contract (the schema block) is not enough —
+        a strong model reaches only ~66% conformance, a weak one ~16%; showing
+        the exact conformant form takes both to 100% and removes the guardrail
+        repair loop. So the governed agent ships examples, not just a schema.
+        The form is the one the guardrail actually accepts: inline-map scope
+        `{<ws>: $workspace_id}`, `LIMIT $limit`, and workspace_id + limit passed
+        in params_json (the layer overwrites workspace_id — the value shown is a
+        placeholder the pin makes safe).
+        """
+        ws = getattr(policy, "workspace_property", "_workspace_id")
+        labels = list(getattr(self.ontology, "nodes", {}).keys())
+        rels = getattr(self.ontology, "relationships", {}) or {}
+        pj = f'{{"workspace_id": "{self.workspace_id}", "limit": 1}}'
+        lines = ["\n\nWorked examples — copy this exact form (the tool rejects "
+                 "anything off-contract):"]
+        if labels:
+            lines.append(
+                f"- Count a label:\n"
+                f"  MATCH (n:{labels[0]} {{{ws}: $workspace_id}}) "
+                f"RETURN count(n) AS v LIMIT $limit\n"
+                f"  params_json: {pj}")
+        for _rt, rd in rels.items():
+            src = getattr(rd, "source", None)
+            tgt = getattr(rd, "target", None)
+            if src and tgt:
+                lines.append(
+                    f"- Traverse a relationship (distinct):\n"
+                    f"  MATCH (a:{src} {{{ws}: $workspace_id}})-[:{_rt}]->"
+                    f"(:{tgt}) RETURN count(DISTINCT a) AS v LIMIT $limit\n"
+                    f"  params_json: {pj}")
+                break
+        return "\n".join(lines)
+
     def build_agent(self, session: OSSession, *,
                     name: str = "seocho_agent",
                     model: Optional[Any] = None,
@@ -539,8 +575,9 @@ class SeochoOS:
         """An openai-agents Agent whose only graph access is this layer.
 
         Instructions carry the same schema block the deterministic planner
-        uses (one rulebook), plus the truncation-honesty rule the FinBench
-        disclosure study motivated.
+        uses (one rulebook), the truncation-honesty rule the FinBench
+        disclosure study motivated, and — since ADR-0169 — worked examples of
+        the exact conformant query form (describing the contract is not enough).
         """
         import json as _json
 
@@ -550,17 +587,21 @@ class SeochoOS:
 
         policy = policy_from_ontology(self.ontology)
         schema = schema_for_prompt(self.ontology, policy)
+        ws = getattr(policy, "workspace_property", "_workspace_id")
         instructions = (
             "You are an analyst querying a graph database with Cypher.\n\n"
             "Schema (use only these labels, relationship types and parameters):\n"
             + _json.dumps(schema, indent=2, default=str)
             + "\n\nRules:\n"
-            "- Every matched node must carry the tenant scope shown in the schema.\n"
-            "- Include a LIMIT; the tool caps rows regardless.\n"
+            f"- Scope every matched node inline: (n:Label {{{ws}: $workspace_id}}) "
+            "— a WHERE clause does not satisfy the check.\n"
+            "- End the query with `LIMIT $limit`, and pass both `workspace_id` "
+            "and `limit` in params_json.\n"
             "- If the tool reports `truncated: true`, say so instead of presenting "
             "a partial result as complete.\n"
             "- If the schema cannot express the question, say what is missing "
-            "instead of inventing labels.")
+            "instead of inventing labels."
+            + self._worked_examples(policy))
         tools = [self.make_graph_tool(session), *extra_tools]
         agent_kwargs: Dict[str, Any] = {"name": name,
                                         "instructions": instructions,

--- a/tests/seocho/test_operating_layer.py
+++ b/tests/seocho/test_operating_layer.py
@@ -414,3 +414,30 @@ def test_session_agent_and_stats_on_one_object(named_ontology):
     stats = sess.os_stats()
     assert stats["workspace_id"] == "acme" and stats["priority"] == "high"
     assert stats["budget"] == 1000
+
+
+def test_build_agent_ships_conformant_worked_examples(named_ontology):
+    """ADR-0169: the governed agent must SHOW the exact conformant form, not
+    just describe the schema — and the shown examples must pass the guardrail."""
+    import re
+
+    from seocho.operating_layer import SeochoOS
+    from seocho.query.hybrid_planner import policy_from_ontology
+    from seocho.query.workload_compiler import validate_text2cypher_fallback
+
+    store = RecordingStore()
+    os_layer = SeochoOS(ontology=named_ontology, graph_store=store,
+                        database="testdb", workspace_id="acme")
+    agent = os_layer.build_agent(os_layer.session("s"), name="t")
+    instr = agent.instructions
+    assert "Worked examples" in instr
+    assert "{_workspace_id: $workspace_id}" in instr      # the inline-map form
+    assert "params_json" in instr and "\"limit\": 1" in instr
+    # every worked-example Cypher must actually pass the guardrail validator
+    policy = policy_from_ontology(named_ontology)
+    examples = re.findall(r"(MATCH .+?LIMIT \$limit)", instr)
+    assert examples, "no worked-example queries found in instructions"
+    for cypher in examples:
+        violations = validate_text2cypher_fallback(
+            cypher, params={"workspace_id": "acme", "limit": 1}, policy=policy)
+        assert not violations, f"shipped example is non-conformant: {violations}"


### PR DESCRIPTION
Applies the killer result (ADR-0169) to the product: **the governed agent now SHOWS the exact conformant form, not just describes the schema.**

ADR-0169 measured conformance as an ICL dose-response — describing the contract leaves gpt-oss at 66% / gemma at 16% (driving the guardrail repair loop); worked examples take both to **100%**. So `os.build_agent` appends two examples derived from *this* ontology (first label + first relationship) in the form the guardrail accepts:
```
MATCH (n:<Label> {_workspace_id: $workspace_id}) RETURN count(n) AS v LIMIT $limit
  params_json: {"workspace_id": "<ws>", "limit": 1}
```
inline-map scope, `LIMIT $limit`, and workspace_id+limit in params_json (the layer overwrites workspace_id — the shown value is a pin-safe placeholder). The Rules are tightened to match (inline scope, not WHERE; pass both params) and align with the actionable rejection hints (#523).

Test asserts the shipped examples are present AND pass the guardrail validator (a non-conformant example would teach drift). 21 OS tests + basic CI green.

Together with #523 (actionable rejections), this attacks the repair loop from both ends: examples → first-try conformance; and when a retry does happen, the message says how to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)