### PR TITLE
refactor(ontology): rename migration 'tombstone' -> 'soft-delete' for clarity

### DIFF
--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1137,6 +1137,12 @@ Each entry must link to a full ADR when impact is non-trivial.
   - honest: exact-name resolution (variants surface as unresolved = boundary-1 ceiling), tf-idf baseline (bge next); +4 tests
   - follow-up: wire into live cypher-gen prompt + repair loop (PR #542 merged), vector fallback for unresolved
 
+## 2026-08-16 (terminology: soft-delete)
+
+- [Clarification] rename ontology-migration "tombstone" -> "soft-delete" (hadry: term unclear)
+  - migration_plan(soft_delete=True) [was tombstone]; graph props _ontology_soft_deleted_at / _soft_delete_reason [were _ontology_tombstoned_at / _tombstone_reason]; new, no production data, safe rename
+  - audit of this session's OS-lifecycle modules: tombstone was the only genuinely-ambiguous term; the rest (GDSF, intern/interning, tenant_floor, shared_boost, anchor, staleness, AMIE-lite, epoch/watermark/fencing[design]) are standard CS/DL/schema-registry terms already explained in module docstrings — no rename needed
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/ontology/core.py
+++ b/src/seocho/ontology/core.py
@@ -2441,7 +2441,7 @@ class Ontology:
     # Migration
     # ------------------------------------------------------------------
 
-    def migration_plan(self, new_ontology: "Ontology", *, tombstone: bool = True) -> Dict[str, Any]:
+    def migration_plan(self, new_ontology: "Ontology", *, soft_delete: bool = True) -> Dict[str, Any]:
         """Compute a migration plan from this ontology to a new version.
 
         Returns Cypher statements needed to transform existing graph
@@ -2451,13 +2451,13 @@ class Ontology:
         ----------
         new_ontology:
             The target ontology to migrate to.
-        tombstone:
+        soft_delete:
             When True (default, seocho-ia4.5) a removed label/relationship is
-            **tombstoned** (``SET ... _ontology_tombstoned_at``, hidden from new
+            **soft-deleted** (``SET ... _ontology_soft_deleted_at``, hidden from new
             reads) rather than destructively deleted — physical deletion becomes a
             later GC decision on a retention clock (gated by the RCU epoch, ia4.3),
             not a migration side effect. A removed property is kept (deprecated),
-            not dropped. Pass ``tombstone=False`` for the legacy destructive plan.
+            not dropped. Pass ``soft_delete=False`` for the legacy destructive (hard-delete) plan.
             Every statement carries a ``data_loss`` flag.
 
         Returns
@@ -2489,16 +2489,16 @@ class Ontology:
         for label in sorted(new_labels - old_labels):
             plan["additions"].append({"type": "node", "label": label})
 
-        # Removed node types (breaking). Tombstone (default) instead of destroy.
+        # Removed node types (breaking). Soft-delete (default) instead of destroy.
         _ts = new_ontology.version
         for label in sorted(old_labels - new_labels):
             plan["removals"].append({"type": "node", "label": label})
             plan["breaking"] = True
-            if tombstone:
+            if soft_delete:
                 plan["cypher_statements"].append({
-                    "description": f"Tombstone :{label} nodes (removed in {_ts})",
-                    "cypher": (f"MATCH (n:{label}) SET n._ontology_tombstoned_at = '{_ts}', "
-                               f"n._tombstone_reason = 'label removed'"),
+                    "description": f"Soft-delete :{label} nodes (removed in {_ts})",
+                    "cypher": (f"MATCH (n:{label}) SET n._ontology_soft_deleted_at = '{_ts}', "
+                               f"n._soft_delete_reason = 'label removed'"),
                     "breaking": True, "data_loss": False,
                 })
             else:
@@ -2518,7 +2518,7 @@ class Ontology:
 
             for prop in sorted(old_props - new_props):
                 plan["removals"].append({"type": "property", "label": label, "property": prop})
-                if tombstone:
+                if soft_delete:
                     # keep the data; mark the property deprecated (no data loss)
                     plan["cypher_statements"].append({
                         "description": f"Deprecate property {prop} on :{label} (kept)",
@@ -2543,11 +2543,11 @@ class Ontology:
         for rtype in sorted(old_rels - new_rels):
             plan["removals"].append({"type": "relationship", "relationship": rtype})
             plan["breaking"] = True
-            if tombstone:
+            if soft_delete:
                 plan["cypher_statements"].append({
-                    "description": f"Tombstone [{rtype}] relationships (removed in {_ts})",
-                    "cypher": (f"MATCH ()-[r:{rtype}]->() SET r._ontology_tombstoned_at = '{_ts}', "
-                               f"r._tombstone_reason = 'rel type removed'"),
+                    "description": f"Soft-delete [{rtype}] relationships (removed in {_ts})",
+                    "cypher": (f"MATCH ()-[r:{rtype}]->() SET r._ontology_soft_deleted_at = '{_ts}', "
+                               f"r._soft_delete_reason = 'rel type removed'"),
                     "breaking": True, "data_loss": False,
                 })
             else:

--- a/tests/seocho/test_ontology_migration.py
+++ b/tests/seocho/test_ontology_migration.py
@@ -118,17 +118,17 @@ class TestMigrationPlan:
         assert ("relationship", "OLD_REL") in removed_types
         assert ("property", "age") in [(r["type"], r.get("property")) for r in removals]
 
-    def test_generates_cypher_for_removals_tombstone_default(self, v1_ontology, v2_ontology):
-        # seocho-ia4.5: default is tombstone-not-delete (no data loss).
+    def test_generates_cypher_for_removals_soft_delete_default(self, v1_ontology, v2_ontology):
+        # seocho-ia4.5: default is soft-delete (not destroy) (no data loss).
         plan = v1_ontology.migration_plan(v2_ontology)
         cyphers = [s["cypher"] for s in plan["cypher_statements"]]
-        assert any("OldEntity" in c and "_ontology_tombstoned_at" in c for c in cyphers)
-        assert any("OLD_REL" in c and "_ontology_tombstoned_at" in c for c in cyphers)
+        assert any("OldEntity" in c and "_ontology_soft_deleted_at" in c for c in cyphers)
+        assert any("OLD_REL" in c and "_ontology_soft_deleted_at" in c for c in cyphers)
         assert not any("DETACH DELETE" in c for c in cyphers)          # nothing destroyed
         assert all(not s.get("data_loss") for s in plan["cypher_statements"])
 
     def test_generates_destructive_cypher_when_opted_in(self, v1_ontology, v2_ontology):
-        plan = v1_ontology.migration_plan(v2_ontology, tombstone=False)
+        plan = v1_ontology.migration_plan(v2_ontology, soft_delete=False)
         cyphers = [s["cypher"] for s in plan["cypher_statements"]]
         assert any("OldEntity" in c and "DELETE" in c for c in cyphers)
         assert any("OLD_REL" in c and "DELETE" in c for c in cyphers)


### PR DESCRIPTION
hadry: 'tombstone' is an unclear term — use the plainer **soft-delete**.

- `Ontology.migration_plan(new, *, soft_delete=True)` (was `tombstone`).
- Graph stamps `_ontology_soft_deleted_at` / `_soft_delete_reason` (were `_ontology_tombstoned_at` / `_tombstone_reason`). Brand-new (ADR-0186, merged this session), **no production data → safe rename**.
- Descriptions/comments/test names updated; `soft_delete=False` still gives the legacy destructive (hard-delete) plan; `data_loss` flag unchanged.

**Terminology audit** (per the same request — 'check our code for other unclear terms'): I swept this session's OS-lifecycle modules (eviction, shared_intern, freshness, compatibility, publish_gate, upper, induce, metrics, intern_grounding, axioms, parallel). **`tombstone` was the only genuinely ambiguous term.** The rest — GDSF, intern/interning (hash-consing), tenant_floor, shared_boost, anchor, staleness, AMIE-lite, epoch/watermark/fencing (RCU design) — are standard CS / description-logic / schema-registry terms already explained in their module docstrings, so no rename is warranted. 15 migration tests pass; ruff + doc-contracts clean.