### PR TITLE
feat(query): text2cypher metric-threshold profile gate (ADR-0189)

### DIFF
--- a/docs/decisions/ADR-0189-text2cypher-profile-gate.md
+++ b/docs/decisions/ADR-0189-text2cypher-profile-gate.md
@@ -1,0 +1,32 @@
+# ADR-0189: text2cypher metric-threshold profile gate (seocho-ia4)
+
+Date: 2026-08-16 · Status: accepted (gate primitive) · seocho-ia4
+
+## Context
+
+text2cypher is the last optimization stage before the GDBMS; cost varies by orders of
+magnitude. hadry wants an agent that detects an "optimization needed" signal, profiles,
+and improves before querying. The AIsummit26 harness already has a detect→profile→improve
+loop but gates ONLY on a 2s wall-clock probe and merely UNLOCKS a hint tool (reminder:
+wiki/text2cypher-optimization-design.md).
+
+## Decision
+
+`query/profile_gate.py` generalizes that into a multi-signal, auto-driving gate:
+- `PlanMetrics` (db_hits, estimated_rows, elapsed_ms, operators, rows_returned, used_index)
+  + `ProfileThresholds` (the "optimization needed" signal).
+- `evaluate_plan` DETECTS breaches (db_hits/estimated_rows/SLO/rows over budget; full-scan
+  without index; cartesian product), PROFILES the plan, and emits an actionable
+  `improve_directive` the agent feeds back into a repair turn — auto-driven, not just
+  unlocked.
+- `parse_explain_metrics` walks a DozerDB/neo4j EXPLAIN/PROFILE tree (duck-typed).
+Deterministic and DB-free → testable without a live graph.
+
+## Consequences
+
+- The missing DETECT→IMPROVE trigger for the text2cypher loop; the rest (grounding
+  ADR-0187, generate_validated_cypher, AIsummit26 harness, bolt-rs) is reuse.
+- +7 tests. Follow-ups: wire into generate_validated_cypher's repair turn; the
+  ontology-source ablation (introspected vs ontology-declared schema — the sharp "is the
+  ontology useful to text2cypher" axis, not yet run on the agent half); the bolt-rs LLM
+  episode loop.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1150,6 +1150,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - (generation,epoch) globally non-decreasing (generation_hwm survives recreate); fencing token rejects stale leader; workspace-keyed (store lacked it); the 'active' pointer latest()-by-sort isn't
   - 8 tests incl. concurrent-CAS-one-winner + recreate-monotonic-generation. Next B2 pin, B3 EBR gate
 
+## 2026-08-16 (text2cypher profile gate)
+
+- [Accepted] ADR-0189 text2cypher metric-threshold profile gate (seocho-ia4)
+  - query/profile_gate.py: evaluate_plan detects db_hits/estimated_rows/SLO/rows/full-scan/cartesian breaches -> profiles -> emits improve_directive (auto-driven, generalizes AIsummit26's 2s-wall-only gate); parse_explain_metrics walks PROFILE tree; DB-free +7 tests
+  - AIsummit26 reminder: ontology-vs-not ablation harness (agent_interaction.py, 468-ep) + 3-tier repair loop + bolt-rs rust-harness already exist -> reuse; NEW = this gate + ontology-source axis (introspected vs declared) + bolt-rs LLM loop
+  - full loop: intern_grounding -> generate -> validate -> EXPLAIN/profile_gate DETECT -> improve_directive repair -> execute(bolt-rs) -> computed-gold 3-layer score
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/query/profile_gate.py
+++ b/src/seocho/query/profile_gate.py
@@ -1,0 +1,138 @@
+"""Metric-threshold profile gate for text2cypher (seocho-ia4).
+
+text2cypher is the LAST place to optimize a query before it hits the GDBMS, and its
+cost varies by orders of magnitude. The AIsummit26 harness already gates on a single
+signal — a 2-second wall-clock probe — and merely *unlocks* a hint tool. This
+generalizes that into the loop hadry wants: a **metric-threshold detector** over the
+real plan signals (db_hits, operators, estimated rows, elapsed) that, on a breach,
+(a) DETECTS which threshold broke, (b) PROFILES the plan (the offending operators), and
+(c) emits an actionable IMPROVE directive the agent hands back to itself — auto-driven,
+not just unlocked. Deterministic and DB-free: it consumes EXPLAIN/PROFILE metrics the
+executor already collects, so it is testable without a live graph.
+
+Flow: generate Cypher -> EXPLAIN/PROFILE -> evaluate_plan(metrics, thresholds) ->
+if breached, feed decision.improve_directive back into the repair turn -> regenerate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+# operators that signal an unindexed / blow-up plan (Neo4j/DozerDB planner vocabulary)
+_FULL_SCAN_OPS = {"AllNodesScan", "NodeByLabelScan"}
+_BLOWUP_OPS = {"CartesianProduct"}
+_EXPAND_ALL = {"Expand(All)", "VarLengthExpand(All)"}
+
+
+@dataclass
+class PlanMetrics:
+    """What EXPLAIN/PROFILE gives us for one candidate Cypher."""
+    db_hits: int = 0
+    estimated_rows: float = 0.0
+    elapsed_ms: float = 0.0
+    operators: List[str] = field(default_factory=list)   # operator-type histogram (flat list ok)
+    rows_returned: int = 0
+    used_index: bool = False
+
+
+@dataclass
+class ProfileThresholds:
+    """The 'optimization needed' signal. Any breach triggers detect->profile->improve."""
+    max_db_hits: int = 200_000
+    max_estimated_rows: float = 100_000.0
+    slo_ms: float = 1_000.0
+    max_rows_returned: int = 1_000
+    forbid_full_scan: bool = True
+    forbid_cartesian: bool = True
+
+
+@dataclass
+class GateDecision:
+    breached: bool
+    reasons: List[str] = field(default_factory=list)
+    profile: Dict[str, object] = field(default_factory=dict)
+    improve_directive: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"breached": self.breached, "reasons": self.reasons,
+                "profile": self.profile, "improve_directive": self.improve_directive}
+
+
+def evaluate_plan(metrics: PlanMetrics, thresholds: Optional[ProfileThresholds] = None) -> GateDecision:
+    """Detect threshold breaches, profile the plan, and emit an improve directive."""
+    t = thresholds or ProfileThresholds()
+    reasons: List[str] = []
+    fixes: List[str] = []
+    ops = set(metrics.operators or [])
+
+    full_scans = sorted(ops & _FULL_SCAN_OPS)
+    if t.forbid_full_scan and full_scans and not metrics.used_index:
+        reasons.append(f"full_scan:{','.join(full_scans)}")
+        fixes.append("Start the match from an INDEXED property lookup (an anchor node "
+                     "bound by a unique/indexed key) instead of a full label/node scan.")
+    if t.forbid_cartesian and (ops & _BLOWUP_OPS):
+        reasons.append("cartesian_product")
+        fixes.append("Remove the cartesian product: connect the disjoint MATCH patterns "
+                     "with an explicit relationship or a shared bound variable.")
+    if metrics.db_hits > t.max_db_hits:
+        reasons.append(f"db_hits {metrics.db_hits} > {t.max_db_hits}")
+        fixes.append("The plan touches too many records; narrow the anchor (add a more "
+                     "selective WHERE on an indexed property) before expanding.")
+    if metrics.estimated_rows > t.max_estimated_rows:
+        reasons.append(f"estimated_rows {metrics.estimated_rows:.0f} > {t.max_estimated_rows:.0f}")
+        fixes.append("Estimated cardinality is huge; add a LIMIT and/or a more selective "
+                     "filter, or aggregate instead of returning raw rows.")
+    if metrics.elapsed_ms > t.slo_ms:
+        reasons.append(f"elapsed_ms {metrics.elapsed_ms:.0f} > SLO {t.slo_ms:.0f}")
+        fixes.append("Exceeds the latency SLO; prefer an indexed anchor and bounded "
+                     "expansion (cap variable-length paths).")
+    if metrics.rows_returned > t.max_rows_returned:
+        reasons.append(f"rows_returned {metrics.rows_returned} > {t.max_rows_returned}")
+        fixes.append("Returns too many rows for a context window; add LIMIT or aggregate.")
+
+    breached = bool(reasons)
+    profile = {
+        "db_hits": metrics.db_hits,
+        "estimated_rows": metrics.estimated_rows,
+        "elapsed_ms": metrics.elapsed_ms,
+        "rows_returned": metrics.rows_returned,
+        "used_index": metrics.used_index,
+        "full_scan_ops": full_scans,
+        "expand_all_ops": sorted(ops & _EXPAND_ALL),
+    }
+    directive = ""
+    if breached:
+        directive = ("Query plan is over budget — revise the Cypher. Issues: "
+                     + "; ".join(reasons) + ". Fixes: " + " ".join(fixes))
+    return GateDecision(breached=breached, reasons=reasons, profile=profile,
+                        improve_directive=directive)
+
+
+def parse_explain_metrics(rows: object, *, elapsed_ms: float = 0.0) -> PlanMetrics:
+    """Best-effort extraction of PlanMetrics from a DozerDB/neo4j EXPLAIN/PROFILE
+    summary. Tolerant of shapes; the executor passes what it has (operators list,
+    db-hits, estimated rows). Kept dependency-free / duck-typed."""
+    db_hits = 0
+    est = 0.0
+    ops: List[str] = []
+    used_index = False
+
+    def _walk(node):
+        nonlocal db_hits, est, used_index
+        if isinstance(node, dict):
+            op = node.get("operatorType") or node.get("operator") or node.get("name")
+            if op:
+                ops.append(str(op))
+                if "index" in str(op).lower():
+                    used_index = True
+            args = node.get("arguments", node)
+            if isinstance(args, dict):
+                db_hits += int(args.get("DbHits", args.get("dbHits", 0)) or 0)
+                est = max(est, float(args.get("EstimatedRows", args.get("estimatedRows", 0)) or 0))
+            for ch in (node.get("children") or []):
+                _walk(ch)
+
+    _walk(rows)
+    return PlanMetrics(db_hits=db_hits, estimated_rows=est, elapsed_ms=elapsed_ms,
+                       operators=ops, used_index=used_index)

--- a/tests/seocho/test_profile_gate.py
+++ b/tests/seocho/test_profile_gate.py
@@ -1,0 +1,58 @@
+"""Metric-threshold profile gate for text2cypher (seocho-ia4)."""
+from __future__ import annotations
+from seocho.query.profile_gate import (
+    PlanMetrics, ProfileThresholds, evaluate_plan, parse_explain_metrics,
+)
+
+
+def test_clean_plan_no_breach():
+    d = evaluate_plan(PlanMetrics(db_hits=50, estimated_rows=10, elapsed_ms=20,
+                                  operators=["NodeIndexSeek", "Expand(Into)"],
+                                  rows_returned=5, used_index=True))
+    assert not d.breached and d.improve_directive == ""
+
+
+def test_full_scan_breach_directs_to_index():
+    d = evaluate_plan(PlanMetrics(operators=["AllNodesScan", "Filter"], db_hits=10,
+                                  used_index=False))
+    assert d.breached and any("full_scan" in r for r in d.reasons)
+    assert "INDEXED" in d.improve_directive
+
+
+def test_cartesian_breach():
+    d = evaluate_plan(PlanMetrics(operators=["CartesianProduct"], db_hits=10))
+    assert d.breached and "cartesian_product" in d.reasons
+    assert "cartesian product" in d.improve_directive.lower()
+
+
+def test_db_hits_and_slo_breach():
+    d = evaluate_plan(PlanMetrics(db_hits=5_000_000, elapsed_ms=8000,
+                                  operators=["NodeIndexSeek"], used_index=True),
+                      ProfileThresholds(max_db_hits=200_000, slo_ms=1000))
+    assert d.breached
+    assert any("db_hits" in r for r in d.reasons)
+    assert any("elapsed_ms" in r for r in d.reasons)
+
+
+def test_rows_and_estimated_breach():
+    d = evaluate_plan(PlanMetrics(estimated_rows=5e6, rows_returned=9999,
+                                  operators=["NodeIndexSeek"], used_index=True))
+    assert d.breached
+    assert any("estimated_rows" in r for r in d.reasons)
+    assert any("rows_returned" in r for r in d.reasons)
+
+
+def test_used_index_suppresses_full_scan_flag():
+    # NodeByLabelScan but an index was used elsewhere -> not flagged as full scan
+    d = evaluate_plan(PlanMetrics(operators=["NodeByLabelScan"], db_hits=10, used_index=True))
+    assert not any("full_scan" in r for r in d.reasons)
+
+
+def test_parse_explain_metrics_walks_plan_tree():
+    plan = {"operatorType": "ProduceResults", "children": [
+        {"operatorType": "Filter", "arguments": {"DbHits": 100, "EstimatedRows": 5},
+         "children": [
+            {"operatorType": "NodeIndexSeek", "arguments": {"DbHits": 2, "EstimatedRows": 1}}]}]}
+    m = parse_explain_metrics(plan, elapsed_ms=12.0)
+    assert m.db_hits == 102 and m.estimated_rows == 5 and m.used_index is True
+    assert "NodeIndexSeek" in m.operators and m.elapsed_ms == 12.0


### PR DESCRIPTION
text2cypher is the **last** place to optimize a query before the GDBMS, and its cost varies by orders of magnitude. hadry wants an agent that DETECTS an 'optimization needed' signal, PROFILES, then IMPROVES before querying.

The AIsummit26 harness already has a detect→profile→improve loop, but it gates **only on a 2-second wall-clock probe** and merely *unlocks* a hint tool. `query/profile_gate.py` generalizes that into a multi-signal, **auto-driving** gate:
- `evaluate_plan(PlanMetrics, ProfileThresholds)` → DETECTS breaches (db_hits / estimated_rows / SLO-ms / rows / full-scan-without-index / cartesian-product), PROFILES the offending plan, and emits an actionable `improve_directive` the agent feeds back into a repair turn.
- `parse_explain_metrics` walks a DozerDB/neo4j EXPLAIN/PROFILE tree (duck-typed).
- Deterministic + DB-free → testable without a live graph. +7 tests.

**Reuse, not rebuild (AIsummit26 reminder):** the ontology-grounded-vs-not text2cypher ablation harness (`agent_interaction.py`, 468 episodes), the 3-tier repair loop, and the bolt-rs `rust-harness` all already exist. The genuinely NEW pieces are this gate, the **ontology-source axis** (introspected store schema vs ontology-declared schema — the sharp 'is the ontology useful to text2cypher' question, not yet run on the agent half), and the **bolt-rs LLM episode loop**. Full loop + reuse map: `wiki/text2cypher-optimization-design.md`. seocho-ia4.