### PR TITLE
fix(store,artifacts): batch embeddings, guard approve, write artifacts atomically (#234 #247 #249)

### DIFF
--- a/extraction/semantic_artifact_store.py
+++ b/extraction/semantic_artifact_store.py
@@ -1,13 +1,39 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_SEMANTIC_ARTIFACT_DIR = "outputs/semantic_artifacts"
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    """Write JSON atomically: serialize to a temp file in the same directory,
+    fsync, then os.replace into place. A crash or concurrent write can no
+    longer leave a truncated artifact that breaks every later read (issue #139).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fp:
+            json.dump(payload, fp, indent=2)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def save_semantic_artifact(
@@ -55,8 +81,7 @@ def save_semantic_artifact(
     }
 
     artifact_path = workspace_path / f"{artifact_id}.json"
-    with artifact_path.open("w", encoding="utf-8") as fp:
-        json.dump(payload, fp, indent=2)
+    _atomic_write_json(artifact_path, payload)
     return payload
 
 
@@ -150,8 +175,14 @@ def list_semantic_artifacts(
 
     rows: List[Dict[str, Any]] = []
     for path in workspace_path.glob("*.json"):
-        with path.open("r", encoding="utf-8") as fp:
-            payload = json.load(fp)
+        try:
+            with path.open("r", encoding="utf-8") as fp:
+                payload = json.load(fp)
+        except (json.JSONDecodeError, OSError) as exc:
+            # A single corrupt/partially-written artifact must not take down the
+            # whole list endpoint (issue #139). Skip it and keep going.
+            logger.warning("Skipping unreadable semantic artifact %s: %s", path, exc)
+            continue
         row = {
             "artifact_id": payload.get("artifact_id"),
             "workspace_id": payload.get("workspace_id"),
@@ -199,12 +230,21 @@ def approve_semantic_artifact(
     with artifact_path.open("r", encoding="utf-8") as fp:
         payload = json.load(fp)
 
+    # Guarded lifecycle transition: draft/approved -> approved only. A
+    # deprecated artifact is end-of-life and must not be silently re-approved
+    # back into the active set (issue #138; mirrors the deprecate guard).
+    current_status = payload.get("status")
+    if current_status == "deprecated":
+        raise ValueError(
+            f"semantic artifact '{artifact_id}' is deprecated and cannot be "
+            f"re-approved (status={current_status})"
+        )
+
     governance = _run_governance_gate(payload, run_reasoner=run_reasoner)
     payload["governance"] = governance
     if governance_enforce and not governance.get("ok", True):
         # Persist the failed verdict so the refusal is auditable, then refuse.
-        with artifact_path.open("w", encoding="utf-8") as fp:
-            json.dump(payload, fp, indent=2)
+        _atomic_write_json(artifact_path, payload)
         raise ValueError(
             f"semantic artifact '{artifact_id}' failed governance gate "
             f"(structural_ok={governance['structural']['ok']}, "
@@ -221,8 +261,7 @@ def approve_semantic_artifact(
     payload["deprecation_note"] = None
     payload["deprecated_at"] = None
 
-    with artifact_path.open("w", encoding="utf-8") as fp:
-        json.dump(payload, fp, indent=2)
+    _atomic_write_json(artifact_path, payload)
     return payload
 
 
@@ -291,8 +330,7 @@ def deprecate_semantic_artifact(
     payload["deprecation_note"] = deprecation_note
     payload["deprecated_at"] = _now_iso()
 
-    with artifact_path.open("w", encoding="utf-8") as fp:
-        json.dump(payload, fp, indent=2)
+    _atomic_write_json(artifact_path, payload)
     return payload
 
 

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -84,6 +84,8 @@ uv run pytest \
   tests/seocho/test_faiss_delete.py \
   tests/seocho/test_delete_source_vectors.py \
   tests/seocho/test_llm_backends.py \
+  tests/seocho/test_semantic_artifact_lifecycle.py \
+  tests/seocho/test_semantic_artifact_durability.py \
   tests/seocho/test_llm_model_override.py \
   tests/seocho/test_model_router.py \
   tests/seocho/test_reflection.py \

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -144,6 +144,28 @@ def _strip_text(value: Optional[str]) -> str:
     return str(value).strip()
 
 
+_EMBED_MAX_BATCH = 2048  # OpenAI-compatible /embeddings cap inputs at ~2048 per request
+
+
+def _embed_in_batches(client: Any, model: str, texts: Sequence[str]) -> List[List[float]]:
+    """Embed ``texts`` in provider-safe sub-batches and concatenate, preserving order.
+
+    A single request for an arbitrarily large input hits the provider's per-request
+    item cap and 400s, losing the whole batch; chunking degrades gracefully instead.
+    Results are reordered by the response ``index`` so concatenation stays aligned.
+    """
+    items = list(texts)
+    out: List[List[float]] = []
+    for start in range(0, len(items), _EMBED_MAX_BATCH):
+        batch = items[start : start + _EMBED_MAX_BATCH]
+        if not batch:
+            continue
+        response = client.embeddings.create(model=model, input=batch)
+        ordered = sorted(response.data, key=lambda item: item.index)
+        out.extend(list(item.embedding) for item in ordered)
+    return out
+
+
 def _resolve_client_kwargs(
     *,
     provider: str,
@@ -1053,11 +1075,7 @@ class OpenAICompatibleBackend(LLMBackend):
                 f"Provider '{self.provider}' does not define a default embedding model. "
                 "Pass an explicit embedding model or use a dedicated embedding backend."
             )
-        response = self._client.embeddings.create(
-            model=resolved_model,
-            input=list(texts),
-        )
-        return [list(item.embedding) for item in response.data]
+        return _embed_in_batches(self._client, resolved_model, texts)
 
     def to_embedding_backend(
         self,
@@ -1214,11 +1232,7 @@ class OpenAICompatibleEmbeddingBackend(EmbeddingBackend):
         model: Optional[str] = None,
     ) -> List[List[float]]:
         resolved_model = _strip_text(model) or self.model
-        response = self._client.embeddings.create(
-            model=resolved_model,
-            input=list(texts),
-        )
-        return [list(item.embedding) for item in response.data]
+        return _embed_in_batches(self._client, resolved_model, texts)
 
     def __repr__(self) -> str:
         return (

--- a/tests/seocho/test_llm_backends.py
+++ b/tests/seocho/test_llm_backends.py
@@ -28,10 +28,14 @@ class _FakeChatCompletions:
 
 
 class _FakeEmbeddings:
+    def __init__(self):
+        self.calls = []
+
     def create(self, *, model, input):
+        self.calls.append(len(input))
         return SimpleNamespace(
             data=[
-                SimpleNamespace(embedding=[float(index + 1), 0.0])
+                SimpleNamespace(index=index, embedding=[float(index + 1), 0.0])
                 for index, _ in enumerate(input)
             ]
         )
@@ -116,6 +120,23 @@ def test_openai_embedding_backend_uses_default_embedding_model(
 
     assert backend.model == "text-embedding-3-small"
     assert vectors == [[1.0, 0.0], [2.0, 0.0]]
+
+
+def test_openai_embedding_backend_batches_large_inputs(
+    fake_openai: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+
+    backend = create_embedding_backend(provider="openai")
+    n = 2048 * 2 + 5
+    vectors = backend.embed([f"t{i}" for i in range(n)])
+
+    # Nothing dropped, and the request is split into provider-safe sub-batches
+    # instead of one oversized call that would 400.
+    assert len(vectors) == n
+    assert backend._client.embeddings.calls == [2048, 2048, 5]
+    assert max(backend._client.embeddings.calls) <= 2048
 
 
 def test_non_embedding_provider_requires_explicit_embedding_model(

--- a/tests/seocho/test_semantic_artifact_durability.py
+++ b/tests/seocho/test_semantic_artifact_durability.py
@@ -1,0 +1,57 @@
+"""Durable writes for the semantic artifact store (#139).
+
+create/approve/deprecate wrote with open("w") + json.dump, so an interrupted
+write left a truncated file that broke every later read, and list_semantic_
+artifacts json.load'd every file with no guard, so one corrupt file 500'd the
+whole list endpoint. Writes are now atomic (temp + os.replace) and listing
+skips unreadable files.
+"""
+
+from __future__ import annotations
+
+import json
+
+from extraction.semantic_artifact_store import (
+    _atomic_write_json,
+    list_semantic_artifacts,
+    save_semantic_artifact,
+)
+
+
+def _save(base_dir, name):
+    return save_semantic_artifact(
+        workspace_id="ws",
+        ontology_candidate={},
+        shacl_candidate={},
+        name=name,
+        base_dir=str(base_dir),
+    )
+
+
+def test_corrupt_artifact_does_not_break_listing(tmp_path):
+    _save(tmp_path, "good-1")
+    _save(tmp_path, "good-2")
+    # Simulate a truncated/partially-written artifact.
+    (tmp_path / "ws" / "sa_broken.json").write_text('{"artifact_id": "sa_broken", ', encoding="utf-8")
+
+    rows = list_semantic_artifacts("ws", base_dir=str(tmp_path))
+
+    names = {r["name"] for r in rows}
+    assert names == {"good-1", "good-2"}  # the corrupt file is skipped, not fatal
+
+
+def test_save_leaves_no_temp_files(tmp_path):
+    _save(tmp_path, "good")
+    files = list((tmp_path / "ws").iterdir())
+    assert all(f.suffix == ".json" and not f.name.endswith(".tmp") for f in files)
+    assert len(files) == 1
+
+
+def test_atomic_write_roundtrip_and_overwrite(tmp_path):
+    path = tmp_path / "a.json"
+    _atomic_write_json(path, {"v": 1})
+    assert json.loads(path.read_text()) == {"v": 1}
+    _atomic_write_json(path, {"v": 2})  # overwrite in place
+    assert json.loads(path.read_text()) == {"v": 2}
+    # no leftover temp files in the directory
+    assert [p.name for p in tmp_path.iterdir()] == ["a.json"]

--- a/tests/seocho/test_semantic_artifact_lifecycle.py
+++ b/tests/seocho/test_semantic_artifact_lifecycle.py
@@ -1,0 +1,55 @@
+"""Lifecycle guard for the semantic artifact store (#138).
+
+approve_semantic_artifact set status="approved" unconditionally, so a
+deprecated artifact could be silently revived to approved and served as the
+active artifact. Approval is now a guarded transition.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from extraction.semantic_artifact_store import (
+    approve_semantic_artifact,
+    deprecate_semantic_artifact,
+    save_semantic_artifact,
+)
+
+
+def _draft(base_dir):
+    # No ontology classes -> the governance gate is "not applicable" and the
+    # heavy ontology build is skipped, keeping the test offline and fast.
+    return save_semantic_artifact(
+        workspace_id="ws",
+        ontology_candidate={},
+        shacl_candidate={},
+        base_dir=str(base_dir),
+    )
+
+
+def test_draft_can_be_approved_then_deprecated(tmp_path):
+    art = _draft(tmp_path)
+    aid = art["artifact_id"]
+    approved = approve_semantic_artifact("ws", aid, "alice", base_dir=str(tmp_path))
+    assert approved["status"] == "approved"
+    deprecated = deprecate_semantic_artifact("ws", aid, "bob", base_dir=str(tmp_path))
+    assert deprecated["status"] == "deprecated"
+
+
+def test_deprecated_artifact_cannot_be_reapproved(tmp_path):
+    art = _draft(tmp_path)
+    aid = art["artifact_id"]
+    approve_semantic_artifact("ws", aid, "alice", base_dir=str(tmp_path))
+    deprecate_semantic_artifact("ws", aid, "bob", base_dir=str(tmp_path))
+
+    with pytest.raises(ValueError, match="deprecated"):
+        approve_semantic_artifact("ws", aid, "alice", base_dir=str(tmp_path))
+
+
+def test_reapproving_an_approved_artifact_is_allowed(tmp_path):
+    # Idempotent re-approval of a still-active artifact stays permitted.
+    art = _draft(tmp_path)
+    aid = art["artifact_id"]
+    approve_semantic_artifact("ws", aid, "alice", base_dir=str(tmp_path))
+    again = approve_semantic_artifact("ws", aid, "alice", base_dir=str(tmp_path))
+    assert again["status"] == "approved"


### PR DESCRIPTION
Re-applies three fixes verified **still present on `main`**, ported against current file locations.

Supersedes #234, #247, #249.

## #234 — a large batch failed as a whole

`embed()` put every text into a single `/embeddings` request. A batch over the provider's input cap came back `400` and the **entire batch was lost**, including the texts that would have succeeded. Both embedding call sites now go through one helper that chunks at 2048 and reorders by the response `index`, so a long ingest degrades into more requests rather than into nothing.

Verified only one `embeddings.create` call remains, inside the helper.

## #247 — `approve()` could revive a deprecated artifact

Nothing checked lifecycle state before promoting, so an artifact retired for a reason could be walked back into active use by an ordinary approve call, leaving no record that it had ever been deprecated.

## #249 — one corrupt file made every artifact unreadable

Writing in place meant an interrupted write left truncated JSON on disk, and `list()` then raised on it — so a single bad file broke listing for *all* artifacts, not just itself. Writes now go through a temp file and rename; `list()` skips a corrupt entry and keeps going.

> `extraction/` is a compatibility surface, so #247/#249 are fixes to behaviour already owned there rather than new product logic (per CLAUDE.md architecture boundaries).

## Validation

```
pytest test_llm_backends test_semantic_artifact_lifecycle
       test_semantic_artifact_durability            -> 46 passed
pytest extraction/tests/test_semantic_run_store
       extraction/tests/test_approve_governance_gate
       extraction/tests/test_semantic_query_flow    -> 25 passed
git diff --check                                    -> clean
```

New tests registered in `scripts/ci/run_basic_ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)