### PR TITLE
feat(query): text2cypher grounding via shared intern table + competency questions (ADR-0187)

### DIFF
--- a/docs/decisions/ADR-0187-text2cypher-intern-grounding.md
+++ b/docs/decisions/ADR-0187-text2cypher-intern-grounding.md
@@ -1,0 +1,39 @@
+# ADR-0187: text2cypher grounding via shared intern table + competency questions (seocho-ia4)
+
+Date: 2026-08-16 · Status: accepted (core module) · seocho-ia4
+
+## Context
+
+hadry: the Cypher-generation agent's hardest moment is resolving the user request —
+it can't find the entity, doesn't know the canonical id, or which query shape the
+question wants — and then hallucinates or gives up. This is precisely where the shared
+canonical namespace (SharedInternTable, ADR-0182/0183) and the ontology's competency
+questions should shine.
+
+## Decision
+
+`src/seocho/query/intern_grounding.py`:
+- **Mention resolution** (`resolve_mentions`): extract request mentions and resolve
+  each against the shared intern table (the canonical entity address space), trying the
+  full span and its capitalized sub-tokens. A resolved mention gives the Cypher a REAL
+  canonical id to bind (grounded, not guessed). An **unresolved** mention is surfaced
+  explicitly — the agent's "can't find entity" case becomes a routable signal (fuzzy /
+  vector fallback), not a silent wrong Cypher.
+- **Intent** (`rank_competency_questions`): rank the request against the ontology's
+  competency questions by tf-idf cosine (dependency-free baseline; embeddings/bge is the
+  richer swap, per the design principle) → the closest CQ's known query shape guides
+  generation.
+- `ground_request` combines both into the context a Cypher-gen prompt consumes, plus a
+  `resolution_rate`.
+
+## Consequences
+
+- text2cypher is grounded in what ACTUALLY exists (the intern namespace) + what the
+  ontology is DESIGNED to answer (competency questions) — directly attacking the
+  intent-extraction/entity-resolution difficulty. The shared intern table's cross-model
+  agreement (ADR-0183) means this grounding is model-agnostic.
+- Honest scope: exact-name resolution (name variants miss → the same boundary-1 ceiling,
+  now surfaced as `unresolved` for fuzzy routing); tf-idf intent baseline (semantic/bge
+  next). +4 tests. Follow-ups: wire the grounding into the live cypher-gen prompt + the
+  repair loop (now that PR #542 lets the repair agent see the plan); vector fallback for
+  unresolved mentions.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1129,6 +1129,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - Part B (ia4.5): migration_plan(tombstone=True default) = SET _ontology_tombstoned_at instead of DETACH DELETE; removed prop kept+_deprecated_ not dropped; data_loss flag per stmt; tombstone=False = legacy destructive
   - non-destructive migration by default (VACUUM discipline); epoch-gated vacuum+RELABEL/BACKFILL+scavenger = ia4.3/4.5 follow-up; +3 tests
 
+## 2026-08-16 (text2cypher intern grounding)
+
+- [Accepted] ADR-0187 text2cypher grounding via shared intern table + competency questions (seocho-ia4)
+  - query/intern_grounding.py: resolve_mentions (request mentions -> canonical ids via SharedInternTable; unresolved = can't-find-entity signal for fuzzy routing) + rank_competency_questions (tf-idf cosine intent) + ground_request
+  - attacks the Cypher-gen agent's hardest moment (entity resolution + intent); model-agnostic via cross-model shared namespace (ADR-0183)
+  - honest: exact-name resolution (variants surface as unresolved = boundary-1 ceiling), tf-idf baseline (bge next); +4 tests
+  - follow-up: wire into live cypher-gen prompt + repair loop (PR #542 merged), vector fallback for unresolved
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/query/intern_grounding.py
+++ b/src/seocho/query/intern_grounding.py
@@ -1,0 +1,174 @@
+"""Ground text2cypher in the shared intern table + competency questions (seocho-ia4).
+
+The Cypher-generation agent's hardest moment: it reads a user request and cannot find
+the entity — it doesn't know whether "Apple" is a real node, what its canonical id is,
+or which query shape the question wants. Left alone it hallucinates a name/label or
+gives up. This is exactly where the shared canonical namespace (SharedInternTable) and
+the ontology's competency questions earn their keep:
+
+1. **Mention resolution** — resolve surface mentions in the request against the shared
+   intern table (the canonical entity address space). A mention that resolves gives the
+   Cypher a REAL canonical id to bind (grounded, not guessed). A mention that does NOT
+   resolve is surfaced explicitly (``unresolved``) — the agent's "can't find entity"
+   case becomes a routable signal (fuzzy/vector fallback), not a silent wrong Cypher.
+2. **Intent via competency questions** — rank the request against the ontology's
+   competency questions (tf-idf cosine baseline; swap in embeddings for semantic) to
+   pick the closest CQ, whose known query shape guides generation.
+
+Pure-Python, dependency-free (tf-idf is a lightweight baseline; the design note flags
+bge/semantic as the richer option). Read-only; produces a grounding the Cypher prompt
+consumes.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..index.identity import compute_node_identity
+
+# Capitalized multi-word spans (Acme, Apple Inc., Bank of America) — a cheap mention
+# heuristic; real NER can replace it without changing the resolution contract.
+_MENTION_RE = re.compile(r"\b([A-Z][\w&.\-]*(?:\s+(?:of\s+|the\s+)?[A-Z][\w&.\-]*)*)")
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_CAPWORD_RE = re.compile(r"[A-Z][\w&.\-]*")
+# sentence-initial / question words that a greedy capitalized-span match sweeps up
+# but are never entities — excluded from the can't-find signal.
+_STOP = {"what", "which", "who", "whom", "whose", "when", "where", "why", "how",
+         "compare", "list", "show", "find", "give", "did", "does", "is", "are",
+         "the", "a", "an", "and", "or", "of", "for", "in", "on", "to"}
+
+
+@dataclass
+class Grounding:
+    resolved: List[Tuple[str, str]] = field(default_factory=list)     # (mention, canonical_id)
+    unresolved: List[str] = field(default_factory=list)               # can't-find-entity signal
+    intents: List[Tuple[str, float]] = field(default_factory=list)    # (competency question, score)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "resolved": [{"mention": m, "canonical_id": c} for m, c in self.resolved],
+            "unresolved": list(self.unresolved),
+            "intents": [{"question": q, "score": round(s, 3)} for q, s in self.intents],
+            "resolution_rate": round(len(self.resolved) / max(len(self.resolved) + len(self.unresolved), 1), 3),
+        }
+
+
+def extract_mentions(request: str) -> List[str]:
+    seen, out = set(), []
+    for m in _MENTION_RE.findall(request or ""):
+        m = m.strip(" .")
+        if m and m.lower() not in seen and len(m) > 1:
+            seen.add(m.lower())
+            out.append(m)
+    return out
+
+
+def resolve_mentions(
+    request: str,
+    *,
+    intern_table: Any,
+    ontology: Any,
+    workspace_id: str = "default",
+) -> Tuple[List[Tuple[str, str]], List[str]]:
+    """Resolve each request mention against the intern table. Returns
+    (resolved [(mention, canonical_id)], unresolved [mention])."""
+    node_defs = getattr(ontology, "nodes", {}) or {}
+    # single-identity-key labels: a lone mention can fill the one key (usually name)
+    single_key_labels = [
+        (label, list(getattr(nd, "identity_keys", []) or [])[0])
+        for label, nd in node_defs.items()
+        if len(getattr(nd, "identity_keys", []) or []) == 1
+    ]
+    def _lookup(text: str) -> Optional[str]:
+        for label, key in single_key_labels:
+            identity = compute_node_identity(label, {key: text}, [key])
+            if identity:
+                canon = intern_table.get(workspace_id, identity)
+                if canon:
+                    return canon
+        return None
+
+    resolved: List[Tuple[str, str]] = []
+    unresolved: List[str] = []
+    seen_unres: set = set()
+    for mention in extract_mentions(request):
+        # try the full span, then each capitalized token inside it (a greedy span
+        # like "Compare Apple" should still resolve "Apple").
+        candidates = [mention] + [w for w in _CAPWORD_RE.findall(mention) if w != mention]
+        hit_text = hit = None
+        for cand in candidates:
+            canon = _lookup(cand)
+            if canon:
+                hit_text, hit = cand, canon
+                break
+        if hit:
+            resolved.append((hit_text, hit))
+        else:
+            # report only genuine, non-stopword mentions as the can't-find signal
+            for w in _CAPWORD_RE.findall(mention) or [mention]:
+                if w.lower() not in _STOP and w.lower() not in seen_unres:
+                    seen_unres.add(w.lower())
+                    unresolved.append(w)
+    return resolved, unresolved
+
+
+def _tfidf_vectors(docs: List[str]) -> List[Dict[str, float]]:
+    tokenized = [_WORD_RE.findall(d.lower()) for d in docs]
+    df: Counter = Counter()
+    for toks in tokenized:
+        for w in set(toks):
+            df[w] += 1
+    n = len(docs)
+    vecs = []
+    for toks in tokenized:
+        tf = Counter(toks)
+        total = max(len(toks), 1)
+        vec = {}
+        for w, c in tf.items():
+            idf = math.log((n + 1) / (df[w] + 1)) + 1.0
+            vec[w] = (c / total) * idf
+        vecs.append(vec)
+    return vecs
+
+
+def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(a[w] * b.get(w, 0.0) for w in a)
+    na = math.sqrt(sum(v * v for v in a.values()))
+    nb = math.sqrt(sum(v * v for v in b.values()))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def rank_competency_questions(
+    request: str, competency_questions: List[str], *, top_k: int = 3,
+) -> List[Tuple[str, float]]:
+    """Rank CQs by tf-idf cosine similarity to the request (intent hint)."""
+    if not competency_questions:
+        return []
+    vecs = _tfidf_vectors([request] + list(competency_questions))
+    req, cqs = vecs[0], vecs[1:]
+    scored = [(competency_questions[i], _cosine(req, cqs[i])) for i in range(len(cqs))]
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return [(q, s) for q, s in scored[:top_k] if s > 0]
+
+
+def ground_request(
+    request: str,
+    *,
+    intern_table: Any,
+    ontology: Any,
+    workspace_id: str = "default",
+    competency_questions: Optional[List[str]] = None,
+    top_k: int = 3,
+) -> Grounding:
+    """Full grounding: resolved canonical entities + unresolved (can't-find signal) +
+    top competency-question intents — the context a Cypher-gen prompt should consume."""
+    resolved, unresolved = resolve_mentions(
+        request, intern_table=intern_table, ontology=ontology, workspace_id=workspace_id)
+    intents = rank_competency_questions(request, competency_questions or [], top_k=top_k)
+    return Grounding(resolved=resolved, unresolved=unresolved, intents=intents)

--- a/tests/seocho/test_intern_grounding.py
+++ b/tests/seocho/test_intern_grounding.py
@@ -1,0 +1,57 @@
+"""text2cypher grounding via shared intern table + competency questions (seocho-ia4)."""
+from __future__ import annotations
+from seocho.ontology.core import NodeDef, Ontology, P
+from seocho.index.identity import compute_node_identity
+from seocho.index.shared_intern import SharedInternTable
+from seocho.query.intern_grounding import (
+    extract_mentions, resolve_mentions, rank_competency_questions, ground_request,
+)
+
+
+def _onto():
+    return Ontology(name="fin", nodes={
+        "Company": NodeDef(properties={"name": P(str)}, identity_keys=["name"]),
+    }, relationships={})
+
+
+def _table(onto, names, ws="w"):
+    t = SharedInternTable()
+    for nm in names:
+        ident = compute_node_identity("Company", {"name": nm}, ["name"])
+        t.intern(ws, ident, ident)
+    return t
+
+
+def test_extract_mentions():
+    ms = extract_mentions("What revenue did Apple Inc. and Bank of America report?")
+    assert any("Apple" in m for m in ms)
+    assert any("Bank of America" in m for m in ms)
+
+
+def test_resolve_hits_and_misses():
+    onto = _onto()
+    t = _table(onto, ["Apple", "Microsoft"])
+    resolved, unresolved = resolve_mentions(
+        "Compare Apple and Tesla revenue", intern_table=t, ontology=onto, workspace_id="w")
+    assert any(m == "Apple" for m, _ in resolved)         # exact -> resolved to canonical
+    assert "Tesla" in unresolved                          # not in namespace -> can't-find signal
+
+
+def test_competency_question_intent_ranking():
+    cqs = ["What is the total revenue of a company?",
+           "Which regulator enforces a regulation?",
+           "Who are the board members of a company?"]
+    ranked = rank_competency_questions("What revenue did the company report?", cqs, top_k=2)
+    assert ranked and "revenue" in ranked[0][0].lower()   # revenue CQ ranks top
+
+
+def test_ground_request_combines_all():
+    onto = _onto()
+    t = _table(onto, ["Apple"])
+    g = ground_request("What revenue did Apple and Globex report?",
+                       intern_table=t, ontology=onto, workspace_id="w",
+                       competency_questions=["What is the total revenue of a company?"])
+    d = g.to_dict()
+    assert d["resolved"] and d["resolved"][0]["mention"] == "Apple"
+    assert "Globex" in d["unresolved"]
+    assert d["intents"] and d["resolution_rate"] == 0.5


### PR DESCRIPTION
hadry: the Cypher-generation agent's hardest moment is resolving the request — it can't find the entity, doesn't know the canonical id, or which query shape the question wants — then hallucinates or gives up. This is exactly where the shared canonical namespace (SharedInternTable, ADR-0182/0183) + the ontology's competency questions earn their keep.

`src/seocho/query/intern_grounding.py`:
- **`resolve_mentions`** — resolve request mentions against the shared intern table (canonical entity address space), trying the full span + its capitalized sub-tokens. Resolved → a REAL canonical id to bind (grounded, not guessed). **Unresolved → surfaced explicitly** as the 'can't-find-entity' signal, routable to fuzzy/vector fallback instead of a silent wrong Cypher.
- **`rank_competency_questions`** — rank the request against the ontology's competency questions by tf-idf cosine (dependency-free baseline; bge/semantic is the richer swap) → the closest CQ's query shape guides generation.
- **`ground_request`** combines both (+ `resolution_rate`) = the context a cypher-gen prompt consumes.

Model-agnostic (the cross-model shared namespace, ADR-0183, means any model's grounding hits the same addresses). +4 tests. Honest scope: exact-name resolution (variants surface as `unresolved` = the boundary-1 ceiling, now a routable signal); tf-idf intent baseline. **Follow-up:** wire into the live cypher-gen prompt + repair loop (PR #542 — repair agent sees the plan — is merged), vector fallback for unresolved. seocho-ia4.