### PR TITLE
feat(ontology): RCU active-version pointer + atomic CAS (ADR-0188, ia4.3 B1)

### DIFF
--- a/docs/decisions/ADR-0188-rcu-active-pointer.md
+++ b/docs/decisions/ADR-0188-rcu-active-pointer.md
@@ -1,0 +1,42 @@
+# ADR-0188: RCU active-version pointer + atomic CAS (seocho-ia4.3 B1)
+
+Date: 2026-08-16 · Status: accepted · seocho-ia4.3 (B1 of the RCU build)
+
+## Context
+
+The RCU model for versioned ontologies (design: wiki/rcu-ontology-versioning-design.md,
+revised after a 2-reviewer adversarial pass that found 3 blockers) needs ONE mutable
+word per (workspace, package_id): the active-version pointer, swapped by an atomic CAS.
+B1 is that pointer + CAS only (B2 pin, B3 EBR gate follow).
+
+## Decision
+
+`ontology/active_pointer.py::ActiveOntologyPointer` — SQLite-backed, cross-process
+atomic (`BEGIN IMMEDIATE` + conditional `UPDATE ... WHERE generation=? AND epoch=?`),
+per (workspace_id, package_id):
+- **Real CAS, not TOCTOU** (review fix): the swap is a single atomic conditional write
+  on the read (generation, epoch) — NOT select-then-compare. Concurrent publishers with
+  the same `expected` → exactly one wins (epoch bumps once), losers see stale expected
+  and no-op.
+- **(generation, epoch), globally non-decreasing** (review fix #7): epoch per swap;
+  generation bumps on recreate, seeded from a persistent `generation_hwm` table that
+  survives delete/restore → a stale reader's old epoch can never be reused against a new
+  version.
+- **Fencing token** rejects a returned-from-the-dead leader below the stored token; the
+  `expected` CAS is the linearization point.
+- Workspace-keyed (the snapshot store lacked a workspace dimension); this is the
+  "active" pointer the store lacked (`latest()`-by-sort ≠ active).
+
+## Result
+
+8 tests: first-publish + read, can't first-publish over an existing pointer, CAS swap
+bumps epoch, wrong-expected fails, stale-fencing-token rejected, **N concurrent CAS →
+exactly one winner (epoch bumps once)**, **recreate → generation strictly increases**,
+workspace/package isolation.
+
+## Consequences
+
+- The RCU read/publish protocol's write side is in place and linearizable. Next: B2
+  (increment-then-recheck reader pin in a REQUEST-level context, decoupled from
+  admission), B3 (EBR gate + conservative shared-store retention). SQLite backing now;
+  etcd-compatible interface later. seocho-ia4.3.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1143,6 +1143,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - migration_plan(soft_delete=True) [was tombstone]; graph props _ontology_soft_deleted_at / _soft_delete_reason [were _ontology_tombstoned_at / _tombstone_reason]; new, no production data, safe rename
   - audit of this session's OS-lifecycle modules: tombstone was the only genuinely-ambiguous term; the rest (GDSF, intern/interning, tenant_floor, shared_boost, anchor, staleness, AMIE-lite, epoch/watermark/fencing[design]) are standard CS/DL/schema-registry terms already explained in module docstrings — no rename needed
 
+## 2026-08-16 (RCU B1 active pointer)
+
+- [Accepted] ADR-0188 RCU active-version pointer + atomic CAS (seocho-ia4.3 B1)
+  - ActiveOntologyPointer (SQLite BEGIN IMMEDIATE conditional UPDATE): real CAS on read (generation,epoch), not TOCTOU; concurrent same-expected -> exactly one winner
+  - (generation,epoch) globally non-decreasing (generation_hwm survives recreate); fencing token rejects stale leader; workspace-keyed (store lacked it); the 'active' pointer latest()-by-sort isn't
+  - 8 tests incl. concurrent-CAS-one-winner + recreate-monotonic-generation. Next B2 pin, B3 EBR gate
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/ontology/__init__.py
+++ b/src/seocho/ontology/__init__.py
@@ -80,6 +80,8 @@ _EXPORTS = {
     "UPPER_RELATION_NAMES": "upper",
     "induce_ontology_from_graph": "induce",
     "induction_report": "induce",
+    "ActiveOntologyPointer": "active_pointer",
+    "ActiveVersion": "active_pointer",
     "compute_ontology_metrics": "metrics",
     "BoundaryViolation": "context_map",
     "BoundedContext": "context_map",

--- a/src/seocho/ontology/active_pointer.py
+++ b/src/seocho/ontology/active_pointer.py
@@ -1,0 +1,191 @@
+"""RCU active-version pointer with atomic compare-and-swap (seocho-ia4.3, B1).
+
+The one mutable word per ``(workspace_id, package_id)`` in the RCU model: which
+immutable ontology version is currently ACTIVE. Publishing a new version is a
+copy-on-write (a new immutable snapshot) followed by a single **atomic CAS** on this
+pointer; readers dereference it once and pin (B2). This is B1 only — the pointer + CAS.
+
+Design decisions forced by the B1/B2 adversarial review (2026-08-16):
+- **Real CAS, not TOCTOU.** The swap is a single atomic conditional UPDATE
+  (``WHERE generation=? AND epoch=?``) under SQLite ``BEGIN IMMEDIATE`` — the
+  ``acknowledge_projection`` UPSERT-RETURNING shape, NOT the racy select-then-compare
+  ``assert_projection_fence``. The ``expected=(generation, epoch)`` check is the
+  linearization point: concurrent publishers with the same ``expected`` → exactly one
+  wins (epoch bumps once); the loser sees its expected epoch is stale and fails.
+- **(generation, epoch), globally non-decreasing.** ``epoch`` bumps per swap.
+  ``generation`` bumps whenever the pointer is (re)created — seeded from a persistent
+  high-water table that survives a delete/restore — so a stale reader holding an old
+  ``epoch`` can never be counted against a new version that reused that epoch value.
+- **Fencing token** additionally rejects a returned-from-the-dead leader whose lease
+  expired (its token is below the stored one); the ``expected`` CAS does the
+  serialization.
+
+SQLite-backed now (cross-process atomic via BEGIN IMMEDIATE), interface-compatible with
+an etcd backing later. Snapshot storage stays the immutable content-addressed store
+(ADR-0117) — this only adds the "which version is active" pointer it lacks.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ActiveVersion:
+    workspace_id: str
+    package_id: str
+    version: str
+    fingerprint: str
+    generation: int
+    epoch: int
+    fencing_token: int
+
+    def expected(self) -> Tuple[int, int]:
+        """The (generation, epoch) a swapper must present to CAS on this pointer."""
+        return (self.generation, self.epoch)
+
+
+class ActiveOntologyPointer:
+    """Atomic, CAS-able active-version pointer per (workspace_id, package_id)."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = str(path)
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()   # in-process guard; BEGIN IMMEDIATE = cross-process
+        self._init_schema()
+
+    def _conn(self) -> sqlite3.Connection:
+        c = sqlite3.connect(self.path, isolation_level=None, timeout=10.0)
+        c.execute("PRAGMA journal_mode=WAL")
+        c.execute("PRAGMA busy_timeout=10000")
+        return c
+
+    def _init_schema(self) -> None:
+        with self._lock, self._conn() as c:
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS active_ontology ("
+                "workspace_id TEXT, package_id TEXT, version TEXT, fingerprint TEXT, "
+                "generation INTEGER, epoch INTEGER, fencing_token INTEGER, "
+                "PRIMARY KEY (workspace_id, package_id))"
+            )
+            # persistent per-key high-water for generation — never deleted, so a
+            # recreated pointer's generation is strictly greater than any prior one.
+            c.execute(
+                "CREATE TABLE IF NOT EXISTS generation_hwm ("
+                "workspace_id TEXT, package_id TEXT, hwm INTEGER, "
+                "PRIMARY KEY (workspace_id, package_id))"
+            )
+
+    def read(self, workspace_id: str, package_id: str) -> Optional[ActiveVersion]:
+        with self._lock, self._conn() as c:
+            row = c.execute(
+                "SELECT version, fingerprint, generation, epoch, fencing_token "
+                "FROM active_ontology WHERE workspace_id=? AND package_id=?",
+                (workspace_id, package_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return ActiveVersion(workspace_id, package_id, row[0], row[1], row[2], row[3], row[4])
+
+    def _next_generation(self, c: sqlite3.Connection, ws: str, pkg: str) -> int:
+        row = c.execute("SELECT hwm FROM generation_hwm WHERE workspace_id=? AND package_id=?",
+                        (ws, pkg)).fetchone()
+        nxt = (row[0] + 1) if row else 0
+        c.execute("INSERT INTO generation_hwm (workspace_id, package_id, hwm) VALUES (?,?,?) "
+                  "ON CONFLICT(workspace_id, package_id) DO UPDATE SET hwm=excluded.hwm",
+                  (ws, pkg, nxt))
+        return nxt
+
+    def publish(
+        self,
+        workspace_id: str,
+        package_id: str,
+        *,
+        version: str,
+        fingerprint: str,
+        fencing_token: int,
+        expected: Optional[Tuple[int, int]] = None,
+    ) -> Tuple[bool, Optional[ActiveVersion]]:
+        """Atomically make ``version`` the ACTIVE pointer.
+
+        - First publish (no row): pass ``expected=None`` → INSERT (generation from the
+          high-water, epoch 0). Fails if a row already exists.
+        - Swap: pass ``expected=(generation, epoch)`` you read → succeeds iff the stored
+          (generation, epoch) still equals ``expected`` AND ``fencing_token`` is not
+          below the stored token; bumps epoch by 1. Otherwise a no-op.
+
+        Returns ``(ok, current)`` — ``current`` is the pointer AFTER the call (the new
+        value on success, or the value that beat you on failure).
+        """
+        with self._lock, self._conn() as c:
+            c.execute("BEGIN IMMEDIATE")
+            try:
+                cur = c.execute(
+                    "SELECT version, fingerprint, generation, epoch, fencing_token "
+                    "FROM active_ontology WHERE workspace_id=? AND package_id=?",
+                    (workspace_id, package_id),
+                ).fetchone()
+
+                if cur is None:
+                    if expected is not None:
+                        c.execute("ROLLBACK")
+                        return (False, None)
+                    gen = self._next_generation(c, workspace_id, package_id)
+                    c.execute(
+                        "INSERT INTO active_ontology "
+                        "(workspace_id, package_id, version, fingerprint, generation, epoch, fencing_token) "
+                        "VALUES (?,?,?,?,?,?,?)",
+                        (workspace_id, package_id, version, fingerprint, gen, 0, int(fencing_token)),
+                    )
+                    c.execute("COMMIT")
+                    return (True, ActiveVersion(workspace_id, package_id, version, fingerprint,
+                                                gen, 0, int(fencing_token)))
+
+                cur_ver, cur_fp, cur_gen, cur_epoch, cur_tok = cur
+                current = ActiveVersion(workspace_id, package_id, cur_ver, cur_fp,
+                                        cur_gen, cur_epoch, cur_tok)
+                # linearization point: the (generation, epoch) CAS; fencing rejects a
+                # stale leader whose token fell behind.
+                if expected != (cur_gen, cur_epoch) or int(fencing_token) < cur_tok:
+                    c.execute("ROLLBACK")
+                    return (False, current)
+                new_epoch = cur_epoch + 1
+                c.execute(
+                    "UPDATE active_ontology SET version=?, fingerprint=?, epoch=?, fencing_token=? "
+                    "WHERE workspace_id=? AND package_id=? AND generation=? AND epoch=?",
+                    (version, fingerprint, new_epoch, int(fencing_token),
+                     workspace_id, package_id, cur_gen, cur_epoch),
+                )
+                c.execute("COMMIT")
+                return (True, ActiveVersion(workspace_id, package_id, version, fingerprint,
+                                            cur_gen, new_epoch, int(fencing_token)))
+            except Exception:
+                c.execute("ROLLBACK")
+                raise
+
+    def recreate(self, workspace_id: str, package_id: str, *, version: str,
+                 fingerprint: str, fencing_token: int) -> ActiveVersion:
+        """Delete + re-publish, bumping generation past any prior one (monotonic across
+        recreation, so old epochs can't be reused against the new pointer)."""
+        with self._lock, self._conn() as c:
+            c.execute("BEGIN IMMEDIATE")
+            try:
+                c.execute("DELETE FROM active_ontology WHERE workspace_id=? AND package_id=?",
+                          (workspace_id, package_id))
+                gen = self._next_generation(c, workspace_id, package_id)
+                c.execute(
+                    "INSERT INTO active_ontology "
+                    "(workspace_id, package_id, version, fingerprint, generation, epoch, fencing_token) "
+                    "VALUES (?,?,?,?,?,?,?)",
+                    (workspace_id, package_id, version, fingerprint, gen, 0, int(fencing_token)),
+                )
+                c.execute("COMMIT")
+                return ActiveVersion(workspace_id, package_id, version, fingerprint,
+                                     gen, 0, int(fencing_token))
+            except Exception:
+                c.execute("ROLLBACK")
+                raise

--- a/tests/seocho/test_active_pointer.py
+++ b/tests/seocho/test_active_pointer.py
@@ -1,0 +1,87 @@
+"""RCU active-version pointer + atomic CAS (seocho-ia4.3 B1)."""
+from __future__ import annotations
+import threading
+from seocho.ontology.active_pointer import ActiveOntologyPointer
+
+
+def _p(tmp_path):
+    return ActiveOntologyPointer(str(tmp_path / "active.db"))
+
+
+def test_first_publish_and_read(tmp_path):
+    p = _p(tmp_path)
+    ok, cur = p.publish("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    assert ok and cur.epoch == 0 and cur.generation == 0 and cur.version == "1.0.0"
+    r = p.read("w", "pkg")
+    assert r.version == "1.0.0" and r.expected() == (0, 0)
+
+
+def test_second_first_publish_fails(tmp_path):
+    p = _p(tmp_path)
+    p.publish("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    ok, cur = p.publish("w", "pkg", version="9.9.9", fingerprint="fpx", fencing_token=1)
+    assert not ok and cur.version == "1.0.0"          # can't first-publish over an existing pointer
+
+
+def test_cas_swap_bumps_epoch(tmp_path):
+    p = _p(tmp_path)
+    _, v0 = p.publish("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    ok, v1 = p.publish("w", "pkg", version="2.0.0", fingerprint="fp2", fencing_token=1,
+                       expected=v0.expected())
+    assert ok and v1.epoch == 1 and v1.version == "2.0.0"
+
+
+def test_cas_wrong_expected_fails(tmp_path):
+    p = _p(tmp_path)
+    p.publish("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    ok, cur = p.publish("w", "pkg", version="2.0.0", fingerprint="fp2", fencing_token=1,
+                        expected=(0, 99))             # stale epoch
+    assert not ok and cur.epoch == 0 and cur.version == "1.0.0"
+
+
+def test_stale_fencing_token_rejected(tmp_path):
+    p = _p(tmp_path)
+    _, v0 = p.publish("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=5)
+    ok, cur = p.publish("w", "pkg", version="2.0.0", fingerprint="fp2", fencing_token=3,
+                        expected=v0.expected())       # token below stored -> fenced off
+    assert not ok and cur.version == "1.0.0"
+
+
+def test_concurrent_cas_exactly_one_winner(tmp_path):
+    p = _p(tmp_path)
+    _, v0 = p.publish("w", "pkg", version="1.0.0", fingerprint="fp0", fencing_token=1)
+    expected = v0.expected()
+    wins = []
+    barrier = threading.Barrier(12)
+
+    def worker(i):
+        barrier.wait()
+        ok, _ = p.publish("w", "pkg", version=f"2.0.{i}", fingerprint=f"fp{i}",
+                          fencing_token=1, expected=expected)
+        if ok:
+            wins.append(i)
+
+    ths = [threading.Thread(target=worker, args=(i,)) for i in range(12)]
+    for t in ths:
+        t.start()
+    for t in ths:
+        t.join()
+    assert len(wins) == 1                              # exactly one CAS wins
+    assert p.read("w", "pkg").epoch == 1               # epoch bumped exactly once
+
+
+def test_recreate_bumps_generation_monotonic(tmp_path):
+    p = _p(tmp_path)
+    p.publish("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    r1 = p.recreate("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    assert r1.generation == 1 and r1.epoch == 0        # generation strictly increased
+    r2 = p.recreate("w", "pkg", version="1.0.0", fingerprint="fp1", fencing_token=1)
+    assert r2.generation == 2                          # never reuses a prior generation
+
+
+def test_workspace_package_isolation(tmp_path):
+    p = _p(tmp_path)
+    p.publish("acme", "pkg", version="1.0.0", fingerprint="a", fencing_token=1)
+    p.publish("globex", "pkg", version="1.0.0", fingerprint="b", fencing_token=1)
+    assert p.read("acme", "pkg").fingerprint == "a"
+    assert p.read("globex", "pkg").fingerprint == "b"  # no cross-workspace collision


### PR DESCRIPTION
First increment of the RCU build (design in wiki/rcu-ontology-versioning-design.md, **revised after the 2-reviewer adversarial pass that caught 3 blockers**).

`ontology/active_pointer.py::ActiveOntologyPointer` — the one mutable word per `(workspace, package_id)` in the RCU model: which immutable version is ACTIVE, swapped by an **atomic CAS**. SQLite-backed, cross-process atomic (`BEGIN IMMEDIATE` + conditional `UPDATE ... WHERE generation=? AND epoch=?`).

- **Real CAS, not TOCTOU** (review fix): single atomic conditional write on the read `(generation, epoch)` — concurrent publishers with the same `expected` → **exactly one wins** (epoch bumps once), losers no-op. NOT the racy select-then-compare `assert_projection_fence`.
- **`(generation, epoch)` globally non-decreasing** (review fix): generation bumps on recreate from a persistent high-water table (survives delete/restore) → a stale reader's old epoch can't be reused against a new version. Fencing token rejects a stale leader.
- **Workspace-keyed** (the snapshot store lacked a workspace dimension) + the explicit "active" pointer the store lacked (`latest()`-by-sort ≠ active).

8 tests: first-publish/read, no double-first-publish, CAS-bumps-epoch, wrong-expected-fails, stale-fencing-rejected, **N concurrent CAS → exactly one winner**, **recreate → generation strictly increases**, workspace isolation. ruff + doc-contracts clean.

Next: B2 (increment-then-recheck reader pin in a request-level context, decoupled from admission — per review), B3 (EBR gate + conservative shared retention). seocho-ia4.3.