### PR TITLE
fix(ontology): enforce declared vocabularies, score type mismatches at 0 (#256 #241 #242)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -103,6 +103,9 @@ uv run pytest \
   tests/seocho/test_finder_cache_synergy.py \
   tests/seocho/test_ontology_extraction_firewall.py \
   tests/seocho/test_ontology_lint.py \
+  tests/seocho/test_shacl_enum_range.py \
+  tests/seocho/test_ontology_merge_conflicts.py \
+  tests/seocho/test_extraction_type_scoring.py \
   tests/seocho/test_ontology_subclass_ttl.py \
   tests/seocho/test_ontology_reasoner.py \
   tests/seocho/test_ontology_iso704_cq.py \

--- a/src/seocho/ontology/core.py
+++ b/src/seocho/ontology/core.py
@@ -44,7 +44,7 @@ import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Set, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import yaml
 
@@ -110,6 +110,13 @@ class Property:
         Human-readable description shown in prompts.
     aliases:
         Alternative names an LLM might use for this property.
+    enum:
+        Optional allowed value set. An extracted value outside it is a
+        validation error, emitted as ``sh:in`` and enforced by
+        :meth:`validate_with_shacl`.
+    value_range:
+        Optional inclusive numeric ``(min, max)`` bound, emitted as
+        ``sh:minInclusive`` / ``sh:maxInclusive``.
 
     Example::
 
@@ -117,6 +124,8 @@ class Property:
 
         name = Property(str, unique=True)
         age = Property(int, required=True, description="Age in years")
+        rating = Property(str, enum=["buy", "hold", "sell"])
+        score = Property(float, value_range=(0.0, 1.0))
     """
 
     type: Union[type, PropertyType, str] = str
@@ -125,6 +134,8 @@ class Property:
     required: bool = False
     description: str = ""
     aliases: List[str] = field(default_factory=list)
+    enum: Optional[List[Any]] = None
+    value_range: Optional[Tuple[float, float]] = None
 
     @property
     def property_type(self) -> PropertyType:
@@ -382,6 +393,8 @@ class Ontology:
             for pname, pd in (nd.get("properties") or {}).items():
                 ptype = PropertyType[pd.get("type", "STRING").upper()] if isinstance(pd, dict) else PropertyType.STRING
                 constraint_str = pd.get("constraint", "").upper() if isinstance(pd, dict) else ""
+                enum_vals = pd.get("enum") if isinstance(pd, dict) else None
+                range_vals = pd.get("range") if isinstance(pd, dict) else None
                 props[pname] = P(
                     type=ptype,
                     unique=constraint_str == "UNIQUE",
@@ -389,6 +402,9 @@ class Ontology:
                     required=pd.get("required", False) if isinstance(pd, dict) else False,
                     description=pd.get("description", "") if isinstance(pd, dict) else "",
                     aliases=pd.get("aliases", []) if isinstance(pd, dict) else [],
+                    enum=list(enum_vals) if enum_vals is not None else None,
+                    value_range=(float(range_vals[0]), float(range_vals[1]))
+                    if range_vals and len(range_vals) == 2 else None,
                 )
             nodes[label] = NodeDef(
                 description=nd.get("description", ""),
@@ -458,6 +474,10 @@ class Ontology:
                     entry["description"] = p.description
                 if p.aliases:
                     entry["aliases"] = list(p.aliases)
+                if p.enum is not None:
+                    entry["enum"] = list(p.enum)
+                if p.value_range is not None:
+                    entry["range"] = [p.value_range[0], p.value_range[1]]
                 props_out[pname] = entry
             node_entry: Dict[str, Any] = {"description": nd.description, "properties": props_out}
             if nd.same_as:
@@ -1140,6 +1160,11 @@ class Ontology:
                 elif p.required:
                     ps["minCount"] = 1
                     ps["message"] = f"Every {label} must have a {pname}."
+                if p.enum is not None:
+                    ps["in"] = list(p.enum)
+                if p.value_range is not None:
+                    ps["minInclusive"] = p.value_range[0]
+                    ps["maxInclusive"] = p.value_range[1]
                 if p.description:
                     ps["description"] = p.description
                 prop_shapes.append(ps)
@@ -1321,6 +1346,36 @@ class Ontology:
                             f"Node '{nid}' ({label}).{pname}: "
                             f"expected boolean, got {type(value).__name__}"
                         )
+
+                # enum (sh:in) — the declared allowed value set. Without this,
+                # a vocabulary could be declared and was never enforced: the
+                # only channel that controlled extracted values was prose in
+                # the prompt.
+                allowed = ps.get("in")
+                if allowed is not None and value is not None and value != "":
+                    if value not in allowed:
+                        errors.append(
+                            f"Node '{nid}' ({label}).{pname}: value {value!r} "
+                            f"not in allowed set {allowed}"
+                        )
+
+                # range (sh:minInclusive / sh:maxInclusive)
+                if ("minInclusive" in ps or "maxInclusive" in ps) and value is not None and value != "":
+                    try:
+                        numeric = float(value)
+                    except (ValueError, TypeError):
+                        errors.append(
+                            f"Node '{nid}' ({label}).{pname}: "
+                            f"non-numeric value {value!r} for a ranged property"
+                        )
+                    else:
+                        lo = ps.get("minInclusive")
+                        hi = ps.get("maxInclusive")
+                        if (lo is not None and numeric < lo) or (hi is not None and numeric > hi):
+                            errors.append(
+                                f"Node '{nid}' ({label}).{pname}: value {value!r} "
+                                f"out of range [{lo}, {hi}]"
+                            )
 
         # Relationship cardinality check
         source_rel_counts: Dict[str, Dict[str, int]] = {}  # node_id -> {rel_type -> count}
@@ -2016,8 +2071,19 @@ class Ontology:
                             type_correct += 1
                         elif p.property_type.value in ("DATETIME", "DATE") and isinstance(val, str):
                             type_correct += 1
+                        elif p.property_type.value == "LIST" and isinstance(val, (list, tuple)):
+                            type_correct += 1
+                        elif p.property_type.value == "POINT" and isinstance(val, (dict, list, tuple)):
+                            type_correct += 1
                         else:
-                            type_correct += 0.5  # partial credit for other types
+                            # A genuine type mismatch scores 0. The old +0.5
+                            # kept malformed extractions above quality_threshold
+                            # and so silently disabled the indexing quality-retry
+                            # gate. LIST and POINT are handled above because they
+                            # fell into this same branch: a correctly typed list
+                            # was docked half a point, which is the other half of
+                            # the same bug.
+                            type_correct += 0
                 score_parts["type_correctness"] = (
                     type_correct / type_checks if type_checks > 0 else 1.0
                 )
@@ -2415,14 +2481,21 @@ class Ontology:
         if strategy == "right_wins":
             return right
 
-        # Check source/target compatibility
+        # Record every conflicting definition. merge() raises on the accumulated
+        # list afterwards in strict mode, so returning early on the first one
+        # meant a cardinality mismatch was never compared: two ontologies
+        # declaring the same relationship ONE_TO_MANY and MANY_TO_MANY merged
+        # silently to the left side's cardinality.
         if left.source != right.source or left.target != right.target:
             conflicts.append(
                 f"Relationship '{rtype}': "
                 f"{left.source}->{left.target} vs {right.source}->{right.target}"
             )
-            if strategy == "strict":
-                return left
+        if str(left.cardinality).strip().upper() != str(right.cardinality).strip().upper():
+            conflicts.append(
+                f"Relationship '{rtype}': cardinality "
+                f"{left.cardinality} vs {right.cardinality}"
+            )
 
         merged_props = dict(left.properties)
         merged_props.update(right.properties)

--- a/tests/seocho/test_extraction_type_scoring.py
+++ b/tests/seocho/test_extraction_type_scoring.py
@@ -1,0 +1,94 @@
+"""A type mismatch must score 0, not half a point.
+
+`score_extraction`'s type check gave `+0.5` "partial credit" to anything that
+fell through its if/elif chain. Two consequences, pulling in opposite directions.
+
+A genuine mismatch — `age` declared INTEGER, extracted as `"thirty"` — kept half
+its credit, so a node with every property mis-typed still scored 0.5 on type
+correctness. The indexing quality-retry gate compares the overall score against
+a threshold, so a malformed extraction stayed above it and the gate never fired.
+
+And `LIST`/`POINT` had no branch of their own, so a *correctly* typed list value
+fell into that same else and was docked half a point for being right. The two
+halves are the same bug: the else branch was doing the work of a type check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P, PropertyType
+
+
+@pytest.fixture
+def person_ontology():
+    return Ontology(
+        name="test",
+        description="Test ontology",
+        nodes={
+            "Person": NodeDef(
+                description="A person",
+                properties={"name": P(str, unique=True), "age": P(int)},
+            ),
+        },
+    )
+
+
+def test_type_mismatch_scores_zero_not_partial(person_ontology):
+    """name is right, age is wrong -> 1 of 2. Previously 1.5 of 2 = 0.75."""
+    data = {
+        "nodes": [
+            {"id": "p1", "label": "Person",
+             "properties": {"name": "Alice", "age": "thirty"}},
+        ],
+        "relationships": [],
+    }
+    scores = person_ontology.score_extraction(data)
+    assert scores["nodes"][0]["details"]["type_correctness"] == 0.5
+
+
+def test_all_wrong_types_score_zero(person_ontology):
+    """The case the retry gate depends on: nothing correct must read as nothing."""
+    data = {
+        "nodes": [
+            {"id": "p1", "label": "Person",
+             "properties": {"name": 123, "age": "not-a-number"}},
+        ],
+        "relationships": [],
+    }
+    scores = person_ontology.score_extraction(data)
+    assert scores["nodes"][0]["details"]["type_correctness"] == 0.0
+
+
+def test_correct_types_still_score_full(person_ontology):
+    """The fix must not make the scorer stricter about values that are right."""
+    data = {
+        "nodes": [
+            {"id": "p1", "label": "Person",
+             "properties": {"name": "Alice", "age": 30}},
+        ],
+        "relationships": [],
+    }
+    scores = person_ontology.score_extraction(data)
+    assert scores["nodes"][0]["details"]["type_correctness"] == 1.0
+
+
+@pytest.mark.parametrize("declared,good,bad", [
+    (PropertyType.LIST, ["a", "b"], "a,b"),
+    (PropertyType.POINT, {"x": 1.0, "y": 2.0}, "1.0,2.0"),
+])
+def test_list_and_point_are_credited_when_correct(declared, good, bad):
+    """Both were unhandled and fell into the partial-credit branch."""
+    onto = Ontology(
+        name="t",
+        nodes={"Doc": NodeDef(description="d", properties={"v": P(declared)})},
+    )
+
+    def score(value):
+        return onto.score_extraction({
+            "nodes": [{"id": "d1", "label": "Doc", "properties": {"v": value}}],
+            "relationships": [],
+        })["nodes"][0]["details"]["type_correctness"]
+
+    assert score(good) == 1.0
+    assert score(bad) == 0.0

--- a/tests/seocho/test_ontology_merge_conflicts.py
+++ b/tests/seocho/test_ontology_merge_conflicts.py
@@ -1,0 +1,49 @@
+"""Regression for #130 — Ontology.merge must record relationship conflicts,
+including cardinality, and raise on them in strict mode. Previously a
+cardinality difference was never compared, so a strict merge silently kept the
+left relationship's cardinality with no signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, RelDef
+
+
+def _onto(cardinality: str, *, source: str = "A", target: str = "B") -> Ontology:
+    return Ontology(
+        name="o",
+        nodes={n: NodeDef(description=n) for n in ("A", "B", "C")},
+        relationships={
+            "R": RelDef(
+                source=source, target=target,
+                cardinality=cardinality, description="d",
+            )
+        },
+    )
+
+
+def test_cardinality_conflict_raises_in_strict_mode() -> None:
+    left = _onto("ONE_TO_MANY")
+    right = _onto("MANY_TO_MANY")
+    with pytest.raises(ValueError, match="cardinality"):
+        left.merge(right, strategy="strict")
+
+
+def test_cardinality_conflict_is_silent_outside_strict() -> None:
+    # union keeps the left cardinality (no raise) — behavior preserved.
+    merged = _onto("ONE_TO_MANY").merge(_onto("MANY_TO_MANY"), strategy="union")
+    assert merged.relationships["R"].cardinality == "ONE_TO_MANY"
+
+
+def test_source_target_conflict_still_raises_in_strict_mode() -> None:
+    left = _onto("ONE_TO_MANY", target="B")
+    right = _onto("ONE_TO_MANY", target="C")
+    with pytest.raises(ValueError, match="A->B vs A->C"):
+        left.merge(right, strategy="strict")
+
+
+def test_matching_relationships_merge_without_conflict() -> None:
+    merged = _onto("ONE_TO_MANY").merge(_onto("ONE_TO_MANY"), strategy="strict")
+    assert merged.relationships["R"].cardinality == "ONE_TO_MANY"

--- a/tests/seocho/test_shacl_enum_range.py
+++ b/tests/seocho/test_shacl_enum_range.py
@@ -1,0 +1,75 @@
+"""Regression for #128 — enum and range constraints declared on an ontology
+must be enforced by validate_with_shacl (the indexing validation path), and
+survive serialization. Previously to_shacl emitted only datatype/cardinality
+and validate_with_shacl ignored enum/range entirely.
+"""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P
+
+
+def _onto() -> Ontology:
+    return Ontology(
+        name="t",
+        nodes={
+            "Rating": NodeDef(
+                properties={
+                    "stance": P(str, enum=["buy", "hold", "sell"]),
+                    "score": P(float, value_range=(0.0, 1.0)),
+                }
+            )
+        },
+    )
+
+
+def test_to_shacl_emits_in_and_range():
+    shape = _onto().to_shacl()["shapes"][0]
+    by_path = {ps["path"]: ps for ps in shape["properties"]}
+    assert by_path["seocho:stance"]["in"] == ["buy", "hold", "sell"]
+    assert by_path["seocho:score"]["minInclusive"] == 0.0
+    assert by_path["seocho:score"]["maxInclusive"] == 1.0
+
+
+def test_enum_violation_is_a_validation_error():
+    data = {
+        "nodes": [{"id": "r1", "label": "Rating", "properties": {"stance": "strong-buy"}}],
+        "relationships": [],
+    }
+    errors = _onto().validate_with_shacl(data)
+    assert any("not in allowed set" in e and "stance" in e for e in errors)
+
+
+def test_enum_member_passes():
+    data = {
+        "nodes": [{"id": "r1", "label": "Rating", "properties": {"stance": "buy"}}],
+        "relationships": [],
+    }
+    errors = _onto().validate_with_shacl(data)
+    assert not any("stance" in e for e in errors)
+
+
+def test_range_violation_is_a_validation_error():
+    data = {
+        "nodes": [{"id": "r1", "label": "Rating", "properties": {"score": 1.5}}],
+        "relationships": [],
+    }
+    errors = _onto().validate_with_shacl(data)
+    assert any("out of range" in e and "score" in e for e in errors)
+
+
+def test_range_member_passes():
+    data = {
+        "nodes": [{"id": "r1", "label": "Rating", "properties": {"score": 0.5}}],
+        "relationships": [],
+    }
+    errors = _onto().validate_with_shacl(data)
+    assert not any("score" in e for e in errors)
+
+
+def test_enum_and_range_survive_dict_roundtrip():
+    restored = Ontology.from_dict(_onto().to_dict())
+    stance = restored.nodes["Rating"].properties["stance"]
+    score = restored.nodes["Rating"].properties["score"]
+    assert stance.enum == ["buy", "hold", "sell"]
+    assert score.value_range == (0.0, 1.0)


### PR DESCRIPTION
Re-applies three ontology fixes verified **still present on `main`**. All three needed manual porting rather than a rebase: `src/seocho/ontology.py` became `src/seocho/ontology/core.py` during the restructuring, and the forks' shared history with `main` collapsed to the root commit.

Supersedes #256, #241, #242.

## #256 — closes `seocho-8v5`, and it's the one that matters

`Property` had no way to declare an allowed value set. `to_shacl()` emitted only `datatype`/`minCount`/`maxCount`/`unique`, and `validate_with_shacl()` checked only those. A vocabulary could be described in prose and never enforced.

**That gap has a measured cost.** ADR-0181's A/B found `Decision.status`, declared `P(str)`, coming back as eight values across 51 documents:

```
CURRENT 88 · proposed 21 · current 8 · applied 8
pending 3 · mitigation 3 · SUPERSEDED 2 · superseded 2
```

An invented vocabulary and a case split at once. A query filtering `status = 'current'` misses 88 of 96. The only channel that fixed it was prose in the extraction prompt — because `P` had no enum argument. Now it does:

```python
status = P(str, enum=["proposed", "applied", "superseded", "reverted"])
score  = P(float, value_range=(0.0, 1.0))
```

Verified against that exact failure: `"CURRENT"` is rejected, `"applied"` passes. Both fields survive the YAML round-trip and emit as `sh:in` / `sh:minInclusive` / `sh:maxInclusive`.

This is also the declarative home ADR-0181 said the OS-contract sidecar's `vocabularies:` block was missing.

## #241 — partial credit hid malformed extractions

`score_extraction`'s type check gave `+0.5` to anything falling through its if/elif chain. A node with **every** property mis-typed still scored 0.5 on type correctness — above the indexing quality-retry threshold, so the gate never fired.

The same `else` also caught `LIST` and `POINT`, which had no case of their own, so a *correctly typed* list was docked half a point for being right. Both halves are one bug: the `else` was doing a type check's job.

## #242 — a cardinality conflict was never compared

`_merge_rel_def` returned early on the first source/target mismatch in strict mode, so two ontologies declaring the same relationship `ONE_TO_MANY` and `MANY_TO_MANY` merged silently to the left side's cardinality. `merge()` raises on the accumulated conflict list afterwards, so recording all conflicts is what the caller already expected.

## Validation

```
pytest test_shacl_enum_range test_ontology_merge_conflicts
       test_extraction_type_scoring                 -> 15 passed
pytest test_ontology test_ontology_lint test_ontology_import
       test_ontology_context test_ontology_subclass_ttl
       test_ontology_enforcement test_ontology_reasoner
       test_ontology_iso704_cq                      -> 112 passed
manual: Decision.status enum rejects "CURRENT", accepts "applied"
git diff --check                                    -> clean
```

New tests registered in `scripts/ci/run_basic_ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)