### PR TITLE
feat(axioms): inductive axiom mining + deductive entailment, A/B vs SHACL-only (ADR-0178)

### DIFF
--- a/docs/decisions/ADR-0178-axiom-ab.json
+++ b/docs/decisions/ADR-0178-axiom-ab.json
@@ -1,0 +1,34 @@
+{
+  "graph": {
+    "nodes": 70,
+    "relationships": 35
+  },
+  "arm_A_shacl_only": {
+    "property_shape_constraints": 13,
+    "axiom_classes_mined": 0,
+    "contradictions_caught": 0,
+    "entailed_edges": 0,
+    "entailed_labels": 0
+  },
+  "arm_B_induced_deduced": {
+    "property_shape_constraints": 13,
+    "candidates_mined": 15,
+    "approved_axioms": 12,
+    "approved_by_kind": {
+      "functional": 4,
+      "inverse_functional": 1,
+      "disjoint": 5,
+      "subclass": 1,
+      "rule": 1
+    },
+    "contradictions_caught": 2,
+    "contradiction_kinds": [
+      "disjoint_violation",
+      "functional_violation"
+    ],
+    "entailed_edges": 1,
+    "entailed_labels": 0,
+    "graph_enrichment_ratio": 0.029
+  },
+  "note": "answer-quality delta requires the live LLM e2e (real dataset -> extraction -> DozerDB); this offline arm measures the mechanism."
+}

--- a/docs/decisions/ADR-0178-axiom-induction-deduction.md
+++ b/docs/decisions/ADR-0178-axiom-induction-deduction.md
@@ -47,6 +47,38 @@ B catches 2 contradictions A structurally CANNOT (cross-type functional + disjoi
 and materializes an edge the LLM never asserted — at a quantified approval burden of
 12 candidates. The "cumbersome" worry becomes a measured number, not a guess.
 
+## Live e2e result (real MARA extraction → DozerDB, 2026-08-16)
+
+`scripts/agentos/e2e_axiom_ab.py`, MARA `MiniMax-M2.7`, dedicated DB `axiome2e`
+(isolated from the finbench data on the same instance), finance-compliance corpus
+(6 docs). End-to-end validated: real extraction → materialize → **corpus-scope**
+mining (reads the whole assembled, interned graph from the store — the cross-chunk /
+cross-document answer, not per-chunk).
+
+- Extraction is REAL (ontology-typed: Company/Regulation/Regulator/Policy/
+  ComplianceIncident/ControlEvidence), not the heuristic fallback (two credential
+  bugs fixed en route: a quoted `MARA_API_KEY` sent verbatim → 401, and the model
+  `MiniMax-M2.5` not on the new plan → swapped to `M2.7`).
+- Whole graph: 30 nodes / 87 rels — but **24/30 are the memory-graph provenance
+  layer** (Document/DocumentVersion/Chunk/Section) and most edges are plumbing
+  (MENTIONS/HAS_CHUNK/HAS_VERSION). The miner must (and now does) scope to the
+  DOMAIN layer, else it just rediscovers "each Document HAS_VERSION its versions".
+- **Domain-scoped: 6 nodes / 7 rels → 2 trivial functional axioms, 0 disjoint/
+  subclass/rule, 0 contradictions, 0 entailed.** The reason is decisive and honest:
+  the 6 docs describe the SAME entities, so interning collapses them to **one
+  instance per type** — there is no statistical mass for domain axioms; and this
+  ontology is single-label (no multi-typing → disjoint/subclass cannot arise by
+  construction).
+
+**Finding:** the pipeline is correct and validated on real extraction, but induced
+axioms need a corpus with **many instances per type** (many companies, regulations,
+incidents) and, for disjoint/subclass, an ontology with multi-typing / a class
+hierarchy. A 6-doc single-scenario sample is far below that threshold. The offline
+fixture (above) already shows the mechanism fires when the data carries the patterns;
+the live gap is corpus scale + type diversity, not the mechanism. Next: re-run on a
+larger, instance-diverse corpus (e.g. FinDER / many filings) before judging the
+answer-quality A/B and the DL-as-shape (ia4.7) decision.
+
 ## Consequences
 
 - The induction→deduction→projection pipeline is real and measured offline. `rules.py`

--- a/docs/decisions/ADR-0178-axiom-induction-deduction.md
+++ b/docs/decisions/ADR-0178-axiom-induction-deduction.md
@@ -1,0 +1,61 @@
+# ADR-0178: inductive axiom mining + deductive entailment, A/B vs SHACL-only (seocho-ia4.8/9/10)
+
+Date: 2026-08-16 · Status: accepted (offline mechanism measured; live e2e pending) · seocho-ia4.8/9/10
+
+## Context
+
+hadry's write-time-rigor thesis (Keet, induction/deduction §2.2.3): a KG earns its
+keep by capturing as AXIOMS what the LLM missed, running validated inference, and
+projecting an enriched graph. Worry: extracting axioms by hand is too cumbersome, and
+SHACL-only over-depends on human-authored shapes. The indexing survey confirmed the
+gap: the indexing path mines only single-*property* shape rules (`rules.py`,
+required/datatype/enum/range) and has NO deductive/entailment step (owlready2 is
+offline-only). The user: "이 실험을 한 번도 안 해봤다" — this A/B is net-new.
+
+## Decision
+
+`src/seocho/axioms.py`:
+- **Induction** (`mine_axioms`) — mines functional / inverse-functional (from edge
+  cardinality stats), disjointness (labels in the multi-label vocabulary that ~never
+  co-occur, confidence-based so a rare violation doesn't suppress the axiom),
+  subclass (A's extent ⊂ B's), and AMIE-lite composition rules R1∧R2⇒R3 — all with
+  support + confidence. `approve()` = the cheap human-APPROVAL gate (keep high
+  support+confidence), NOT authoring — this is the resolution to "cumbersome".
+- **Deduction** (`materialize_entailments`) — applies approved axioms: subclass
+  closure (ancestor labels) + composition rules (new edges), marks them
+  `_entailed:"true"` (auditable, like `_out_of_ontology`), and DETECTS contradictions
+  (functional / disjoint violations). Structural only; owlready2 stays offline.
+
+Natural insertion point (from the survey): after the existing rule hook at
+`pipeline.py:1002`, feeding the already-built per-document `graph_for_rules`, before
+`_shape_and_write_graph` (so entailed edges inherit the provenance stamp).
+
+## Result — A/B on a deterministic extracted-graph fixture (offline mechanism)
+
+`scripts/agentos/ablation_axiom_ab.py` (70 nodes / 35 rels, planted patterns +
+violations):
+
+| metric | A: SHACL-only | B: induced+deduced |
+|---|---|---|
+| property-shape constraints | 13 | 13 |
+| axiom classes mined (approved) | 0 | **12** (functional 4, inv-func 1, disjoint 5, subclass 1, rule 1) |
+| contradictions caught | 0 | **2** (disjoint + functional violation) |
+| entailed edges added | 0 | **1** (composition rule) |
+| approval burden | — | **12 of 15** mined |
+
+B catches 2 contradictions A structurally CANNOT (cross-type functional + disjoint),
+and materializes an edge the LLM never asserted — at a quantified approval burden of
+12 candidates. The "cumbersome" worry becomes a measured number, not a guess.
+
+## Consequences
+
+- The induction→deduction→projection pipeline is real and measured offline. `rules.py`
+  (property shapes) + `axioms.py` (relational/logical axioms) are complementary.
+- **Honest scope:** this measures the MECHANISM (axioms mined, contradictions caught,
+  entailed structure, approval burden). It does NOT yet measure ANSWER QUALITY — does
+  the enriched projection help the LLM answer better? That needs the live e2e (real
+  dataset → API extraction → DozerDB), which is the pending run and the decision gate:
+  adopt DL-as-shape (ia4.7) IFF the live answer-quality lift justifies the burden+cost;
+  else record "SHACL sufficient". ia4.7 stays BLOCKED on ia4.10.
+- 6 unit tests; new top-level module (0 regressions). Design: wiki/axiom-induction-
+  deduction-projection-design.md.

--- a/docs/decisions/ADR-0178-e2e-axiom-ab.json
+++ b/docs/decisions/ADR-0178-e2e-axiom-ab.json
@@ -1,0 +1,40 @@
+{
+  "graph": {
+    "nodes": 6,
+    "relationships": 7,
+    "docs_ingested": 0
+  },
+  "arm_A_shacl_only": {
+    "axiom_classes_mined": 0,
+    "contradictions_caught": 0,
+    "entailed_edges": 0,
+    "entailed_labels": 0
+  },
+  "arm_B_induced_deduced": {
+    "candidates_mined": 2,
+    "approved_axioms": 2,
+    "approved_by_kind": {
+      "functional": 1,
+      "inverse_functional": 1
+    },
+    "contradictions_caught": 0,
+    "contradiction_kinds": [],
+    "entailed_edges": 0,
+    "entailed_labels": 0
+  },
+  "top_axioms": [
+    {
+      "kind": "functional",
+      "subject": "MITIGATED_BY",
+      "support": 2,
+      "confidence": 1.0
+    },
+    {
+      "kind": "inverse_functional",
+      "subject": "MITIGATED_BY",
+      "support": 2,
+      "confidence": 1.0
+    }
+  ],
+  "note": "mechanism on REAL extracted data; answer-quality A/B (competency questions) is the next layer."
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1063,6 +1063,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - live refusal-ROC (real v1->v2 diff, property-level ground truth): always_warn 100/0, always_block 0/100, fresh_OLD(false-major) 0/83, fresh_label 0/50, fresh_prop 0/0 => freshness dominates corners; over-refusal shrinks with signal fidelity (OLD->label->prop), 0 under throughout
   - non-tautological (ground truth property-level, signals coarser); fully-live (real data answers) = pending e2e
   - 8 tests; promotes ADR-0176 to real signals
+## 2026-08-16 (axiom induction + deduction)
+
+- [Accepted] ADR-0178 inductive axiom mining + deductive entailment, A/B vs SHACL-only (seocho-ia4.8/9/10)
+  - axioms.py: mine_axioms (functional/inverse-functional/disjoint/subclass/AMIE-lite rules w/ support+confidence) + approve() gate + materialize_entailments (subclass closure + rule edges marked _entailed; functional/disjoint contradiction detection); structural, owlready2 stays offline
+  - resolves 'axiom extraction cumbersome' (mined not authored -> approval gate) + 'SHACL shapes human-in-loop' (shapes induced)
+  - A/B (offline fixture): SHACL-only 0 axioms / 0 contradictions / 0 entailed vs induced+deduced 12 axioms / 2 contradictions caught (functional+disjoint, which SHACL can't see) / 1 entailed edge; approval burden 12 of 15
+  - honest: mechanism measured offline; ANSWER-QUALITY delta = pending live e2e (never run) which gates DL-as-shape ia4.7
+  - 6 tests; insertion point pipeline.py:1002; complements rules.py
 
 ## Template
 

--- a/scripts/agentos/ablation_axiom_ab.py
+++ b/scripts/agentos/ablation_axiom_ab.py
@@ -1,0 +1,161 @@
+"""A/B: SHACL-only vs induced+deduced axioms on an extracted graph (seocho-ia4.10).
+
+hadry (2026-08-16): "이 실험을 한 번도 안 해봤다." This is the never-run test of the
+write-time-rigor bet — does mining richer axioms (induction) + materializing
+entailments (deduction) buy anything over the SHACL-only status quo?
+
+- Arm A (SHACL-only, today): rules.infer_rules_from_graph — single-property shape
+  constraints (required/datatype/enum/range) only.
+- Arm B (induced+deduced): axioms.mine_axioms -> approve -> materialize_entailments —
+  functional/inverse-functional, disjointness, subclass, composition rules, plus
+  entailment materialization and contradiction detection.
+
+Runs OFFLINE on a deterministic extracted-graph fixture (no API, no DB), so the
+MECHANISM metrics are measurable now: axioms mined, approval burden (# candidates a
+human reviews), contradictions the SHACL-only arm cannot catch, entailed structure
+added. The remaining metric — does the enriched projection improve LLM ANSWER
+quality — needs the live e2e (real dataset -> extraction -> DozerDB), which is the
+pending run this harness is the offline half of.
+
+Usage: python scripts/agentos/ablation_axiom_ab.py --out outputs/agentos/axiom_ab.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from seocho.axioms import approve, materialize_entailments, mine_axioms  # noqa: E402
+from seocho.rules import infer_rules_from_graph  # noqa: E402
+
+
+def _fixture() -> Dict[str, Any]:
+    """A deterministic extracted graph with real axiom-bearing patterns + planted
+    violations the SHACL-only arm cannot see."""
+    nodes = []
+    rels = []
+    # Customers and Orders: each Order PLACED_BY exactly one Customer (functional),
+    # except one planted violation.
+    for i in range(8):
+        nodes.append({"id": f"cust-{i}", "label": "Customer", "properties": {"name": f"C{i}"}})
+    for i in range(12):
+        nodes.append({"id": f"order-{i}", "label": "Order", "properties": {"amount": i * 10}})
+        rels.append({"source": f"order-{i}", "target": f"cust-{i % 8}", "type": "PLACED_BY"})
+    rels.append({"source": "order-0", "target": "cust-3", "type": "PLACED_BY"})  # functional VIOLATION
+
+    # Managers are Employees (subclass): every Manager node also carries Employee.
+    for i in range(5):
+        nodes.append({"id": f"mgr-{i}", "label": ["Manager", "Employee"], "properties": {"name": f"M{i}"}})
+    for i in range(10):
+        nodes.append({"id": f"emp-{i}", "label": "Employee", "properties": {"name": f"E{i}"}})
+
+    # Person vs Company: disjoint (multi-label vocabulary) with ONE planted violation.
+    # 14 each -> 1 violation gives confidence 1 - 1/15 = 0.933 >= 0.9 (mined despite it).
+    for i in range(14):
+        nodes.append({"id": f"person-{i}", "label": "Person", "properties": {"name": f"P{i}"}})
+    for i in range(14):
+        nodes.append({"id": f"co-{i}", "label": "Company", "properties": {"name": f"Co{i}"}})
+    nodes.append({"id": "mix-0", "label": ["Person", "Company"], "properties": {"name": "X"}})  # disjoint VIOLATION
+
+    # Composition rule: WORKS_IN(x,team) ^ LOCATED_IN(team,city) => BASED_IN(x,city).
+    # 12 WORKS_IN paths; BASED_IN asserted for all but 1 -> rule confidence 11/12=0.917
+    # >= 0.9 (mined), and materialize entails the 1 missing edge.
+    cities = ["nyc", "sf", "ldn"]
+    for c in cities:
+        nodes.append({"id": f"team-{c}", "label": "Team", "properties": {}})
+        nodes.append({"id": f"city-{c}", "label": "City", "properties": {}})
+        rels.append({"source": f"team-{c}", "target": f"city-{c}", "type": "LOCATED_IN"})
+    for i in range(10):   # 10 DISTINCT employees -> 10 distinct (emp,city) body paths
+        c = cities[i % 3]
+        rels.append({"source": f"emp-{i}", "target": f"team-{c}", "type": "WORKS_IN"})
+        if i != 0:        # miss exactly one BASED_IN -> confidence 9/10=0.9, entail 1
+            rels.append({"source": f"emp-{i}", "target": f"city-{c}", "type": "BASED_IN"})
+    return {"nodes": nodes, "relationships": rels}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--min-support", type=int, default=3)
+    ap.add_argument("--min-confidence", type=float, default=0.9)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    graph = _fixture()
+    n_nodes = len(graph["nodes"])
+    n_rels = len(graph["relationships"])
+
+    # --- Arm A: SHACL-only (status quo) ---
+    # rules.py is single-label (as real extraction nodes are); give it a
+    # first-label view so the multi-label fixture nodes don't break it. This does
+    # not change Arm A's property-shape output (it only reads node.properties).
+    single = {
+        "nodes": [{**n, "label": (n["label"][0] if isinstance(n.get("label"), list)
+                                  else n.get("label"))} for n in graph["nodes"]],
+        "relationships": graph["relationships"],
+    }
+    ruleset = infer_rules_from_graph(single)
+    arm_a = {
+        "property_shape_constraints": len(ruleset.rules),
+        "axiom_classes_mined": 0,          # SHACL-only mines no cross-type/edge axioms
+        "contradictions_caught": 0,        # cannot see functional/disjoint violations
+        "entailed_edges": 0,
+        "entailed_labels": 0,
+    }
+
+    # --- Arm B: induced + deduced ---
+    candidates = mine_axioms(graph, min_support=args.min_support, min_confidence=args.min_confidence)
+    approved = approve(candidates, min_support=args.min_support, min_confidence=args.min_confidence)
+    ent = materialize_entailments(graph, approved)
+    by_kind: Dict[str, int] = {}
+    for c in approved:
+        by_kind[c.kind] = by_kind.get(c.kind, 0) + 1
+    arm_b = {
+        "property_shape_constraints": len(ruleset.rules),   # B keeps A's shapes too
+        "candidates_mined": len(candidates),
+        "approved_axioms": len(approved),                    # the human approval burden
+        "approved_by_kind": by_kind,
+        "contradictions_caught": len(ent["contradictions"]),
+        "contradiction_kinds": sorted({c["kind"] for c in ent["contradictions"]}),
+        "entailed_edges": ent["entailed_edges"],
+        "entailed_labels": ent["entailed_labels"],
+        "graph_enrichment_ratio": round(ent["entailed_edges"] / max(n_rels, 1), 3),
+    }
+
+    report = {
+        "graph": {"nodes": n_nodes, "relationships": n_rels},
+        "arm_A_shacl_only": arm_a,
+        "arm_B_induced_deduced": arm_b,
+        "note": "answer-quality delta requires the live LLM e2e (real dataset -> "
+                "extraction -> DozerDB); this offline arm measures the mechanism.",
+    }
+
+    print("=== axiom A/B: SHACL-only vs induced+deduced (seocho-ia4.10) ===")
+    print(f"  graph: {n_nodes} nodes, {n_rels} rels")
+    print(f"  {'metric':26s} {'A: SHACL-only':>14s} {'B: induced+deduced':>20s}")
+    print(f"  {'property-shape constraints':26s} {arm_a['property_shape_constraints']:>14d} "
+          f"{arm_b['property_shape_constraints']:>20d}")
+    print(f"  {'axiom classes mined':26s} {arm_a['axiom_classes_mined']:>14d} "
+          f"{arm_b['approved_axioms']:>20d}  {arm_b['approved_by_kind']}")
+    print(f"  {'contradictions caught':26s} {arm_a['contradictions_caught']:>14d} "
+          f"{arm_b['contradictions_caught']:>20d}  {arm_b['contradiction_kinds']}")
+    print(f"  {'entailed edges added':26s} {arm_a['entailed_edges']:>14d} "
+          f"{arm_b['entailed_edges']:>20d}")
+    print(f"  {'entailed labels added':26s} {arm_a['entailed_labels']:>14d} "
+          f"{arm_b['entailed_labels']:>20d}")
+    print(f"  approval burden (candidates a human reviews) = {arm_b['approved_axioms']} "
+          f"of {arm_b['candidates_mined']} mined")
+    print("  NOTE: answer-quality delta needs the live e2e (this is the offline mechanism half).")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agentos/e2e_axiom_ab.py
+++ b/scripts/agentos/e2e_axiom_ab.py
@@ -1,0 +1,179 @@
+"""LIVE e2e: SHACL-only vs induced+deduced axioms on a REAL extracted graph.
+
+The live half of ADR-0178 / seocho-ia4.10. Runs the real SEOCHO indexing pipeline
+(LLM extraction via MARA -> materialize to DozerDB) over a document corpus, then
+mines axioms at CORPUS scope — reading the whole assembled graph from the store, NOT
+per-chunk (the seocho-ia4.8 cross-chunk answer: chunks are the extraction window;
+axioms are graph statistics over the interned, cross-document-merged store).
+
+Arm A (SHACL-only): the ontology's shape constraints only.
+Arm B (induced+deduced): mine_axioms over the store graph -> approve -> materialize
+entailments + detect contradictions.
+
+Measures the MECHANISM on real extracted data: axioms mined, approval burden,
+contradictions caught, entailed structure. (Answer-quality A/B is the next layer,
+via competency questions — left as a follow-up flag.)
+
+Isolation: a dedicated DozerDB database + workspace, so it never touches other data.
+
+Usage:
+  NEO4J_PASSWORD=<pw> python scripts/agentos/e2e_axiom_ab.py \
+      --graph bolt://localhost:17687 \
+      --database axiome2e --workspace axiom_e2e \
+      --llm mara/MiniMax-M2.5 --docs examples/finance-compliance/sample_docs \
+      --out outputs/agentos/e2e_axiom_ab.json [--smoke 2]
+
+(the DozerDB password is read from --neo4j-password or the NEO4J_PASSWORD env var.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import sys
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "src"))
+
+from seocho.axioms import approve, materialize_entailments, mine_axioms  # noqa: E402
+
+
+def _load_env(root: Path) -> None:
+    # worktrees don't carry .env; fall back to the main lab/seocho tree.
+    candidates = [root / ".env", Path("/home/hadry/lab/seocho/.env")]
+    for envf in candidates:
+        if envf.exists():
+            for line in envf.read_text().splitlines():
+                if line.strip() and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    os.environ.setdefault(k.strip(), v.strip())
+            return
+
+
+def _load_ontology(root: Path) -> Any:
+    path = root / "examples" / "finance-compliance" / "ontology.py"
+    spec = importlib.util.spec_from_file_location("_fc_ontology", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.build_ontology()
+
+
+def _read_store_graph(uri: str, user: str, pw: str, database: str, ws: str) -> Dict[str, Any]:
+    """Read the WHOLE materialized graph (workspace-scoped) — corpus scope, all docs
+    merged by interning. This is where cross-chunk / cross-document axioms live."""
+    from neo4j import GraphDatabase
+    d = GraphDatabase.driver(uri, auth=(user, pw))
+    nodes: List[Dict[str, Any]] = []
+    rels: List[Dict[str, Any]] = []
+    with d.session(database=database) as s:
+        for r in s.run(
+            "MATCH (n) WHERE coalesce(n._workspace_id, n.workspace_id, $ws) = $ws "
+            "RETURN elementId(n) AS id, labels(n) AS labels, properties(n) AS props",
+            ws=ws,
+        ):
+            labs = [x for x in (r["labels"] or []) if not str(x).startswith("_")]
+            nodes.append({"id": r["id"], "label": labs, "properties": dict(r["props"] or {})})
+        for r in s.run(
+            "MATCH (a)-[e]->(b) WHERE coalesce(a._workspace_id, a.workspace_id, $ws) = $ws "
+            "RETURN elementId(a) AS source, elementId(b) AS target, type(e) AS type",
+            ws=ws,
+        ):
+            rels.append({"source": r["source"], "target": r["target"], "type": r["type"]})
+    d.close()
+    return {"nodes": nodes, "relationships": rels}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--graph", default="bolt://localhost:17687")
+    ap.add_argument("--neo4j-user", default="neo4j")
+    ap.add_argument("--neo4j-password", default=None,
+                    help="DozerDB password (or set NEO4J_PASSWORD)")
+    ap.add_argument("--database", default="axiome2e")
+    ap.add_argument("--workspace", default="axiom_e2e")
+    ap.add_argument("--llm", default="mara/MiniMax-M2.5")
+    ap.add_argument("--docs", default="examples/finance-compliance/sample_docs")
+    ap.add_argument("--min-support", type=int, default=2)
+    ap.add_argument("--min-confidence", type=float, default=0.8)
+    ap.add_argument("--smoke", type=int, default=0, help="ingest only the first N docs")
+    ap.add_argument("--skip-ingest", action="store_true",
+                    help="skip extraction; mine the already-materialized graph")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    _load_env(_ROOT)
+    pw = args.neo4j_password or os.environ.get("NEO4J_PASSWORD", "")
+    onto = _load_ontology(_ROOT)
+
+    ingested = 0
+    if not args.skip_ingest:
+        from seocho import Seocho
+        api_key = os.environ.get("MARA_API_KEY") if args.llm.startswith("mara/") else None
+        s = Seocho.local(onto, llm=args.llm, graph=args.graph,
+                         neo4j_user=args.neo4j_user, neo4j_password=pw,
+                         api_key=api_key, workspace_id=args.workspace)
+        docs = sorted(Path(args.docs).glob("*.txt"))
+        if args.smoke:
+            docs = docs[: args.smoke]
+        for p in docs:
+            s.add(p.read_text(), database=args.database)
+            ingested += 1
+            print(f"  ingested {p.name}")
+
+    # --- read the assembled graph from the store (corpus scope) ---
+    graph = _read_store_graph(args.graph, args.neo4j_user, pw,
+                              args.database, args.workspace)
+    n_nodes, n_rels = len(graph["nodes"]), len(graph["relationships"])
+
+    # --- Arm B: induce + deduce over the store graph ---
+    candidates = mine_axioms(graph, min_support=args.min_support,
+                             min_confidence=args.min_confidence)
+    approved = approve(candidates, min_support=args.min_support,
+                       min_confidence=args.min_confidence)
+    ent = materialize_entailments(graph, approved)
+    by_kind: Dict[str, int] = {}
+    for c in approved:
+        by_kind[c.kind] = by_kind.get(c.kind, 0) + 1
+
+    report = {
+        "graph": {"nodes": n_nodes, "relationships": n_rels, "docs_ingested": ingested},
+        "arm_A_shacl_only": {"axiom_classes_mined": 0, "contradictions_caught": 0,
+                             "entailed_edges": 0, "entailed_labels": 0},
+        "arm_B_induced_deduced": {
+            "candidates_mined": len(candidates),
+            "approved_axioms": len(approved),
+            "approved_by_kind": by_kind,
+            "contradictions_caught": len(ent["contradictions"]),
+            "contradiction_kinds": sorted({c["kind"] for c in ent["contradictions"]}),
+            "entailed_edges": ent["entailed_edges"],
+            "entailed_labels": ent["entailed_labels"],
+        },
+        "top_axioms": [
+            {"kind": c.kind, "subject": c.subject, "support": c.support, "confidence": c.confidence}
+            for c in sorted(approved, key=lambda c: (-c.support, -c.confidence))[:15]
+        ],
+        "note": "mechanism on REAL extracted data; answer-quality A/B (competency "
+                "questions) is the next layer.",
+    }
+
+    b = report["arm_B_induced_deduced"]
+    print(f"\n=== LIVE e2e axiom A/B (real MARA extraction -> DozerDB {args.database}) ===")
+    print(f"  graph: {n_nodes} nodes, {n_rels} rels ({ingested} docs)")
+    print("  Arm A (SHACL-only):   0 axioms, 0 contradictions, 0 entailed")
+    print(f"  Arm B (induced+deduced): {b['approved_axioms']} axioms {b['approved_by_kind']}")
+    print(f"                            {b['contradictions_caught']} contradictions {b['contradiction_kinds']}")
+    print(f"                            {b['entailed_edges']} entailed edges, {b['entailed_labels']} entailed labels")
+    print(f"  approval burden: {b['approved_axioms']} of {b['candidates_mined']} mined")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agentos/e2e_axiom_ab.py
+++ b/scripts/agentos/e2e_axiom_ab.py
@@ -50,7 +50,15 @@ def _load_env(root: Path) -> None:
             for line in envf.read_text().splitlines():
                 if line.strip() and not line.startswith("#") and "=" in line:
                     k, v = line.split("=", 1)
-                    os.environ.setdefault(k.strip(), v.strip())
+                    k = k.strip()
+                    # Only load LLM/provider API keys from .env; NEVER load NEO4J_*
+                    # (the .env points at a different DozerDB instance than this
+                    # e2e uses — loading it caused a wrong-password lockout).
+                    if k.startswith("NEO4J") or k.startswith("BOLT"):
+                        continue
+                    # strip surrounding quotes — a quoted key is otherwise sent
+                    # verbatim (quotes included) and 401s.
+                    os.environ.setdefault(k, v.strip().strip('"').strip("'"))
             return
 
 
@@ -62,13 +70,24 @@ def _load_ontology(root: Path) -> Any:
     return mod.build_ontology()
 
 
-def _read_store_graph(uri: str, user: str, pw: str, database: str, ws: str) -> Dict[str, Any]:
+# The runtime memory-graph scaffolding (ensure_memory_graph) is provenance plumbing,
+# not domain knowledge — axioms must be mined over DOMAIN nodes/rels, else the miner
+# just rediscovers that "each Document HAS_VERSION its versions" etc.
+_MEMORY_LABELS = {"Document", "DocumentVersion", "Chunk", "Section", "Observation"}
+_MEMORY_RELS = {"HAS_CHUNK", "HAS_VERSION", "CURRENT_VERSION", "HAS_SECTION",
+                "MENTIONS", "HAS_OBSERVATION", "NEXT_CHUNK"}
+
+
+def _read_store_graph(uri: str, user: str, pw: str, database: str, ws: str,
+                      *, domain_only: bool = True) -> Dict[str, Any]:
     """Read the WHOLE materialized graph (workspace-scoped) — corpus scope, all docs
-    merged by interning. This is where cross-chunk / cross-document axioms live."""
+    merged by interning. This is where cross-chunk / cross-document axioms live.
+    With ``domain_only`` the memory-graph provenance layer is excluded."""
     from neo4j import GraphDatabase
     d = GraphDatabase.driver(uri, auth=(user, pw))
     nodes: List[Dict[str, Any]] = []
     rels: List[Dict[str, Any]] = []
+    domain_ids: set = set()
     with d.session(database=database) as s:
         for r in s.run(
             "MATCH (n) WHERE coalesce(n._workspace_id, n.workspace_id, $ws) = $ws "
@@ -76,12 +95,18 @@ def _read_store_graph(uri: str, user: str, pw: str, database: str, ws: str) -> D
             ws=ws,
         ):
             labs = [x for x in (r["labels"] or []) if not str(x).startswith("_")]
+            if domain_only and (not labs or any(x in _MEMORY_LABELS for x in labs)):
+                continue
+            domain_ids.add(r["id"])
             nodes.append({"id": r["id"], "label": labs, "properties": dict(r["props"] or {})})
         for r in s.run(
             "MATCH (a)-[e]->(b) WHERE coalesce(a._workspace_id, a.workspace_id, $ws) = $ws "
             "RETURN elementId(a) AS source, elementId(b) AS target, type(e) AS type",
             ws=ws,
         ):
+            if domain_only and (r["type"] in _MEMORY_RELS
+                                or r["source"] not in domain_ids or r["target"] not in domain_ids):
+                continue
             rels.append({"source": r["source"], "target": r["target"], "type": r["type"]})
     d.close()
     return {"nodes": nodes, "relationships": rels}

--- a/src/seocho/axioms.py
+++ b/src/seocho/axioms.py
@@ -1,0 +1,272 @@
+"""Inductive axiom mining + deductive entailment materialization (seocho-ia4.8/ia4.9).
+
+The existing `rules.py` mines only single-*property* SHACL-shape axioms (required /
+datatype / enum / range). This module adds the richer axiom classes the write-time-
+rigor thesis needs — mined automatically from the extracted graph (induction), so a
+human APPROVES candidates rather than AUTHORS them — plus a cheap, structural
+deductive step that materializes entailed edges/labels so the projected graph carries
+inferred structure the LLM can traverse. See wiki/axiom-induction-deduction-
+projection-design.md.
+
+Induction (``mine_axioms``): over {nodes, relationships},
+- functional / inverse-functional: a relationship type where (almost) every source
+  has <=1 target (resp. target has <=1 source) — the DL functional/IFP property, and
+  the write-time interning `identity_keys` signal in shape form.
+- disjoint: two labels that never co-occur on a node (owl:disjointWith candidate) —
+  catches the 동명이인 / wrong-subgraph boundary-1 error at write time.
+- subclass: label A whose every instance also carries label B (A ⊑ B).
+- rule (AMIE-lite): a 2-hop composition R1(x,y) ∧ R2(y,z) ⇒ R3(x,z), with
+  support/confidence.
+All candidates carry support + confidence; the caller keeps those at/above a
+threshold (the cheap human-approval gate).
+
+Deduction (``materialize_entailments``): applies confirmed axioms — subclass closure
+(ancestor labels), composition rules (new edges) — and DETECTS contradictions
+(functional / disjoint violations). Entailed elements are marked ``_entailed:"true"``
+(analogous to the existing ``_out_of_ontology`` stamp) so induced/deduced assertions
+stay auditable against asserted ones. Structural only; a full OWL reasoner
+(owlready2) stays offline (governance), never on this path.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set, Tuple
+
+
+@dataclass
+class AxiomCandidate:
+    kind: str                    # functional | inverse_functional | disjoint | subclass | rule
+    subject: str                 # relationship type or label (or "R1,R2=>R3" for rule)
+    detail: Dict[str, Any] = field(default_factory=dict)
+    support: int = 0             # # of instances the pattern is drawn from
+    confidence: float = 0.0      # fraction consistent with the axiom
+
+    def key(self) -> Tuple[str, str]:
+        return (self.kind, self.subject)
+
+
+def _node_labels(nodes: List[Dict[str, Any]]) -> Dict[str, Set[str]]:
+    """node id -> set of labels (a node may carry several; label may be str or list)."""
+    out: Dict[str, Set[str]] = {}
+    for n in nodes:
+        nid = str(n.get("id", ""))
+        lab = n.get("label", n.get("labels", []))
+        labs = {str(lab)} if isinstance(lab, str) else {str(x) for x in (lab or [])}
+        out.setdefault(nid, set()).update({x for x in labs if x})
+    return out
+
+
+def mine_axioms(
+    graph: Dict[str, Any],
+    *,
+    min_support: int = 3,
+    min_confidence: float = 0.9,
+    mine_rules: bool = True,
+) -> List[AxiomCandidate]:
+    """Induce candidate axioms from an extracted graph. Returns ALL candidates with
+    support/confidence; the caller filters by threshold (the approval gate)."""
+    nodes = graph.get("nodes", []) or []
+    rels = graph.get("relationships", []) or []
+    labels_of = _node_labels(nodes)
+    out: List[AxiomCandidate] = []
+
+    # --- functional / inverse-functional per relationship type -----------------
+    by_type_src: Dict[str, Dict[str, Set[str]]] = defaultdict(lambda: defaultdict(set))
+    by_type_tgt: Dict[str, Dict[str, Set[str]]] = defaultdict(lambda: defaultdict(set))
+    for r in rels:
+        rt = str(r.get("type", ""))
+        s, t = str(r.get("source", "")), str(r.get("target", ""))
+        if rt and s and t:
+            by_type_src[rt][s].add(t)
+            by_type_tgt[rt][t].add(s)
+    for rt, src_map in by_type_src.items():
+        n = len(src_map)
+        if n >= min_support:
+            consistent = sum(1 for tgts in src_map.values() if len(tgts) <= 1)
+            conf = consistent / n
+            out.append(AxiomCandidate("functional", rt,
+                                      {"reading": "each source has <=1 target"},
+                                      support=n, confidence=round(conf, 3)))
+    for rt, tgt_map in by_type_tgt.items():
+        n = len(tgt_map)
+        if n >= min_support:
+            consistent = sum(1 for srcs in tgt_map.values() if len(srcs) <= 1)
+            conf = consistent / n
+            out.append(AxiomCandidate("inverse_functional", rt,
+                                      {"reading": "each target has <=1 source"},
+                                      support=n, confidence=round(conf, 3)))
+
+    # --- disjointness: labels that (almost) never co-occur ---------------------
+    # Restricted to the MULTI-LABEL VOCABULARY — labels that the modeling actually
+    # multi-types somewhere. Between labels that are never multi-typed, disjointness
+    # is trivially true for every unrelated pair (combinatorial noise); it is only a
+    # meaningful CANDIDATE among classes where overlap is structurally possible.
+    # Confidence-based, so a rare violation does not suppress the axiom (the violation
+    # is then caught deductively by materialize_entailments).
+    label_counts: Dict[str, int] = defaultdict(int)
+    cooccur: Dict[Tuple[str, str], int] = defaultdict(int)
+    multi_vocab: Set[str] = set()
+    for labs in labels_of.values():
+        for lb in labs:
+            label_counts[lb] += 1
+        if len(labs) > 1:
+            multi_vocab.update(labs)
+        ls = sorted(labs)
+        for i in range(len(ls)):
+            for j in range(i + 1, len(ls)):
+                cooccur[(ls[i], ls[j])] += 1
+    candidates_lbl = sorted(lb for lb in multi_vocab if label_counts[lb] >= min_support)
+    for i in range(len(candidates_lbl)):
+        for j in range(i + 1, len(candidates_lbl)):
+            a, b = candidates_lbl[i], candidates_lbl[j]
+            co = cooccur.get((a, b), 0)
+            conf = 1.0 - co / max(min(label_counts[a], label_counts[b]), 1)
+            if conf >= min_confidence:
+                out.append(AxiomCandidate("disjoint", f"{a}|{b}",
+                                          {"labels": [a, b], "cooccurrences": co},
+                                          support=min(label_counts[a], label_counts[b]),
+                                          confidence=round(conf, 3)))
+
+    # --- subclass: A's instances all also carry B ------------------------------
+    inst_of: Dict[str, Set[str]] = defaultdict(set)
+    for nid, labs in labels_of.items():
+        for lb in labs:
+            inst_of[lb].add(nid)
+    present = sorted(lb for lb, c in label_counts.items() if c >= min_support)
+    for a in present:
+        for b in present:
+            if a == b:
+                continue
+            if inst_of[a] and inst_of[a] <= inst_of[b] and len(inst_of[a]) < len(inst_of[b]):
+                out.append(AxiomCandidate("subclass", f"{a}=>{b}",
+                                          {"child": a, "parent": b},
+                                          support=len(inst_of[a]), confidence=1.0))
+
+    # --- AMIE-lite composition rules: R1(x,y) ^ R2(y,z) => R3(x,z) --------------
+    if mine_rules:
+        out.extend(_mine_composition_rules(rels, min_support=min_support))
+
+    return out
+
+
+def _mine_composition_rules(rels, *, min_support: int) -> List[AxiomCandidate]:
+    out: List[AxiomCandidate] = []
+    edges: Dict[str, List[Tuple[str, str]]] = defaultdict(list)   # type -> [(s,t)]
+    pair_types: Dict[Tuple[str, str], Set[str]] = defaultdict(set)  # (s,t) -> {types}
+    for r in rels:
+        rt, s, t = str(r.get("type", "")), str(r.get("source", "")), str(r.get("target", ""))
+        if rt and s and t:
+            edges[rt].append((s, t))
+            pair_types[(s, t)].add(rt)
+    by_src: Dict[str, List[Tuple[str, str]]] = defaultdict(list)   # type indexed by source
+    for rt, es in edges.items():
+        for s, t in es:
+            by_src[s].append((rt, t))
+    # count body support and head co-occurrence
+    body: Dict[Tuple[str, str], int] = defaultdict(int)
+    bodyhead: Dict[Tuple[str, str, str], int] = defaultdict(int)
+    for r in rels:
+        r1, x, y = str(r.get("type", "")), str(r.get("source", "")), str(r.get("target", ""))
+        if not (r1 and x and y):
+            continue
+        for (r2, z) in by_src.get(y, []):
+            body[(r1, r2)] += 1
+            for r3 in pair_types.get((x, z), set()):
+                bodyhead[(r1, r2, r3)] += 1
+    for (r1, r2, r3), bh in bodyhead.items():
+        b = body[(r1, r2)]
+        if b >= min_support and r3 not in (r1, r2):
+            out.append(AxiomCandidate("rule", f"{r1},{r2}=>{r3}",
+                                      {"body": [r1, r2], "head": r3},
+                                      support=b, confidence=round(bh / b, 3)))
+    return out
+
+
+def approve(candidates: List[AxiomCandidate], *, min_support: int = 3,
+            min_confidence: float = 0.9) -> List[AxiomCandidate]:
+    """The cheap approval gate: keep high-support, high-confidence candidates."""
+    return [c for c in candidates
+            if c.support >= min_support and c.confidence >= min_confidence]
+
+
+def materialize_entailments(
+    graph: Dict[str, Any],
+    axioms: List[AxiomCandidate],
+) -> Dict[str, Any]:
+    """Deduce: apply confirmed axioms (subclass closure, composition rules) to add
+    entailed labels/edges (marked ``_entailed``), and detect contradictions
+    (functional / disjoint violations). Returns a report + the enriched graph."""
+    nodes = [dict(n) for n in (graph.get("nodes", []) or [])]
+    rels = [dict(r) for r in (graph.get("relationships", []) or [])]
+    labels_of = _node_labels(nodes)
+    node_by_id = {str(n.get("id", "")): n for n in nodes}
+
+    entailed_labels = 0
+    entailed_edges: List[Dict[str, Any]] = []
+    contradictions: List[Dict[str, Any]] = []
+
+    # subclass closure: A ⊑ B -> stamp label B on A's instances
+    for ax in axioms:
+        if ax.kind == "subclass":
+            child, parent = ax.detail["child"], ax.detail["parent"]
+            for nid, labs in labels_of.items():
+                if child in labs and parent not in labs:
+                    n = node_by_id.get(nid)
+                    if n is not None:
+                        props = n.setdefault("properties", {})
+                        props[f"_entailed_label_{parent}"] = "true"
+                        labs.add(parent)
+                        entailed_labels += 1
+
+    # disjoint violation detection
+    for ax in axioms:
+        if ax.kind == "disjoint":
+            a, b = ax.detail["labels"]
+            for nid, labs in labels_of.items():
+                if a in labs and b in labs:
+                    contradictions.append({"kind": "disjoint_violation",
+                                           "node": nid, "labels": [a, b]})
+
+    # functional violation detection
+    by_type_src: Dict[str, Dict[str, Set[str]]] = defaultdict(lambda: defaultdict(set))
+    for r in rels:
+        rt, s, t = str(r.get("type", "")), str(r.get("source", "")), str(r.get("target", ""))
+        if rt and s and t:
+            by_type_src[rt][s].add(t)
+    for ax in axioms:
+        if ax.kind == "functional":
+            for s, tgts in by_type_src.get(ax.subject, {}).items():
+                if len(tgts) > 1:
+                    contradictions.append({"kind": "functional_violation",
+                                           "rel_type": ax.subject, "source": s,
+                                           "targets": sorted(tgts)})
+
+    # composition rules: add entailed head edges where absent
+    existing = {(str(r.get("source")), str(r.get("target")), str(r.get("type"))) for r in rels}
+    by_src: Dict[str, List[Tuple[str, str]]] = defaultdict(list)
+    for r in rels:
+        by_src[str(r.get("source", ""))].append((str(r.get("type", "")), str(r.get("target", ""))))
+    for ax in axioms:
+        if ax.kind == "rule":
+            r1, r2 = ax.detail["body"]
+            r3 = ax.detail["head"]
+            for r in rels:
+                if str(r.get("type")) != r1:
+                    continue
+                x, y = str(r.get("source", "")), str(r.get("target", ""))
+                for (rt2, z) in by_src.get(y, []):
+                    if rt2 == r2 and (x, z, r3) not in existing:
+                        entailed_edges.append({"source": x, "target": z, "type": r3,
+                                               "properties": {"_entailed": "true"}})
+                        existing.add((x, z, r3))
+
+    rels.extend(entailed_edges)
+    return {
+        "nodes": nodes,
+        "relationships": rels,
+        "entailed_labels": entailed_labels,
+        "entailed_edges": len(entailed_edges),
+        "contradictions": contradictions,
+    }

--- a/tests/seocho/test_axioms.py
+++ b/tests/seocho/test_axioms.py
@@ -1,0 +1,74 @@
+"""Inductive axiom mining + deductive entailment (seocho-ia4.8/ia4.9)."""
+
+from __future__ import annotations
+
+from seocho.axioms import approve, materialize_entailments, mine_axioms
+
+
+def _g(nodes, rels):
+    return {"nodes": nodes, "relationships": rels}
+
+
+def test_mine_functional_relationship():
+    nodes = [{"id": f"o{i}", "label": "Order"} for i in range(5)] + \
+            [{"id": f"c{i}", "label": "Cust"} for i in range(5)]
+    rels = [{"source": f"o{i}", "target": f"c{i}", "type": "PLACED_BY"} for i in range(5)]
+    ax = mine_axioms(_g(nodes, rels), min_support=3)
+    fn = [a for a in ax if a.kind == "functional" and a.subject == "PLACED_BY"]
+    assert fn and fn[0].confidence == 1.0
+
+
+def test_mine_subclass():
+    nodes = [{"id": f"m{i}", "label": ["Manager", "Employee"]} for i in range(4)] + \
+            [{"id": f"e{i}", "label": "Employee"} for i in range(4)]
+    ax = mine_axioms(_g(nodes, []), min_support=3)
+    sub = [a for a in ax if a.kind == "subclass"]
+    assert any(a.detail == {"child": "Manager", "parent": "Employee"} for a in sub)
+
+
+def test_mine_disjoint_confidence_tolerates_rare_violation():
+    nodes = [{"id": f"p{i}", "label": "Person"} for i in range(10)]
+    nodes += [{"id": f"c{i}", "label": "Company"} for i in range(10)]
+    # both Person and Company enter the multi-label vocabulary via one mixed node,
+    # which is also the rare disjoint violation the axiom must tolerate:
+    nodes += [{"id": "mix", "label": ["Person", "Company"]}]
+    ax = mine_axioms(_g(nodes, []), min_support=3, min_confidence=0.9)
+    dj = [a for a in ax if a.kind == "disjoint"]
+    assert any(set(a.detail["labels"]) == {"Person", "Company"} for a in dj)
+
+
+def test_mine_composition_rule():
+    rels = []
+    for i in range(6):
+        rels += [{"source": f"x{i}", "target": f"y{i}", "type": "R1"},
+                 {"source": f"y{i}", "target": f"z{i}", "type": "R2"}]
+        if i != 0:
+            rels.append({"source": f"x{i}", "target": f"z{i}", "type": "R3"})
+    ax = mine_axioms(_g([], rels), min_support=3, mine_rules=True)
+    rules = [a for a in ax if a.kind == "rule" and a.detail.get("head") == "R3"]
+    assert rules and 0.8 <= rules[0].confidence < 1.0
+
+
+def test_materialize_detects_functional_violation():
+    nodes = [{"id": f"o{i}", "label": "Order"} for i in range(5)]
+    rels = [{"source": f"o{i}", "target": f"c{i}", "type": "PLACED_BY"} for i in range(5)]
+    rels.append({"source": "o0", "target": "cX", "type": "PLACED_BY"})   # violation
+    ax = approve(mine_axioms(_g(nodes, rels), min_support=3, min_confidence=0.8),
+                 min_support=3, min_confidence=0.8)
+    ent = materialize_entailments(_g(nodes, rels), ax)
+    assert any(c["kind"] == "functional_violation" for c in ent["contradictions"])
+
+
+def test_materialize_adds_entailed_edge():
+    rels = []
+    for i in range(6):
+        rels += [{"source": f"x{i}", "target": f"y{i}", "type": "R1"},
+                 {"source": f"y{i}", "target": f"z{i}", "type": "R2"}]
+        if i != 0:
+            rels.append({"source": f"x{i}", "target": f"z{i}", "type": "R3"})
+    ax = approve(mine_axioms(_g([], rels), min_support=3, min_confidence=0.8),
+                 min_support=3, min_confidence=0.8)
+    ent = materialize_entailments(_g([], rels), ax)
+    assert ent["entailed_edges"] >= 1
+    assert any(r.get("properties", {}).get("_entailed") == "true"
+               for r in ent["relationships"])


### PR DESCRIPTION
## The never-run experiment: does write-time axiom rigor buy anything?

hadry's write-time-rigor thesis (Keet, induction/deduction §2.2.3): a KG earns its keep by capturing as **axioms** what the LLM missed, running validated inference, and projecting an enriched graph. Two worries: (1) extracting axioms by hand is too cumbersome; (2) SHACL-only over-depends on human-authored shapes. The indexing survey confirmed the gap — indexing mines only single-**property** shape rules (`rules.py`) and has **no deductive/entailment step** (owlready2 is offline-only). This is the first time the alternative has been built and measured.

## What this adds — `src/seocho/axioms.py`

**Induction (`mine_axioms`)** — mines, with support+confidence, the axiom classes `rules.py` can't:
- **functional / inverse-functional** from edge cardinality stats (the DL functional/IFP property = the write-time interning signal in shape form)
- **disjointness** — restricted to the *multi-label vocabulary* (classes the modeling actually multi-types; avoids the combinatorial noise of "every unrelated pair is trivially disjoint"), confidence-based so a rare violation doesn't suppress the axiom
- **subclass** (extent containment), **AMIE-lite composition rules** R1∧R2⇒R3

`approve()` is the cheap **human-APPROVAL gate** (keep high support+confidence) — axioms are *mined, not authored*, which resolves the "cumbersome" worry; SHACL shapes are *induced, not hand-written*, which removes the human-in-the-loop dependence.

**Deduction (`materialize_entailments`)** — applies approved axioms (subclass closure + composition-rule edges, marked `_entailed:"true"` so they stay auditable against asserted facts) and **detects contradictions** (functional / disjoint violations). Structural only; a full OWL reasoner stays offline.

Natural insertion point (from the indexing survey): after the existing rule hook at `pipeline.py:1002`, feeding the per-document graph, before `_shape_and_write_graph` (so entailed edges inherit the provenance stamp).

## Result — A/B on a deterministic extracted-graph fixture

`scripts/agentos/ablation_axiom_ab.py` (70 nodes / 35 rels, planted patterns + violations), runs offline (no API/DB):

| metric | A: SHACL-only | B: induced+deduced |
|---|---|---|
| property-shape constraints | 13 | 13 |
| axiom classes mined (approved) | **0** | **12** (functional 4, inv-func 1, disjoint 5, subclass 1, rule 1) |
| contradictions caught | **0** | **2** (functional + disjoint — SHACL structurally cannot) |
| entailed edges added | **0** | **1** (composition rule filled a gap the LLM didn't assert) |
| approval burden | — | **12 of 15** mined |

B catches contradictions A can't even see, and enriches the graph — at a **quantified** approval burden (the "cumbersome" worry is now a number, not a guess).

## Honest scope

This measures the **mechanism** (axioms mined, contradictions caught, entailed structure, approval burden). It does **not** yet measure **answer quality** — does the enriched projection help the LLM answer better? That needs the **live e2e** (real dataset → API extraction → DozerDB), which is the pending run and the decision gate: adopt DL-as-shape (ia4.7) IFF the live answer-quality lift justifies the burden+cost; else record "SHACL sufficient". **ia4.7 is BLOCKED on ia4.10 (this experiment's live half).**

## Validation
- `+6` unit tests (`tests/seocho/test_axioms.py`): functional / subclass / disjoint-confidence / composition-rule mining, functional-violation + entailed-edge deduction.
- New top-level module (like `rules.py`) → 120 index/rules/axiom tests pass, **0 regressions**.
- `ruff` clean; ADR-0178 + JSON; `check-doc-contracts.sh` passes.

seocho-ia4.8 (miner) + ia4.9 (deduction) + ia4.10 (A/B, offline half). Design: `wiki/axiom-induction-deduction-projection-design.md`.
