### PR TITLE
fix(query,session): year order, per-call category, nested loops, driver leak (#240 #252 #236 #259)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -58,6 +58,10 @@ uv run pytest \
   tests/seocho/test_query_proxy_workspace_enforcement.py \
   tests/seocho/test_ontology_context.py \
   tests/seocho/test_session_agent.py \
+  tests/seocho/test_stream_async_in_thread.py \
+  tests/seocho/test_extraction_category_per_call.py \
+  tests/seocho/test_financial_delta_direction.py \
+  tests/seocho/test_neo4j_store_close.py \
   tests/seocho/test_response_cache_wiring.py \
   tests/seocho/test_user_facing_edge_cases.py \
   tests/seocho/test_connectors.py \

--- a/src/seocho/index/extraction_engine.py
+++ b/src/seocho/index/extraction_engine.py
@@ -312,8 +312,7 @@ class CanonicalExtractionEngine:
             )
 
         if self._extraction is not None:
-            self._extraction.category = category
-            return self._extraction.render(text, metadata=metadata)
+            return self._extraction.render(text, metadata=metadata, category=category)
 
         system = (
             "You are an expert entity extraction system.\n"

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -902,7 +902,7 @@ class IndexingPipeline:
                         f"Available relationships: {', '.join(self.ontology.relationships.keys())}."
                     )
                     try:
-                        retry_system, retry_user = self._extraction.render(chunk, metadata=metadata)
+                        retry_system, retry_user = self._extraction.render(chunk, metadata=metadata, category=category)
                         retry_system += f"\n\n{guidance}"
                         retry_response = complete_with_task_hints(
                             self.llm,

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -496,8 +496,7 @@ class _LocalEngine:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Run extraction only (no graph write)."""
-        self._extraction.category = category
-        system, user = self._extraction.render(content, metadata=metadata)
+        system, user = self._extraction.render(content, metadata=metadata, category=category)
 
         response = complete_with_task_hints(
             self.llm,

--- a/src/seocho/query/answering.py
+++ b/src/seocho/query/answering.py
@@ -185,14 +185,24 @@ class QueryAnswerSynthesizer:
                 return f"For {company}, {metric_label} was {series}."
 
         if intent == "financial_metric_delta":
-            target_years = self._ordered_years(years or [row["year"] for row in selected_rows])
-            if len(target_years) < 2:
-                return self._direct_answer(
-                    question,
-                    supporting_fact,
-                    priority_terms=intent_data.get("metric_aliases", ()),
-                ) or None
-            start_year, end_year = target_years[0], target_years[-1]
+            # Follow the order the years were stated in the question: "change
+            # from 2023 to 2021" must report 2023 -> 2021 (a decrease), not the
+            # chronological 2021 -> 2023. Fall back to chronological order only
+            # when the question did not name the years (issue #131).
+            phrased_years = self._dedupe_years(years)
+            if len(phrased_years) >= 2:
+                start_year, end_year = phrased_years[0], phrased_years[-1]
+            else:
+                target_years = self._ordered_years(
+                    years or [row["year"] for row in selected_rows]
+                )
+                if len(target_years) < 2:
+                    return self._direct_answer(
+                        question,
+                        supporting_fact,
+                        priority_terms=intent_data.get("metric_aliases", ()),
+                    ) or None
+                start_year, end_year = target_years[0], target_years[-1]
             by_year = {row["year"]: row for row in selected_rows if row.get("year")}
             start_row = by_year.get(start_year)
             end_row = by_year.get(end_year)
@@ -703,13 +713,20 @@ class QueryAnswerSynthesizer:
                 return match.group(1)
         return ""
 
-    def _ordered_years(self, years: Sequence[Any]) -> List[str]:
+    def _dedupe_years(self, years: Sequence[Any]) -> List[str]:
+        """Dedupe years preserving the order they were given (e.g. as phrased in
+        the question). Use this where stated order carries meaning, such as a
+        delta's start/end; use :meth:`_ordered_years` where chronological order
+        is wanted."""
         deduped: List[str] = []
         for year in years:
             text = str(year).strip()
             if text and text not in deduped:
                 deduped.append(text)
-        return sorted(deduped)
+        return deduped
+
+    def _ordered_years(self, years: Sequence[Any]) -> List[str]:
+        return sorted(self._dedupe_years(years))
 
     def _humanize_metric_label(self, intent_data: Dict[str, Any]) -> str:
         metric_name = str(intent_data.get("metric_name", "")).strip()

--- a/src/seocho/query/strategy.py
+++ b/src/seocho/query/strategy.py
@@ -398,13 +398,18 @@ class ExtractionStrategy(PromptStrategy):
     def render(self, text: str, **kwargs: Any) -> tuple[str, str]:
         ctx = self.ontology.to_extraction_context()
 
+        # Prefer a per-call category so concurrent add() calls on a shared
+        # strategy do not race on instance state; fall back to the constructor
+        # default (issue #134).
+        category = kwargs.get("category") or self.category
+
         # If user provided a custom template, use it
         if self.prompt_template is not None:
             return self.prompt_template.render(ctx, text)
 
         # Auto-select category-specific prompt if available
-        if self.category in CATEGORY_PROMPT_MAP:
-            auto_template = PRESET_PROMPTS.get(CATEGORY_PROMPT_MAP[self.category])
+        if category in CATEGORY_PROMPT_MAP:
+            auto_template = PRESET_PROMPTS.get(CATEGORY_PROMPT_MAP[category])
             if auto_template is not None:
                 return auto_template.render(ctx, text)
 
@@ -412,7 +417,7 @@ class ExtractionStrategy(PromptStrategy):
         # chunks, maximizing provider-side prompt cache hits.
         metadata = kwargs.get("metadata")
         cache_key = (
-            self.category,
+            category,
             self.shacl_constraints,
             self.vocabulary_terms,
             self.developer_instructions,

--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import queue
 import threading
 import time
 import uuid
@@ -104,6 +105,53 @@ def _run_sync(
     if "error" in box:
         raise box["error"]
     return box["value"]
+
+
+def _stream_async_in_thread(make_agen):
+    """Drive an async generator from synchronous code, yielding items as they arrive.
+
+    Like :func:`_run_sync`, the work runs in a worker thread that owns its own event
+    loop, so this is safe to call from a thread that already has a running loop
+    (Jupyter, FastAPI, ``pytest-asyncio``) instead of crashing on a nested
+    ``loop.run_until_complete``. Items stream through a queue in real time; iterator
+    cleanup (``aclose`` + task cancellation on loop shutdown) happens in the worker.
+
+    ``make_agen`` is a zero-arg factory that returns the async generator; it is
+    invoked inside the worker's loop so loop-bound setup runs on the right loop.
+    """
+    items: "queue.Queue" = queue.Queue()
+
+    def _runner() -> None:
+        async def _drive() -> None:
+            agen = make_agen()
+            try:
+                async for item in agen:
+                    items.put(("item", item))
+            finally:
+                aclose = getattr(agen, "aclose", None)
+                if aclose is not None:
+                    try:
+                        await aclose()
+                    except Exception:  # noqa: BLE001
+                        pass
+
+        try:
+            asyncio.run(_drive())
+        except BaseException as exc:  # noqa: BLE001
+            items.put(("error", exc))
+        finally:
+            items.put(("done", None))
+
+    worker = threading.Thread(target=_runner, name="seocho-stream", daemon=True)
+    worker.start()
+    while True:
+        kind, payload = items.get()
+        if kind == "item":
+            yield payload
+        elif kind == "error":
+            raise payload
+        else:
+            return
 
 
 class Session:
@@ -873,42 +921,20 @@ class Session:
             from .agents_runtime import get_agents_runtime
             agent = self._get_query_agent()
 
-            async def _stream():
-                result = get_agents_runtime().run_streamed(agent=agent, input=full_msg)
-                async for event in result.stream_events():
-                    if hasattr(event, 'data') and hasattr(event.data, 'delta'):
-                        yield event.data.delta
+            def _make_stream():
+                async def _agen():
+                    result = get_agents_runtime().run_streamed(agent=agent, input=full_msg)
+                    async for event in result.stream_events():
+                        if hasattr(event, "data") and hasattr(event.data, "delta"):
+                            yield event.data.delta
 
-            import asyncio
-            loop = asyncio.new_event_loop()
-            ait = _stream().__aiter__()
-            try:
-                while True:
-                    try:
-                        chunk = loop.run_until_complete(ait.__anext__())
-                        yield chunk
-                    except StopAsyncIteration:
-                        break
-            finally:
-                # seocho-hnf9: drain the async iterator + cancel any
-                # pending tasks before closing the loop so resources
-                # bound to the iterator (HTTP connections, etc.) are
-                # released even if the consumer raised mid-stream.
-                try:
-                    loop.run_until_complete(ait.aclose())
-                except Exception:
-                    pass
-                try:
-                    pending = asyncio.all_tasks(loop=loop)
-                    for task in pending:
-                        task.cancel()
-                    if pending:
-                        loop.run_until_complete(
-                            asyncio.gather(*pending, return_exceptions=True)
-                        )
-                except Exception:
-                    pass
-                loop.close()
+                return _agen()
+
+            # Drive the async stream from a worker thread that owns its own loop,
+            # so ask_stream is safe to call inside an already-running loop
+            # (Jupyter/FastAPI) instead of crashing on a nested run_until_complete.
+            # Chunks still stream in real time through the queue.
+            yield from _stream_async_in_thread(_make_stream)
         except Exception as exc:
             logger.warning("Streaming failed, falling back: %s", exc)
             answer = self.ask(question, database=database)

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -524,6 +524,7 @@ class Neo4jGraphStore(GraphStore):
 
         _log_packstream_codec_once()
         self._driver = GraphDatabase.driver(uri, auth=(user, password))
+        self._closed = False
         self._uri = uri
         self._user = user
         self._schema_cache: Dict[str, Dict[str, Any]] = {}
@@ -1434,7 +1435,27 @@ class Neo4jGraphStore(GraphStore):
             return []
 
     def close(self) -> None:
-        self._driver.close()
+        # Idempotent: releasing the driver's connection pool more than once
+        # (e.g. explicit close() then __del__/__exit__) must be a no-op.
+        if not getattr(self, "_closed", True):
+            self._closed = True
+            self._driver.close()
+
+    def __enter__(self) -> "Neo4jGraphStore":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        # Best-effort safety net so a store that goes out of scope without an
+        # explicit close()/with-block does not leak its connection pool for the
+        # process lifetime (issue #135). Guarded: __del__ can run during
+        # interpreter shutdown when modules/globals are already torn down.
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def __repr__(self) -> str:
         return f"Neo4jGraphStore(uri={self._uri!r})"

--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -52,8 +52,7 @@ def make_extract_entities_tool(ontology: Any, llm: Any, extraction_prompt: Any =
         Returns:
             JSON string with extracted nodes and relationships.
         """
-        strategy.category = category
-        system, user = strategy.render(text)
+        system, user = strategy.render(text, category=category)
         try:
             response = complete_with_task_hints(
                 llm,

--- a/tests/seocho/test_extraction_category_per_call.py
+++ b/tests/seocho/test_extraction_category_per_call.py
@@ -1,0 +1,66 @@
+"""Regression for #134 — ExtractionStrategy must select its prompt from a
+per-call category, not shared instance state. _LocalEngine reused one strategy
+and set strategy.category per call, so two concurrent add() calls raced and one
+could render with the other's category.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.query.strategy import (
+    CATEGORY_PROMPT_MAP,
+    PRESET_PROMPTS,
+    ExtractionStrategy,
+)
+
+
+def _strategy() -> ExtractionStrategy:
+    onto = Ontology(name="t", nodes={"Doc": NodeDef(properties={"name": P(str)})})
+    return ExtractionStrategy(onto, category="general")
+
+
+def _expected(strategy: ExtractionStrategy, category: str, text: str):
+    ctx = strategy.ontology.to_extraction_context()
+    return PRESET_PROMPTS[CATEGORY_PROMPT_MAP[category]].render(ctx, text)
+
+
+def test_render_uses_per_call_category() -> None:
+    strategy = _strategy()
+    fin = strategy.render("text", category="Financials")
+    legal = strategy.render("text", category="Legal")
+
+    assert fin == _expected(strategy, "Financials", "text")
+    assert legal == _expected(strategy, "Legal", "text")
+    assert fin != legal
+
+
+def test_render_does_not_mutate_instance_category() -> None:
+    strategy = _strategy()
+    strategy.render("text", category="Financials")
+    assert strategy.category == "general"  # untouched
+    # falls back to the constructor default when no per-call category is given
+    # (compare the system prompt — the part category drives)
+    assert strategy.render("text")[0] == strategy.render("text", category="general")[0]
+
+
+def test_concurrent_renders_do_not_cross_talk() -> None:
+    strategy = _strategy()
+    categories = ["Financials", "Legal", "Risk", "Governance"]
+    expected = {c: _expected(strategy, c, "text") for c in categories}
+    errors: list[str] = []
+
+    def worker(cat: str) -> None:
+        for _ in range(50):
+            if strategy.render("text", category=cat) != expected[cat]:
+                errors.append(cat)
+                return
+
+    threads = [threading.Thread(target=worker, args=(c,)) for c in categories * 4]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []

--- a/tests/seocho/test_financial_delta_direction.py
+++ b/tests/seocho/test_financial_delta_direction.py
@@ -1,0 +1,64 @@
+"""Regression for #131 — a delta must follow the year order stated in the
+question. `financial_metric_delta` derived start/end from `_ordered_years`,
+which always sorts chronologically, so "change from 2023 to 2021" was answered
+as 2021 -> 2023 with the sign and increased/decreased direction reversed.
+"""
+
+from __future__ import annotations
+
+from seocho.query.answering import QueryAnswerSynthesizer
+
+
+def _synth() -> QueryAnswerSynthesizer:
+    # No llm / strategy needed: the delta branch is fully deterministic.
+    return QueryAnswerSynthesizer.__new__(QueryAnswerSynthesizer)
+
+
+_RECORDS = [
+    {"company": "ACME", "metric_name": "revenue", "year": "2021", "value": 100},
+    {"company": "ACME", "metric_name": "revenue", "year": "2023", "value": 150},
+]
+
+
+def _intent(years: list[str]) -> dict:
+    return {
+        "intent": "financial_metric_delta",
+        "years": years,
+        "anchor_entity": "ACME",
+        "metric_name": "revenue",
+        "metric_aliases": ["revenue"],
+    }
+
+
+def test_delta_follows_descending_question_phrasing() -> None:
+    answer = _synth()._build_financial_answer(
+        "how did revenue change from 2023 to 2021",
+        _RECORDS,
+        _intent(["2023", "2021"]),
+    )
+    # 2023 (150) -> 2021 (100): a decrease of 50, reported in the stated order.
+    assert "decreased" in answer
+    assert "from 2023 to 2021" in answer
+    assert "increased" not in answer
+
+
+def test_delta_follows_ascending_question_phrasing() -> None:
+    answer = _synth()._build_financial_answer(
+        "how did revenue change from 2021 to 2023",
+        _RECORDS,
+        _intent(["2021", "2023"]),
+    )
+    assert "increased" in answer
+    assert "from 2021 to 2023" in answer
+    assert "decreased" not in answer
+
+
+def test_delta_without_stated_years_defaults_to_chronological() -> None:
+    # No years named in the question → fall back to chronological order.
+    answer = _synth()._build_financial_answer(
+        "how did revenue change",
+        _RECORDS,
+        _intent([]),
+    )
+    assert "increased" in answer
+    assert "from 2021 to 2023" in answer

--- a/tests/seocho/test_neo4j_store_close.py
+++ b/tests/seocho/test_neo4j_store_close.py
@@ -1,0 +1,66 @@
+"""Regression for #135 — Neo4jGraphStore must release its driver connection
+pool deterministically. It opened a driver in __init__ but had no context
+manager, no __del__, and nothing cascaded a close(), so per-request/per-
+workspace stores leaked pools for the process lifetime.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+
+@pytest.fixture
+def _fake_neo4j(monkeypatch):
+    captured = {}
+
+    def driver(uri, auth=None, **kw):
+        captured["driver"] = _FakeDriver()
+        return captured["driver"]
+
+    mod = types.ModuleType("neo4j")
+    mod.GraphDatabase = types.SimpleNamespace(driver=driver)
+    monkeypatch.setitem(sys.modules, "neo4j", mod)
+    return captured
+
+
+def _store():
+    from seocho.store.graph import Neo4jGraphStore
+
+    return Neo4jGraphStore("bolt://localhost:7687", "neo4j", "pw")
+
+
+def test_context_manager_closes_driver(_fake_neo4j):
+    with _store():
+        pass
+    assert _fake_neo4j["driver"].close_calls == 1
+
+
+def test_close_is_idempotent(_fake_neo4j):
+    store = _store()
+    store.close()
+    store.close()
+    assert _fake_neo4j["driver"].close_calls == 1
+
+
+def test_del_closes_driver_as_safety_net(_fake_neo4j):
+    store = _store()
+    store.__del__()  # simulate GC finalization
+    assert _fake_neo4j["driver"].close_calls == 1
+
+
+def test_del_after_explicit_close_does_not_double_close(_fake_neo4j):
+    store = _store()
+    store.close()
+    store.__del__()
+    assert _fake_neo4j["driver"].close_calls == 1

--- a/tests/seocho/test_stream_async_in_thread.py
+++ b/tests/seocho/test_stream_async_in_thread.py
@@ -1,0 +1,53 @@
+"""Regression tests for ``seocho.session._stream_async_in_thread``.
+
+``ask_stream`` used to drive its async generator with ``asyncio.new_event_loop()``
++ ``loop.run_until_complete(...)``, which raises ``RuntimeError`` whenever an outer
+loop is already running — the default inside Jupyter cells, FastAPI handlers, and
+``pytest-asyncio`` fixtures. The helper drives the generator on a worker thread
+that owns its own loop, so streaming is safe from any context while still
+delivering chunks in real time. These tests pin both branches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from seocho.session import _stream_async_in_thread
+
+
+def _counter_factory(n: int):
+    async def _agen():
+        for i in range(n):
+            yield i
+
+    return _agen
+
+
+def test_stream_in_plain_context_yields_all_items() -> None:
+    assert list(_stream_async_in_thread(_counter_factory(3))) == [0, 1, 2]
+
+
+def test_stream_works_inside_running_event_loop() -> None:
+    """The regression: streaming from inside a running loop must not raise."""
+
+    async def _outer():
+        # asyncio.get_running_loop() is active here — the case that used to crash.
+        return list(_stream_async_in_thread(_counter_factory(3)))
+
+    assert asyncio.run(_outer()) == [0, 1, 2]
+
+
+def test_stream_propagates_exceptions_after_partial_output() -> None:
+    def _boom_factory():
+        async def _agen():
+            yield 1
+            raise ValueError("stream boom")
+
+        return _agen()
+
+    gen = _stream_async_in_thread(_boom_factory)
+    assert next(gen) == 1
+    with pytest.raises(ValueError, match="stream boom"):
+        next(gen)


### PR DESCRIPTION
Re-applies four fixes verified **still present on `main`**, ported against current file locations. Like #548/#549/#551, the forks' shared history with `main` collapsed to the root commit, so no rebase was possible.

Supersedes #240, #252, #236, #259.

## #240 — the delta was reported in the wrong direction

`financial_metric_delta` always sorted years chronologically. "What changed from **2023 to 2021**" was answered 2021 → 2023: right magnitude, **wrong sign**, stated as fact. Years named in the question now keep their stated order; chronological sorting applies only when the question names none.

## #252 — concurrent `add()` calls picked each other's prompt

`ExtractionStrategy.render()` read `self.category`, which the caller set on the shared instance immediately before calling. Two concurrent extractions raced and one used the other's category prompt. The category now travels as a per-call argument, so the instance attribute stops being request state.

## #236 — `ask_stream` crashed wherever a loop was already running

It called `asyncio.new_event_loop()` + `run_until_complete()`, which raises `RuntimeError` inside Jupyter, FastAPI, or `pytest-asyncio` — every place a user is most likely to try streaming. The generator now runs in a worker thread owning its own loop, with items arriving through a queue, mirroring the existing `_run_sync` pattern.

Verified directly rather than by test alone:

```
inside running loop -> ['tok0', 'tok1', 'tok2']
error propagates    -> upstream failed
```

> A previous fix (`seocho-hnf9`) added iterator-drain and task-cancel cleanup to the same function's `finally` block. That addressed a different failure and left the nested-loop crash untouched — no test covered it.

## #259 — the driver was never released

`Neo4jGraphStore` opened a driver in `__init__` with no `__enter__`/`__exit__` and no `__del__`, and `close()` was not idempotent, so a store going out of scope leaked its connection pool. Context-manager support and a guarded `__del__` close it; `close()` is now safe to call twice.

## Validation

```
pytest test_financial_delta_direction test_extraction_category_per_call
       test_stream_async_in_thread test_neo4j_store_close   -> 13 passed
pytest test_session_agent test_extraction_engine test_indexing_design
       test_client_boundaries test_graph_ensure_database
       test_cypher_builder test_run_sync_cancellation       -> 70 passed
git diff --check                                            -> clean
```

New tests registered in `scripts/ci/run_basic_ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)