### PR TITLE
Fix tenant isolation bypass in execute_cypher

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -387,7 +387,13 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(
+                cypher,
+                params=params,
+                database=database,
+                workspace_id=workspace_id,
+                enforce_workspace_filter=True,
+            )
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
## Severity
High

## Vulnerability
The `make_execute_cypher_tool` factory in `src/seocho/tools.py` provides an `execute_cypher` tool to agents allowing raw Cypher execution. It currently calls `graph_store.query()` without passing `workspace_id=workspace_id` or setting `enforce_workspace_filter=True`. This allows dynamic queries to bypass tenant boundaries and query or mutate data across the entire database without any workspace restriction check.

## Impact
A compromised or hallucinating agent using this tool could leak sensitive context or corrupt memory entries belonging to other tenants.

## Fix
Updated `make_execute_cypher_tool` to explicitly pass `workspace_id=workspace_id` and `enforce_workspace_filter=True` into the underlying `graph_store.query()` invocation.

## Validation
- Checked that tests for tool creation still pass (`uv run pytest tests/seocho/test_session_agent.py`)
- Verified standard CI tests continue to pass (`bash scripts/ci/run_basic_ci.sh`)

## Risks
If an agent relies on `execute_cypher` to intentionally fetch global, non-workspace data (e.g. system schemas), those queries will now be rejected by the workspace filter enforcer.

Modified Files: src/seocho/tools.py

---
*PR created automatically by Jules for task [4191188995136312691](https://jules.google.com/task/4191188995136312691) started by @tteon*