### PR TITLE
feat(client): group the facade into namespaces, generate the async surface (ADR-0171)

### DIFF
--- a/docs/decisions/ADR-0171-client-namespaces.md
+++ b/docs/decisions/ADR-0171-client-namespaces.md
@@ -1,0 +1,94 @@
+# ADR-0171: Grouped namespaces on the client facade
+
+- Status: Accepted
+- Date: 2026-08-16
+- Ticket: `seocho-6yf`
+- Related: `ADR-0170` (ontology subpackage), `docs/SDK_CONTRACT.md`
+
+## Context
+
+`Seocho` carries 80 public methods on one object. Grouped by what they do:
+
+| count | group |
+|---|---|
+| 24 | ontology governance |
+| **23** | **no category at all** |
+| 9 | read / query |
+| 8 | lifecycle / platform |
+| 8 | agents |
+| 8 | write / index |
+
+The 23-method bucket is the diagnosis, not a classification failure. It holds
+`advanced`, `get`, `execute`, `react`, `router`, `semantic`, `extract`, `chat`,
+`delete`, `migrate`, `qualify_graph`, `project_canonical_graph` and eleven more.
+Those are accretion, not a vocabulary: a caller cannot predict the method name
+from the task, and `coverage_stats` / `qualify_graph` read as generic graph
+operations while being ontology governance.
+
+`AsyncSeocho` had 56 methods to `Seocho`'s 80 — 55 shared, and **25 sync methods
+with no async counterpart and no declared reason**: `index_file`,
+`index_directory`, `reindex`, `plan`, `agent`, `build_agent`, `session`,
+`execute_query`, `close` and more. That is a correctness liability, since 55
+pairs were kept behaviourally identical by hand.
+
+## Decision
+
+Add four grouped views — `index`, `governance`, `platform`, `sessions` —
+covering 54 of the 80 methods, and generate the async surface from the sync one.
+
+## Additive, and not yet deprecating
+
+Every flat method still exists, unchanged and un-warned. A deprecation pass
+belongs *after* these names have been reviewed: emitting warnings that push
+users onto names still under discussion is worse than the flat list they
+already know.
+
+## Three things the implementation was forced into, each an improvement
+
+**`governance`, not `ontology`.** The first attempt used `sc.ontology` and
+failed at construction — `self.ontology` is already the registered `Ontology`
+object (`client.py:286`). The collision produced a better split than the one
+planned: the noun stays the thing, the namespace is what you do to it.
+
+**`query` and `agents` are excluded.** Both are existing public method names, so
+a namespace of the same name must shadow a callable and carry dual
+call/attribute semantics. The package already does that for `seocho.agents` at
+module level, so it is possible — but it is a behavioural change to a public
+method rather than an addition, and it needs its own deprecation cycle.
+
+**Namespaces resolve through the owner on every access, never caching bound
+methods.** A cache would keep serving the pre-patch callable after
+`monkeypatch.setattr` or a runtime-applied decorator — the same failure mode
+that made `ADR-0170` use `sys.modules` aliases instead of forwarding shims. The
+namespaces bind to whichever facade owns them, so the same four classes yield
+coroutines on `AsyncSeocho` with no second mapping table.
+
+## The async surface is generated
+
+`_fill_async_surface()` walks `Seocho` and adds a `to_thread` delegate for every
+public method `AsyncSeocho` has not defined itself. Hand-written coroutines keep
+winning, so anything needing real async behaviour rather than thread offload is
+unaffected.
+
+Deliberately skipped, and asserted as such: constructors (`local`, `remote`,
+`from_*`) build a `Seocho`, and an async factory returning a sync client would
+misdescribe the object; `close` must not offload teardown to a worker thread
+while the loop may still hold references; properties read state, so awaiting one
+would make a field look like an operation.
+
+The gap is now pinned by a test comparing the two surfaces, so it cannot reopen.
+
+## Consequences
+
+- 54 of 80 methods have a predictable prefix; 26 remain flat, of which
+  `query`/`agents` are deliberate and the rest are the read/agent groups that
+  need the callable-namespace decision first.
+- `AsyncSeocho` covers the sync surface minus seven documented exclusions.
+- Zero public API removed. `pip install seocho` users see additions only.
+
+## Follow-ups
+
+- Deprecation pass on the flat aliases once the names settle.
+- The callable-namespace decision for `query` and `agents`.
+- `client.py` is still 3,688 lines; `ADR-0170`'s follow-up to split `client_*`
+  into mixins is unaffected by this change and still open.

--- a/docs/decisions/ADR-0174-client-namespaces.md
+++ b/docs/decisions/ADR-0174-client-namespaces.md
@@ -1,9 +1,9 @@
-# ADR-0171: Grouped namespaces on the client facade
+# ADR-0174: Grouped namespaces on the client facade
 
 - Status: Accepted
 - Date: 2026-08-16
 - Ticket: `seocho-6yf`
-- Related: `ADR-0170` (ontology subpackage), `docs/SDK_CONTRACT.md`
+- Related: `ADR-0173` (ontology subpackage), `docs/SDK_CONTRACT.md`
 
 ## Context
 
@@ -59,7 +59,7 @@ method rather than an addition, and it needs its own deprecation cycle.
 **Namespaces resolve through the owner on every access, never caching bound
 methods.** A cache would keep serving the pre-patch callable after
 `monkeypatch.setattr` or a runtime-applied decorator — the same failure mode
-that made `ADR-0170` use `sys.modules` aliases instead of forwarding shims. The
+that made `ADR-0173` use `sys.modules` aliases instead of forwarding shims. The
 namespaces bind to whichever facade owns them, so the same four classes yield
 coroutines on `AsyncSeocho` with no second mapping table.
 
@@ -90,5 +90,5 @@ The gap is now pinned by a test comparing the two surfaces, so it cannot reopen.
 
 - Deprecation pass on the flat aliases once the names settle.
 - The callable-namespace decision for `query` and `agents`.
-- `client.py` is still 3,688 lines; `ADR-0170`'s follow-up to split `client_*`
+- `client.py` is still 3,688 lines; `ADR-0173`'s follow-up to split `client_*`
   into mixins is unaffected by this change and still open.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1063,3 +1063,7 @@ Use this block for new entries:
   modules (7,872 LOC) become `src/seocho/ontology/`; lazy `__init__` because the
   core/serialization cycles predate the move, `sys.modules` aliases so
   `monkeypatch` still reaches the canonical module; zero public API change
+- [Accepted] ADR-0174 client-namespaces (seocho-6yf) — `sc.index` / `sc.governance`
+  / `sc.platform` / `sc.sessions` group 54 of 80 facade methods; `AsyncSeocho`'s
+  25 missing methods are generated rather than hand-written; additive, nothing
+  deprecated yet

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -113,6 +113,7 @@ uv run pytest \
   tests/seocho/test_import_boundaries.py \
   tests/seocho/test_ontology_package_surface.py \
   tests/seocho/test_package_completeness.py \
+  tests/seocho/test_client_namespaces.py \
   -q
 
 git diff --check

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -66,6 +66,12 @@ def _warn_deprecated_factory(name: str, migration_hint: str) -> None:
 # them off the module-top preserves the lazy-import contract verified by
 # tests/test_import_surface.py — accessing `seocho.Seocho` (the class
 # object) must NOT eagerly load the storage backends.
+from .client_namespaces import (
+    IndexNamespace,
+    OntologyNamespace,
+    PlatformNamespace,
+    SessionNamespace,
+)
 from .client_artifacts import (
     approved_artifacts_from_ontology as build_approved_artifacts_from_ontology,
 )
@@ -371,6 +377,38 @@ class Seocho:
 
     # ------------------------------------------------------------------
     # Convenience factories — shorten the 0→hello-world distance
+    # ------------------------------------------------------------------
+    # Grouped views (seocho-6yf). Additive: every flat method below still
+    # exists and is not deprecated. See client_namespaces.py for why `query`
+    # and `agents` are deliberately excluded.
+    # ------------------------------------------------------------------
+
+    @property
+    def index(self) -> "IndexNamespace":
+        """Writing into the graph — `sc.index.file(...)`, `sc.index.directory(...)`."""
+        return IndexNamespace(self)
+
+    @property
+    def governance(self) -> "OntologyNamespace":
+        """Operations ON the ontology — artifacts, profiles, signals, curation.
+
+        Named `governance` rather than `ontology` because `self.ontology` is
+        already the registered `Ontology` object. The collision forced a better
+        split than the one originally planned: the noun stays the thing, the
+        namespace is what you do to it.
+        """
+        return OntologyNamespace(self)
+
+    @property
+    def platform(self) -> "PlatformNamespace":
+        """Deployment-shell surface — what exists, health, teardown."""
+        return PlatformNamespace(self)
+
+    @property
+    def sessions(self) -> "SessionNamespace":
+        """Platform session state — history, reset, chat."""
+        return SessionNamespace(self)
+
     # ------------------------------------------------------------------
 
     @classmethod
@@ -3304,11 +3342,52 @@ class ExecutionPlanBuilder:
 
 
 class AsyncSeocho:
-    """Async wrapper around the sync client for notebook and app usage."""
+    """Async wrapper around the sync client for notebook and app usage.
+
+    Methods written out below are hand-authored. Everything else on
+    :class:`Seocho` is generated at class creation as a `to_thread` delegate by
+    :func:`_fill_async_surface`, so the two surfaces cannot drift.
+
+    Before that generator this class had 56 methods to `Seocho`'s 80, and the
+    25 absent ones — `index_file`, `index_directory`, `reindex`, `plan`,
+    `agent`, `build_agent`, `session`, `execute_query`, `close`, … — had no
+    declared reason for being absent. 55 pairs were kept identical by hand
+    (`seocho-6yf`).
+    """
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the async client. Accepts the same arguments as :class:`Seocho`."""
         self._client = Seocho(**kwargs)
+
+    # The same grouped views as the sync client. `_Namespace` resolves through
+    # `getattr(owner, ...)`, so binding to the async client yields the async
+    # delegates -- `await sc.index.file(...)` -- with no second mapping table.
+
+    @property
+    def index(self) -> "IndexNamespace":
+        """Writing into the graph. Members are coroutines."""
+        return IndexNamespace(self)
+
+    @property
+    def governance(self) -> "OntologyNamespace":
+        """Operations ON the ontology — artifacts, profiles, signals, curation.
+
+        Named `governance` rather than `ontology` because `self.ontology` is
+        already the registered `Ontology` object. The collision forced a better
+        split than the one originally planned: the noun stays the thing, the
+        namespace is what you do to it.
+        """
+        return OntologyNamespace(self)
+
+    @property
+    def platform(self) -> "PlatformNamespace":
+        """Deployment-shell surface."""
+        return PlatformNamespace(self)
+
+    @property
+    def sessions(self) -> "SessionNamespace":
+        """Platform session state."""
+        return SessionNamespace(self)
 
     async def add(self, content: str, **kwargs: Any) -> Memory:
         """Async version of :meth:`Seocho.add`."""
@@ -3686,3 +3765,62 @@ def __getattr__(name: str):  # noqa: D401  (module-level dunder)
         globals()["RuntimeBundleClientHelper"] = _RBCH
         return _RBCH
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ----------------------------------------------------------------------
+# Async surface completion (seocho-6yf)
+# ----------------------------------------------------------------------
+
+
+def _fill_async_surface() -> None:
+    """Give `AsyncSeocho` a `to_thread` delegate for every un-overridden method.
+
+    Only fills gaps: a name already defined on `AsyncSeocho` is left alone, so
+    the hand-written coroutines above — and any that genuinely need different
+    async behaviour rather than thread offload — keep winning.
+
+    Deliberately skipped:
+
+    * constructors (`local`, `remote`, `from_*`) — they build a `Seocho`, and an
+      async factory returning a sync client would be a lie about the object.
+    * `close` — offloading teardown to a worker thread while the event loop may
+      still hold references is worse than an explicit sync call.
+    * properties — `last_query_metadata` reads state, so awaiting it would make
+      a field look like an operation.
+    """
+    import functools
+    import inspect
+
+    skip = {
+        "local", "remote", "from_agent_design", "from_indexing_design",
+        "from_runtime_bundle", "close",
+    }
+
+    def _delegate(method_name: str):
+        sync_method = getattr(Seocho, method_name)
+
+        @functools.wraps(sync_method)
+        async def _async(self: "AsyncSeocho", *args: Any, **kwargs: Any) -> Any:
+            return await asyncio.to_thread(
+                getattr(self._client, method_name), *args, **kwargs
+            )
+
+        _async.__doc__ = (
+            f"Async version of :meth:`Seocho.{method_name}` "
+            f"(generated `to_thread` delegate)."
+        )
+        return _async
+
+    for name, attr in vars(Seocho).items():
+        if name.startswith("_") or name in skip:
+            continue
+        if name in vars(AsyncSeocho):
+            continue
+        if isinstance(attr, (property, classmethod, staticmethod)):
+            continue
+        if not inspect.isfunction(attr):
+            continue
+        setattr(AsyncSeocho, name, _delegate(name))
+
+
+_fill_async_surface()

--- a/src/seocho/client_namespaces.py
+++ b/src/seocho/client_namespaces.py
@@ -1,0 +1,175 @@
+"""Grouped views over the `Seocho` facade.
+
+`Seocho` carries 80 public methods. Grouped by what they actually do, 24 are
+ontology governance, 8 write, 8 agents, 8 platform lifecycle, 9 read — and 23
+fall into no category at all (`advanced`, `get`, `execute`, `react`, `router`,
+`semantic`, `extract`, …). That last bucket is the diagnosis rather than a
+classification failure: the names are accretion, not a vocabulary, so a caller
+cannot predict the method from the task (`seocho-6yf`).
+
+These namespaces give the largest coherent groups a predictable prefix:
+
+    sc.index.file("a.pdf")          instead of  sc.index_file("a.pdf")
+    sc.governance.score()           instead of  sc.coverage_stats()
+    sc.platform.graphs()            instead of  sc.graphs()
+
+Additive on purpose. Every existing method still exists, unchanged and
+un-warned. A deprecation pass belongs after these names have been reviewed —
+emitting 80 warnings that push users onto names still under discussion would be
+worse than the flat list.
+
+`query` and `agents` are deliberately not namespaced. Both are already public
+method names, so a namespace of the same name would have to shadow a callable
+and carry dual call/attribute semantics. That is doable — the package already
+does it for `seocho.agents` at module level — but it is a behavioural change to
+a public method rather than an addition, and it belongs in its own change with
+its own deprecation cycle.
+
+Namespaces resolve lazily and hold only a reference to the owning client, so
+constructing `Seocho` costs nothing extra.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class _Namespace:
+    """A read-only view that forwards to methods on the owning facade.
+
+    Bound methods are fetched from the owner on each access rather than cached,
+    so anything that patches or wraps a facade method — `monkeypatch.setattr`,
+    a tracing decorator applied at runtime — is still seen through the
+    namespace. A cache here would silently serve the pre-patch callable, which
+    is the same failure mode that made the ontology package use `sys.modules`
+    aliases instead of forwarding shims.
+    """
+
+    __slots__ = ("_owner",)
+
+    #: short name on the namespace -> method name on the facade
+    _METHODS: Dict[str, str] = {}
+
+    def __init__(self, owner: Any) -> None:
+        object.__setattr__(self, "_owner", owner)
+
+    def __getattr__(self, name: str) -> Any:
+        target = self._METHODS.get(name)
+        if target is None:
+            raise AttributeError(
+                f"{type(self).__name__!r} has no attribute {name!r}; "
+                f"available: {', '.join(sorted(self._METHODS))}"
+            )
+        return getattr(self._owner, target)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError(
+            f"{type(self).__name__} is a view over the client; "
+            f"set {name!r} on the client itself"
+        )
+
+    def __dir__(self) -> List[str]:
+        return sorted(self._METHODS)
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} of {type(self._owner).__name__}>"
+
+
+class IndexNamespace(_Namespace):
+    """Writing into the graph: ingestion, re-indexing, deletion, schema setup."""
+
+    _METHODS = {
+        "add": "add",
+        "batch": "add_batch",
+        "graph": "add_graph",
+        "with_details": "add_with_details",
+        "file": "index_file",
+        "directory": "index_directory",
+        "reindex": "reindex",
+        "delete": "delete",
+        "delete_source": "delete_source",
+        "extract": "extract",
+        "raw": "raw_ingest",
+        "migrate": "migrate",
+        "ensure_constraints": "ensure_constraints",
+        "ensure_fulltext_indexes": "ensure_fulltext_indexes",
+    }
+
+
+class OntologyNamespace(_Namespace):
+    """Ontology definition, artifacts, profiles, signals, and curation.
+
+    The largest group by far — 24 of the facade's 80 methods — and the one
+    whose flat names were least predictable: `coverage_stats`,
+    `qualify_graph` and `project_canonical_graph` all read as generic graph
+    operations while being ontology governance.
+    """
+
+    _METHODS = {
+        # definition
+        "register": "register_ontology",
+        "get": "get_ontology",
+        "score": "coverage_stats",
+        "prompt_context": "prompt_context_from_ontology",
+        "qualify_graph": "qualify_graph",
+        "project_canonical_graph": "project_canonical_graph",
+        # artifacts
+        "artifacts": "list_artifacts",
+        "artifact": "get_artifact",
+        "draft_artifact": "create_artifact_draft",
+        "draft_from_ontology": "artifact_draft_from_ontology",
+        "approved_from_ontology": "approved_artifacts_from_ontology",
+        "approve_artifact": "approve_artifact",
+        "promote_artifact": "promote_artifact",
+        "deprecate_artifact": "deprecate_artifact",
+        "validate_artifact": "validate_artifact",
+        "diff_artifacts": "diff_artifacts",
+        "apply_artifact": "apply_artifact",
+        # profiles
+        "upsert_profile": "upsert_ontology_profile",
+        "profiles": "list_ontology_profiles",
+        "profile": "get_ontology_profile",
+        "promote_profile": "promote_ontology_profile",
+        "compile_profile": "compile_ontology_profile",
+        "select_profile": "select_ontology_profile",
+        "evaluate_profile": "evaluate_ontology_profile",
+        # signals and curation
+        "create_signal": "create_ontology_signal",
+        "signals": "list_ontology_signals",
+        "curation_cases": "list_curation_cases",
+        "preview_curation": "preview_curation_decision",
+        "apply_curation": "apply_curation_decision",
+    }
+
+
+class PlatformNamespace(_Namespace):
+    """Deployment-shell surface: what exists, whether it is healthy, teardown."""
+
+    _METHODS = {
+        "graphs": "graphs",
+        "resolve_graphs": "resolve_graphs",
+        "databases": "databases",
+        "health": "health",
+        "semantic_runs": "semantic_runs",
+        "semantic_run": "semantic_run",
+        "export_bundle": "export_runtime_bundle",
+        "close": "close",
+    }
+
+
+class SessionNamespace(_Namespace):
+    """Conversation state on the platform session store."""
+
+    _METHODS = {
+        "history": "session_history",
+        "reset": "reset_session",
+        "chat": "platform_chat",
+    }
+
+
+__all__ = [
+    "IndexNamespace",
+    "OntologyNamespace",
+    "PlatformNamespace",
+    "SessionNamespace",
+]

--- a/tests/seocho/test_client_namespaces.py
+++ b/tests/seocho/test_client_namespaces.py
@@ -1,0 +1,109 @@
+"""The grouped views must be additive, and the two facades must not drift.
+
+`Seocho` had 80 public methods with 23 in no category at all, and `AsyncSeocho`
+had 56 — 25 sync methods with no async counterpart and no declared reason
+(`seocho-6yf`). These tests pin both halves of the fix: the namespaces add
+without removing, and the async surface is generated so it cannot fall behind
+again.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from seocho.client import AsyncSeocho, Seocho
+from seocho.client_namespaces import (
+    IndexNamespace,
+    OntologyNamespace,
+    PlatformNamespace,
+    SessionNamespace,
+)
+
+_NAMESPACES = {
+    "index": IndexNamespace,
+    "governance": OntologyNamespace,
+    "platform": PlatformNamespace,
+    "sessions": SessionNamespace,
+}
+
+# Constructors return a Seocho, so an async factory would misdescribe the
+# object; close() must not offload teardown to a worker thread; properties
+# read state rather than act.
+_INTENTIONALLY_SYNC_ONLY = {
+    "local", "remote", "from_agent_design", "from_indexing_design",
+    "from_runtime_bundle", "close", "last_query_metadata",
+}
+
+
+@pytest.mark.parametrize("attr,cls", sorted(_NAMESPACES.items()))
+def test_namespace_is_exposed_on_both_facades(attr, cls):
+    for facade in (Seocho, AsyncSeocho):
+        prop = getattr(facade, attr, None)
+        assert isinstance(prop, property), f"{facade.__name__}.{attr} is not a property"
+
+
+@pytest.mark.parametrize("cls", sorted(_NAMESPACES.values(), key=lambda c: c.__name__))
+def test_every_mapping_points_at_a_real_method(cls):
+    """A typo here would be a silently broken namespace member."""
+    missing = [t for t in cls._METHODS.values() if not hasattr(Seocho, t)]
+    assert not missing, f"{cls.__name__} maps to nonexistent methods: {missing}"
+
+
+def test_namespaces_are_additive_not_replacements():
+    """Every flat method a namespace covers must still be callable directly."""
+    for cls in _NAMESPACES.values():
+        for target in cls._METHODS.values():
+            assert hasattr(Seocho, target), f"{target} disappeared"
+
+
+def test_namespace_resolves_through_the_owner_each_time():
+    """No caching: a patched method must be visible through the namespace.
+
+    A namespace that captured bound methods at construction would keep serving
+    the pre-patch callable — the same failure that made the ontology package
+    use sys.modules aliases rather than forwarding shims.
+    """
+    client = object.__new__(Seocho)
+    sentinel = object()
+    client.index_file = lambda *a, **k: sentinel  # type: ignore[method-assign]
+    assert IndexNamespace(client).file() is sentinel
+
+
+def test_namespace_rejects_unknown_members_with_a_useful_error():
+    ns = IndexNamespace(object.__new__(Seocho))
+    with pytest.raises(AttributeError) as excinfo:
+        ns.no_such_operation
+    assert "available:" in str(excinfo.value)
+
+
+def test_namespace_is_read_only():
+    ns = IndexNamespace(object.__new__(Seocho))
+    with pytest.raises(AttributeError):
+        ns.file = lambda: None
+
+
+def test_async_surface_covers_the_sync_one():
+    """The regression this whole change exists to prevent."""
+    sync = {n for n in dir(Seocho) if not n.startswith("_")}
+    asyn = {n for n in dir(AsyncSeocho) if not n.startswith("_")}
+    gap = sync - asyn - _INTENTIONALLY_SYNC_ONLY
+    assert not gap, f"AsyncSeocho is missing: {sorted(gap)}"
+
+
+def test_generated_delegates_are_coroutines():
+    for name in ("index_file", "index_directory", "reindex", "execute_query"):
+        assert inspect.iscoroutinefunction(getattr(AsyncSeocho, name)), name
+
+
+def test_hand_written_async_methods_are_not_overwritten():
+    """The generator fills gaps only; an explicit coroutine must keep winning."""
+    assert "add" in vars(AsyncSeocho)
+    assert inspect.iscoroutinefunction(AsyncSeocho.add)
+
+
+def test_query_and_agents_are_still_plain_methods():
+    """Documented exclusion: namespacing them would shadow a public callable."""
+    for name in ("query", "agents"):
+        assert not isinstance(getattr(Seocho, name), property), name


### PR DESCRIPTION
`ADR-0171`. Implements `seocho-6yf`.

## The measurement

`Seocho` carries **80 public methods on one object**. Grouped by what they actually do:

| count | group |
|---|---|
| 24 | ontology governance |
| **23** | **no category at all** |
| 9 | read / query |
| 8 | lifecycle / platform |
| 8 | agents |
| 8 | write / index |

The 23-method bucket is the diagnosis, not a classification failure. It holds `advanced`, `get`, `execute`, `react`, `router`, `semantic`, `extract`, `chat`, `delete`, `migrate`, `qualify_graph`, `project_canonical_graph` and eleven more. Those are accretion, not a vocabulary — a caller cannot predict the method name from the task, and `coverage_stats`/`qualify_graph` read as generic graph operations while being ontology governance.

`AsyncSeocho` had **56 methods to `Seocho`'s 80** — 55 shared and **25 sync methods with no async counterpart and no declared reason** (`index_file`, `index_directory`, `reindex`, `plan`, `agent`, `build_agent`, `session`, `execute_query`, …), while 55 pairs were kept behaviourally identical by hand.

## What this adds

```python
sc.index.file("a.pdf")          # was sc.index_file(...)
sc.governance.score()           # was sc.coverage_stats()
sc.platform.graphs()            # was sc.graphs()
sc.sessions.history()           # was sc.session_history()
```

Four views covering **54 of the 80** methods. **Additive** — every flat method still exists, unchanged and **un-warned**. A deprecation pass belongs *after* these names are reviewed; emitting warnings that push users onto names still under discussion is worse than the flat list they already know.

## Three things the implementation was forced into, each an improvement

**`governance`, not `ontology`.** The first attempt used `sc.ontology` and failed at construction — `self.ontology` is already the registered `Ontology` object (`client.py:286`). The collision produced a better split than the one planned: **the noun stays the thing, the namespace is what you do to it.**

**`query` and `agents` are excluded, and the exclusion is tested.** Both are existing public method names, so a namespace of the same name must shadow a callable and carry dual call/attribute semantics. That is possible — the package already does it for `seocho.agents` at module level — but it is a *behavioural change to a public method* rather than an addition, and needs its own deprecation cycle.

**Namespaces resolve through the owner on every access and never cache bound methods.** A cache would keep serving the pre-patch callable after `monkeypatch.setattr` or a runtime-applied decorator — the same failure mode that made `ADR-0170` use `sys.modules` aliases instead of forwarding shims. Because they bind to whichever facade owns them, the same four classes yield **coroutines** on `AsyncSeocho` with no second mapping table.

## The async surface is generated, not written

`_fill_async_surface()` walks `Seocho` and adds a `to_thread` delegate for every public method `AsyncSeocho` has not defined itself. Hand-written coroutines keep winning, so anything needing real async behaviour rather than thread offload is untouched.

Skipped deliberately, and asserted as such rather than left implicit:

- **constructors** (`local`, `remote`, `from_*`) build a `Seocho`; an async factory returning a sync client would misdescribe the object
- **`close`** must not offload teardown to a worker thread while the loop may still hold references
- **properties** read state, so awaiting one would make a field look like an operation

A test now compares both surfaces, so the gap cannot reopen.

## Validation

`bash scripts/ci/run_basic_ci.sh` → **782 passed, 3 skipped**, with the new test file registered in that script's explicit list. `check-doc-contracts.sh` passes. `git diff --check` clean.

**Zero public API removed** — `pip install seocho` users see additions only.

## Follow-ups

- Deprecation pass on the flat aliases once the names settle.
- The callable-namespace decision for `query` and `agents`.
- `client.py` is still 3,688 lines; splitting `client_*` into mixins is unaffected and still open.
