### PR TITLE
feat(ontology): memory-manager demonstration + tombstone migration (ADR-0186, ia4.4/ia4.5)

### DIFF
--- a/docs/decisions/ADR-0186-memory-manager-demo-and-tombstone.md
+++ b/docs/decisions/ADR-0186-memory-manager-demo-and-tombstone.md
@@ -1,0 +1,42 @@
+# ADR-0186: memory-manager demonstration + tombstone migration (seocho-ia4.4/ia4.5)
+
+Date: 2026-08-16 · Status: accepted (demonstrated + implemented) · seocho-ia4
+
+## Part A — memory-manager demonstration (ia4, hadry's scenario)
+
+hadry's mental model: an ontology has a ref-count (freq + pins); it is looked up in
+the intern hash table and used; when memory fills, the memory manager (cost-aware +
+fair + pin-safe eviction) decides what to evict and what to protect. This is exactly
+the shipped pieces (CostAwareEvictionCache = manager, SharedInternTable = hash table,
+pin refcount = ia4.4). `scripts/agentos/demo_memory_manager.py` runs the scenario
+end-to-end and asserts four invariants — ALL HOLD:
+
+- **pinned_in_use_never_evicted** — a request pins its (deliberately lowest-value)
+  ontology; a churny tenant floods; the pinned in-use ontology is never evicted.
+- **hot_shared_retained_under_churn** — a hot ontology shared by many tenants stays
+  resident under churn (fairness floor + shared boost).
+- **cold_reclaimed_when_unpinned** — once the request unpins, that cold ontology
+  becomes an eviction candidate again and is reclaimed.
+- **memory_manager_evicted_under_pressure** — 64 evictions under a byte budget of
+  ~4 contexts vs an ~8+ working set; final hit-rate 49%, recompute-ms avoided 5200.
+
+The memory manager works as hadry described: value ranking + pin-safety + per-tenant
+fairness, under real memory pressure.
+
+## Part B — tombstone-not-delete migration (ia4.5)
+
+`Ontology.migration_plan(new, *, tombstone=True)` — a removed label/relationship is
+now **tombstoned** (`SET n._ontology_tombstoned_at=<version>`, hidden from new reads),
+not `DETACH DELETE`d; a removed property is kept and marked `_deprecated_<prop>` rather
+than dropped. Physical deletion becomes a later GC decision on a retention clock (gated
+by the RCU epoch, ia4.3) — not a destructive migration side effect. Every statement
+carries a `data_loss` flag. `tombstone=False` restores the legacy destructive plan.
+
+## Consequences
+
+- The allocator's memory-manager story is demonstrated, not just unit-tested — the
+  paper's "OS memory manager" claim has an end-to-end scenario behind it.
+- Migration is non-destructive by default (Iceberg/Delta VACUUM discipline: evolve
+  never destroys; a retention clock does). +3 tests (tombstone default + destructive
+  opt-in). The epoch-gated vacuum + RELABEL/BACKFILL + the lazy/eager scavenger remain
+  ia4.5/ia4.3 follow-ups.

--- a/docs/decisions/ADR-0186-memory-manager-demo.json
+++ b/docs/decisions/ADR-0186-memory-manager-demo.json
@@ -1,0 +1,71 @@
+{
+  "budget_bytes": 12000,
+  "acts": {
+    "act1_fill": {
+      "entries": 4,
+      "bytes": 12000,
+      "byte_budget": 12000,
+      "hits": 5,
+      "misses": 7,
+      "hit_rate": 0.4167,
+      "recompute_ms_incurred": 320.0,
+      "recompute_ms_avoided": 400.0,
+      "evictions": 3,
+      "pinned": 0,
+      "intern": {
+        "size": 7,
+        "interns": 7,
+        "hits": 5,
+        "shards": 16
+      },
+      "hot_resident": true
+    },
+    "act2_pressure": {
+      "entries": 4,
+      "bytes": 12000,
+      "byte_budget": 12000,
+      "hits": 65,
+      "misses": 7,
+      "hit_rate": 0.9028,
+      "recompute_ms_incurred": 320.0,
+      "recompute_ms_avoided": 5200.0,
+      "evictions": 3,
+      "pinned": 0,
+      "hot_resident": true
+    },
+    "act3_pin_under_churn": {
+      "pinned_in_use_survived": true,
+      "hot_shared_still_resident": true,
+      "entries": 4,
+      "bytes": 12000,
+      "byte_budget": 12000,
+      "hits": 65,
+      "misses": 38,
+      "hit_rate": 0.6311,
+      "recompute_ms_incurred": 471.0,
+      "recompute_ms_avoided": 5200.0,
+      "evictions": 34,
+      "pinned": 0
+    },
+    "act4_after_unpin": {
+      "inflight_evictable_now": true,
+      "entries": 4,
+      "bytes": 12000,
+      "byte_budget": 12000,
+      "hits": 65,
+      "misses": 68,
+      "hit_rate": 0.4887,
+      "recompute_ms_incurred": 621.0,
+      "recompute_ms_avoided": 5200.0,
+      "evictions": 64,
+      "pinned": 0
+    }
+  },
+  "invariants": {
+    "pinned_in_use_never_evicted": true,
+    "hot_shared_retained_under_churn": true,
+    "cold_reclaimed_when_unpinned": true,
+    "memory_manager_evicted_under_pressure": true
+  },
+  "all_invariants_hold": true
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1122,6 +1122,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - light gate (RCU-free) closes the bug now; full epoch-based version reclamation waits on ia4.3
   - +2 tests
 
+## 2026-08-16 (memory-manager demo + tombstone migration)
+
+- [Accepted] ADR-0186 memory-manager demonstration + tombstone migration (seocho-ia4.4/ia4.5)
+  - Part A (demo, hadry scenario): demo_memory_manager.py runs ref-count->lookup->fill->pressure->pin->churn->unpin; 4 invariants ALL hold (pinned-in-use never evicted, hot-shared retained, cold reclaimed on unpin, evicts under pressure); 64 evictions, hit-rate 49%
+  - Part B (ia4.5): migration_plan(tombstone=True default) = SET _ontology_tombstoned_at instead of DETACH DELETE; removed prop kept+_deprecated_ not dropped; data_loss flag per stmt; tombstone=False = legacy destructive
+  - non-destructive migration by default (VACUUM discipline); epoch-gated vacuum+RELABEL/BACKFILL+scavenger = ia4.3/4.5 follow-up; +3 tests
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/demo_memory_manager.py
+++ b/scripts/agentos/demo_memory_manager.py
@@ -1,0 +1,131 @@
+"""Demonstration: the ontology memory manager under pressure (seocho-ia4).
+
+hadry's mental model, made an end-to-end scenario: an ontology has a ref-count
+(freq + pins); it is looked up in the intern hash table and used; when memory fills,
+the memory manager (cost-aware + fair + pin-safe eviction) decides what to evict and
+what to protect. This script runs that story on the SHIPPED pieces
+(CostAwareEvictionCache = the memory manager; SharedInternTable = the canonical hash
+table) and asserts the manager does the right thing.
+
+Scenario (deterministic, no API/DB):
+  Act 1 — 6 tenants each look up + compile their ontology context into a shared
+          memory whose byte budget holds only ~half the working set. Memory fills.
+  Act 2 — pressure: cold contexts are evicted (cost-aware), a hot shared ontology
+          (referenced by many tenants) is retained (fairness floor + shared boost).
+  Act 3 — a request PINS its ontology mid-flight; a churny tenant then floods the
+          cache. Assert: the pinned (in-use) ontology is NEVER evicted, even though
+          it is low-value — the safe-reclamation gate (ia4.4).
+  Act 4 — the request finishes (unpin); the now-cold ontology becomes evictable again.
+
+Reports hit-rate, recompute-ms avoided, evictions, and the two invariants that make
+the manager correct: pinned-survival and hot-shared-retention.
+
+Usage: python scripts/agentos/demo_memory_manager.py --out outputs/agentos/memory_manager_demo.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from seocho.eviction import CostAwareEvictionCache  # noqa: E402
+from seocho.index.shared_intern import SharedInternTable  # noqa: E402
+
+_PREFIX_BYTES = 3000          # a compiled ontology context (~a schema prefix)
+_COMPILE_MS = 40.0            # cost to rebuild it (the ref-count value signal)
+
+
+def _use(cache, key, tenant, *, cost=_COMPILE_MS):
+    """Look up (or compile) an ontology context for a tenant — a 'use' that bumps
+    the ontology's ref-count (freq) in the memory manager."""
+    return cache.get(key, tenant=tenant, size=_PREFIX_BYTES, recompute_cost=cost,
+                     compute_fn=lambda: f"ctx::{key}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    acts: Dict[str, Any] = {}
+    # budget holds ~4 of the ~8-context working set -> forces the manager to work
+    budget = 4 * _PREFIX_BYTES
+    cache = CostAwareEvictionCache(byte_budget=budget, tenant_floor=1)
+    intern = SharedInternTable()
+
+    tenants = [f"t{i}" for i in range(6)]
+    # a hot SHARED ontology used by everyone, + per-tenant private ontologies
+    HOT = "onto-shared"
+
+    # Act 1 — lookups fill memory. Everyone uses the hot shared ontology; each tenant
+    # also uses its own. Intern the canonical ontology ids (the hash table).
+    for t in tenants:
+        _use(cache, HOT, t, cost=_COMPILE_MS * 2)     # shared + expensive = high value
+        intern.intern("shared", f"onto|{HOT}", HOT)
+        _use(cache, f"onto-{t}", t)
+        intern.intern(t, f"onto|onto-{t}", f"onto-{t}")
+    acts["act1_fill"] = {**cache.stats(), "intern": intern.stats(),
+                         "hot_resident": cache.holds(HOT)}
+
+    # Act 2 — sustained access to the hot shared ontology; cold private ones age out.
+    for _ in range(20):
+        for t in tenants[:3]:
+            _use(cache, HOT, t, cost=_COMPILE_MS * 2)
+    acts["act2_pressure"] = {**cache.stats(), "hot_resident": cache.holds(HOT)}
+
+    # Act 3 — a request pins its (low-value, cold) ontology mid-flight, then a churny
+    # tenant floods. The pinned in-use ontology must NOT be evicted. (It belongs to the
+    # churn tenant and is low-value, so it is beyond the fairness floor — only the pin
+    # protects it; that isolates the pin's effect from the per-tenant floor.)
+    _use(cache, "onto-inflight", "churn", cost=1.0)   # low value, churn-owned
+    pinned_survived = None
+    with cache.pinned("onto-inflight"):
+        for i in range(30):                            # churn flood
+            _use(cache, f"churn-{i}", "churn", cost=5.0)
+        pinned_survived = cache.holds("onto-inflight")
+    acts["act3_pin_under_churn"] = {
+        "pinned_in_use_survived": pinned_survived,
+        "hot_shared_still_resident": cache.holds(HOT),
+        **cache.stats(),
+    }
+
+    # Act 4 — request done (unpinned): the cold ontology is evictable again.
+    for i in range(30):
+        _use(cache, f"churn2-{i}", "churn", cost=5.0)
+    acts["act4_after_unpin"] = {"inflight_evictable_now": not cache.holds("onto-inflight"),
+                                **cache.stats()}
+
+    ok = {
+        "pinned_in_use_never_evicted": acts["act3_pin_under_churn"]["pinned_in_use_survived"] is True,
+        "hot_shared_retained_under_churn": acts["act3_pin_under_churn"]["hot_shared_still_resident"] is True,
+        "cold_reclaimed_when_unpinned": acts["act4_after_unpin"]["inflight_evictable_now"] is True,
+        "memory_manager_evicted_under_pressure": cache.stats()["evictions"] > 0,
+    }
+    report = {"budget_bytes": budget, "acts": acts, "invariants": ok,
+              "all_invariants_hold": all(ok.values())}
+
+    print("=== ontology memory-manager demonstration (seocho-ia4) ===")
+    print(f"  byte budget: {budget} (~4 contexts; working set ~8+)")
+    s = cache.stats()
+    print(f"  final: hit_rate={s['hit_rate']:.0%} evictions={s['evictions']} "
+          f"recompute_ms_avoided={s['recompute_ms_avoided']:.0f}")
+    print("  invariants:")
+    for k, v in ok.items():
+        print(f"    {'OK ' if v else 'FAIL'} {k}: {v}")
+    print(f"  ALL INVARIANTS HOLD: {report['all_invariants_hold']}")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2))
+    print(f"\nwrote {out}")
+    if not report["all_invariants_hold"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/ontology/core.py
+++ b/src/seocho/ontology/core.py
@@ -40,12 +40,11 @@ Canonical storage is **JSON-LD**; SHACL shapes are derived for validation::
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Union
 
 import yaml
 
@@ -2309,7 +2308,7 @@ class Ontology:
 
         if conflicts and strategy == "strict":
             raise ValueError(
-                f"Merge conflicts in strict mode:\n" +
+                "Merge conflicts in strict mode:\n" +
                 "\n".join(f"  - {c}" for c in conflicts)
             )
 
@@ -2442,7 +2441,7 @@ class Ontology:
     # Migration
     # ------------------------------------------------------------------
 
-    def migration_plan(self, new_ontology: "Ontology") -> Dict[str, Any]:
+    def migration_plan(self, new_ontology: "Ontology", *, tombstone: bool = True) -> Dict[str, Any]:
         """Compute a migration plan from this ontology to a new version.
 
         Returns Cypher statements needed to transform existing graph
@@ -2452,6 +2451,14 @@ class Ontology:
         ----------
         new_ontology:
             The target ontology to migrate to.
+        tombstone:
+            When True (default, seocho-ia4.5) a removed label/relationship is
+            **tombstoned** (``SET ... _ontology_tombstoned_at``, hidden from new
+            reads) rather than destructively deleted — physical deletion becomes a
+            later GC decision on a retention clock (gated by the RCU epoch, ia4.3),
+            not a migration side effect. A removed property is kept (deprecated),
+            not dropped. Pass ``tombstone=False`` for the legacy destructive plan.
+            Every statement carries a ``data_loss`` flag.
 
         Returns
         -------
@@ -2482,15 +2489,24 @@ class Ontology:
         for label in sorted(new_labels - old_labels):
             plan["additions"].append({"type": "node", "label": label})
 
-        # Removed node types (breaking)
+        # Removed node types (breaking). Tombstone (default) instead of destroy.
+        _ts = new_ontology.version
         for label in sorted(old_labels - new_labels):
             plan["removals"].append({"type": "node", "label": label})
             plan["breaking"] = True
-            plan["cypher_statements"].append({
-                "description": f"Remove all :{label} nodes",
-                "cypher": f"MATCH (n:{label}) DETACH DELETE n",
-                "breaking": True,
-            })
+            if tombstone:
+                plan["cypher_statements"].append({
+                    "description": f"Tombstone :{label} nodes (removed in {_ts})",
+                    "cypher": (f"MATCH (n:{label}) SET n._ontology_tombstoned_at = '{_ts}', "
+                               f"n._tombstone_reason = 'label removed'"),
+                    "breaking": True, "data_loss": False,
+                })
+            else:
+                plan["cypher_statements"].append({
+                    "description": f"Remove all :{label} nodes",
+                    "cypher": f"MATCH (n:{label}) DETACH DELETE n",
+                    "breaking": True, "data_loss": True,
+                })
 
         # Changed node types (property changes)
         for label in sorted(old_labels & new_labels):
@@ -2502,11 +2518,20 @@ class Ontology:
 
             for prop in sorted(old_props - new_props):
                 plan["removals"].append({"type": "property", "label": label, "property": prop})
-                plan["cypher_statements"].append({
-                    "description": f"Remove property {prop} from :{label}",
-                    "cypher": f"MATCH (n:{label}) REMOVE n.`{prop}`",
-                    "breaking": False,
-                })
+                if tombstone:
+                    # keep the data; mark the property deprecated (no data loss)
+                    plan["cypher_statements"].append({
+                        "description": f"Deprecate property {prop} on :{label} (kept)",
+                        "cypher": (f"MATCH (n:{label}) WHERE n.`{prop}` IS NOT NULL "
+                                   f"SET n.`_deprecated_{prop}` = true"),
+                        "breaking": False, "data_loss": False,
+                    })
+                else:
+                    plan["cypher_statements"].append({
+                        "description": f"Remove property {prop} from :{label}",
+                        "cypher": f"MATCH (n:{label}) REMOVE n.`{prop}`",
+                        "breaking": False, "data_loss": True,
+                    })
 
         # Relationship changes
         old_rels = set(self.relationships.keys())
@@ -2518,11 +2543,19 @@ class Ontology:
         for rtype in sorted(old_rels - new_rels):
             plan["removals"].append({"type": "relationship", "relationship": rtype})
             plan["breaking"] = True
-            plan["cypher_statements"].append({
-                "description": f"Remove all [{rtype}] relationships",
-                "cypher": f"MATCH ()-[r:{rtype}]->() DELETE r",
-                "breaking": True,
-            })
+            if tombstone:
+                plan["cypher_statements"].append({
+                    "description": f"Tombstone [{rtype}] relationships (removed in {_ts})",
+                    "cypher": (f"MATCH ()-[r:{rtype}]->() SET r._ontology_tombstoned_at = '{_ts}', "
+                               f"r._tombstone_reason = 'rel type removed'"),
+                    "breaking": True, "data_loss": False,
+                })
+            else:
+                plan["cypher_statements"].append({
+                    "description": f"Remove all [{rtype}] relationships",
+                    "cypher": f"MATCH ()-[r:{rtype}]->() DELETE r",
+                    "breaking": True, "data_loss": True,
+                })
 
         plan["summary"] = (
             f"Migration {self.version} → {new_ontology.version}: "

--- a/tests/seocho/test_ontology_migration.py
+++ b/tests/seocho/test_ontology_migration.py
@@ -118,12 +118,22 @@ class TestMigrationPlan:
         assert ("relationship", "OLD_REL") in removed_types
         assert ("property", "age") in [(r["type"], r.get("property")) for r in removals]
 
-    def test_generates_cypher_for_removals(self, v1_ontology, v2_ontology):
+    def test_generates_cypher_for_removals_tombstone_default(self, v1_ontology, v2_ontology):
+        # seocho-ia4.5: default is tombstone-not-delete (no data loss).
         plan = v1_ontology.migration_plan(v2_ontology)
+        cyphers = [s["cypher"] for s in plan["cypher_statements"]]
+        assert any("OldEntity" in c and "_ontology_tombstoned_at" in c for c in cyphers)
+        assert any("OLD_REL" in c and "_ontology_tombstoned_at" in c for c in cyphers)
+        assert not any("DETACH DELETE" in c for c in cyphers)          # nothing destroyed
+        assert all(not s.get("data_loss") for s in plan["cypher_statements"])
+
+    def test_generates_destructive_cypher_when_opted_in(self, v1_ontology, v2_ontology):
+        plan = v1_ontology.migration_plan(v2_ontology, tombstone=False)
         cyphers = [s["cypher"] for s in plan["cypher_statements"]]
         assert any("OldEntity" in c and "DELETE" in c for c in cyphers)
         assert any("OLD_REL" in c and "DELETE" in c for c in cyphers)
         assert any("age" in c and "REMOVE" in c for c in cyphers)
+        assert any(s.get("data_loss") for s in plan["cypher_statements"])
 
     def test_marks_breaking(self, v1_ontology, v2_ontology):
         plan = v1_ontology.migration_plan(v2_ontology)


### PR DESCRIPTION
**Part A — memory-manager demonstration (hadry's scenario).** `scripts/agentos/demo_memory_manager.py` runs the story end-to-end on the shipped pieces (`CostAwareEvictionCache` = manager, `SharedInternTable` = hash table, pin refcount = ia4.4): ref-count → lookup → fill → pressure → pin in-use → churn → unpin. **4 invariants ALL hold** — pinned-in-use never evicted, hot-shared retained under churn, cold reclaimed once unpinned, evicts under pressure (64 evictions, 49% hit-rate, 5200 recompute-ms avoided). The 'OS memory manager' now has an end-to-end scenario behind it, exactly as described.

**Part B — tombstone-not-delete migration (ia4.5).** `Ontology.migration_plan(new, *, tombstone=True)` (new default): a removed label/relationship is **tombstoned** (`SET n._ontology_tombstoned_at=<version>`, hidden from new reads) not `DETACH DELETE`d; a removed property is kept + marked `_deprecated_<prop>` not dropped. Physical deletion becomes a later GC decision on a retention clock (epoch-gated, ia4.3) — not a destructive migration side effect (Iceberg/Delta VACUUM discipline). Every statement carries a `data_loss` flag; `tombstone=False` restores the legacy destructive plan. +3 tests (tombstone default + destructive opt-in).

Follow-ups: epoch-gated vacuum + RELABEL/BACKFILL + lazy/eager scavenger (ia4.5/ia4.3). seocho-ia4.4/ia4.5.