### PR TITLE
fix(eval,tracing): normalize FinDER categories, give spans auditable context (#105 #113)

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -95,6 +95,7 @@ uv run pytest \
   tests/seocho/test_debate_quorum.py \
   tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
+  tests/seocho/test_trace_span_context.py \
   tests/seocho/test_observability_contract.py \
   tests/seocho/test_golden_signal_emitters.py \
   tests/seocho/test_cypher_builder.py \

--- a/src/seocho/eval/benchmarks/finder.py
+++ b/src/seocho/eval/benchmarks/finder.py
@@ -37,9 +37,12 @@ from __future__ import annotations
 
 import os
 import random
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 CATEGORIES: tuple[str, ...] = (
@@ -53,6 +56,16 @@ CATEGORIES: tuple[str, ...] = (
     "ShareholderReturn",
 )
 
+
+def _category_key(value: str) -> str:
+    """Collapse a category label to a casing/spacing-insensitive lookup key."""
+    return "".join(str(value).split()).lower()
+
+
+# Reverse index derived from CATEGORIES so the normalizer and the declared
+# category set cannot drift apart.
+_CANONICAL_BY_KEY: dict[str, str] = {_category_key(c): c for c in CATEGORIES}
+
 DEFAULT_HF_REPO = os.getenv("FINDER_HF_REPO", "Linq-AI-Research/FinDER")
 DEFAULT_HF_SUBSET = os.getenv("FINDER_HF_SUBSET", "")  # no subset
 DEFAULT_HF_SPLIT = os.getenv("FINDER_HF_SPLIT", "train")
@@ -64,9 +77,25 @@ def _cache_dir() -> Path:
 
 
 def _normalize_category(raw: Optional[str]) -> str:
+    """Normalize a raw FinDER category to its declared :data:`CATEGORIES` form.
+
+    Stripping whitespace without folding case meant the multi-word categories
+    never matched: FinDER ships "Company overview", CATEGORIES declares
+    "CompanyOverview", and the old normalizer produced "Companyoverview". A
+    filter on either multi-word category silently returned zero rows -- a wrong
+    answer that looks like an empty slice rather than an error.
+
+    Resolution is casing- and spacing-insensitive through _CANONICAL_BY_KEY,
+    which is derived from CATEGORIES so the two cannot drift. An unknown label
+    falls back to a title-cased form rather than failing, so a category FinDER
+    adds later still loads.
+    """
     if raw is None:
         return ""
-    return "".join(str(raw).split())
+    canonical = _CANONICAL_BY_KEY.get(_category_key(raw))
+    if canonical is not None:
+        return canonical
+    return "".join(word[:1].upper() + word[1:] for word in str(raw).split())
 
 
 def _coerce_bool(value) -> bool:

--- a/src/seocho/tracing.py
+++ b/src/seocho/tracing.py
@@ -854,19 +854,66 @@ def log_extraction(
     validation_errors: int,
     elapsed_seconds: float,
     metadata: Optional[Dict[str, Any]] = None,
+    system_prompt: Optional[str] = None,
+    user_prompt: Optional[str] = None,
+    completion: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    stage: str = "extraction",
 ) -> None:
-    """Log an extraction event."""
+    """Log an extraction event.
+
+    The span carried counts and a bare model name, so it could show that an
+    extraction happened but not what was asked or which tenant asked it. With
+    the prompt body and the semantic context (stage, ontology, workspace,
+    provider-qualified model) one span is enough to audit an extraction, and
+    traces can be filtered per tenant.
+
+    Prompt and completion bodies go through :func:`capture_text`, so they appear
+    only when content capture is enabled and are omitted entirely otherwise --
+    the same opt-in policy every other content field obeys. Passing them here
+    does not decide that they are recorded.
+    """
+    model_tag = f"{provider}/{model}" if provider else model
+    input_data: Dict[str, Any] = {
+        "text_preview": text_preview[:200],
+        "ontology": ontology_name,
+        "model": model_tag,
+    }
+    captured_system = capture_text(system_prompt)
+    if captured_system is not None:
+        input_data["system_prompt"] = captured_system
+    captured_user = capture_text(user_prompt)
+    if captured_user is not None:
+        input_data["user_prompt"] = captured_user
+
+    output_data: Dict[str, Any] = {
+        "nodes": nodes_count,
+        "relationships": relationships_count,
+        "score": round(score, 3),
+        "validation_errors": validation_errors,
+    }
+    captured_completion = capture_text(completion)
+    if captured_completion is not None:
+        output_data["completion"] = captured_completion
+
+    tags = [
+        "extraction", f"stage:{stage}",
+        f"model:{model_tag}", f"ontology:{ontology_name}",
+    ]
+    if workspace_id:
+        tags.append(f"workspace:{workspace_id}")
+
     log_span(
         "sdk.extraction",
-        input_data={"text_preview": text_preview[:200], "ontology": ontology_name, "model": model},
-        output_data={
-            "nodes": nodes_count,
-            "relationships": relationships_count,
-            "score": round(score, 3),
-            "validation_errors": validation_errors,
+        input_data=input_data,
+        output_data=output_data,
+        metadata={
+            "elapsed_seconds": round(elapsed_seconds, 2),
+            "workspace_id": workspace_id,
+            **(metadata or {}),
         },
-        metadata={"elapsed_seconds": round(elapsed_seconds, 2), **(metadata or {})},
-        tags=["extraction", f"model:{model}"],
+        tags=tags,
     )
 
 
@@ -881,8 +928,35 @@ def log_query(
     reasoning_attempts: int = 0,
     elapsed_seconds: float = 0.0,
     metadata: Optional[Dict[str, Any]] = None,
+    answer: Optional[str] = None,
+    workspace_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    stage: str = "query",
 ) -> None:
-    """Log a query event."""
+    """Log a query event.
+
+    Carries the provider-qualified model, stage / ontology / workspace tags and,
+    when content capture is on, the synthesized ``answer``. Without the
+    workspace tag a trace could not be filtered per tenant, which is what makes
+    a shared deployment auditable.
+    """
+    model_tag = f"{provider}/{model}" if provider else model
+    output_data: Dict[str, Any] = {
+        "cypher_preview": cypher[:200],
+        "result_count": result_count,
+        "reasoning_attempts": reasoning_attempts,
+    }
+    captured_answer = capture_text(answer)
+    if captured_answer is not None:
+        output_data["answer"] = captured_answer
+
+    tags = [
+        "query", f"stage:{stage}",
+        f"model:{model_tag}", f"ontology:{ontology_name}",
+    ]
+    if workspace_id:
+        tags.append(f"workspace:{workspace_id}")
+
     log_span(
         "sdk.query",
         input_data={
@@ -890,17 +964,14 @@ def log_query(
             "ontology": ontology_name,
             **({"ontology_package": ontology_package} if ontology_package else {}),
         },
-        output_data={
-            "cypher_preview": cypher[:200],
-            "result_count": result_count,
-            "reasoning_attempts": reasoning_attempts,
-        },
+        output_data=output_data,
         metadata={
-            "model": model,
+            "model": model_tag,
             "elapsed_seconds": round(elapsed_seconds, 2),
+            "workspace_id": workspace_id,
             **(metadata or {}),
         },
-        tags=["query", f"model:{model}"],
+        tags=tags,
     )
 
 

--- a/tests/seocho/test_trace_span_context.py
+++ b/tests/seocho/test_trace_span_context.py
@@ -1,0 +1,104 @@
+"""Extraction and query spans must carry enough context to audit, and no more.
+
+The spans recorded counts and a bare model name. That is enough to show an
+extraction happened and nothing about what was asked, which ontology governed
+it, or which tenant it belonged to — so a shared deployment could not filter its
+own traces, and a bad extraction could not be traced back to the prompt that
+produced it.
+
+The second half matters as much as the first. Prompt and completion bodies are
+content, and this package already has an opt-in policy for content: `capture_text`
+returns None when capture is disabled and callers omit the field entirely. The
+original fix predated that policy and would have written prompt bodies
+unconditionally. Passing a prompt to `log_extraction` must not by itself decide
+that it is recorded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho import tracing
+
+
+class _Recorder(tracing.TracingBackend):
+    """Captures spans instead of shipping them."""
+
+    def __init__(self):
+        self.spans = []
+
+    def log_span(self, name, *, input_data=None, output_data=None,
+                 metadata=None, tags=None, **kwargs):
+        self.spans.append({
+            "name": name, "input": input_data or {}, "output": output_data or {},
+            "metadata": metadata or {}, "tags": list(tags or []),
+        })
+
+    def flush(self):
+        pass
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """log_span fans out to tracing._BACKENDS, so that list is the real seam."""
+    rec = _Recorder()
+    monkeypatch.setattr(tracing, "_BACKENDS", [rec])
+    return rec
+
+
+def _extract(**kwargs):
+    tracing.log_extraction(
+        text_preview="some source text", ontology_name="enterprise",
+        model="MiniMax-M2.5", nodes_count=4, relationships_count=2,
+        score=0.9, validation_errors=0, elapsed_seconds=1.5, **kwargs,
+    )
+
+
+def test_span_carries_workspace_and_ontology_tags(recorder, monkeypatch):
+    monkeypatch.setattr(tracing, "content_capture_enabled", lambda: False)
+    _extract(workspace_id="tenant-a", provider="mara")
+
+    assert recorder.spans, "log_extraction emitted no span"
+    span = recorder.spans[-1]
+    assert "workspace:tenant-a" in span["tags"]
+    assert "ontology:enterprise" in span["tags"]
+    assert "model:mara/MiniMax-M2.5" in span["tags"], "provider must qualify the model"
+
+
+def test_prompt_body_is_omitted_when_capture_is_off(monkeypatch, recorder):
+    """Passing a prompt must not be what decides it gets recorded."""
+    monkeypatch.setattr(tracing, "content_capture_enabled", lambda: False)
+    _extract(system_prompt="SECRET SYSTEM PROMPT",
+             user_prompt="a customer's private document",
+             completion="the model's answer")
+
+    assert recorder.spans, "log_extraction emitted no span"
+    span = recorder.spans[-1]
+    assert "system_prompt" not in span["input"]
+    assert "user_prompt" not in span["input"]
+    assert "completion" not in span["output"]
+
+
+def test_prompt_body_is_recorded_when_capture_is_on(monkeypatch, recorder):
+    monkeypatch.setattr(tracing, "content_capture_enabled", lambda: True)
+    _extract(system_prompt="SYS", user_prompt="USR", completion="OUT")
+
+    assert recorder.spans, "log_extraction emitted no span"
+    span = recorder.spans[-1]
+    assert span["input"]["system_prompt"] == "SYS"
+    assert span["input"]["user_prompt"] == "USR"
+    assert span["output"]["completion"] == "OUT"
+
+
+def test_capture_text_governs_the_new_fields():
+    """Direct check that does not depend on backend routing."""
+    import os
+
+    prompt = "x" * 5000
+    captured = tracing.capture_text(prompt)
+    if captured is None:
+        assert not tracing.content_capture_enabled()
+    else:
+        assert len(captured) < len(prompt), "long content must be truncated"
+        assert "chars]" in captured
+    assert tracing.capture_text(None) is None


### PR DESCRIPTION
Re-applies two fixes verified **still present on `main`**. Both predate the `seocho/` → `src/seocho/` restructuring, so they were ported by hand rather than rebased.

Supersedes #105, #113.

## #105 — two categories could never match

`_normalize_category` stripped whitespace without folding case. FinDER ships `"Company overview"`; `CATEGORIES` declares `"CompanyOverview"`; the normalizer produced `"Companyoverview"`. Filtering on either multi-word category **silently returned zero rows** — a wrong answer that reads as an empty slice rather than an error.

Resolution now goes through a reverse index derived *from* `CATEGORIES`, so the normalizer and the declared set cannot drift apart. An unknown label still title-cases through, so a category FinDER adds later keeps loading.

```
'Company overview'  -> 'CompanyOverview'    in CATEGORIES: True
'COMPANY OVERVIEW'  -> 'CompanyOverview'    in CATEGORIES: True
'CompanyOverview'   -> 'CompanyOverview'    in CATEGORIES: True
'Shareholder return'-> 'ShareholderReturn'  in CATEGORIES: True
```

## #113 — spans could not be audited or filtered by tenant

`log_extraction` and `log_query` recorded counts and a bare model name: enough to show an extraction happened, nothing about what was asked, which ontology governed it, or whose data it was. Spans now carry `stage`, `ontology`, provider-qualified `model` and `workspace` tags, plus optionally the prompt body and completion.

### One deliberate deviation from the original PR

#113 predates `capture_text()` and would have written prompt bodies **unconditionally**. This package has an opt-in content policy — `capture_text` returns `None` when capture is disabled and callers omit the field entirely — and prompts and completions are content.

They now go through that policy, so passing a prompt to `log_extraction` is not by itself what decides it gets recorded. Both directions are tested: capture off → `system_prompt`/`user_prompt`/`completion` absent from the span; capture on → present.

## ⚠️ #160 should be closed, not merged

I reported earlier that #160 was the cleanest merge — byte-identical base, zero conflict. That was measured against an older `main`. Its target, `examples/finder/04_private_opik.ipynb`, was **deleted by the Opik removal** (#518, ADR-0166). There is nothing left to patch.

## Validation

```
pytest test_trace_span_context                     -> 4 passed
pytest test_tracing test_tracing_otel test_observability
       test_observability_contract test_llm_observability
       test_tracing_native_trace_id                -> 30 passed, 1 skipped
pytest test_finder_benchmark_script test_finder_eval_helpers
       test_finder_judge test_finder_synergy       -> 33 passed
git diff --check                                   -> clean
```

New test registered in `scripts/ci/run_basic_ci.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)