### PR TITLE
feat(index): indexing parallelism — concurrent extraction + shared intern table (ADR-0182)

### DIFF
--- a/docs/decisions/ADR-0182-indexing-concurrency.json
+++ b/docs/decisions/ADR-0182-indexing-concurrency.json
@@ -1,0 +1,37 @@
+{
+  "chunks": 12,
+  "extract_latency_s": 0.4,
+  "extraction_concurrency": {
+    "1": {
+      "wall_s": 4.806,
+      "speedup": 1.0
+    },
+    "2": {
+      "wall_s": 2.404,
+      "speedup": 2.0
+    },
+    "4": {
+      "wall_s": 1.203,
+      "speedup": 4.0
+    },
+    "8": {
+      "wall_s": 0.802,
+      "speedup": 5.99
+    },
+    "12": {
+      "wall_s": 0.403,
+      "speedup": 11.94
+    }
+  },
+  "interning": {
+    "ops": 200000,
+    "wall_s": 0.167,
+    "ops_per_s": 1194727,
+    "time_to_intern_one_doc_of_extraction_worth": 0.0005
+  },
+  "verdict": {
+    "extraction_is_io_bound_concurrency_win": 5.99,
+    "interning_share_of_a_sequential_extract": 0.000104,
+    "rust_intern_table_warranted_now": false
+  }
+}

--- a/docs/decisions/ADR-0182-indexing-parallelism.md
+++ b/docs/decisions/ADR-0182-indexing-parallelism.md
@@ -1,0 +1,65 @@
+# ADR-0182: indexing parallelism — concurrent extraction + shared intern table
+
+Date: 2026-08-16 · Status: accepted (measured) · seocho-ia4 (indexing parallelism)
+
+## Context
+
+hadry: indexing has parallelizable parts — implement in Rust, multi-thread, from a
+shared-memory perspective (SEOCHO aims to be an OS). We separated the kinds of
+parallelism and let measurement decide where each tool belongs, in four steps.
+
+## Decision & result (the four steps)
+
+**Step 1 — concurrent extraction (I/O-bound → threads, not Rust).** Per-chunk LLM
+extraction is a network round-trip, independent across chunks. `index/parallel.py::
+concurrent_map` (order-preserving, exception-capturing thread pool) pre-fetches all
+chunk extractions concurrently; the deterministic post-processing loop is unchanged
+and still runs in chunk order. Opt-in via `SEOCHO_EXTRACTION_CONCURRENCY` /
+`_extraction_concurrency` (default 1 = exact back-compat). A per-chunk failure is
+captured in place and re-raised into the existing strict/guided fallback handler —
+so behavior is identical to sequential. Existing index/pipeline/extraction tests
+pass **identically** with concurrency off (151) and on (=4, 151).
+
+**Step 2 — profile (measure before optimizing).** `scripts/agentos/
+bench_indexing_concurrency.py` (deterministic, mock latency):
+
+| extraction (12 chunks @ 0.4s, I/O-bound) | wall | speedup |
+|---|---|---|
+| 1 worker | 4.81s | 1.0× |
+| 4 | 1.20s | 4.0× |
+| 8 | 0.80s | **5.99×** |
+| 12 | 0.40s | 11.94× |
+
+Interning (CPU-bound): **1.19M ops/s** — interning a whole doc's entities ≈ 0.5 ms,
+negligible beside a multi-second extraction.
+
+**Step 3 — shared-memory intern table (the OS shared-memory core).**
+`index/shared_intern.py::SharedInternTable` — a process-wide, thread-safe,
+workspace-scoped (protection-domain-keyed), sharded (per-shard lock) map from a
+composite identity to its canonical id. First-writer-wins, so the same entity
+interned on N threads converges to ONE canonical address (proven: 16 threads racing
+one entity → one id, zero fragmentation). This is hadry's "shared memory" made
+concrete — the allocator's canonical-entity namespace shared across concurrent
+extraction workers / agents. **Built in Python.**
+
+**Step 4 — Rust only when measured-warranted (don't premature-optimize).** The
+profile settles it with data: extraction is I/O-bound (a thread pool wins ~6–12×;
+Rust buys nothing for network waits), and interning does 1.2M ops/s (CPU is nowhere
+near the bottleneck). **A Rust `seocho-core` concurrent intern table is NOT warranted
+now.** Documented escalation trigger: revisit when interning throughput matters
+(< ~50k ops/s under real load, or the CPU tail — dedup + axiom mining + cosine —
+becomes a measured share of indexing wall-clock at scale). SEOCHO already has a
+`seocho-core` Rust crate (cosine/rules) + rust-ext codec, so the escalation path is
+short when the data calls for it.
+
+## Consequences
+
+- The big indexing win (overlapping LLM round-trips) is delivered, opt-in, safe, and
+  measured (~6× at 8 workers). The shared-memory intern table gives correct
+  cross-thread interning (no fragmentation) for when concurrency is enabled.
+- Composes with the OS concurrency discipline: the shared intern table is the
+  shared-memory structure the RCU/EBR reclamation work (ia4.3/.4) governs.
+- Follow-ups: wire `SharedInternTable` into the pipeline's identity step under
+  concurrency; async (vs thread) extraction if the sync client becomes a limit;
+  Rust intern table iff the escalation trigger fires. +7 tests
+  (`test_indexing_parallel.py`).

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1088,6 +1088,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - structure/axiom-support: bootstrap wins (hierarchical types 36/36 vs 0, axioms 20 vs 13)
   - drift INCONCLUSIVE: string-norm metric too weak for semantic synonyms; bootstrap increased granularity; true control = grouping under ~11 upper cats not fewer types; embedding-cluster metric = follow-up
   - decision: wiring bootstrap mode into engine warranted (recall fear disproven)
+## 2026-08-16 (indexing parallelism)
+
+- [Accepted] ADR-0182 indexing parallelism — concurrent extraction + shared intern table (seocho-ia4)
+  - step 1: concurrent_map pre-fetches per-chunk LLM extraction (I/O-bound -> thread pool, order-preserving, opt-in SEOCHO_EXTRACTION_CONCURRENCY); 151 index tests pass identically off AND on
+  - step 2 profile: extraction near-linear (8w=5.99x, 12w=11.94x); interning 1.19M ops/s (~0.5ms/doc, negligible)
+  - step 3: SharedInternTable = thread-safe workspace-scoped sharded intern table (shared-memory core); 16 threads racing one entity converge to one canonical id (no fragmentation)
+  - step 4: Rust intern table NOT warranted now (data: extraction I/O-bound, interning 1.2M ops/s); trigger documented; measure-first
+  - +7 tests
 
 ## Template
 

--- a/scripts/agentos/bench_indexing_concurrency.py
+++ b/scripts/agentos/bench_indexing_concurrency.py
@@ -1,0 +1,106 @@
+"""Profile the indexing parallelism win (seocho-ia4, step 2).
+
+Two measurements, deterministic (mock latency, no API/DB), to decide where effort
+belongs:
+
+1. **Extraction concurrency (I/O-bound):** per-chunk LLM extraction is a network
+   round-trip. A mock extract fn sleeps a realistic latency; we sweep worker counts
+   over N chunks and report wall-clock + speedup. This is the dominant indexing cost
+   and the step-1 win — it is a CONCURRENCY problem (overlap waits), not a compute
+   one, so a thread pool (concurrent_map) is the right tool; Rust buys nothing here.
+
+2. **Interning throughput (CPU-bound):** the SharedInternTable is the compute-bound
+   piece a Rust concurrent map could accelerate. We measure intern ops/sec so the
+   step-3/step-4 decision (Rust or not) rests on data: if interning is far from the
+   bottleneck vs the extraction wall-clock, Rust is NOT yet warranted.
+
+Usage: python scripts/agentos/bench_indexing_concurrency.py --out outputs/agentos/indexing_concurrency.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import sys
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "src"))
+
+from seocho.index.parallel import concurrent_map  # noqa: E402
+from seocho.index.shared_intern import SharedInternTable  # noqa: E402
+
+_N_CHUNKS = 12
+_EXTRACT_LATENCY_S = 0.4     # a realistic per-chunk LLM extract round-trip
+_INTERN_OPS = 200_000
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    def mock_extract(_chunk):
+        time.sleep(_EXTRACT_LATENCY_S)   # simulate the network round-trip
+        return {"nodes": [], "relationships": []}
+
+    # 1. extraction concurrency sweep
+    conc: Dict[str, Any] = {}
+    base = None
+    for w in (1, 2, 4, 8, 12):
+        t0 = time.perf_counter()
+        concurrent_map(list(range(_N_CHUNKS)), mock_extract, max_workers=w)
+        dt = time.perf_counter() - t0
+        if base is None:
+            base = dt
+        conc[str(w)] = {"wall_s": round(dt, 3), "speedup": round(base / dt, 2)}
+
+    # 2. interning throughput (CPU-bound) — is it anywhere near the bottleneck?
+    t = SharedInternTable()
+    t0 = time.perf_counter()
+    for i in range(_INTERN_OPS):
+        t.intern("ws", f"company|e{i % 5000}", f"id-{i % 5000}")
+    intern_dt = time.perf_counter() - t0
+    intern_ops_per_s = int(_INTERN_OPS / intern_dt)
+
+    seq_extract_wall = conc["1"]["wall_s"]
+    report = {
+        "chunks": _N_CHUNKS,
+        "extract_latency_s": _EXTRACT_LATENCY_S,
+        "extraction_concurrency": conc,
+        "interning": {
+            "ops": _INTERN_OPS,
+            "wall_s": round(intern_dt, 3),
+            "ops_per_s": intern_ops_per_s,
+            "time_to_intern_one_doc_of_extraction_worth": round(
+                (_N_CHUNKS * 50) / intern_ops_per_s, 5),  # ~50 nodes/chunk
+        },
+        "verdict": {
+            "extraction_is_io_bound_concurrency_win": conc["8"]["speedup"],
+            "interning_share_of_a_sequential_extract": round(
+                (intern_dt * (_N_CHUNKS * 50 / _INTERN_OPS)) / seq_extract_wall, 6),
+            "rust_intern_table_warranted_now": intern_ops_per_s < 50_000,
+        },
+    }
+
+    c = report["extraction_concurrency"]
+    print("=== indexing parallelism profile (seocho-ia4 step 2) ===")
+    print(f"  extraction ({_N_CHUNKS} chunks @ {_EXTRACT_LATENCY_S}s each, I/O-bound):")
+    for w in ("1", "2", "4", "8", "12"):
+        print(f"    workers={w:>2}: {c[w]['wall_s']:>6.2f}s  ({c[w]['speedup']}x)")
+    print(f"  interning (CPU-bound): {intern_ops_per_s:,} ops/s "
+          f"-> interning a whole doc's entities ~ "
+          f"{report['interning']['time_to_intern_one_doc_of_extraction_worth']*1000:.2f} ms")
+    print(f"  => extraction concurrency win (8w): {c['8']['speedup']}x; "
+          f"Rust intern table warranted now: {report['verdict']['rust_intern_table_warranted_now']}")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/index/parallel.py
+++ b/src/seocho/index/parallel.py
@@ -1,0 +1,71 @@
+"""Concurrency primitive for indexing (seocho-ia4: indexing parallelism, step 1).
+
+The dominant indexing cost is per-chunk LLM extraction/linking — embarrassingly
+parallel across chunks, but **I/O-bound** (LLM API round-trips), so the win is
+overlapping the network waits, not local compute. A thread pool over the sync LLM
+client suffices (Rust/processes buy nothing for I/O-bound work). CPU-bound stages
+(interning, dedup, mining) are a separate story — see ``shared_intern`` and the
+profile ADR.
+
+``concurrent_map`` is order-preserving and exception-capturing: it never reorders
+results (the deterministic post-processing that follows depends on chunk order) and
+never lets one chunk's failure abort the batch (each item's exception is returned in
+place, so the caller applies its own per-item fallback — mirroring the pipeline's
+strict/guided fallback contract).
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, List, Sequence, TypeVar, Union
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def concurrent_map(
+    items: Sequence[T],
+    fn: Callable[[T], R],
+    *,
+    max_workers: int = 1,
+    capture_exceptions: bool = True,
+) -> List[Union[R, Exception]]:
+    """Apply ``fn`` to each item, up to ``max_workers`` at a time, order-preserved.
+
+    - ``max_workers <= 1`` runs sequentially (zero overhead, exact back-compat).
+    - With ``capture_exceptions`` (default) a failing item yields the ``Exception``
+      object in its result slot instead of aborting the batch; the caller decides
+      how to handle it (e.g. the pipeline's heuristic fallback).
+    """
+    n = len(items)
+    if n == 0:
+        return []
+    if max_workers <= 1:
+        out: List[Union[R, Exception]] = []
+        for it in items:
+            try:
+                out.append(fn(it))
+            except Exception as exc:  # noqa: BLE001
+                if not capture_exceptions:
+                    raise
+                out.append(exc)
+        return out
+
+    results: List[Any] = [None] * n
+    with ThreadPoolExecutor(max_workers=min(max_workers, n)) as ex:
+        futs = {ex.submit(fn, it): i for i, it in enumerate(items)}
+        for fut, i in list(futs.items()):
+            try:
+                results[i] = fut.result()
+            except Exception as exc:  # noqa: BLE001
+                if not capture_exceptions:
+                    raise
+                results[i] = exc
+    return results
+
+
+def resolve_workers(requested: int, n_items: int, *, cap: int = 16) -> int:
+    """Clamp a requested worker count to something sane for a batch of ``n_items``."""
+    if requested <= 1:
+        return 1
+    return max(1, min(requested, n_items, cap))

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -45,6 +45,7 @@ _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 from .chunk import Chunk, build_chunk_id, chunk as _canonical_chunk
 from .extraction_engine import CanonicalExtractionEngine
+from .parallel import concurrent_map, resolve_workers
 from .property_shaper import PropertyShaper
 from ..store.llm import complete_with_task_hints
 
@@ -254,6 +255,13 @@ class IndexingPipeline:
         self.enable_dedup = enable_dedup
         self.enable_rule_constraints = enable_rule_constraints
         self.vector_store = vector_store
+        # Per-chunk LLM extraction is I/O-bound and independent across chunks, so it
+        # can overlap (seocho-ia4 parallelism, step 1). Opt-in; 1 = sequential
+        # (exact back-compat). Set via SEOCHO_EXTRACTION_CONCURRENCY or the attribute.
+        try:
+            self._extraction_concurrency = int(os.environ.get("SEOCHO_EXTRACTION_CONCURRENCY", "1") or "1")
+        except ValueError:
+            self._extraction_concurrency = 1
         self._seen_hashes: set = set()
         self.extraction_prompt = extraction_prompt
         self.ontology_profile = str(ontology_profile or "default")
@@ -756,18 +764,38 @@ class IndexingPipeline:
         chunk_records: List[Dict[str, Any]] = []
         _total_usage: Dict[str, int] = {}
 
+        # Concurrent extraction pre-fetch (seocho-ia4 step 1): the LLM extract call
+        # per chunk is I/O-bound and independent, so overlap the round-trips while
+        # keeping the deterministic post-processing loop below in chunk order. A
+        # per-chunk failure is captured in place (Exception) and re-raised into the
+        # existing per-chunk fallback handler, so behavior is identical to sequential.
+        _workers = resolve_workers(getattr(self, "_extraction_concurrency", 1), len(chunks))
+        _prefetched = None
+        if _workers > 1:
+            _prefetched = concurrent_map(
+                chunks,
+                lambda c: self._graph_extraction.extract(
+                    c.text, category=category, metadata=metadata),
+                max_workers=_workers,
+            )
+
         for i, chunk_obj in enumerate(chunks):
             chunk = chunk_obj.text
             if on_chunk:
                 on_chunk(i, len(chunks))
 
-            # Extract
+            # Extract (use the concurrent pre-fetch when enabled)
             try:
-                response = self._graph_extraction.extract(
-                    chunk,
-                    category=category,
-                    metadata=metadata,
-                )
+                if _prefetched is not None:
+                    response = _prefetched[i]
+                    if isinstance(response, Exception):
+                        raise response
+                else:
+                    response = self._graph_extraction.extract(
+                        chunk,
+                        category=category,
+                        metadata=metadata,
+                    )
                 extracted = response
             except Exception as exc:
                 if not self.enforcement_policy.allow_heuristic_fallback:

--- a/src/seocho/index/shared_intern.py
+++ b/src/seocho/index/shared_intern.py
@@ -1,0 +1,75 @@
+"""A thread-safe shared intern table — the allocator's shared-memory core.
+
+hadry's OS-shared-memory intuition made concrete: the intern table IS the
+canonical-entity namespace (the allocator's heap). When indexing goes concurrent
+(``parallel.concurrent_map`` over chunks) or several agents write under one
+workspace, they must see ONE canonical address per entity — otherwise the same
+entity, interned on two threads, fragments into two nodes and cross-chunk axioms
+lose support. This is a **process-wide, thread-safe, workspace-scoped** map from a
+composite identity to its canonical id: shared memory with a protection domain.
+
+Keyed by ``(workspace_id, compute_node_identity(...))`` so tenants never collide
+(the ``workspace_id`` protection domain). Sharded by key hash under per-shard locks
+so concurrent interning does not serialize on one global lock — the same discipline
+a concurrent allocator uses. Pure-Python today; if profiling shows this is the
+CPU-bound hot path at scale, it is the natural candidate for a Rust
+``seocho-core`` concurrent map (the profile ADR states the trigger — we do not
+Rust-rewrite before measuring).
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Dict, Tuple
+
+
+class SharedInternTable:
+    """Concurrent (workspace, identity) -> canonical-id intern table."""
+
+    def __init__(self, *, shards: int = 16) -> None:
+        self._shards = max(1, shards)
+        self._maps: list[Dict[Tuple[str, str], str]] = [dict() for _ in range(self._shards)]
+        self._locks = [threading.Lock() for _ in range(self._shards)]
+        self._interns = 0
+        self._hits = 0
+        self._stats_lock = threading.Lock()
+
+    def _shard(self, key: Tuple[str, str]) -> int:
+        return hash(key) % self._shards
+
+    def intern(self, workspace_id: str, identity: str, canonical_id: str) -> str:
+        """Return the canonical id for ``(workspace_id, identity)``, inserting
+        ``canonical_id`` if unseen. First writer wins — subsequent callers (any
+        thread) get the same address, so concurrent interning of the same entity
+        converges to one node. Thread-safe."""
+        key = (str(workspace_id), str(identity))
+        s = self._shard(key)
+        with self._locks[s]:
+            existing = self._maps[s].get(key)
+            if existing is not None:
+                with self._stats_lock:
+                    self._hits += 1
+                return existing
+            self._maps[s][key] = canonical_id
+        with self._stats_lock:
+            self._interns += 1
+        return canonical_id
+
+    def get(self, workspace_id: str, identity: str) -> str:
+        key = (str(workspace_id), str(identity))
+        return self._maps[self._shard(key)].get(key, "")
+
+    def __len__(self) -> int:
+        return sum(len(m) for m in self._maps)
+
+    def stats(self) -> Dict[str, int]:
+        return {"size": len(self), "interns": self._interns, "hits": self._hits,
+                "shards": self._shards}
+
+    def clear(self) -> None:
+        for i in range(self._shards):
+            with self._locks[i]:
+                self._maps[i].clear()
+        with self._stats_lock:
+            self._interns = 0
+            self._hits = 0

--- a/tests/seocho/test_indexing_parallel.py
+++ b/tests/seocho/test_indexing_parallel.py
@@ -1,0 +1,79 @@
+"""Indexing concurrency primitive + shared intern table (seocho-ia4 parallelism)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from seocho.index.parallel import concurrent_map, resolve_workers
+from seocho.index.shared_intern import SharedInternTable
+
+
+def test_concurrent_map_order_preserved():
+    out = concurrent_map([1, 2, 3, 4, 5], lambda x: x * x, max_workers=4)
+    assert out == [1, 4, 9, 16, 25]
+
+
+def test_concurrent_map_captures_exceptions_in_place():
+    def f(x):
+        if x == 3:
+            raise ValueError("boom")
+        return x
+    out = concurrent_map([1, 2, 3, 4], f, max_workers=3)
+    assert out[0] == 1 and out[3] == 4
+    assert isinstance(out[2], ValueError)   # failure in its slot, batch survived
+
+
+def test_concurrent_map_overlaps_io_latency():
+    # 8 items each "waiting" 0.1s (simulated LLM round-trip). Sequential ~0.8s;
+    # with 8 workers it should overlap to ~0.1s. Assert a real speedup.
+    def slow(x):
+        time.sleep(0.1)
+        return x
+    t0 = time.perf_counter()
+    concurrent_map(list(range(8)), slow, max_workers=8)
+    parallel = time.perf_counter() - t0
+    assert parallel < 0.4, f"expected overlap, got {parallel:.2f}s"
+
+
+def test_resolve_workers_clamps():
+    assert resolve_workers(1, 100) == 1
+    assert resolve_workers(8, 3) == 3          # not more than items
+    assert resolve_workers(100, 100, cap=16) == 16
+
+
+def test_shared_intern_same_entity_one_address():
+    t = SharedInternTable()
+    a = t.intern("ws", "company|apple", "apple-1")
+    b = t.intern("ws", "company|apple", "apple-2")   # second writer, same identity
+    assert a == b == "apple-1"                        # first writer wins -> one node
+    assert len(t) == 1
+
+
+def test_shared_intern_workspace_isolation():
+    t = SharedInternTable()
+    t.intern("acme", "company|apple", "x")
+    t.intern("globex", "company|apple", "y")          # same identity, diff tenant
+    assert t.get("acme", "company|apple") == "x"
+    assert t.get("globex", "company|apple") == "y"    # no collision across domains
+    assert len(t) == 2
+
+
+def test_shared_intern_concurrent_convergence():
+    # 16 threads race to intern the SAME entity with different candidate ids;
+    # exactly one canonical id must win for all -> no fragmentation.
+    t = SharedInternTable()
+    results = []
+    barrier = threading.Barrier(16)
+
+    def worker(tid):
+        barrier.wait()
+        results.append(t.intern("ws", "company|acme", f"cand-{tid}"))
+
+    ths = [threading.Thread(target=worker, args=(i,)) for i in range(16)]
+    for th in ths:
+        th.start()
+    for th in ths:
+        th.join()
+    assert len(set(results)) == 1        # all threads got the SAME canonical id
+    assert len(t) == 1


### PR DESCRIPTION
hadry: indexing has parallelizable parts → Rust/multi-thread/shared-memory. We separated the *kinds* of parallelism and let measurement pick the tool, in 4 steps.

**Step 1 — concurrent extraction (I/O-bound → threads).** Per-chunk LLM extraction is a network round-trip, independent across chunks. `index/parallel.py::concurrent_map` (order-preserving, exception-in-place) pre-fetches all chunk extractions concurrently; the deterministic post-processing loop is unchanged. Opt-in via `SEOCHO_EXTRACTION_CONCURRENCY` (default 1 = exact back-compat). **151 index/pipeline/extraction tests pass identically off and on(=4).**

**Step 2 — profile (measure first).** `bench_indexing_concurrency.py`: extraction near-linear (4w 4.0×, **8w 5.99×**, 12w 11.94×); interning **1.19M ops/s** (~0.5 ms/doc — negligible beside a multi-second extraction).

**Step 3 — shared-memory intern table.** `index/shared_intern.py::SharedInternTable` — process-wide, thread-safe, **workspace-scoped** (protection domain), sharded; first-writer-wins so the same entity interned on N threads converges to ONE canonical id (16-thread race → one id, no fragmentation). hadry's *shared memory* made concrete: the allocator's canonical-entity namespace shared across concurrent workers/agents.

**Step 4 — Rust only when warranted.** The profile settles it: extraction is I/O-bound (threads win ~6–12×; Rust buys nothing for network waits) and interning does 1.2M ops/s (CPU nowhere near the bottleneck). **A Rust concurrent intern table is NOT warranted now** — escalation trigger documented (interning < ~50k ops/s, or the CPU tail becomes a measured share at scale). `seocho-core` already exists for the short escalation path.

Composes with the OS concurrency discipline (the shared intern table is what RCU/EBR reclamation, ia4.3/.4, governs). +7 tests. ADR-0182. seocho-ia4.