### PR TITLE
fix(vector): score semantics, dimension guard, tombstoned search, orphan vectors (#235 #245 #246 #261)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -76,6 +76,9 @@ uv run pytest \
   tests/seocho/test_dedup_scope.py \
   tests/seocho/test_indexing_fallback_honesty.py \
   tests/seocho/test_provider_timeout_defaults.py \
+  tests/seocho/test_faiss_vector_store.py \
+  tests/seocho/test_faiss_delete.py \
+  tests/seocho/test_delete_source_vectors.py \
   tests/seocho/test_llm_backends.py \
   tests/seocho/test_llm_model_override.py \
   tests/seocho/test_model_router.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -1483,6 +1483,19 @@ class IndexingPipeline:
 
         Returns
         -------
-        Summary with ``nodes_deleted``, ``relationships_deleted``.
+        Summary with ``nodes_deleted``, ``relationships_deleted`` (and
+        ``vectors_deleted`` when a vector store is attached).
         """
-        return self.graph_store.delete_by_source(source_id, database=database)
+        summary = self.graph_store.delete_by_source(source_id, database=database)
+        # Also drop the source's vectors so the vector store stays consistent
+        # with the graph; otherwise stale vectors keep surfacing as top-k hits
+        # pointing at deleted nodes (issue #123). reindex() goes through here.
+        if self.vector_store is not None:
+            try:
+                removed = self.vector_store.delete_by_source(source_id)
+                summary = {**summary, "vectors_deleted": int(removed or 0)}
+            except Exception as exc:
+                logger.warning(
+                    "Vector delete for source_id=%s failed: %s", source_id, exc
+                )
+        return summary

--- a/src/seocho/store/vector.py
+++ b/src/seocho/store/vector.py
@@ -418,14 +418,37 @@ class LanceDBVectorStore(VectorStore):
         return True
 
     def delete_by_source(self, source_id: str) -> int:
-        # Vectors are keyed by ``{source_id}_chunk_{ordinal}``; metadata is a
-        # JSON string here, so match on the id prefix (issue #123).
+        """Delete this source's vectors — by range, never by LIKE.
+
+        Vectors are keyed ``{source_id}_chunk_{ordinal:04d}``, and matching that
+        with ``id LIKE 'src_chunk_%'`` deletes other documents' vectors. In SQL
+        LIKE, ``_`` matches any single character, so the pattern is
+        ``src`` + any + ``chunk`` + any + anything, and a neighbouring source
+        ``src_chunked_v2`` — whose ids are ``src_chunked_v2_chunk_0000`` —
+        matches it. `reindex()` routes through here, so a routine re-index of
+        one document silently destroyed another's retrieval surface, and the
+        loss surfaced later as a retrieval or generation failure rather than as
+        a delete bug. A source id containing ``%`` or ``_`` widened it further,
+        since only quotes were escaped.
+
+        A half-open range on the id prefix has none of that: it is exact, needs
+        no escaping beyond quotes, and an ordered index can serve it.
+        """
         if self._table is None:
             return 0
         before = self.count()
-        safe = str(source_id).replace("'", "''")
+
+        def _quote(value: str) -> str:
+            return str(value).replace("'", "''")
+
+        prefix = f"{source_id}_chunk_"
+        # chr(ord('_') + 1) == '`' — the successor of the prefix, so the range
+        # is exactly the ids that start with it.
+        upper = f"{source_id}_chunk`"
         try:
-            self._table.delete(f"id LIKE '{safe}_chunk_%'")
+            self._table.delete(
+                f"id >= '{_quote(prefix)}' AND id < '{_quote(upper)}'"
+            )
         except Exception:
             return 0
         return max(0, before - self.count())

--- a/src/seocho/store/vector.py
+++ b/src/seocho/store/vector.py
@@ -21,12 +21,19 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class VectorSearchResult:
-    """A single similarity search result."""
+    """A single similarity search result.
+
+    ``score`` is always a similarity where higher means a better match, regardless
+    of backend: FAISS inner-product and LanceDB L2 distance are normalized to the
+    same higher-is-better convention so scores are comparable across stores.
+    ``metric`` records the score semantic for callers.
+    """
 
     id: str
     text: str
     score: float
     metadata: Dict[str, Any] = field(default_factory=dict)
+    metric: str = "similarity"
 
 
 class VectorStore(ABC):
@@ -53,6 +60,17 @@ class VectorStore(ABC):
     @abstractmethod
     def delete(self, doc_id: str) -> bool:
         """Remove a document from the index."""
+
+    def delete_by_source(self, source_id: str) -> int:
+        """Delete every vector belonging to ``source_id`` and return the count.
+
+        The indexing pipeline keys vectors by ``{source_id}_chunk_{ordinal}``,
+        so deleting a source's vectors keeps the vector store consistent with
+        the graph on delete_source/reindex (issue #123). Default is a no-op for
+        custom stores that don't track source provenance; the built-in backends
+        override it.
+        """
+        return 0
 
     @abstractmethod
     def count(self) -> int:
@@ -101,9 +119,32 @@ class FAISSVectorStore(VectorStore):
         self._index = faiss.IndexFlatIP(dimension)
         self._docs: List[Dict[str, Any]] = []
         self._id_to_idx: Dict[str, int] = {}
+        # IndexFlatIP cannot remove a single vector, so delete() tombstones the
+        # doc and search() over-fetches by this count to still return `limit`
+        # live results (issue #122).
+        self._tombstones = 0
 
     def _embed(self, texts: Sequence[str]) -> Any:
         return _normalize_vectors(self._embedding_backend.embed(texts, model=self._model))
+
+    def _ensure_dimension(self, vectors: Any) -> None:
+        """Validate embedding width against the index, adopting the first
+        embedding's dimension when the index is still empty.
+
+        Without this, an embedding model with a non-default width (e.g.
+        text-embedding-3-large at 3072) reached faiss as a size mismatch and
+        raised an opaque assertion in native code (issue #121).
+        """
+        width = int(vectors.shape[1])
+        if self._index.ntotal == 0 and width != self._dimension:
+            self._dimension = width
+            self._index = self._faiss.IndexFlatIP(width)
+        elif width != self._dimension:
+            raise ValueError(
+                f"Embedding dimension mismatch: this FAISSVectorStore holds "
+                f"{self._dimension}-dim vectors but received {width}-dim. All "
+                f"vectors in a store must come from one embedding model."
+            )
 
     def add(
         self,
@@ -116,6 +157,7 @@ class FAISSVectorStore(VectorStore):
             self.delete(doc_id)
 
         vectors = self._embed([text])
+        self._ensure_dimension(vectors)
         idx = len(self._docs)
         self._index.add(vectors)
         self._docs.append({"id": doc_id, "text": text, "metadata": metadata or {}})
@@ -132,6 +174,7 @@ class FAISSVectorStore(VectorStore):
 
         texts = [str(item["text"]) for item in items]
         vectors = self._embed(texts)
+        self._ensure_dimension(vectors)
         start_idx = len(self._docs)
         self._index.add(vectors)
 
@@ -153,7 +196,10 @@ class FAISSVectorStore(VectorStore):
             return []
 
         query_vec = self._embed([query])
-        k = min(limit, self._index.ntotal)
+        # Over-fetch by the tombstone count: deleted vectors still occupy
+        # top-k slots, so fetching only `limit` could drop live results behind
+        # them. Bounded by ntotal (issue #122).
+        k = min(limit + self._tombstones, self._index.ntotal)
         scores, indices = self._index.search(query_vec, k)
 
         results: List[VectorSearchResult] = []
@@ -167,10 +213,13 @@ class FAISSVectorStore(VectorStore):
                 VectorSearchResult(
                     id=str(doc["id"]),
                     text=str(doc["text"]),
-                    score=float(score),
+                    score=float(score),  # inner product on normalized vectors: higher = better
                     metadata=dict(doc.get("metadata", {})),
+                    metric="similarity",
                 )
             )
+            if len(results) >= limit:
+                break
 
         return results
 
@@ -184,7 +233,23 @@ class FAISSVectorStore(VectorStore):
             "metadata": {},
             "_deleted": True,
         }
+        self._tombstones += 1
         return True
+
+    def delete_by_source(self, source_id: str) -> int:
+        prefix = f"{source_id}_chunk_"
+        ids = [
+            str(doc["id"])
+            for doc in self._docs
+            if not doc.get("_deleted")
+            and (
+                str(doc.get("metadata", {}).get("source_id", "")) == source_id
+                or str(doc["id"]).startswith(prefix)
+            )
+        ]
+        for doc_id in ids:
+            self.delete(doc_id)
+        return len(ids)
 
     def count(self) -> int:
         return len(self._id_to_idx)
@@ -327,13 +392,17 @@ class LanceDBVectorStore(VectorStore):
                 metadata = raw_metadata
             else:
                 metadata = {}
-            score = row.get("_distance", row.get("score", 0.0))
+            # LanceDB returns L2 distance (lower = closer); convert to a similarity
+            # (higher = better) so scores are comparable with the FAISS backend.
+            raw_distance = float(row.get("_distance", row.get("score", 0.0)))
+            score = 1.0 / (1.0 + raw_distance)
             results.append(
                 VectorSearchResult(
                     id=str(row.get("id", "")),
                     text=str(row.get("text", "")),
-                    score=float(score),
+                    score=score,
                     metadata=metadata,
+                    metric="similarity",
                 )
             )
         return results
@@ -347,6 +416,19 @@ class LanceDBVectorStore(VectorStore):
         except Exception:
             return False
         return True
+
+    def delete_by_source(self, source_id: str) -> int:
+        # Vectors are keyed by ``{source_id}_chunk_{ordinal}``; metadata is a
+        # JSON string here, so match on the id prefix (issue #123).
+        if self._table is None:
+            return 0
+        before = self.count()
+        safe = str(source_id).replace("'", "''")
+        try:
+            self._table.delete(f"id LIKE '{safe}_chunk_%'")
+        except Exception:
+            return 0
+        return max(0, before - self.count())
 
     def count(self) -> int:
         if self._table is None:

--- a/tests/seocho/test_delete_source_vectors.py
+++ b/tests/seocho/test_delete_source_vectors.py
@@ -1,0 +1,77 @@
+"""Regression for #123 — delete_source/reindex must also drop the source's
+vectors. Previously they removed graph nodes only, leaving orphan vectors that
+kept surfacing as top-k hits pointing at deleted/stale graph nodes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.index.chunk import build_chunk_id
+from seocho.index.pipeline import IndexingPipeline
+from seocho.ontology import NodeDef, Ontology, P
+
+
+class _FakeGraphStore:
+    def delete_by_source(self, source_id, *, database="neo4j"):
+        return {"nodes_deleted": 1, "relationships_deleted": 0}
+
+
+class _SpyVectorStore:
+    def __init__(self):
+        self.deleted = []
+
+    def delete_by_source(self, source_id):
+        self.deleted.append(source_id)
+        return 3
+
+
+def _pipeline(vector_store):
+    onto = Ontology(name="t", nodes={"Doc": NodeDef(properties={"name": P(str)})})
+    return IndexingPipeline(
+        ontology=onto, graph_store=_FakeGraphStore(), llm=object(),
+        vector_store=vector_store,
+    )
+
+
+def test_delete_source_also_deletes_vectors():
+    spy = _SpyVectorStore()
+    summary = _pipeline(spy).delete_source("src-1")
+    assert spy.deleted == ["src-1"]
+    assert summary["vectors_deleted"] == 3
+    assert summary["nodes_deleted"] == 1
+
+
+def test_delete_source_without_vector_store_is_unaffected():
+    summary = _pipeline(None).delete_source("src-1")
+    assert "vectors_deleted" not in summary
+    assert summary["nodes_deleted"] == 1
+
+
+# --- FAISS backend end-to-end (requires faiss-cpu) ---
+
+faiss = pytest.importorskip("faiss")
+pytest.importorskip("numpy")
+
+from seocho.store.vector import FAISSVectorStore
+
+
+class _Embed:
+    def embed(self, texts, *, model=None):
+        return [[float(abs(hash(str(t))) % 97) / 97.0, 1.0] for t in texts]
+
+
+def test_faiss_delete_by_source_removes_only_that_source():
+    store = FAISSVectorStore(embedding_backend=_Embed(), dimension=2)
+    for src in ("srcA", "srcB"):
+        for ordinal in range(3):
+            cid = build_chunk_id(src, ordinal)
+            store.add(cid, f"text {cid}", metadata={"source_id": src})
+    assert store.count() == 6
+
+    removed = store.delete_by_source("srcA")
+    assert removed == 3
+    assert store.count() == 3
+    # only srcB vectors remain
+    remaining = {r.metadata["source_id"] for r in store.search("text", limit=10)}
+    assert remaining == {"srcB"}

--- a/tests/seocho/test_delete_source_vectors.py
+++ b/tests/seocho/test_delete_source_vectors.py
@@ -75,3 +75,69 @@ def test_faiss_delete_by_source_removes_only_that_source():
     # only srcB vectors remain
     remaining = {r.metadata["source_id"] for r in store.search("text", limit=10)}
     assert remaining == {"srcB"}
+
+
+def _code_without_docstring(func) -> str:
+    """Source with the docstring removed — the docstrings here *discuss* LIKE."""
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    node = tree.body[0]
+    if (node.body and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)):
+        node.body = node.body[1:]
+    return ast.unparse(node)
+
+
+# ---------------------------------------------------------------------------
+# Regression: the LanceDB predicate must not match a neighbouring source.
+# ---------------------------------------------------------------------------
+
+def test_lancedb_predicate_is_a_range_not_a_like():
+    """`id LIKE 'src_chunk_%'` deletes other documents' vectors.
+
+    In SQL LIKE, `_` matches any single character, so that pattern reads as
+    `src` + any + `chunk` + any + anything. A source `report_chunked_v2`, whose
+    ids look like `report_chunked_v2_chunk_0000`, matches `report_chunk_%`:
+
+        report   -> literal
+        _        -> the real '_'
+        chunk    -> literal
+        _        -> the 'e' of "chunked"      <-- the bug
+        %        -> the rest
+
+    reindex() routes through delete_by_source, so re-indexing one document
+    silently destroyed another's vectors, and the loss showed up later as a
+    retrieval or generation failure rather than as a delete bug.
+    """
+    from seocho.store.vector import LanceDBVectorStore
+
+    source = _code_without_docstring(LanceDBVectorStore.delete_by_source)
+    assert "LIKE" not in source.upper(), (
+        "LIKE treats '_' as a wildcard; use a half-open range on the id prefix"
+    )
+
+    # And the range itself must be exact.
+    lo, hi = "report_chunk_", "report_chunk`"
+    assert lo <= "report_chunk_0000" < hi
+    assert not (lo <= "report_chunked_v2_chunk_0000" < hi), (
+        "a neighbouring source is still inside the range"
+    )
+    assert not (lo <= "reportX_chunk_0000" < hi)
+
+
+def test_backends_agree_on_delete_semantics():
+    """FAISS matched by prefix while LanceDB matched by LIKE — same call, two
+    meanings. A caller cannot reason about delete_source if the answer depends
+    on which vector backend is configured."""
+    from seocho.store.vector import FAISSVectorStore, LanceDBVectorStore
+
+    faiss_src = _code_without_docstring(FAISSVectorStore.delete_by_source)
+    lance_src = _code_without_docstring(LanceDBVectorStore.delete_by_source)
+    assert "LIKE" not in (faiss_src + lance_src).upper()
+    assert "_chunk_" in faiss_src and "_chunk_" in lance_src, (
+        "both backends must key on the same chunk-id scheme"
+    )

--- a/tests/seocho/test_faiss_delete.py
+++ b/tests/seocho/test_faiss_delete.py
@@ -1,0 +1,70 @@
+"""FAISSVectorStore delete behavior (requires faiss-cpu).
+
+#122 — a deleted (tombstoned) vector must not consume a top-k slot: search
+over-fetches by the tombstone count so it still returns up to `limit` live
+results, and the deleted doc never appears.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("faiss")
+pytest.importorskip("numpy")
+
+from seocho.store.vector import FAISSVectorStore
+
+
+class _AngleBackend:
+    """Maps known texts to fixed 2-D vectors for deterministic ranking."""
+
+    _VECS = {
+        "q": [1.0, 0.0],
+        "near": [0.99, 0.14],
+        "mid": [0.70, 0.71],
+        "far": [0.0, 1.0],
+    }
+
+    def embed(self, texts, *, model=None):
+        return [self._VECS.get(str(t), [0.5, 0.5]) for t in texts]
+
+
+def _store() -> FAISSVectorStore:
+    return FAISSVectorStore(embedding_backend=_AngleBackend(), dimension=2)
+
+
+def test_deleted_doc_not_in_results() -> None:
+    store = _store()
+    store.add("near", "near")
+    store.add("far", "far")
+    assert store.delete("near") is True
+    ids = [r.id for r in store.search("q", limit=5)]
+    assert "near" not in ids
+    assert ids == ["far"]
+
+
+def test_delete_still_returns_full_limit_of_live_results() -> None:
+    # The deleted doc ranks at the very top; a limit=2 search with 3 live docs
+    # remaining must return 2 live results, not 1 (the tombstone must not eat a
+    # top-k slot). On main, search fetched only `limit` and returned 1.
+    store = _store()
+    store.add("dead", "near")  # top-ranked, then deleted
+    store.add("near", "near")
+    store.add("mid", "mid")
+    store.add("far", "far")
+
+    assert store.delete("dead") is True
+    results = store.search("q", limit=2)
+    ids = [r.id for r in results]
+
+    assert "dead" not in ids
+    assert len(ids) == 2          # full limit of live results
+    assert ids[0] in {"near", "dead"} and ids[0] == "near"
+
+
+def test_count_reflects_live_docs_after_delete() -> None:
+    store = _store()
+    store.add("a", "near")
+    store.add("b", "far")
+    store.delete("a")
+    assert store.count() == 1

--- a/tests/seocho/test_faiss_vector_store.py
+++ b/tests/seocho/test_faiss_vector_store.py
@@ -1,0 +1,59 @@
+"""FAISSVectorStore behavior tests (require faiss-cpu).
+
+#121 — embedding dimension is adopted from the first vector and a later
+mismatch raises a clear Python error instead of an opaque native assertion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("faiss")
+pytest.importorskip("numpy")
+
+from seocho.store.vector import FAISSVectorStore
+
+
+class _FixedWidthBackend:
+    """Embeds each text to a deterministic nonzero vector of a given width."""
+
+    def __init__(self, width: int) -> None:
+        self.width = width
+
+    def embed(self, texts, *, model=None):
+        out = []
+        for text in texts:
+            seed = float(abs(hash(str(text))) % 97) / 97.0
+            vec = [seed] + [0.0] * (self.width - 1)
+            vec[-1] = 1.0  # keep a nonzero norm
+            out.append(vec)
+        return out
+
+
+def _store(width: int = 8, dimension: int = 1536) -> FAISSVectorStore:
+    return FAISSVectorStore(embedding_backend=_FixedWidthBackend(width), dimension=dimension)
+
+
+def test_first_embedding_dimension_is_adopted() -> None:
+    # Default dimension is 1536 but the model emits width-8 vectors; the store
+    # must adopt 8 on first add instead of raising a native faiss assertion.
+    store = _store(width=8, dimension=1536)
+    store.add("a", "alpha")
+    assert store._dimension == 8
+    assert store.count() == 1
+
+
+def test_add_batch_adopts_first_dimension() -> None:
+    store = _store(width=16, dimension=1536)
+    n = store.add_batch([{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}])
+    assert n == 2
+    assert store._dimension == 16
+    assert store.count() == 2
+
+
+def test_dimension_mismatch_raises_clear_error() -> None:
+    store = _store(width=8, dimension=1536)
+    store.add("a", "alpha")  # locks the index to width 8
+    store._embedding_backend = _FixedWidthBackend(16)  # different width
+    with pytest.raises(ValueError, match="dimension mismatch"):
+        store.add("b", "beta")

--- a/tests/seocho/test_vector_store.py
+++ b/tests/seocho/test_vector_store.py
@@ -40,13 +40,14 @@ class _FakeQuery:
         return self
 
     def to_arrow(self):
-        def score(row):
+        # Real LanceDB returns L2 distance (lower = closer), ordered ascending.
+        def distance(row):
             vector = row["vector"]
-            return sum(left * right for left, right in zip(self._query_vector, vector))
+            return sum((left - right) ** 2 for left, right in zip(self._query_vector, vector)) ** 0.5
 
-        rows = sorted(self._rows, key=score, reverse=True)[: self._limit]
+        rows = sorted(self._rows, key=distance)[: self._limit]
         return _FakeArrowTable(
-            [{**row, "_distance": float(score(row))} for row in rows]
+            [{**row, "_distance": float(distance(row))} for row in rows]
         )
 
 
@@ -105,6 +106,33 @@ def test_lancedb_vector_store_round_trip(monkeypatch):
     assert store.count() == 2
     assert store.delete("doc-alpha") is True
     assert store.count() == 1
+
+
+def test_lancedb_scores_are_similarity_higher_is_better(monkeypatch):
+    module = ModuleType("lancedb")
+    module.connect = lambda uri, **kwargs: _FakeLanceDB()
+    monkeypatch.setitem(sys.modules, "lancedb", module)
+
+    store = LanceDBVectorStore(
+        uri="/tmp/fake-lancedb",
+        table_name="docs",
+        embedding_backend=_FakeEmbeddingBackend(),
+        model="fake-embed",
+    )
+    store.add("doc-alpha", "alpha report")  # vector [1, 0]
+    store.add("doc-other", "gamma report")  # vector [0.5, 0.5]
+    store.add("doc-beta", "beta report")    # vector [0, 1]
+
+    results = store.search("alpha question", limit=3)  # query vector [1, 0]
+
+    # Raw L2 distance is lower-is-better; after conversion the score is a
+    # similarity (higher-is-better), so it is comparable with the FAISS backend.
+    assert [r.id for r in results] == ["doc-alpha", "doc-other", "doc-beta"]
+    scores = [r.score for r in results]
+    assert scores == sorted(scores, reverse=True)        # higher = better, monotonic with closeness
+    assert all(0.0 < s <= 1.0 for s in scores)           # bounded similarity
+    assert results[0].score == 1.0                       # exact match: distance 0 -> similarity 1.0
+    assert all(r.metric == "similarity" for r in results)
 
 
 def test_create_vector_store_supports_lancedb(monkeypatch):


### PR DESCRIPTION
Re-applies four vector-store fixes verified **still present on `main`**. Like #548, these sat on forks whose shared history with `main` collapsed to the repo's root commit — GitHub reports them `CONFLICTING` and no rebase can reconcile them, so the logic is re-applied against current file locations.

Supersedes #235, #245, #246, #261.

## What was wrong

**#235 — one field, two opposite meanings.** `VectorSearchResult.score` carried FAISS inner product (higher = better) from one backend and raw LanceDB L2 distance (lower = better) from the other. Any caller ranking or thresholding got the right answer on FAISS and the reverse on LanceDB. LanceDB distance is now converted to a similarity, and the dataclass carries an explicit `metric` field so the convention is stated rather than assumed.

> One correction to the original PR: its two cited consumers (`ontology_control_plane.py`, `agent/matchmaker.py`) do **not** read this field on `main` today — they compute their own scores. The inconsistency is still real; it's a public SDK dataclass.

**#245 — a non-default embedding width crashed inside C++.** A store built for 1536 dims and fed 3072-dim vectors (e.g. `text-embedding-3-large`) hit a faiss native assertion with no usable message. Width is now checked in Python, and an empty index adopts the first embedding's width instead of insisting on the constructor's guess.

**#246 — deletes silently shrank result sets.** `IndexFlatIP` cannot remove a vector, so `delete()` tombstones the document — but `search()` still asked for exactly `limit`, so tombstones occupying top-k slots pushed live results out. A search after deletions returned fewer than `limit` while matches existed. Search now over-fetches by the tombstone count and stops at `limit` live hits.

**#261 — `delete_source` left the vectors behind.** It deleted graph nodes only, so stale embeddings kept surfacing as top-k hits pointing at nodes that no longer exist. `reindex()` goes through the same path, so re-indexing a changed document accumulated vectors for text that was gone.

`VectorStore.delete_by_source` defaults to a no-op, so custom stores that don't track source provenance are unaffected; both built-in backends implement it, and the pipeline reports `vectors_deleted`.

## Validation

```
pytest test_vector_store test_faiss_vector_store test_faiss_delete
       test_delete_source_vectors            -> 12 passed
pytest test_indexing_design test_client_boundaries
       test_operating_layer                  -> 34 passed
git diff --check                             -> clean
```

New tests registered in `scripts/ci/run_basic_ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)