### PR TITLE
feat(index): wire SharedInternTable into the identity step (ADR-0182 follow-up)

### DIFF
--- a/src/seocho/index/identity.py
+++ b/src/seocho/index/identity.py
@@ -48,6 +48,9 @@ def apply_identity_keys(
     ontology: Any,
     nodes: List[Dict[str, Any]],
     relationships: List[Dict[str, Any]],
+    *,
+    intern_table: Any = None,
+    workspace_id: str = "default",
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Rewrite node ids to composite identities and remap relationship endpoints.
 
@@ -56,6 +59,16 @@ def apply_identity_keys(
     keep their original ids. When two nodes in the same payload resolve to the
     same identity, both point at that id — the store's MERGE then folds them,
     which is the intended same-entity behavior.
+
+    When an ``intern_table`` (:class:`~seocho.index.shared_intern.SharedInternTable`)
+    is supplied, each resolved identity is interned in the workspace-scoped canonical
+    namespace (the allocator's shared-memory intern table): first-writer-wins, so the
+    same entity resolved on concurrent chunk-extraction threads — or across documents
+    in the same session — converges to one canonical id, and the table's hit count
+    measures interning *collapse* (duplicate entities folded), the allocator's
+    defining metric. Opt-in: no table → behavior unchanged (the composite id is
+    already deterministic; the table adds the shared registry + census + concurrency
+    safety for the whole workspace).
     """
     node_defs = getattr(ontology, "nodes", {}) or {}
     id_remap: Dict[str, str] = {}
@@ -72,6 +85,10 @@ def apply_identity_keys(
         new_id = compute_node_identity(label, props, identity_keys)
         if not new_id:
             continue
+        if intern_table is not None:
+            # Register/resolve in the workspace canonical namespace. The composite
+            # id is the identity AND the canonical address; first-writer-wins.
+            new_id = intern_table.intern(workspace_id, new_id, new_id)
         old_id = str(node.get("id") or props.get("name") or "")
         if old_id:
             id_remap[old_id] = new_id

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -262,6 +262,13 @@ class IndexingPipeline:
             self._extraction_concurrency = int(os.environ.get("SEOCHO_EXTRACTION_CONCURRENCY", "1") or "1")
         except ValueError:
             self._extraction_concurrency = 1
+        # The allocator's shared-memory intern table: one workspace-scoped canonical
+        # namespace across chunks/documents (and concurrency-safe under the concurrent
+        # extraction above). Populated at the identity step; its hit count measures
+        # interning collapse (ADR-0182 / ADR-0160).
+        from .shared_intern import SharedInternTable
+
+        self._intern_table = SharedInternTable()
         self._seen_hashes: set = set()
         self.extraction_prompt = extraction_prompt
         self.ontology_profile = str(ontology_profile or "default")
@@ -599,7 +606,10 @@ class IndexingPipeline:
         # store's single-key MERGE. No-op for ontologies without identity_keys.
         from seocho.index.identity import apply_identity_keys
 
-        all_nodes, all_rels = apply_identity_keys(self.ontology, all_nodes, all_rels)
+        all_nodes, all_rels = apply_identity_keys(
+            self.ontology, all_nodes, all_rels,
+            intern_table=self._intern_table, workspace_id=self.workspace_id,
+        )
 
         if _graph_cot_properties_enabled():
             shaper = PropertyShaper()

--- a/tests/seocho/test_indexing_parallel.py
+++ b/tests/seocho/test_indexing_parallel.py
@@ -77,3 +77,27 @@ def test_shared_intern_concurrent_convergence():
         th.join()
     assert len(set(results)) == 1        # all threads got the SAME canonical id
     assert len(t) == 1
+
+
+def test_apply_identity_keys_interns_and_measures_collapse():
+    """apply_identity_keys wired to a SharedInternTable registers canonical ids and
+    counts collapse (same entity across calls -> a hit)."""
+    from seocho.index.identity import apply_identity_keys
+    from seocho.index.shared_intern import SharedInternTable
+
+    class _ND:
+        identity_keys = ["name", "year"]
+
+    class _Onto:
+        nodes = {"Company": _ND()}
+
+    table = SharedInternTable()
+    # doc 1: Apple(2023)
+    n1 = [{"id": "x1", "label": "Company", "properties": {"name": "Apple", "year": "2023"}}]
+    apply_identity_keys(_Onto(), n1, [], intern_table=table, workspace_id="ws")
+    # doc 2: the SAME entity again (different raw id) -> must intern to the same canonical
+    n2 = [{"id": "x2", "label": "Company", "properties": {"name": "Apple", "year": "2023"}}]
+    apply_identity_keys(_Onto(), n2, [], intern_table=table, workspace_id="ws")
+    assert n1[0]["id"] == n2[0]["id"]                       # converged to one canonical id
+    s = table.stats()
+    assert s["size"] == 1 and s["interns"] == 1 and s["hits"] == 1   # collapse measured


### PR DESCRIPTION
Completes ADR-0182's follow-up: the shared-memory intern table is now populated by the **live indexing path**, not just unit-tested.

- `apply_identity_keys` accepts an optional `intern_table` + `workspace_id`; each resolved composite identity is interned in the workspace-scoped canonical namespace (first-writer-wins). The pipeline holds one `SharedInternTable` and passes it at the identity step.
- **Effect:** the same entity resolved on concurrent chunk-extraction threads (ADR-0182 step 1) OR across documents in a session converges to **one canonical id** — the allocator's shared-memory heap. The table's hit count measures interning **collapse** (duplicate entities folded), the allocator's defining metric (ADR-0160), now observable on the live path.
- **Safe:** opt-in and behavior-preserving (the composite id is already deterministic; the table adds the shared registry + census + concurrency safety). Only the pipeline calls the new kwargs; other callers unaffected. +1 test (same entity across 2 calls → one canonical id, collapse measured); **174 identity/pipeline/index tests pass, 0 regressions**.

seocho-ia4. Composes with the concurrent extraction (ADR-0182) and the RCU/EBR reclamation discipline (ia4.3/.4).