### PR TITLE
feat(query): let the repair agent see the query plan, not just the error

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -110,6 +110,7 @@ uv run pytest \
   tests/seocho/test_sweep.py \
   tests/seocho/test_entity_identity.py \
   tests/seocho/test_triage_metadata.py \
+  tests/seocho/test_plan_quality_explain.py \
   tests/seocho/test_import_boundaries.py \
   tests/seocho/test_ontology_package_surface.py \
   tests/seocho/test_package_completeness.py \

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -823,9 +823,18 @@ class _LocalEngine:
                     params = fb_params
 
         attempts = []
-        if reasoning_mode and repair_budget > 0 and not records:
+        # A plan hint enters the repair loop the same way an error does. Repair
+        # previously fired only on `not records`, so a query that returned rows
+        # while planning a full scan was a success that could never be improved
+        # -- and that is exactly the query whose cost explodes with the graph:
+        # ADR-0144 measured 25 db hits against 6.6M at SF1000 for the same
+        # answer, while at SF1 the two shapes were 4 ms apart.
+        plan_hint = self._plan_repair_hint(cypher, params, database,
+                                           executor=executor, ontology=active_ontology)
+        if reasoning_mode and repair_budget > 0 and (not records or plan_hint):
             with timer.stage("repair"):
-                attempts.append({"cypher": cypher, "result_count": 0, "error": None})
+                attempts.append({"cypher": cypher, "result_count": len(records or []),
+                                 "error": None, "plan_hint": plan_hint})
 
                 for _attempt_num in range(repair_budget):
                     repair_cypher, repair_params, repair_error = self._generate_repair_query(
@@ -1133,6 +1142,33 @@ class _LocalEngine:
         )
         execution = active_executor.execute(QueryPlan(question="", cypher=cypher, params=params))
         return execution.records, execution.error
+
+    def _plan_repair_hint(self, cypher: str, params: Dict, database: str, *,
+                          executor: Optional[GraphQueryExecutor] = None,
+                          ontology: Optional[Any] = None) -> Optional[str]:
+        """EXPLAIN the query and, if it plans a scan, say what to do instead.
+
+        EXPLAIN rather than PROFILE: it compiles without executing, so this can
+        gate every query instead of a sample, and the seek/scan distinction is
+        already settled at plan time.
+
+        Behind SEOCHO_PLAN_GATE and off by default, because it changes WHEN
+        repair fires. A behaviour change belongs behind a flag until it has been
+        measured on a real corpus.
+        """
+        import os
+
+        if os.getenv("SEOCHO_PLAN_GATE", "").strip().lower() not in {"1", "true", "on"}:
+            return None
+        try:
+            from .query.plan_quality import repair_hint, summarize_plan
+
+            explained = (executor or GraphQueryExecutor(
+                graph_store=self.graph_store, database=database,
+            )).explain(QueryPlan(question="", cypher=cypher, params=params))
+            return repair_hint(summarize_plan(explained), ontology)
+        except Exception:  # noqa: BLE001 — a planning probe must never fail a query
+            return None
 
     def _generate_repair_query(
         self,

--- a/src/seocho/query/executor.py
+++ b/src/seocho/query/executor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Dict, Optional
 
 from .contracts import QueryExecution, QueryPlan
 
@@ -14,6 +14,20 @@ class GraphQueryExecutor:
     def __init__(self, *, graph_store: Any, database: str) -> None:
         self.graph_store = graph_store
         self.database = database
+
+    def explain(self, plan: QueryPlan) -> Optional[Dict[str, Any]]:
+        """Return the query's plan tree without executing it.
+
+        Advisory: a backend that cannot EXPLAIN returns None, and the caller
+        treats that as "no signal" rather than as a bad plan.
+        """
+        explainer = getattr(self.graph_store, "explain_plan", None)
+        if explainer is None:
+            return None
+        try:
+            return explainer(plan.cypher, params=plan.params, database=self.database)
+        except Exception:  # noqa: BLE001 — never let a planning probe fail a query
+            return None
 
     def execute(self, plan: QueryPlan) -> QueryExecution:
         try:

--- a/src/seocho/query/plan_quality.py
+++ b/src/seocho/query/plan_quality.py
@@ -27,6 +27,98 @@ SEEK_OPERATORS = (
 )
 
 
+def summarize_plan(plan: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Flatten an EXPLAIN tree — the same signals, before the query runs.
+
+    `PROFILE` executes the query to get real `dbHits`; `EXPLAIN` only compiles
+    it and reports the optimiser's `EstimatedRows`. That difference is what
+    makes a pre-execution gate possible at all: EXPLAIN costs nothing, so it can
+    run on every query rather than on a sample, and the seek/scan distinction —
+    the signal that actually predicts how a query behaves as the graph grows —
+    is already decided at plan time.
+
+    Verified against DozerDB 5.26.3: `EXPLAIN MATCH (n:X) WHERE n.name='x'`
+    yields NodeByLabelScan, and dropping the label yields AllNodesScan, both
+    without touching the data. Operator names arrive suffixed (`NodeByLabelScan
+    @neo4j`), which the substring matching below already tolerates.
+
+    `estimated_rows` is the optimiser's guess and is often wrong in absolute
+    terms; it is carried for ordering candidates, never as a cost claim.
+    """
+    if not plan:
+        return {"available": False, "source": "explain"}
+
+    operators: List[str] = []
+    estimated = 0.0
+
+    def walk(node: Dict[str, Any]) -> None:
+        nonlocal estimated
+        operators.append(str(node.get("operatorType", "")))
+        args = node.get("args") or {}
+        try:
+            estimated = max(estimated, float(args.get("EstimatedRows") or 0))
+        except (TypeError, ValueError):
+            pass
+        for child in node.get("children", []) or []:
+            walk(child)
+
+    walk(plan)
+    scans = [op for op in operators if any(s in op for s in SCAN_OPERATORS)]
+    seeks = [op for op in operators if any(s in op for s in SEEK_OPERATORS)]
+    return {
+        "available": True,
+        "source": "explain",
+        "estimated_rows": estimated,
+        "operator_count": len(operators),
+        "scans": scans,
+        "seeks": seeks,
+        "sargable": bool(seeks) and not scans,
+    }
+
+
+def repair_hint(summary: Dict[str, Any], ontology: Any = None) -> Optional[str]:
+    """Turn a bad plan into an instruction the repair prompt can act on.
+
+    The repair loop today sees only errors, so a query that runs and burns 6.6M
+    db hits is treated as a success. This gives it the other half.
+
+    The last line is the part worth having. Because the ontology declares which
+    properties are unique, the hint can state that an index seek EXISTS rather
+    than suggesting the model guess — the schema is the evidence, not the
+    model's prior.
+    """
+    if not summary.get("available") or summary.get("sargable"):
+        return None
+    scans = summary.get("scans") or []
+    if not scans:
+        return None
+
+    lines = [
+        "The previous query was valid but not sargable.",
+        f"  plan operators: {', '.join(sorted(set(scans))[:3])}",
+        f"  estimated rows: {summary.get('estimated_rows', 0):.0f}",
+        "  A scan grows with the graph; a seek does not.",
+    ]
+
+    indexed: List[str] = []
+    for label, node in (getattr(ontology, "nodes", None) or {}).items():
+        for prop, spec in (getattr(node, "properties", None) or {}).items():
+            if getattr(spec, "unique", False):
+                indexed.append(f"{label}.{prop}")
+    if indexed:
+        lines.append(
+            "  The ontology declares these as unique, so an index seek is "
+            f"available on: {', '.join(sorted(indexed)[:6])}."
+        )
+        lines.append("  Rewrite as an anchored lookup on one of them.")
+    else:
+        lines.append(
+            "  The ontology declares no unique property, so no seek is "
+            "available; narrow the match instead of anchoring it."
+        )
+    return "\n".join(lines)
+
+
 def summarize_profile(profile: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Flatten a PROFILE tree into plan-quality signals.
 

--- a/src/seocho/query/planner.py
+++ b/src/seocho/query/planner.py
@@ -103,9 +103,15 @@ class DeterministicQueryPlanner:
             )
 
         ctx = active_ontology.to_query_context()
+        # A plan hint travels the same channel as an error, because to the
+        # repair agent they are the same kind of fact: a reason the previous
+        # attempt is not the answer. Without it a query that returns rows while
+        # planning a full scan reads as a success and is never revisited, which
+        # is exactly the query whose cost explodes as the graph grows.
         attempts_summary = "\n".join(
             f"  Attempt {i+1}: {a['cypher'][:100]}... → {a['result_count']} results"
             + (f" (error: {a['error']})" if a.get("error") else "")
+            + (f"\n{a['plan_hint']}" if a.get("plan_hint") else "")
             for i, a in enumerate(attempts)
         )
 
@@ -113,7 +119,19 @@ class DeterministicQueryPlanner:
             "You are a knowledge graph query repair agent.\n"
             "\n"
             "Task:\n"
-            "- Generate one relaxed alternative query plan after earlier attempts failed.\n\n"
+            + (
+                "- The previous attempt returned rows but plans a scan. Generate one "
+                "NARROWER plan that anchors on an indexed property. Do not relax the "
+                "match — relaxing it makes the scan wider.\n\n"
+                if any(a.get("plan_hint") for a in attempts)
+                # Two different repairs share one prompt, and they pull in
+                # opposite directions: an empty result wants a looser match, an
+                # unsargable plan wants a tighter one. Telling the model to
+                # "relax" when the problem is a full scan makes the plan worse.
+                else "- Generate one relaxed alternative query plan after earlier "
+                     "attempts failed.\n\n"
+            )
+            +
             "Context:\n"
             f'- Ontology: "{ctx["ontology_name"]}".\n'
             f"--- Graph Schema ---\n{ctx['graph_schema']}\n\n"

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -717,6 +717,35 @@ class Neo4jGraphStore(GraphStore):
             self.invalidate_schema_cache(database)
         return summary
 
+    def explain_plan(
+        self,
+        cypher: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        database: str = "neo4j",
+    ) -> Optional[Dict[str, Any]]:
+        """Compile the query and return its plan tree. Does NOT execute it.
+
+        Separate from `query` because the plan lives on the result summary and
+        `query` is contracted to return records; widening that return type to
+        smuggle a plan out would change every caller. Returns None when the
+        backend reports no plan, so a caller can tell "no signal" from "bad
+        plan" rather than conflating them.
+
+        Verified against DozerDB 5.26.3: EXPLAIN yields args.EstimatedRows and
+        no dbHits, with operators suffixed as `NodeByLabelScan@neo4j`.
+        """
+        try:
+            with self._driver.session(
+                    database=database, default_access_mode="READ") as session:
+                summary = session.run(f"EXPLAIN {cypher}",
+                                      parameters=dict(params or {})).consume()
+                plan = getattr(summary, "plan", None)
+                return dict(plan) if plan else None
+        except Exception:  # noqa: BLE001 — planning is advisory; never fail a caller
+            logger.debug("EXPLAIN unavailable for query: %s", cypher[:120])
+            return None
+
     def query(
         self,
         cypher: str,

--- a/tests/seocho/test_plan_quality_explain.py
+++ b/tests/seocho/test_plan_quality_explain.py
@@ -1,0 +1,125 @@
+"""EXPLAIN-based plan signals, and the repair hint they produce.
+
+Shapes verified against a live DozerDB 5.26.3: `EXPLAIN MATCH (n:X) WHERE
+n.name='x'` yields NodeByLabelScan and dropping the label yields AllNodesScan,
+both without touching data. Operator names arrive suffixed as
+`NodeByLabelScan@neo4j`, which is why matching is by substring.
+
+The point of EXPLAIN over PROFILE is that it costs nothing, so a gate can run on
+every query instead of a sample — and the seek/scan distinction, which is what
+predicts behaviour as the graph grows, is already decided at plan time.
+"""
+
+from __future__ import annotations
+
+from seocho import NodeDef, Ontology, P
+from seocho.query.plan_quality import repair_hint, summarize_plan
+
+
+def _plan(*operators: str) -> dict:
+    """Nest operators outermost-first, as Neo4j returns them."""
+    node: dict = {"operatorType": operators[-1], "args": {"EstimatedRows": 41000.0},
+                  "children": []}
+    for op in reversed(operators[:-1]):
+        node = {"operatorType": op, "args": {"EstimatedRows": 0.5}, "children": [node]}
+    return node
+
+
+def _ontology() -> Ontology:
+    return Ontology(name="probe", nodes={
+        "Decision": NodeDef(properties={"name": P(str, unique=True), "note": P(str)})})
+
+
+def test_a_label_scan_is_not_sargable():
+    summary = summarize_plan(_plan("ProduceResults@neo4j", "Filter@neo4j",
+                                   "NodeByLabelScan@neo4j"))
+    assert summary["sargable"] is False
+    assert summary["scans"] == ["NodeByLabelScan@neo4j"]
+    assert summary["estimated_rows"] == 41000.0
+
+
+def test_an_index_seek_is_sargable():
+    summary = summarize_plan(_plan("ProduceResults@neo4j", "NodeUniqueIndexSeek@neo4j"))
+    assert summary["sargable"] is True
+    assert summary["scans"] == []
+
+
+def test_one_scan_anywhere_fails_the_whole_plan():
+    """Deliberately strict: a single growing component is the thing to alert on."""
+    summary = summarize_plan(_plan("ProduceResults@neo4j", "NodeIndexSeek@neo4j",
+                                   "AllNodesScan@neo4j"))
+    assert summary["seeks"] and summary["scans"]
+    assert summary["sargable"] is False
+
+
+def test_an_absent_plan_is_reported_as_unavailable():
+    assert summarize_plan(None) == {"available": False, "source": "explain"}
+
+
+def test_a_sargable_plan_produces_no_hint():
+    summary = summarize_plan(_plan("ProduceResults@neo4j", "NodeUniqueIndexSeek@neo4j"))
+    assert repair_hint(summary, _ontology()) is None
+
+
+def test_the_hint_names_an_indexed_property_from_the_ontology():
+    """The schema is the evidence — the model is not asked to guess."""
+    summary = summarize_plan(_plan("ProduceResults@neo4j", "NodeByLabelScan@neo4j"))
+    hint = repair_hint(summary, _ontology())
+    assert "Decision.name" in hint
+    assert "index seek is available" in hint
+    assert "NodeByLabelScan" in hint
+
+
+def test_the_hint_says_so_when_no_seek_is_available():
+    """Telling the model to anchor on an index that does not exist is worse
+    than telling it there is none."""
+    ontology = Ontology(name="flat", nodes={
+        "Decision": NodeDef(properties={"note": P(str)})})
+    hint = repair_hint(summarize_plan(_plan("ProduceResults@neo4j",
+                                            "AllNodesScan@neo4j")), ontology)
+    assert "no unique property" in hint
+    assert "narrow the match" in hint
+
+
+def test_the_gate_is_off_unless_asked(monkeypatch):
+    """It changes WHEN repair fires, so it stays behind a flag until measured."""
+    from seocho.local_engine import _LocalEngine
+
+    monkeypatch.delenv("SEOCHO_PLAN_GATE", raising=False)
+    engine = object.__new__(_LocalEngine)
+
+    class _Executor:
+        def explain(self, plan):
+            raise AssertionError("must not be consulted when the gate is off")
+
+    assert engine._plan_repair_hint("MATCH (n) RETURN n", {}, "neo4j",
+                                    executor=_Executor()) is None
+
+
+def test_a_planning_failure_never_propagates(monkeypatch):
+    """A probe on the read path must not be able to fail a user's query."""
+    from seocho.local_engine import _LocalEngine
+
+    monkeypatch.setenv("SEOCHO_PLAN_GATE", "1")
+    engine = object.__new__(_LocalEngine)
+
+    class _Boom:
+        def explain(self, plan):
+            raise RuntimeError("EXPLAIN unsupported on this backend")
+
+    assert engine._plan_repair_hint("MATCH (n) RETURN n", {}, "neo4j",
+                                    executor=_Boom()) is None
+
+
+def test_a_backend_without_explain_yields_no_signal():
+    """`None` means no signal, and must not read as a good plan or a bad one."""
+    from seocho.query.contracts import QueryPlan
+    from seocho.query.executor import GraphQueryExecutor
+
+    class _Store:
+        pass
+
+    executor = GraphQueryExecutor(graph_store=_Store(), database="neo4j")
+    assert executor.explain(QueryPlan(question="", cypher="MATCH (n) RETURN n",
+                                      params={})) is None
+    assert summarize_plan(None)["available"] is False


### PR DESCRIPTION
The text2cypher repair loop fires on `not records` and receives only previous attempts and their **error text**. A query that returns rows while planning a full scan is therefore a success it can never improve — and that is exactly the query whose cost explodes as the graph grows.

`ADR-0144` measured the same answer at **25 db hits and 6.6M at SF1000**, while at SF1 the two shapes were **4 ms apart**. Neither accuracy tests nor wall-clock separate them; the plan does.

## EXPLAIN, not PROFILE

| | executes | returns |
|---|---|---|
| `EXPLAIN q` | **no** | `args.EstimatedRows`, `operatorType`, `children` |
| `PROFILE q` | yes | the above **+ `dbHits`, `rows`, `pageCacheHits`** |

Because EXPLAIN costs a compile and nothing else, it can gate **every** query rather than a sample — and the seek/scan distinction, the property that predicts behaviour at scale, is already settled at plan time.

**Shapes verified against a live DozerDB 5.26.3, not assumed.** Operators arrive suffixed as `NodeByLabelScan@neo4j`, which the existing substring matching tolerates. `MATCH (n:X) WHERE n.name = $v` plans a `NodeByLabelScan`; dropping the label plans an `AllNodesScan`. Both without touching data.

## What the repair agent now sees

```
The previous query was valid but not sargable.
  plan operators: NodeByLabelScan@neo4j
  estimated rows: 10
  A scan grows with the graph; a seek does not.
  The ontology declares these as unique, so an index seek is available
  on: PQProbe.name.
  Rewrite as an anchored lookup on one of them.
```

That output is from the live instance, not a fixture.

**The last two lines are the point.** Because the ontology declares which properties are unique, the hint states that an index seek *exists* rather than asking the model to guess. Where nothing is unique it says so and suggests narrowing instead — pointing a model at an index that does not exist is worse than admitting there is none.

## The prompt's task line is now conditional

It previously always asked for a *"relaxed alternative"*. That is right for an empty result and **wrong for a full scan**: relaxing the match makes the scan wider. The two failure modes share one prompt and pull in opposite directions, so the instruction follows the failure.

## Design notes

`explain_plan` is a separate `GraphStore` method rather than a wider return type on `query` — the plan lives on the result summary, and `query` is contracted to return records. A backend without it yields `None`, which callers treat as *no signal* rather than as a verdict.

Behind **`SEOCHO_PLAN_GATE`, off by default**. It changes *when* repair fires, and a behaviour change belongs behind a flag until it has been measured on a real corpus.

## Validation

`bash scripts/ci/run_basic_ci.sh` → **818 passed, 3 skipped**, with the new test file added to that script's explicit list.

Covered: a scan anywhere fails the whole plan; the hint names an indexed property from the ontology; it says so when no seek is available; the gate does nothing unless asked; a planning failure never propagates into the user's query; and a backend without EXPLAIN yields no signal rather than a verdict.

## Follow-up

The PROFILE-sampled post-hoc metrics (`SEOCHO_PLAN_PROFILE_SAMPLE`, `seocho.query.db_hits.count`) are a separate change on `feat/serve-track-kv-dissection` and are not in this PR.
