### PR TITLE
fix(index): four indexing-robustness bugs from stale contributor PRs (#239 #237 #243 #263)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -73,6 +73,9 @@ uv run pytest \
   tests/seocho/test_benchmarking.py \
   tests/seocho/test_finder_benchmark_script.py \
   tests/seocho/test_indexing_design.py \
+  tests/seocho/test_dedup_scope.py \
+  tests/seocho/test_indexing_fallback_honesty.py \
+  tests/seocho/test_provider_timeout_defaults.py \
   tests/seocho/test_llm_backends.py \
   tests/seocho/test_llm_model_override.py \
   tests/seocho/test_model_router.py \

--- a/src/seocho/index/chunk.py
+++ b/src/seocho/index/chunk.py
@@ -90,13 +90,12 @@ def chunk(
     list of :class:`Chunk`. A single-element list is returned for short
     inputs (including the empty string).
     """
-    bodies = _split_bodies(
+    records = _split_with_offsets(
         text,
         max_chars=max_chars,
         overlap_chars=overlap_chars,
         separator=separator,
     )
-    offsets = _locate_bodies(text, bodies)
     section_annotations = _locate_sections(text)
     return [
         _build_chunk(
@@ -107,7 +106,7 @@ def chunk(
             end=end,
             section_annotations=section_annotations,
         )
-        for i, (body, (start, end)) in enumerate(zip(bodies, offsets))
+        for i, (body, start, end) in enumerate(records)
     ]
 
 
@@ -138,66 +137,84 @@ def _build_chunk(
     )
 
 
-def _split_bodies(
+def _paragraph_spans(
+    text: str,
+    separator: str,
+) -> List[tuple[str, int, int]]:
+    """Yield ``(stripped_paragraph, char_start, char_end)`` for each non-empty
+    paragraph, with offsets into the *original* ``text``.
+
+    Splitting on a fixed separator discards positions, but they are
+    recoverable: segment ``i`` begins at the running cursor, and stripping a
+    paragraph only shifts its start past the leading whitespace and pulls its
+    end in past the trailing whitespace. Tracking offsets here (rather than
+    searching for the post-processed body afterwards) is what lets overlapped
+    chunks keep correct provenance — see issue #124.
+    """
+    spans: List[tuple[str, int, int]] = []
+    cursor = 0
+    for raw in text.split(separator):
+        stripped = raw.strip()
+        if stripped:
+            lead = len(raw) - len(raw.lstrip())
+            start = cursor + lead
+            spans.append((stripped, start, start + len(stripped)))
+        cursor += len(raw) + len(separator)
+    return spans
+
+
+def _split_with_offsets(
     text: str,
     *,
     max_chars: int,
     overlap_chars: int,
     separator: str,
-) -> List[str]:
-    """Pure chunker — identical algorithm to the legacy ``chunk_text``."""
-    if len(text) <= max_chars:
-        return [text]
+) -> List[tuple[str, int, int]]:
+    """Chunker that emits ``(body, char_start, char_end)`` per chunk.
 
-    paragraphs = text.split(separator)
-    chunks: List[str] = []
+    The body strings are byte-for-byte identical to the legacy ``chunk_text``
+    output (the back-compat shim depends on this). Offsets are tracked during
+    splitting from real paragraph positions instead of being recovered with a
+    post-hoc ``str.find``, so they stay correct even when a chunk carries an
+    overlap prefix or spans multiple paragraphs.
+
+    ``[char_start, char_end)`` covers the chunk's *own* (non-overlap) content:
+    ``char_start`` is the source start of the first paragraph this chunk
+    introduces, ``char_end`` the end of its last paragraph. The leading overlap
+    prefix is borrowed context whose provenance already belongs to the previous
+    chunk, so the spans tile the document without gaps. Empty input maps to
+    ``(-1, -1)`` to preserve the documented "offset unknown" sentinel.
+    """
+    if len(text) <= max_chars:
+        return [(text, 0, len(text))] if text else [("", -1, -1)]
+
+    records: List[tuple[str, int, int]] = []
     current: List[str] = []
     current_len = 0
+    cur_start: Optional[int] = None  # source start of this chunk's first own paragraph
+    cur_end: Optional[int] = None  # source end of the last paragraph added
 
-    for para in paragraphs:
-        para = para.strip()
-        if not para:
-            continue
-
+    for para, p_start, p_end in _paragraph_spans(text, separator):
         if current_len + len(para) + len(separator) > max_chars and current:
-            chunk_body = separator.join(current)
-            chunks.append(chunk_body)
+            body = separator.join(current)
+            records.append((body, cur_start, cur_end))
 
-            overlap_text = chunk_body[-overlap_chars:] if overlap_chars > 0 else ""
+            overlap_text = body[-overlap_chars:] if overlap_chars > 0 else ""
             current = [overlap_text] if overlap_text else []
             current_len = len(overlap_text)
+            cur_start = None
+            cur_end = None
 
+        if cur_start is None:
+            cur_start = p_start
+        cur_end = p_end
         current.append(para)
         current_len += len(para) + len(separator)
 
-    if current:
-        chunks.append(separator.join(current))
+    if current and cur_start is not None:
+        records.append((separator.join(current), cur_start, cur_end))
 
-    return chunks if chunks else [text]
-
-
-def _locate_bodies(content: str, bodies: List[str]) -> List[tuple[int, int]]:
-    """Find each body's ``(char_start, char_end)`` in ``content``.
-
-    Uses a forward-search cursor with a 512-char lookback (same heuristic as
-    the previous ``_estimate_chunk_offsets`` helper) so overlapping chunks
-    can still be located. Empty bodies and unlocatable chunks get
-    ``(-1, -1)``.
-    """
-    offsets: List[tuple[int, int]] = []
-    search_start = 0
-    for body in bodies:
-        if not body:
-            offsets.append((-1, -1))
-            continue
-        start = content.find(body, max(search_start - 512, 0))
-        if start < 0:
-            start = content.find(body)
-        end = start + len(body) if start >= 0 else -1
-        offsets.append((start, end))
-        if end >= 0:
-            search_start = end
-    return offsets
+    return records if records else [(text, 0, len(text))]
 
 
 def _locate_sections(text: str) -> List[dict[str, object]]:

--- a/src/seocho/index/file_reader.py
+++ b/src/seocho/index/file_reader.py
@@ -196,14 +196,20 @@ def read_csv_file(path: Path) -> List[Dict[str, Any]]:
     """
     records: List[Dict[str, Any]] = []
     with open(path, newline="", encoding="utf-8", errors="replace") as f:
-        reader = csv.DictReader(f)
+        # restval="" so a row shorter than the header yields "" rather than None
+        # for the missing fields. DictReader otherwise sets them to None, and a
+        # None `content` then crashes index_file's `content.strip()` (issue #140).
+        reader = csv.DictReader(f, restval="")
         for i, row in enumerate(reader):
-            if "content" in row:
-                content = row["content"]
-                meta = {k: v for k, v in row.items() if k != "content"}
+            # Rows longer than the header collect overflow under the None
+            # restkey; drop it so metadata stays string-keyed and serializable.
+            cells = {k: v for k, v in row.items() if k is not None}
+            if "content" in cells:
+                content = cells.get("content") or ""
+                meta = {k: v for k, v in cells.items() if k != "content"}
             else:
-                content = " | ".join(f"{k}: {v}" for k, v in row.items() if v)
-                meta = dict(row)
+                content = " | ".join(f"{k}: {v}" for k, v in cells.items() if v)
+                meta = dict(cells)
             meta["source_file"] = str(path)
             meta["row_index"] = i
             records.append({"content": content, "metadata": meta})

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -134,7 +134,18 @@ class IndexingResult:
 
     @property
     def ok(self) -> bool:
-        return len(self.write_errors) == 0 and self.chunks_processed > 0
+        # A degraded (heuristic-fallback) extraction is not a clean success.
+        # Under strict enforcement a failure already lands in write_errors, so
+        # ok is False there; under the default guided/open profiles the
+        # capitalized-token heuristic manufactures Entity/MENTIONS structure,
+        # nothing is recorded as an error, and the caller was told the run
+        # succeeded. The degradation is reported in fallback_used, which only
+        # helps a caller who already suspects it.
+        return (
+            len(self.write_errors) == 0
+            and self.chunks_processed > 0
+            and not self.fallback_used
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -269,7 +280,6 @@ class IndexingPipeline:
         from .shared_intern import SharedInternTable
 
         self._intern_table = SharedInternTable()
-        self._seen_hashes: set = set()
         self.extraction_prompt = extraction_prompt
         self.ontology_profile = str(ontology_profile or "default")
 
@@ -717,6 +727,7 @@ class IndexingPipeline:
         metadata: Optional[Dict[str, Any]] = None,
         on_chunk: Optional[Callable[[int, int], None]] = None,
         source_id: Optional[str] = None,
+        _seen_hashes: Optional[set] = None,
     ) -> IndexingResult:
         """Index a single document (with automatic chunking).
 
@@ -747,15 +758,19 @@ class IndexingPipeline:
         )
         result.ontology_context = ontology_context.metadata(usage="indexing")
 
-        # Dedup check
-        if self.enable_dedup:
+        # Dedup check — scoped to a single batch ingest via _seen_hashes.
+        # Standalone index() calls pass None and are never deduplicated against
+        # earlier, independent calls: a process-lifetime instance set silently
+        # dropped legitimately re-submitted documents, and the caller saw a
+        # successful result with nothing written.
+        if self.enable_dedup and _seen_hashes is not None:
             h = content_hash(content)
-            if h in self._seen_hashes:
+            if h in _seen_hashes:
                 result.deduplicated = True
                 result.skipped_chunks = 1
-                logger.info("Skipping duplicate content (hash=%s)", h)
+                logger.info("Skipping duplicate content within batch (hash=%s)", h)
                 return result
-            self._seen_hashes.add(h)
+            _seen_hashes.add(h)
 
         # Chunk
         import time as _time
@@ -1308,6 +1323,9 @@ class IndexingPipeline:
         BatchIndexingResult with per-document results.
         """
         batch = BatchIndexingResult(total_documents=len(documents))
+        # Dedup is scoped to THIS batch only — a later batch, or a standalone
+        # index() call, re-submitting the same text indexes it again.
+        seen_hashes: set = set()
 
         for i, doc in enumerate(documents):
             if on_document:
@@ -1316,6 +1334,7 @@ class IndexingPipeline:
             result = self.index(
                 doc, database=database,
                 category=category, metadata=metadata,
+                _seen_hashes=seen_hashes,
             )
 
             batch.results.append(result)
@@ -1436,11 +1455,8 @@ class IndexingPipeline:
             source_id,
         )
 
-        # 2. Remove from dedup cache (allow re-indexing same content)
-        h = content_hash(content)
-        self._seen_hashes.discard(h)
-
-        # 3. Index fresh
+        # 2. Index fresh. Dedup is per-batch now, so a standalone index() call
+        #    is never blocked by an earlier ingest — no dedup cache to clear.
         result = self.index(
             content,
             database=database,

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -33,6 +33,12 @@ class ProviderSpec:
     default_model: str = "gpt-4o"
     default_embedding_model: Optional[str] = None
     supports_embeddings: bool = False
+    # Per-provider default request timeout (seconds). Reasoning-model presets
+    # override the 120s baseline: a single-document extraction routinely runs
+    # far longer, and the timeout was tripping the heuristic fallback rather
+    # than surfacing as an error, so the run reported success on manufactured
+    # Entity/MENTIONS structure.
+    default_timeout: float = 120.0
 
 
 _PROVIDER_SPECS: Dict[str, ProviderSpec] = {
@@ -59,6 +65,9 @@ _PROVIDER_SPECS: Dict[str, ProviderSpec] = {
         default_model="kimi-k2.5",
         default_embedding_model=None,
         supports_embeddings=False,
+        # kimi-k2.5 single-document extraction was measured at 160-1450s; the
+        # 120s baseline cut it off and silently degraded to heuristics.
+        default_timeout=900.0,
     ),
     "grok": ProviderSpec(
         name="grok",
@@ -68,6 +77,8 @@ _PROVIDER_SPECS: Dict[str, ProviderSpec] = {
         default_model="grok-4.20-reasoning",
         default_embedding_model=None,
         supports_embeddings=False,
+        # Default model is a reasoning preset — same headroom.
+        default_timeout=900.0,
     ),
     "qwen": ProviderSpec(
         name="qwen",
@@ -100,6 +111,10 @@ _PROVIDER_SPECS: Dict[str, ProviderSpec] = {
         default_model="MiniMax-M2.5",
         default_embedding_model=None,
         supports_embeddings=False,
+        # MiniMax-M2.x is a reasoning model and mara is the default provider
+        # for this repo, so it needs the headroom most. Added here rather than
+        # inherited: the preset postdates the kimi/grok ones.
+        default_timeout=900.0,
     ),
 }
 
@@ -1373,11 +1388,21 @@ def create_llm_backend(
     model: Optional[str] = None,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
-    timeout: float = 120.0,
+    timeout: Optional[float] = None,
 ) -> OpenAICompatibleBackend:
-    """Create an OpenAI-compatible LLM backend by provider preset."""
+    """Create an OpenAI-compatible LLM backend by provider preset.
+
+    When ``timeout`` is None the provider preset's ``default_timeout`` applies,
+    so reasoning presets (mara, kimi, grok) get more headroom than the 120s
+    baseline. Pass an explicit timeout to override.
+    """
 
     provider_key = str(provider).strip().lower() or "openai"
+    if timeout is None:
+        try:
+            timeout = get_provider_spec(provider_key).default_timeout
+        except ValueError:
+            timeout = 120.0
     if provider_key == "openai":
         return OpenAIBackend(
             model=model or get_provider_spec("openai").default_model,

--- a/tests/seocho/test_chunk.py
+++ b/tests/seocho/test_chunk.py
@@ -74,6 +74,41 @@ class TestChunkFunctionHappyPath:
         first = chunks[0]
         assert text[first.char_start : first.char_end] == first.text
 
+    def test_overlapped_long_chunks_keep_valid_offsets(self):
+        # Regression for #124. Two effects combined to collapse overlapped
+        # chunks to (-1, -1) under the old post-hoc `str.find` locator:
+        #   1. bodies longer than ~512 chars carry a 200-char overlap prefix
+        #      that drifts out of the 512-char lookback window, and
+        #   2. paragraphs are stripped before re-joining, so a body whose
+        #      source had surrounding whitespace no longer matches verbatim
+        #      and `find` returns -1.
+        # The whitespace padding below reproduces (2) on top of (1). Offsets
+        # are now tracked from real paragraph positions, so they stay valid.
+        paragraphs = [
+            "   " + f"Paragraph {i}: " + ("lorem ipsum dolor sit amet " * 6).strip() + "   "
+            for i in range(12)
+        ]
+        text = "\n\n".join(paragraphs)
+        chunks = chunk(text, source_id="doc1", max_chars=800, overlap_chars=200)
+
+        assert len(chunks) > 1
+        assert any(len(c.text) > 512 for c in chunks)  # the failing-size regime
+
+        prev_start = -1
+        for c in chunks:
+            # No chunk loses its provenance (the old code returned (-1, -1)).
+            assert c.char_start >= 0
+            assert c.char_end > c.char_start
+            assert c.char_end <= len(text)
+            # Spans advance monotonically through the document.
+            assert c.char_start >= prev_start
+            prev_start = c.char_start
+            # The span ends exactly at this chunk's last paragraph, so the
+            # source slice resolves the chunk's own (non-overlap) tail even
+            # when stripping changed the body away from the raw source.
+            last_paragraph = c.text.split("\n\n")[-1]
+            assert text[c.char_start : c.char_end].endswith(last_paragraph)
+
     def test_markdown_headings_attach_section_paths(self):
         text = (
             "# Overview\n\n"

--- a/tests/seocho/test_dedup_scope.py
+++ b/tests/seocho/test_dedup_scope.py
@@ -1,0 +1,60 @@
+"""Regression for #133 — content dedup must be scoped to a single batch ingest,
+not a process-lifetime instance set. The shared `_seen_hashes` set silently
+dropped a document re-submitted in a separate add()/index() call.
+"""
+
+from __future__ import annotations
+
+from seocho.index.pipeline import IndexingPipeline
+from seocho.indexing import IndexingResult, content_hash
+from seocho.ontology import NodeDef, Ontology, P
+
+
+def _pipeline() -> IndexingPipeline:
+    onto = Ontology(name="t", nodes={"Doc": NodeDef(properties={"name": P(str)})})
+    # graph_store/llm are unused on the paths under test.
+    return IndexingPipeline(ontology=onto, graph_store=object(), llm=object())
+
+
+def test_no_process_lifetime_dedup_state() -> None:
+    # The cross-call leak was the instance set itself; it must be gone.
+    assert not hasattr(_pipeline(), "_seen_hashes")
+
+
+def test_duplicate_within_batch_set_is_skipped_early() -> None:
+    # Second occurrence within one batch (its hash already in the batch set)
+    # short-circuits to deduplicated without touching the graph/llm.
+    pipeline = _pipeline()
+    text = "hello world"
+    result = pipeline.index(text, _seen_hashes={content_hash(text)})
+    assert result.deduplicated is True
+    assert result.skipped_chunks == 1
+
+
+def test_standalone_index_has_no_dedup_set() -> None:
+    # No _seen_hashes passed -> dedup gate is never consulted, so a standalone
+    # re-submission is not dropped. The duplicate branch needs a set to fire;
+    # with None it cannot, which is the fix.
+    pipeline = _pipeline()
+    # Pre-"seeing" the hash is impossible because there is no shared set; assert
+    # the signature default keeps standalone calls independent.
+    import inspect
+
+    assert inspect.signature(pipeline.index).parameters["_seen_hashes"].default is None
+
+
+def test_each_batch_gets_a_fresh_dedup_set(monkeypatch) -> None:
+    pipeline = _pipeline()
+    seen_sets = []
+
+    def fake_index(doc, *, _seen_hashes=None, **kwargs):
+        seen_sets.append(_seen_hashes)
+        return IndexingResult(source_id="x", chunks_processed=1, total_nodes=0)
+
+    monkeypatch.setattr(pipeline, "index", fake_index)
+    pipeline.index_batch(["a", "a"])  # two docs, one batch
+    pipeline.index_batch(["a"])       # a separate batch
+
+    assert seen_sets[0] is seen_sets[1]        # same batch -> same dedup set
+    assert seen_sets[0] is not seen_sets[2]    # new batch -> fresh set
+    assert isinstance(seen_sets[0], set)

--- a/tests/seocho/test_file_indexer.py
+++ b/tests/seocho/test_file_indexer.py
@@ -63,6 +63,32 @@ class TestCSVReader:
         records = read_csv_file(f)
         assert len(records) == 0
 
+    def test_csv_short_row_does_not_crash(self, tmp_dir):
+        # Regression #140: a data row shorter than the header used to leave
+        # content=None (DictReader restval), which crashed index_file's
+        # content.strip(). Missing fields now coerce to "".
+        f = tmp_dir / "ragged.csv"
+        f.write_text("id,content,category\n1,ACME news,news\n2\n")
+        records = read_csv_file(f)
+        assert len(records) == 2
+        assert records[1]["content"] == ""
+        # every content is a real string, so downstream .strip() is safe
+        for r in records:
+            assert isinstance(r["content"], str)
+            r["content"].strip()  # would raise AttributeError on None
+        assert records[1]["metadata"]["category"] == ""
+
+    def test_csv_long_row_drops_overflow_restkey(self, tmp_dir):
+        # A row longer than the header collects overflow under DictReader's
+        # None restkey; metadata must stay string-keyed and serializable.
+        f = tmp_dir / "long.csv"
+        f.write_text("id,content\n1,hello,extra1,extra2\n")
+        records = read_csv_file(f)
+        assert len(records) == 1
+        assert records[0]["content"] == "hello"
+        assert None not in records[0]["metadata"]
+        json.dumps(records[0]["metadata"])  # must be serializable
+
 
 class TestJSONReader:
     def test_json_array(self, tmp_dir):

--- a/tests/seocho/test_indexing_fallback_honesty.py
+++ b/tests/seocho/test_indexing_fallback_honesty.py
@@ -1,0 +1,63 @@
+"""A degraded extraction must not report itself as a clean success.
+
+`IndexingResult.ok` used to be `no write errors and chunks_processed > 0`. Under
+strict enforcement that was already right: an extraction failure lands in
+`write_errors`, so `ok` was False. Under the default guided/open profiles it was
+not. There, `allow_heuristic_fallback` is True, so a failure substitutes the
+capitalized-token heuristic — manufactured `Entity`/`MENTIONS` structure that
+the ontology never declared — records no error, and `ok` stayed True.
+
+The degradation was reported, in `fallback_used`. That only helps a caller who
+already suspects it, and the callers that matter (batch counters, CI gates) read
+`ok`. So a run could substitute ontology-free structure for every chunk and be
+counted a success.
+"""
+
+from __future__ import annotations
+
+from seocho.index.pipeline import BatchIndexingResult, IndexingResult
+
+
+def test_clean_run_is_ok():
+    result = IndexingResult(chunks_processed=3)
+    assert result.ok
+
+
+def test_fallback_run_is_not_ok():
+    result = IndexingResult(chunks_processed=3, fallback_used=True,
+                            fallback_reason="extraction timed out")
+    assert not result.ok, (
+        "a run whose graph came from the heuristic fallback reported success"
+    )
+
+
+def test_write_errors_still_dominate():
+    """The original condition must keep working, not be replaced by the new one."""
+    result = IndexingResult(chunks_processed=3, write_errors=["boom"])
+    assert not result.ok
+
+    assert not IndexingResult(chunks_processed=0).ok
+
+
+def test_batch_counts_a_degraded_document_as_failed():
+    """The reason `ok` matters: batch counters read it, `fallback_used` they do not."""
+    batch = BatchIndexingResult(total_documents=2)
+    for result in (IndexingResult(chunks_processed=1),
+                   IndexingResult(chunks_processed=1, fallback_used=True)):
+        batch.results.append(result)
+        if result.deduplicated:
+            batch.skipped += 1
+        elif result.ok:
+            batch.successful += 1
+        else:
+            batch.failed += 1
+
+    assert (batch.successful, batch.failed) == (1, 1)
+    assert not batch.ok
+
+
+def test_ok_is_surfaced_in_to_dict():
+    """Consumers reading the serialized form must see the same verdict."""
+    payload = IndexingResult(chunks_processed=1, fallback_used=True).to_dict()
+    assert payload["ok"] is False
+    assert payload["fallback_used"] is True

--- a/tests/seocho/test_provider_timeout_defaults.py
+++ b/tests/seocho/test_provider_timeout_defaults.py
@@ -1,0 +1,46 @@
+"""Reasoning presets need more than the 120s baseline request timeout.
+
+`create_llm_backend` hardcoded `timeout=120.0` for every provider. Single-document
+extraction on a reasoning model routinely runs longer than that, and the timeout
+did not surface as an error — it raised inside the extraction call, which the
+default enforcement profile catches and answers with the capitalized-token
+heuristic. So the observable result of too short a timeout was ontology-free
+graph structure, not a timeout message.
+
+mara is this repo's default provider and serves MiniMax-class reasoning models,
+so it is the preset that needed the headroom most and the one the original fix
+predates.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.store.llm import create_llm_backend, get_provider_spec, list_provider_specs
+
+REASONING_PRESETS = ("mara", "kimi", "grok")
+
+
+@pytest.mark.parametrize("provider", REASONING_PRESETS)
+def test_reasoning_presets_get_headroom(provider):
+    assert get_provider_spec(provider).default_timeout > 120.0
+
+
+def test_non_reasoning_presets_keep_the_baseline():
+    """The headroom is targeted, not a blanket raise that hides real hangs."""
+    for name, spec in list_provider_specs().items():
+        if name not in REASONING_PRESETS:
+            assert spec.default_timeout == 120.0, name
+
+
+@pytest.mark.parametrize("provider", REASONING_PRESETS)
+def test_backend_receives_the_preset_timeout(provider):
+    backend = create_llm_backend(provider=provider, api_key="test-key",
+                                 model="test-model")
+    assert backend._timeout == get_provider_spec(provider).default_timeout
+
+
+def test_explicit_timeout_still_wins():
+    backend = create_llm_backend(provider="mara", api_key="test-key",
+                                 model="test-model", timeout=5.0)
+    assert backend._timeout == 5.0


### PR DESCRIPTION
Re-applies four contributor fixes that were verified **still broken on `main` today**. All four sat on forks whose shared history with `main` collapsed to the repo's root commit, so GitHub reports them `CONFLICTING` and no ordinary rebase can reconcile them. The logic was correct; only the file locations moved.

Supersedes #239, #237, #243, and the reporting half of #263.

## What was wrong

| PR | Bug | Confirmed |
|---|---|---|
| #239 | Ragged CSV row → `content=None` → `AttributeError` kills the whole file's ingest | reproduced on current code |
| #237 | Overlapped/padded chunks lose `char_start`/`char_end` → `(-1, -1)` | reproduced on current code |
| #243 | Dedup scoped to the process, not the batch — a re-submitted document is silently dropped and reported successful | read on current code |
| #263 | `IndexingResult.ok` stayed `True` when the heuristic fallback manufactured the graph | read on current code |

The #263 one is the one worth reading twice. Under **strict** enforcement a failure already lands in `write_errors`, so `ok` was False. Under the **default** guided/open profiles `allow_heuristic_fallback` is True: extraction fails, the capitalized-token heuristic substitutes `Entity`/`MENTIONS` structure the ontology never declared, nothing is recorded as an error, and `ok` stayed True. Batch counters and CI gates read `ok`. A run that degraded every chunk counted as a clean success.

## ⚠️ Behaviour change

`IndexingResult.ok` is now `False` when `fallback_used` is `True`. A caller that wants to treat a degraded run as success must read `fallback_used` explicitly. This is the point of the change, but it is a public SDK behaviour change and worth flagging.

## Two deliberate deviations from the original PRs

**Not ported:** #263's `extraction_on_failure="raise"/"degrade"` constructor argument. The PR predates `enforcement_policy.allow_heuristic_fallback` (strict=False, guided/open=True), which already provides that exact control. Adding the argument would give one concern two knobs.

**Extended:** #263 raised the request timeout for `kimi`/`grok`. `mara` postdates the PR, is this repo's default provider, and serves MiniMax-class reasoning models — so it needed the headroom most and is included at 900s. A too-short timeout never surfaced as a timeout: it raised inside extraction, which the default profile answers with the heuristic, so the observable symptom was ontology-free structure.

## Not included

**#154 is held back.** It moves `elementId()` *into* the queries feeding `gds.graph.project.cypher`, which requires integer ids, and this codebase's own pattern converts to `elementId()` only *after* algorithms run via `gds.util.asNode()`. It needs a live DozerDB/GDS instance to settle, and is the one reviewed PR whose fix looks like a regression.

## Validation

```
pytest test_file_indexer test_chunk test_dedup_scope
       test_indexing_fallback_honesty test_provider_timeout_defaults  -> 47 passed
pytest test_indexing_design test_ontology_enforcement test_llm_backends
       test_extraction_engine test_ontology_extraction_firewall       -> 83 passed
git diff --check                                                     -> clean
```

New tests are registered in `scripts/ci/run_basic_ci.sh` — an unregistered test file silently never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)