### PR TITLE
feat(ontology): RCU reader pin/epoch registry (ADR-0190, ia4.3 B2)

### DIFF
--- a/docs/decisions/ADR-0190-rcu-version-pin.md
+++ b/docs/decisions/ADR-0190-rcu-version-pin.md
@@ -1,0 +1,42 @@
+# ADR-0190: RCU reader pin/epoch registry (seocho-ia4.3 B2)
+
+Date: 2026-08-16 · Status: accepted · seocho-ia4.3 (B2)
+
+## Context
+
+B2 = the read side of RCU: a request pins the ACTIVE version's epoch for its whole
+duration (no torn read); min-pinned-epoch tells the reclaimer which versions still have
+readers. The B1/B2 adversarial review found all three blockers here; this incorporates
+the fixes.
+
+## Decision
+
+`ontology/version_pin.py::VersionPinRegistry(pointer)` — sharded refcount by
+(ws, pkg, epoch), composing with the B1 ActiveOntologyPointer:
+- **[fix #1] increment-then-recheck** (publish-before-observe): `pin` reads the pointer →
+  E, increments refcount[E], RE-READS; if the pointer advanced, decrements E and retries
+  on the new epoch. The refcount is published before the reader proceeds, and the
+  returned epoch is refcounted AND current — closing the read-vs-reclaim race. `pin`
+  returns the epoch it incremented; `unpin` decrements THAT epoch (never a fresh read).
+- **[fix #2] request-level, decoupled from admission**: a standalone registry a
+  request-context wrapper drives (`with reg.pinned(ws,pkg): ...` around the whole
+  request), NOT wired inside LaneScheduler.acquire (gate-disable short-circuit + per-
+  Cypher-call granularity would both break the guarantee).
+- **[fix #6] `min_pinned_epoch` returns None with no pins** (never "current") — the B3
+  gate owns the grace-period decision.
+- **[fix #4] liveness** = the `pinned` context manager releases in `finally` (also on
+  request abort/deadline), never an external forced-unpin.
+
+## Result
+
+7 tests: pin returns+refcounts current epoch, None when no pointer, tracks a new epoch
+after a swap, **increment-then-recheck retries a mid-pin swap (transient epoch released,
+stable epoch pinned)**, min-pinned reflects the oldest live pin and advances as readers
+leave, context-manager release, 16 concurrent pins with no leak.
+
+## Consequences
+
+- The RCU read side is correct per review. Next: B3 (EBR reclamation gate = mark
+  RETIRING-first-then-read-refcounts + grace-period quiescence + conservative shared-
+  store retention; = ia4.4-full + ia4.5-vacuum), then B4 (barrier uses pinned_epoch).
+  seocho-ia4.3.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1157,6 +1157,12 @@ Each entry must link to a full ADR when impact is non-trivial.
   - AIsummit26 reminder: ontology-vs-not ablation harness (agent_interaction.py, 468-ep) + 3-tier repair loop + bolt-rs rust-harness already exist -> reuse; NEW = this gate + ontology-source axis (introspected vs declared) + bolt-rs LLM loop
   - full loop: intern_grounding -> generate -> validate -> EXPLAIN/profile_gate DETECT -> improve_directive repair -> execute(bolt-rs) -> computed-gold 3-layer score
 
+## 2026-08-16 (RCU B2 version pin)
+
+- [Accepted] ADR-0190 RCU reader pin/epoch registry (seocho-ia4.3 B2)
+  - VersionPinRegistry(pointer): increment-then-recheck pin (publish-before-observe, retries mid-pin swap), returns incremented epoch, unpin decrements that epoch; request-level context manager decoupled from admission; min_pinned_epoch None-when-no-pins (gate decides); finally-release liveness
+  - all 3 review blockers fixed; 7 tests incl. mid-pin-swap retry + min-advances. Next B3 EBR gate, B4 barrier
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/ontology/__init__.py
+++ b/src/seocho/ontology/__init__.py
@@ -82,6 +82,7 @@ _EXPORTS = {
     "induction_report": "induce",
     "ActiveOntologyPointer": "active_pointer",
     "ActiveVersion": "active_pointer",
+    "VersionPinRegistry": "version_pin",
     "compute_ontology_metrics": "metrics",
     "BoundaryViolation": "context_map",
     "BoundedContext": "context_map",

--- a/src/seocho/ontology/version_pin.py
+++ b/src/seocho/ontology/version_pin.py
@@ -1,0 +1,103 @@
+"""RCU reader pin/epoch registry (seocho-ia4.3, B2).
+
+The read side of RCU: a request pins the ACTIVE ontology version's epoch for its whole
+duration, reads a frozen version (no torn read), and unpins at the end; the minimum
+pinned epoch tells the reclaimer (B3) which versions still have readers.
+
+Redesigned per the B1/B2 adversarial review — the three blockers were all here:
+- **[fix #1] increment-then-recheck (publish-before-observe):** ``pin`` reads the active
+  pointer → E, increments ``refcount[(ws,pkg,E)]``, then RE-READS the pointer; if it
+  advanced, it decrements E and retries on the new epoch. So the refcount is *published*
+  before the reader can proceed, and the returned epoch is both refcounted and current —
+  closing the read-vs-reclaim race. ``pin`` returns the epoch it actually incremented;
+  ``unpin`` decrements THAT epoch, never a fresh read.
+- **[fix #2] request-level, decoupled from admission:** this is a standalone registry the
+  request-context wrapper drives (``with reg.pinned(ws,pkg): ...`` around the whole agent
+  request) — NOT wired inside LaneScheduler.acquire (which short-circuits when the gate is
+  disabled and fires per-Cypher-call, both of which would break the guarantee).
+- **[fix #6] ``min_pinned_epoch`` returns None when there are no pins** (never "current"),
+  so the B3 reclamation gate — not this function — owns the grace-period decision.
+
+Sharded locks (SharedInternTable discipline). Composes with the B1 ``ActiveOntologyPointer``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections import defaultdict
+from typing import Any, Dict, Optional, Tuple
+
+
+class VersionPinRegistry:
+    def __init__(self, pointer: Any, *, shards: int = 16, max_retries: int = 64) -> None:
+        self._pointer = pointer
+        self._shards = max(1, shards)
+        self._locks = [threading.Lock() for _ in range(self._shards)]
+        self._counts: list[Dict[Tuple[str, str, int], int]] = [defaultdict(int) for _ in range(self._shards)]
+        self._max_retries = max_retries
+
+    def _shard(self, ws: str, pkg: str) -> int:
+        return hash((ws, pkg)) % self._shards
+
+    def _incr(self, ws: str, pkg: str, epoch: int) -> None:
+        s = self._shard(ws, pkg)
+        with self._locks[s]:
+            self._counts[s][(ws, pkg, epoch)] += 1
+
+    def _decr(self, ws: str, pkg: str, epoch: int) -> None:
+        s = self._shard(ws, pkg)
+        with self._locks[s]:
+            key = (ws, pkg, epoch)
+            if self._counts[s].get(key, 0) > 0:
+                self._counts[s][key] -= 1
+                if self._counts[s][key] == 0:
+                    del self._counts[s][key]
+
+    def pin(self, ws: str, pkg: str) -> Optional[int]:
+        """Pin the current active epoch (increment-then-recheck). Returns the pinned
+        epoch, or None if there is no active pointer for (ws, pkg)."""
+        for _ in range(self._max_retries):
+            av = self._pointer.read(ws, pkg)
+            if av is None:
+                return None
+            e = av.epoch
+            self._incr(ws, pkg, e)                       # publish
+            av2 = self._pointer.read(ws, pkg)            # observe
+            if av2 is not None and av2.epoch == e:
+                return e                                  # stable: refcount published on the current epoch
+            self._decr(ws, pkg, e)                        # pointer moved mid-pin -> retry on the new epoch
+        # extremely contended: pin the last observed epoch rather than spin forever
+        av = self._pointer.read(ws, pkg)
+        if av is None:
+            return None
+        self._incr(ws, pkg, av.epoch)
+        return av.epoch
+
+    def unpin(self, ws: str, pkg: str, epoch: int) -> None:
+        self._decr(ws, pkg, epoch)
+
+    def pin_count(self, ws: str, pkg: str, epoch: int) -> int:
+        s = self._shard(ws, pkg)
+        with self._locks[s]:
+            return self._counts[s].get((ws, pkg, epoch), 0)
+
+    def min_pinned_epoch(self, ws: str, pkg: str) -> Optional[int]:
+        """Lowest epoch with a live pin for (ws, pkg), or None if no readers.
+        Never substitutes the current epoch — the B3 reclamation gate decides."""
+        s = self._shard(ws, pkg)
+        with self._locks[s]:
+            epochs = [k[2] for k, c in self._counts[s].items()
+                      if k[0] == ws and k[1] == pkg and c > 0]
+        return min(epochs) if epochs else None
+
+    @contextlib.contextmanager
+    def pinned(self, ws: str, pkg: str):
+        """Request-level pin: pin for the whole request, unpin in finally (also
+        released on request abort/deadline — the liveness bound, review fix #4)."""
+        epoch = self.pin(ws, pkg)
+        try:
+            yield epoch
+        finally:
+            if epoch is not None:
+                self.unpin(ws, pkg, epoch)

--- a/tests/seocho/test_version_pin.py
+++ b/tests/seocho/test_version_pin.py
@@ -1,0 +1,87 @@
+"""RCU reader pin/epoch registry (seocho-ia4.3 B2)."""
+from __future__ import annotations
+import threading
+from seocho.ontology.active_pointer import ActiveOntologyPointer
+from seocho.ontology.version_pin import VersionPinRegistry
+
+
+def _setup(tmp_path):
+    p = ActiveOntologyPointer(str(tmp_path / "active.db"))
+    p.publish("w", "pkg", version="1.0.0", fingerprint="fp0", fencing_token=1)
+    return p, VersionPinRegistry(p)
+
+
+def test_pin_returns_current_epoch_and_refcounts(tmp_path):
+    p, reg = _setup(tmp_path)
+    e = reg.pin("w", "pkg")
+    assert e == 0 and reg.pin_count("w", "pkg", 0) == 1
+    assert reg.min_pinned_epoch("w", "pkg") == 0
+    reg.unpin("w", "pkg", e)
+    assert reg.min_pinned_epoch("w", "pkg") is None      # None, never "current" (fix #6)
+
+
+def test_pin_none_when_no_pointer(tmp_path):
+    p = ActiveOntologyPointer(str(tmp_path / "a.db"))
+    reg = VersionPinRegistry(p)
+    assert reg.pin("w", "absent") is None
+
+
+def test_pin_after_swap_tracks_new_epoch(tmp_path):
+    p, reg = _setup(tmp_path)
+    _, v = p.publish("w", "pkg", version="2.0.0", fingerprint="fp1", fencing_token=1, expected=(0, 0))
+    assert v.epoch == 1
+    e = reg.pin("w", "pkg")
+    assert e == 1 and reg.min_pinned_epoch("w", "pkg") == 1
+
+
+def test_increment_then_recheck_retries_on_mid_pin_swap(tmp_path, monkeypatch):
+    # simulate a swap landing BETWEEN the reader's read and its recheck: the first two
+    # reads see epoch 0 (read, then incr), the recheck sees epoch 1 -> must retry, and
+    # end with the transient epoch-0 refcount released.
+    p, reg = _setup(tmp_path)
+    p.publish("w", "pkg", version="2.0.0", fingerprint="fp1", fencing_token=1, expected=(0, 0))  # now epoch 1
+    from seocho.ontology.active_pointer import ActiveVersion
+    seq = [ActiveVersion("w", "pkg", "1.0.0", "fp0", 0, 0, 1),   # pin: read -> E=0
+           ActiveVersion("w", "pkg", "2.0.0", "fp1", 0, 1, 1),   # pin: recheck -> E2=1 (swap!)
+           ActiveVersion("w", "pkg", "2.0.0", "fp1", 0, 1, 1),   # retry: read -> 1
+           ActiveVersion("w", "pkg", "2.0.0", "fp1", 0, 1, 1)]   # retry: recheck -> 1 (stable)
+    calls = {"i": 0}
+    def fake_read(ws, pkg):
+        v = seq[min(calls["i"], len(seq) - 1)]; calls["i"] += 1; return v
+    monkeypatch.setattr(p, "read", fake_read)
+    e = reg.pin("w", "pkg")
+    assert e == 1                                          # pinned the stable current epoch
+    assert reg.pin_count("w", "pkg", 0) == 0               # transient epoch-0 pin was released
+    assert reg.pin_count("w", "pkg", 1) == 1
+
+
+def test_min_pinned_reflects_oldest_live_pin(tmp_path):
+    p, reg = _setup(tmp_path)
+    e0 = reg.pin("w", "pkg")                                # epoch 0
+    p.publish("w", "pkg", version="2.0.0", fingerprint="fp1", fencing_token=1, expected=(0, 0))
+    e1 = reg.pin("w", "pkg")                                # epoch 1
+    assert reg.min_pinned_epoch("w", "pkg") == 0           # oldest live pin
+    reg.unpin("w", "pkg", e0)
+    assert reg.min_pinned_epoch("w", "pkg") == 1           # advances after old reader leaves
+    reg.unpin("w", "pkg", e1)
+    assert reg.min_pinned_epoch("w", "pkg") is None
+
+
+def test_pinned_context_manager_releases(tmp_path):
+    p, reg = _setup(tmp_path)
+    with reg.pinned("w", "pkg") as e:
+        assert e == 0 and reg.pin_count("w", "pkg", 0) == 1
+    assert reg.min_pinned_epoch("w", "pkg") is None
+
+
+def test_concurrent_pins_all_counted(tmp_path):
+    p, reg = _setup(tmp_path)
+    barrier = threading.Barrier(16)
+    def worker():
+        barrier.wait()
+        e = reg.pin("w", "pkg")
+        reg.unpin("w", "pkg", e)
+    ths = [threading.Thread(target=worker) for _ in range(16)]
+    for t in ths: t.start()
+    for t in ths: t.join()
+    assert reg.min_pinned_epoch("w", "pkg") is None        # all released, no leak


### PR DESCRIPTION
The read side of RCU (B2), **redesigned per the B1/B2 adversarial review — all three blockers were here**.

`ontology/version_pin.py::VersionPinRegistry(pointer)` — sharded refcount by `(ws, pkg, epoch)`, composing with B1's `ActiveOntologyPointer`:
- **[fix #1] increment-then-recheck (publish-before-observe):** `pin` reads the pointer → E, increments `refcount[E]`, RE-READS; if the pointer advanced, decrements E and retries on the new epoch → the refcount is published before the reader proceeds, and the returned epoch is refcounted AND current — **closing the read-vs-reclaim race**. `pin` returns the epoch it incremented; `unpin` decrements THAT epoch.
- **[fix #2] request-level, decoupled from admission:** a standalone registry driven by a request-context wrapper (`with reg.pinned(ws,pkg): ...`), NOT inside `LaneScheduler.acquire` (whose gate-disable short-circuit + per-Cypher-call granularity would break the guarantee).
- **[fix #6]** `min_pinned_epoch` returns None with no pins (never 'current') — the B3 gate owns the grace period. **[fix #4]** liveness via `finally`-release (also on request abort), never an external forced-unpin.

7 tests: refcounts current epoch, None when no pointer, tracks a new epoch after a swap, **increment-then-recheck retries a mid-pin swap (transient epoch released, stable pinned)**, min-pinned reflects oldest live pin + advances as readers leave, context-manager release, 16 concurrent pins no leak.

Next: B3 (EBR reclamation gate: RETIRING-first-then-read-refcounts + grace-period quiescence + conservative shared retention = ia4.4-full + ia4.5-vacuum), B4 (barrier uses pinned_epoch). seocho-ia4.3.