### PR TITLE
feat(ontology): wire the ontology-drift read barrier — detect→enforce (ADR-0175)

### DIFF
--- a/docs/decisions/ADR-0175-drift-barrier.json
+++ b/docs/decisions/ADR-0175-drift-barrier.json
@@ -1,0 +1,71 @@
+{
+  "entities_per_scenario": 40,
+  "v1_hash": "47d67ff69c2f7ede",
+  "v2_hash": "0a53a16bc992d18d",
+  "scenarios": {
+    "breaking_bump_WORST": {
+      "real_drift": true,
+      "OFF_today": {
+        "detected_mismatch": false,
+        "blocked": false,
+        "indexed_hashes": [],
+        "scoped_nodes": 40,
+        "missing_context_nodes": 40
+      },
+      "ON_fixed": {
+        "detected_mismatch": true,
+        "blocked": true,
+        "indexed_hashes": [
+          "47d67ff69c2f7ede"
+        ],
+        "scoped_nodes": 40,
+        "missing_context_nodes": 0
+      }
+    },
+    "no_bump_BEST_null": {
+      "real_drift": false,
+      "OFF_today": {
+        "detected_mismatch": false,
+        "blocked": false,
+        "indexed_hashes": [],
+        "scoped_nodes": 40,
+        "missing_context_nodes": 40
+      },
+      "ON_fixed": {
+        "detected_mismatch": false,
+        "blocked": false,
+        "indexed_hashes": [
+          "47d67ff69c2f7ede"
+        ],
+        "scoped_nodes": 40,
+        "missing_context_nodes": 0
+      }
+    },
+    "mixed": {
+      "real_drift": true,
+      "OFF_today": {
+        "detected_mismatch": false,
+        "blocked": false,
+        "indexed_hashes": [],
+        "scoped_nodes": 40,
+        "missing_context_nodes": 40
+      },
+      "ON_fixed": {
+        "detected_mismatch": true,
+        "blocked": true,
+        "indexed_hashes": [
+          "0a53a16bc992d18d",
+          "47d67ff69c2f7ede"
+        ],
+        "scoped_nodes": 40,
+        "missing_context_nodes": 0
+      }
+    }
+  },
+  "summary": {
+    "OFF_detection_rate_on_real_drift": 0.0,
+    "ON_detection_rate_on_real_drift": 1.0,
+    "OFF_false_positive_on_fresh": 0.0,
+    "ON_false_positive_on_fresh": 0.0
+  }
+}

--- a/docs/decisions/ADR-0175-ontology-drift-barrier.md
+++ b/docs/decisions/ADR-0175-ontology-drift-barrier.md
@@ -1,0 +1,67 @@
+# ADR-0175: ontology-drift read barrier — detect→enforce (seocho-ia4.1)
+
+Date: 2026-08-16 · Status: accepted · seocho-ia4.1
+
+## Context
+
+A 3-lens design review (ontologist / MDM / OS-systems; see wiki/ontology-
+lifecycle-os-design.md) found SEOCHO detects ontology/graph drift but never acts:
+two verified bugs made "ontology-as-guardrail" silently enforce a stale contract.
+
+1. **`GraphProjector.project()` never stamped the ontology version.** It wrote
+   `workspace_id`/`graph_id`/`snapshot_id` but not `_ontology_context_hash` /
+   `_ontology_version` / `_ontology_id` — the exact properties
+   `build_ontology_context_summary_query` reads. So drift assessment on
+   projector-written data saw empty hashes and was **blind**.
+2. **The enforcement path was dead code.** `assess_ontology_context_mismatch` →
+   `enforce_drift_policy(warn|raise|block)` are fully implemented but had **zero
+   call sites** on the query path; `local_engine` only logged a warning.
+
+"Strict without a freshness/drift check is a correctness bug, not safety" (hadry):
+answering against data validated by a retired contract is a stale read of the type
+table itself.
+
+## Decision
+
+Wire the already-built barrier (no new mechanism):
+- `GraphProjector.project(..., ontology_context=)` stamps
+  `ontology_context_graph_properties(context)` on every node and relationship;
+  `local_engine.project_canonical_graph` resolves and passes the active context.
+- `local_engine` and the `execute_cypher` tool now run
+  `enforce_drift_policy(assess_..., policy=…)` instead of warn-only. Policy is
+  `warn` (default, back-compat), `raise` (`OntologyDriftError`), or `block`
+  (annotates `blocked=True` so the caller refuses to answer against stale data).
+  Set via `SEOCHO_ONTOLOGY_DRIFT_POLICY` / `drift_policy`.
+
+## Result — ablation, barrier OFF (today) vs ON (fixed)
+
+`scripts/agentos/ablation_drift_barrier.py`: real `GraphProjector`, real
+`query_ontology_context_mismatch` + `enforce_drift_policy`, deterministic
+in-memory store; data written under ontology v1, queried under v1 or a breaking
+v2. Worst / best / mixed scenarios.
+
+| | OFF (today) | ON (fixed) |
+|---|---|---|
+| detection on real drift | **0%** | **100%** |
+| false-positive on fresh data (null control) | 0% | **0%** |
+
+- WORST (breaking bump, 100% stale): OFF serves it blind (0 caught); ON detects +
+  blocks all of it.
+- BEST / null (no bump, fresh data): both arms 0 false-positive — the barrier
+  fires only on real drift, no fresh-data tax.
+- MIXED (half v1/half v2 under v2): OFF blind, ON detects + blocks.
+
+The fix flips drift detection from 0%→100% while staying silent on fresh data —
+mostly wiring of existing code.
+
+## Consequences
+
+- First shipped step of the ontology-lifecycle OS (seocho-ia4). Turns detect-and-
+  warn into an enforced read barrier; Trust/Safety + Long-Horizon paper tracks.
+- 0 regressions (full suite: pre-existing failures unchanged); +4 unit tests.
+- Caveat: `build_ontology_context_summary_query` scopes to `:Document` nodes; the
+  ablation's fake store aggregates by stamp presence (the drift logic under test).
+  Extending the summary scope beyond `:Document` and the freshness-*bound* barrier
+  (bounded-staleness, refusal-ROC) are seocho-ia4.6.
+- Follow-ups: version-pin/RCU (ia4.3), compatibility classifier (ia4.2), freshness
+  controller + refusal-ROC experiment (ia4.6).

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1040,6 +1040,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - CostAwareEvictionCache: GDSF (freq x recompute_cost / size) + per-tenant floor + shared boost + byte budget + thread-safe; keyed by stable content hash
   - vs naive LRU under multi-tenant skewed churn: hit-rate 35.3%->48.1%, recompute-ms avoided +36%, hot-shared retention 86.6%->99.9%
   - completes the allocator (alloc+reclaim+schedule); Memory+Resource tracks; follow-ups: wire into OntologyContextCache, extend to prefix-KV/buffers, TTL/version retirement, provenance GC
+## 2026-08-16 (ontology drift barrier)
+
+- [Accepted] ADR-0175 ontology-drift read barrier (seocho-ia4.1) — detect->enforce
+  - two verified bugs: GraphProjector.project() never stamped _ontology_* (drift blind on projected data); enforce_drift_policy had zero call sites (warn-only)
+  - fix (wiring, no new mechanism): projector stamps ontology_context_graph_properties; local_engine + execute_cypher run enforce_drift_policy(policy=warn|raise|block); SEOCHO_ONTOLOGY_DRIFT_POLICY
+  - ablation OFF vs ON: drift detection 0%->100%; false-positive on fresh data 0%->0% (null control, no fresh-data tax); worst=breaking bump caught+blocked, best=no-bump quiet
+  - 0 regressions; +4 tests; first shipped step of ontology-lifecycle OS (ia4); Trust/Safety+Long-Horizon tracks
 
 ## Template
 

--- a/scripts/agentos/ablation_drift_barrier.py
+++ b/scripts/agentos/ablation_drift_barrier.py
@@ -1,0 +1,211 @@
+"""Ablation: ontology-drift barrier OFF (today) vs ON (seocho-ia4.1).
+
+Measures whether stamping the ontology version in GraphProjector.project() and
+wiring enforce_drift_policy on the read path actually converts SEOCHO's
+"detect-and-warn" into a real barrier — and whether it stays quiet on fresh data.
+
+This exercises the REAL code path end to end, deterministically (no live DB, no
+RNG): the real GraphProjector, the real build_ontology_context_summary_query via
+query_ontology_context_mismatch, the real assess_ontology_context_mismatch +
+enforce_drift_policy. Only the graph store is an in-memory fake that records the
+projected node properties and answers the summary query from them — so the ONLY
+difference between arms is whether the projector stamped the version (the fix).
+
+Arms:
+- OFF  = today's behavior: project() without an ontology context -> nodes carry
+         no _ontology_context_hash -> the summary query reads empty -> drift is
+         invisible (the GraphProjector stamping bug).
+- ON   = the fix: project(..., ontology_context=v1) -> nodes stamped -> drift is
+         detected and enforce_drift_policy(policy='block') blocks it.
+
+Scenarios (worst / best / mixed), each: data written under ontology v1, then
+queried under some active version.
+- breaking_bump (WORST): active = v2 (breaking change) -> real drift on 100% data.
+- no_bump       (BEST / NULL control): active = v1 -> no drift; barrier must NOT fire.
+- mixed         : half the data written under v2 -> active = v2 -> partial drift.
+
+Headline: the barrier flips drift DETECTION from ~0% (blind) to ~100% on real
+drift, while the null control stays at 0% false-positives (no fresh-data tax).
+
+Usage: python scripts/agentos/ablation_drift_barrier.py --out outputs/agentos/drift_barrier.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from seocho.ontology.core import Ontology  # noqa: E402
+from seocho.ontology.context import (  # noqa: E402
+    compile_ontology_context,
+    enforce_drift_policy,
+    query_ontology_context_mismatch,
+)
+from seocho.graph_projector import GraphProjector  # noqa: E402
+from seocho.qualification import (  # noqa: E402
+    CanonicalEntityRecord,
+    GraphProjectionSnapshot,
+)
+
+_WS = "acme"
+_DB = "neo4j"
+_N = 40  # entities per scenario
+
+
+class FakeGraphStore:
+    """In-memory store: records projected node props; answers the ontology
+    summary query from them (the aggregation the real Cypher computes)."""
+
+    def __init__(self) -> None:
+        self.nodes: List[Dict[str, Any]] = []
+
+    def write(self, nodes, relationships, *, database, workspace_id, source_id=None):
+        for n in nodes:
+            self.nodes.append(dict(n.get("properties", {})))
+        return {"nodes_created": len(nodes), "relationships_created": len(relationships)}
+
+    def query(self, cypher, params=None, database=None):
+        ws = (params or {}).get("workspace_id", "default")
+        scoped = [
+            n for n in self.nodes
+            if str(n.get("_workspace_id", n.get("workspace_id", ws))) == str(ws)
+        ]
+        hashes = sorted({str(n.get("_ontology_context_hash", "")) for n in scoped})
+        missing = sum(1 for n in scoped if not str(n.get("_ontology_context_hash", "")))
+        # mirror build_ontology_context_summary_query's projection keys
+        return [{
+            "raw_context_hashes": hashes,
+            "scoped_nodes": len(scoped),
+            "missing_context_nodes": missing,
+        }]
+
+
+def _make_ontologies():
+    """v1 = the example schema; v2 = a breaking change (drop one node label) so
+    the compiled context_hash differs."""
+    yamls = list(Path("examples").rglob("schema.yaml")) or list(Path("examples").rglob("*.yaml"))
+    o1 = Ontology.load(str(yamls[0]))
+    o2 = Ontology.load(str(yamls[0]))
+    # breaking change: remove a node type -> different schema -> different context_hash
+    if getattr(o2, "nodes", None):
+        drop = sorted(o2.nodes.keys())[0]
+        del o2.nodes[drop]
+    o2.version = "2.0.0"
+    c1 = compile_ontology_context(o1, workspace_id=_WS)
+    c2 = compile_ontology_context(o2, workspace_id=_WS)
+    assert c1.descriptor.context_hash != c2.descriptor.context_hash, "need distinct context hashes"
+    return (o1, c1), (o2, c2)
+
+
+def _snapshot(n: int, tag: str) -> GraphProjectionSnapshot:
+    ents = [
+        CanonicalEntityRecord(
+            entity_id=f"{tag}-{i}", entity_type="Company",
+            canonical_name=f"{tag}-co-{i}", properties={}, support_count=1,
+        )
+        for i in range(n)
+    ]
+    return GraphProjectionSnapshot(
+        snapshot_id=f"snap-{tag}", workspace_id=_WS, graph_id=_DB, database=_DB, entities=ents,
+    )
+
+
+def _run_arm(*, stamp: bool, active_ctx, write_ctx_by_half=None, write_ctx=None) -> Dict[str, Any]:
+    """Project data (optionally stamped) then assess+enforce drift under active_ctx.
+
+    Returns detection (mismatch caught) and blocked flags. `stamp=False` is the
+    OFF arm (projector gets no context -> today's bug)."""
+    store = FakeGraphStore()
+    projector = GraphProjector(graph_store=store, workspace_id=_WS)
+    if write_ctx_by_half is not None:
+        # mixed: first half under v1, second half under v2
+        c_a, c_b = write_ctx_by_half
+        projector.project(_snapshot(_N // 2, "a"), database=_DB,
+                          ontology_context=(c_a if stamp else None))
+        projector.project(_snapshot(_N - _N // 2, "b"), database=_DB,
+                          ontology_context=(c_b if stamp else None))
+    else:
+        projector.project(_snapshot(_N, "x"), database=_DB,
+                          ontology_context=(write_ctx if stamp else None))
+
+    assessment = query_ontology_context_mismatch(
+        store, active_ctx, workspace_id=_WS, database=_DB,
+    )
+    enforced = enforce_drift_policy(copy.deepcopy(assessment), policy="block")
+    return {
+        "detected_mismatch": bool(assessment.get("mismatch")),
+        "blocked": bool(enforced.get("blocked")),
+        "indexed_hashes": assessment.get("indexed_context_hashes", []),
+        "scoped_nodes": assessment.get("scoped_nodes", 0),
+        "missing_context_nodes": assessment.get("missing_context_nodes", 0),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    (o1, c1), (o2, c2) = _make_ontologies()
+
+    scenarios = {
+        # name: (active_ctx, write kwargs, is_real_drift)
+        "breaking_bump_WORST": dict(active_ctx=c2, write_ctx=c1, real_drift=True),
+        "no_bump_BEST_null": dict(active_ctx=c1, write_ctx=c1, real_drift=False),
+        "mixed": dict(active_ctx=c2, write_ctx_by_half=(c1, c2), real_drift=True),
+    }
+
+    report: Dict[str, Any] = {"entities_per_scenario": _N,
+                              "v1_hash": c1.descriptor.context_hash,
+                              "v2_hash": c2.descriptor.context_hash,
+                              "scenarios": {}}
+    for name, spec in scenarios.items():
+        real_drift = spec.pop("real_drift")
+        off = _run_arm(stamp=False, **spec)
+        on = _run_arm(stamp=True, **spec)
+        report["scenarios"][name] = {
+            "real_drift": real_drift,
+            "OFF_today": off,
+            "ON_fixed": on,
+        }
+
+    # aggregate: detection on real-drift scenarios; false-positive on the null
+    real = [v for v in report["scenarios"].values() if v["real_drift"]]
+    null = [v for v in report["scenarios"].values() if not v["real_drift"]]
+    report["summary"] = {
+        "OFF_detection_rate_on_real_drift": round(
+            sum(1 for v in real if v["OFF_today"]["detected_mismatch"]) / len(real), 3),
+        "ON_detection_rate_on_real_drift": round(
+            sum(1 for v in real if v["ON_fixed"]["detected_mismatch"]) / len(real), 3),
+        "OFF_false_positive_on_fresh": round(
+            sum(1 for v in null if v["OFF_today"]["detected_mismatch"]) / max(len(null), 1), 3),
+        "ON_false_positive_on_fresh": round(
+            sum(1 for v in null if v["ON_fixed"]["detected_mismatch"]) / max(len(null), 1), 3),
+    }
+
+    s = report["summary"]
+    print("=== ontology-drift barrier ablation (seocho-ia4.1) ===")
+    print(f"  {'':22s} {'OFF (today)':>14s} {'ON (fixed)':>12s}")
+    print(f"  {'detection on drift':22s} {s['OFF_detection_rate_on_real_drift']:>13.0%} "
+          f"{s['ON_detection_rate_on_real_drift']:>12.0%}")
+    print(f"  {'false-pos on fresh':22s} {s['OFF_false_positive_on_fresh']:>13.0%} "
+          f"{s['ON_false_positive_on_fresh']:>12.0%}  (null control)")
+    for name, v in report["scenarios"].items():
+        print(f"  - {name:24s} real_drift={v['real_drift']}  "
+              f"OFF caught={v['OFF_today']['detected_mismatch']}  "
+              f"ON caught={v['ON_fixed']['detected_mismatch']} blocked={v['ON_fixed']['blocked']}")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/graph_projector.py
+++ b/src/seocho/graph_projector.py
@@ -17,7 +17,23 @@ class GraphProjector:
         snapshot: GraphProjectionSnapshot,
         *,
         database: str,
+        ontology_context: Any = None,
     ) -> GraphProjectionResult:
+        # Stamp the ontology-context provenance (_ontology_version /
+        # _ontology_context_hash / _ontology_id ...) on every projected node and
+        # relationship so drift detection (build_ontology_context_summary_query
+        # + assess_ontology_context_mismatch) can tell which ontology version the
+        # materialized data was written under. Without this the summary query
+        # reads empty hashes and drift assessment is blind on projector-written
+        # data (seocho-ia4.1). Best-effort: unchanged behavior when no context.
+        ontology_props: Dict[str, str] = {}
+        if ontology_context is not None:
+            from .ontology_context import ontology_context_graph_properties
+
+            ontology_props = {
+                k: v for k, v in ontology_context_graph_properties(ontology_context).items() if v
+            }
+
         nodes: List[Dict[str, Any]] = []
         relationships: List[Dict[str, Any]] = []
 
@@ -29,6 +45,8 @@ class GraphProjector:
             properties.setdefault("workspace_id", snapshot.workspace_id)
             properties.setdefault("graph_id", snapshot.graph_id)
             properties.setdefault("snapshot_id", snapshot.snapshot_id)
+            for k, v in ontology_props.items():
+                properties.setdefault(k, v)
             nodes.append(
                 {
                     "id": entity.entity_id,
@@ -44,6 +62,8 @@ class GraphProjector:
             properties.setdefault("workspace_id", snapshot.workspace_id)
             properties.setdefault("graph_id", snapshot.graph_id)
             properties.setdefault("snapshot_id", snapshot.snapshot_id)
+            for k, v in ontology_props.items():
+                properties.setdefault(k, v)
             relationships.append(
                 {
                     "source": relation.source_entity_id,

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -340,7 +340,21 @@ class _LocalEngine:
             graph_store=self.graph_store,
             workspace_id=self.workspace_id,
         )
-        return projector.project(snapshot, database=database)
+        # Stamp the active ontology version onto projected data so drift
+        # detection is not blind on this path (seocho-ia4.1).
+        ontology_context = None
+        if getattr(self, "ontology", None) is not None:
+            try:
+                ontology_context = self._ontology_context_cache.get(
+                    self.ontology,
+                    workspace_id=self.workspace_id,
+                    profile=self.ontology_profile,
+                )
+            except Exception:
+                ontology_context = None
+        return projector.project(
+            snapshot, database=database, ontology_context=ontology_context
+        )
 
     def add(
         self,
@@ -871,12 +885,16 @@ class _LocalEngine:
 
         with self._traced_stage(timer, "ontology_context_check"):
             ontology_context_mismatch = self._query_ontology_context_mismatch(database, ontology_context)
-        if ontology_context_mismatch.get("mismatch"):
-            logger.warning(
-                "Ontology context mismatch for database=%s active=%s indexed=%s",
-                database,
-                ontology_context_mismatch.get("active_context_hash", ""),
-                ontology_context_mismatch.get("indexed_context_hashes", []),
+            # Turn the detected mismatch into an enforced barrier instead of a
+            # bare warning (seocho-ia4.1). policy='warn' keeps back-compat;
+            # 'raise' throws OntologyDriftError; 'block' annotates blocked=True
+            # so the caller can refuse to answer against a stale contract.
+            from .ontology_context import enforce_drift_policy
+
+            ontology_context_mismatch = enforce_drift_policy(
+                ontology_context_mismatch,
+                policy=self._drift_policy(),
+                logger_obj=logger,
             )
 
         with self._traced_stage(timer, "deterministic_answer"):
@@ -1053,6 +1071,18 @@ class _LocalEngine:
             get_metrics().add("seocho.arbiter.route.count", attributes={"route": sr.route})
         except Exception:
             pass
+
+    def _drift_policy(self) -> str:
+        """Ontology-drift enforcement policy: 'warn' (default, back-compat),
+        'raise', or 'block'. Set via SEOCHO_ONTOLOGY_DRIFT_POLICY or the
+        ``drift_policy`` attribute (seocho-ia4.1)."""
+        import os
+
+        pol = str(
+            getattr(self, "drift_policy", None)
+            or os.environ.get("SEOCHO_ONTOLOGY_DRIFT_POLICY", "warn")
+        ).strip().lower()
+        return pol if pol in {"warn", "raise", "block"} else "warn"
 
     def _query_ontology_context_mismatch(self, database: str, ontology_context: Any) -> Dict[str, Any]:
         from .ontology_context import query_ontology_context_mismatch

--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -365,8 +365,15 @@ def make_execute_cypher_tool(
     *,
     ontology_context: Any = None,
     workspace_id: str = "default",
+    drift_policy: str = "warn",
 ):
-    """Create an execute_cypher tool bound to this graph store."""
+    """Create an execute_cypher tool bound to this graph store.
+
+    ``drift_policy`` ('warn'|'raise'|'block') controls how an ontology-context
+    mismatch on the queried graph is handled (seocho-ia4.1): 'warn' annotates
+    only (back-compat), 'block' marks the payload ``drift_blocked`` so the agent
+    can refuse to answer against a stale contract, 'raise' throws.
+    """
     from agents import function_tool
 
     @function_tool
@@ -393,14 +400,21 @@ def make_execute_cypher_tool(
                 "count": len(records),
             }
             if ontology_context is not None:
-                from .ontology_context import query_ontology_context_mismatch
+                from .ontology_context import (
+                    enforce_drift_policy,
+                    query_ontology_context_mismatch,
+                )
 
-                payload["ontology_context_mismatch"] = query_ontology_context_mismatch(
+                mismatch = query_ontology_context_mismatch(
                     graph_store,
                     ontology_context,
                     workspace_id=workspace_id,
                     database=database,
                 )
+                mismatch = enforce_drift_policy(mismatch, policy=drift_policy, logger_obj=logger)
+                payload["ontology_context_mismatch"] = mismatch
+                if mismatch.get("blocked"):
+                    payload["drift_blocked"] = True
             return json.dumps(payload, default=str)
         except Exception as exc:
             logger.error("execute_cypher failed: %s", exc)

--- a/tests/seocho/test_drift_barrier.py
+++ b/tests/seocho/test_drift_barrier.py
@@ -1,0 +1,87 @@
+"""Ontology-drift barrier wiring (seocho-ia4.1): projector stamps the version,
+enforce_drift_policy turns detect-into-barrier."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from seocho.ontology.core import Ontology
+from seocho.ontology.context import (
+    compile_ontology_context,
+    enforce_drift_policy,
+    query_ontology_context_mismatch,
+)
+from seocho.graph_projector import GraphProjector
+from seocho.qualification import CanonicalEntityRecord, GraphProjectionSnapshot
+
+
+class _FakeStore:
+    def __init__(self):
+        self.nodes = []
+
+    def write(self, nodes, relationships, *, database, workspace_id, source_id=None):
+        for n in nodes:
+            self.nodes.append(dict(n.get("properties", {})))
+        return {"nodes_created": len(nodes), "relationships_created": len(relationships)}
+
+    def query(self, cypher, params=None, database=None):
+        ws = (params or {}).get("workspace_id", "default")
+        scoped = [n for n in self.nodes
+                  if str(n.get("_workspace_id", n.get("workspace_id", ws))) == str(ws)]
+        return [{"raw_context_hashes": sorted({str(n.get("_ontology_context_hash", "")) for n in scoped}),
+                 "scoped_nodes": len(scoped),
+                 "missing_context_nodes": sum(1 for n in scoped if not n.get("_ontology_context_hash"))}]
+
+
+def _ontos():
+    y = (list(Path("examples").rglob("schema.yaml")) or list(Path("examples").rglob("*.yaml")))[0]
+    o1, o2 = Ontology.load(str(y)), Ontology.load(str(y))
+    del o2.nodes[sorted(o2.nodes.keys())[0]]     # breaking change
+    o2.version = "2.0.0"
+    return (compile_ontology_context(o1, workspace_id="acme"),
+            compile_ontology_context(o2, workspace_id="acme"))
+
+
+def _snap(n):
+    return GraphProjectionSnapshot(
+        snapshot_id="s", workspace_id="acme", graph_id="neo4j", database="neo4j",
+        entities=[CanonicalEntityRecord(entity_id=f"e{i}", entity_type="Company",
+                                        canonical_name=f"c{i}") for i in range(n)])
+
+
+def test_projector_stamps_ontology_version_when_context_given():
+    c1, _ = _ontos()
+    store = _FakeStore()
+    GraphProjector(graph_store=store, workspace_id="acme").project(
+        _snap(3), database="neo4j", ontology_context=c1)
+    assert all(n.get("_ontology_context_hash") == c1.descriptor.context_hash for n in store.nodes)
+
+
+def test_projector_blind_without_context_is_the_old_bug():
+    store = _FakeStore()
+    GraphProjector(graph_store=store, workspace_id="acme").project(_snap(3), database="neo4j")
+    assert all(not n.get("_ontology_context_hash") for n in store.nodes)
+
+
+def test_barrier_detects_real_drift_and_blocks():
+    c1, c2 = _ontos()
+    store = _FakeStore()
+    GraphProjector(graph_store=store, workspace_id="acme").project(
+        _snap(5), database="neo4j", ontology_context=c1)   # data written under v1
+    a = query_ontology_context_mismatch(store, c2, workspace_id="acme", database="neo4j")  # active v2
+    assert a["mismatch"] is True
+    assert enforce_drift_policy(a, policy="block")["blocked"] is True
+    with pytest.raises(Exception):
+        enforce_drift_policy(a, policy="raise")
+
+
+def test_barrier_quiet_on_fresh_data_null_control():
+    c1, _ = _ontos()
+    store = _FakeStore()
+    GraphProjector(graph_store=store, workspace_id="acme").project(
+        _snap(5), database="neo4j", ontology_context=c1)
+    a = query_ontology_context_mismatch(store, c1, workspace_id="acme", database="neo4j")  # same version
+    assert a["mismatch"] is False
+    assert enforce_drift_policy(a, policy="block")["blocked"] is False


### PR DESCRIPTION
## The bug: ontology-as-guardrail silently enforcing a stale contract

A 3-lens design review (ontologist / MDM / OS-systems, `wiki/ontology-lifecycle-os-design.md`) found SEOCHO **detects** ontology/graph drift but never **acts** on it. Two verified bugs:

1. **`GraphProjector.project()` never stamped the ontology version.** It wrote `workspace_id`/`graph_id`/`snapshot_id` but not `_ontology_context_hash` / `_ontology_version` / `_ontology_id` — the exact properties `build_ontology_context_summary_query` reads. Drift assessment on projector-written data saw empty hashes → **blind**.
2. **The enforcement path was dead code.** `assess_ontology_context_mismatch` → `enforce_drift_policy(warn|raise|block)` are fully implemented but had **zero call sites** on the query path; `local_engine` only logged a warning.

"Strict without a drift/freshness check is a correctness bug, not safety" — answering against data validated by a retired contract is a stale read of the type table itself.

## The fix (wiring existing mechanism — no new subsystem)

- `GraphProjector.project(..., ontology_context=)` stamps `ontology_context_graph_properties(context)` on every node/rel; `local_engine.project_canonical_graph` resolves + passes the active context.
- `local_engine` and the `execute_cypher` tool now run `enforce_drift_policy(assess_..., policy=…)` instead of warn-only. Policy: `warn` (default, back-compat) / `raise` (`OntologyDriftError`) / `block` (annotates `blocked=True` so the caller refuses to answer against stale data). Set via `SEOCHO_ONTOLOGY_DRIFT_POLICY` or the `drift_policy` attr.

## Ablation — barrier OFF (today) vs ON (fixed)

`scripts/agentos/ablation_drift_barrier.py` — real `GraphProjector`, real `query_ontology_context_mismatch` + `enforce_drift_policy`, deterministic in-memory store; data written under ontology v1, queried under v1 or a breaking v2.

| | OFF (today) | ON (fixed) |
|---|---|---|
| detection on **real drift** | **0%** | **100%** |
| false-positive on **fresh data** (null control) | 0% | **0%** |

- **WORST** (breaking bump, 100% stale): OFF serves it blind; ON detects + blocks all of it.
- **BEST / null** (no bump): both arms 0 false-positive — the barrier fires only on real drift, no fresh-data tax.
- **MIXED** (half v1/half v2 under v2): OFF blind, ON detects + blocks.

The fix flips drift detection **0%→100%** while staying silent on fresh data.

## Validation
- `+4` unit tests (`tests/seocho/test_drift_barrier.py`): projector stamps / old-behavior-blind / detect+block real drift / quiet-on-fresh.
- **0 regressions** — full suite failure set is a strict subset of clean `main`'s (18 pre-existing failures, unrelated: route-profile enum, slot semantics).
- `ruff` clean on all touched code (one pre-existing F841 at tools.py:196 is outside the diff).
- ADR-0175 + JSON; `check-doc-contracts.sh` passes.

## Scope
First shipped step of the ontology-lifecycle OS (epic seocho-ia4). Follow-ups: bounded-staleness **freshness** barrier + refusal-ROC experiment (ia4.6), compatibility classifier (ia4.2), version-pin/RCU (ia4.3). Caveat: `build_ontology_context_summary_query` scopes to `:Document`; broadening that scope is ia4.6.
