### PR TITLE
feat(eviction): pin-aware safe-reclamation gate (ADR-0185, seocho-ia4.4)

### DIFF
--- a/docs/decisions/ADR-0185-pin-aware-eviction.md
+++ b/docs/decisions/ADR-0185-pin-aware-eviction.md
@@ -1,0 +1,34 @@
+# ADR-0185: pin-aware eviction — safe-reclamation gate (light) (seocho-ia4.4)
+
+Date: 2026-08-16 · Status: accepted · seocho-ia4.4
+
+## Context
+
+The cost-aware eviction cache (ADR-0180) ranks by VALUE (GDSF) but had NO safety
+gate: it could evict an entry a concurrent request is mid-flight on (a
+use-after-evict / use-after-free-class latent bug). Safety (never reclaim something
+in use) is orthogonal to value (what's least useful).
+
+## Decision
+
+Add a pin refcount to `CostAwareEvictionCache`:
+- `_Entry.pins`; `pin(key)` / `unpin(key)` / `pinned(key)` context manager /
+  `pinned_count()`; `stats()["pinned"]`.
+- `_evict_to_budget` chooses victims only among **unpinned** (and unprotected)
+  entries — a pinned entry is never evicted, even if it is the lowest-value victim.
+  If everything over budget is pinned/protected, the cache stays temporarily over
+  budget until an unpin, rather than reclaiming an in-use entry.
+
+This is the **light** safe-reclamation gate: it closes the use-after-evict bug on the
+hot cache with a simple refcount, RCU-free. The **full** epoch-based gate (version
+reclamation via `reader_refcount(epoch)==0 AND epoch < min_pinned_epoch AND
+provenance_refcount==0 AND not ACTIVE`) needs the RCU reader-pin/epoch clock and lands
+with ia4.3.
+
+## Consequences
+
+- The eviction cache is now cost-aware AND safe: value ranks only among already-safe
+  candidates. Callers pin an entry for the duration of an in-flight use
+  (`with cache.pinned(key): ...`).
+- +2 tests (pinned entry survives pressure; context manager releases). Completes the
+  light half of ia4.4; the epoch-gated version-reclamation half is ia4.3-dependent.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1114,6 +1114,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - derive_drift_policy ties verdict to ia4.1 read barrier (BREAKING/FORWARD->block); PublishCompatibilityError carries report
   - turns silent-breaking publishes into explicit blocked-by-default; +4 tests; completes ia4.2
 
+## 2026-08-16 (pin-aware eviction)
+
+- [Accepted] ADR-0185 pin-aware eviction — safe-reclamation gate (light) (seocho-ia4.4)
+  - eviction cache ranked value but had NO safety gate -> could evict an in-flight entry (use-after-evict bug)
+  - add pin/unpin/pinned() refcount; _evict_to_budget skips pinned entries; stats.pinned
+  - light gate (RCU-free) closes the bug now; full epoch-based version reclamation waits on ia4.3
+  - +2 tests
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/eviction.py
+++ b/src/seocho/eviction.py
@@ -26,6 +26,7 @@ N-way concurrency the LaneScheduler admits).
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Hashable, Set
@@ -39,6 +40,7 @@ class _Entry:
     freq: int = 0                   # reference count since admission
     tenants: Set[str] = field(default_factory=set)   # who has referenced it
     value: float = 0.0              # cached GDSF priority (with aging term)
+    pins: int = 0                   # in-flight readers; pinned entries are never evicted
 
 
 class CostAwareEvictionCache:
@@ -144,10 +146,15 @@ class CostAwareEvictionCache:
                     protected.add(e.key)
         # Evict lowest-priority unprotected entries until under budget.
         while self._bytes > self.byte_budget:
+            # Safety gate (seocho-ia4.4): never evict a PINNED entry — one a
+            # concurrent request is mid-flight on. Value ranking chooses only among
+            # already-safe (unpinned, unprotected) candidates. The full epoch-based
+            # gate (min_pinned_epoch / version reclamation) is ia4.3/RCU; this is the
+            # hot-cache pin refcount that closes the use-after-evict bug without it.
             candidates = [e for e in self._entries.values()
-                          if e.key not in protected]
+                          if e.key not in protected and e.pins <= 0]
             if not candidates:
-                break                    # everything is floor-protected
+                break                    # everything is floor-protected or pinned
             victim = min(candidates, key=self._priority)
             self._age = self._priority(victim)   # GDSF aging: raise the floor
             self._bytes -= victim.size
@@ -167,11 +174,43 @@ class CostAwareEvictionCache:
             "recompute_ms_incurred": round(self.recompute_ms_incurred, 1),
             "recompute_ms_avoided": round(self.recompute_ms_avoided, 1),
             "evictions": self.evictions,
+            "pinned": sum(1 for e in self._entries.values() if e.pins > 0),
         }
 
     def holds(self, key: Hashable) -> bool:
         with self._lock:
             return key in self._entries
+
+    # -- pinning (ia4.4): protect an in-use entry from reclamation ------------
+    def pin(self, key: Hashable) -> bool:
+        """Mark ``key`` as in-use so it is never evicted until unpinned. Returns
+        False if the key is not resident."""
+        with self._lock:
+            e = self._entries.get(key)
+            if e is None:
+                return False
+            e.pins += 1
+            return True
+
+    def unpin(self, key: Hashable) -> None:
+        with self._lock:
+            e = self._entries.get(key)
+            if e is not None and e.pins > 0:
+                e.pins -= 1
+
+    @contextlib.contextmanager
+    def pinned(self, key: Hashable):
+        """Context manager: pin ``key`` for the duration of an in-flight use."""
+        ok = self.pin(key)
+        try:
+            yield ok
+        finally:
+            if ok:
+                self.unpin(key)
+
+    def pinned_count(self) -> int:
+        with self._lock:
+            return sum(1 for e in self._entries.values() if e.pins > 0)
 
     def clear(self) -> None:
         with self._lock:

--- a/tests/seocho/test_eviction.py
+++ b/tests/seocho/test_eviction.py
@@ -102,3 +102,31 @@ def test_ontology_context_cache_stable_key_and_fairness():
     b = cache.get(o2, workspace_id="acme")   # id()-keyed cache would MISS here
     assert a is b, "stable content key must hit across distinct instances"
     assert cache.stats()["hits"] >= 1
+
+
+def test_pinned_entry_is_never_evicted():
+    """A pinned (in-use) entry survives budget pressure even when it is the
+    lowest-value victim (seocho-ia4.4 safe-reclamation gate)."""
+    c = CostAwareEvictionCache(byte_budget=250)   # holds ~2 size-100 entries
+    _get(c, "hot", size=100, cost=1.0)            # low value, but we'll pin it
+    assert c.pin("hot")
+    for i in range(6):                            # flood -> pressure
+        _get(c, f"x{i}", size=100, cost=50.0)
+    assert c.holds("hot"), "pinned entry must not be evicted under pressure"
+    assert c.stats()["pinned"] == 1
+    c.unpin("hot")
+    # once unpinned, it is a normal (low-value) eviction candidate again
+    for i in range(6):
+        _get(c, f"y{i}", size=100, cost=50.0)
+    assert not c.holds("hot")
+
+
+def test_pinned_context_manager():
+    c = CostAwareEvictionCache(byte_budget=250)
+    _get(c, "k", size=100, cost=1.0)
+    with c.pinned("k") as ok:
+        assert ok
+        for i in range(6):
+            _get(c, f"z{i}", size=100, cost=50.0)
+        assert c.holds("k")            # protected inside the context
+    assert c.pinned_count() == 0       # released on exit


### PR DESCRIPTION
The cost-aware eviction cache (ADR-0180) ranks by **value** (GDSF) but had **no safety gate** — it could evict an entry a concurrent request is mid-flight on (use-after-evict / use-after-free-class latent bug). Safety is orthogonal to value.

Adds a pin refcount to `CostAwareEvictionCache`: `_Entry.pins`, `pin()`/`unpin()`/`pinned()` context manager/`pinned_count()`, `stats()['pinned']`. `_evict_to_budget` picks victims **only among unpinned** (and unprotected) entries — a pinned entry is never evicted even as the lowest-value victim; if everything over budget is pinned, the cache stays briefly over budget rather than reclaiming an in-use entry.

This is the **light** gate (RCU-free) that closes the bug now. The **full** epoch-based version-reclamation gate (`reader_refcount(epoch)==0 AND epoch < min_pinned_epoch AND provenance_refcount==0 AND not ACTIVE`) needs the RCU reader-pin/epoch clock and lands with **ia4.3**. +2 tests (pinned survives pressure; context manager releases). Completes the light half of ia4.4.