### PR TITLE
fix(observability): turn tracing on, wire the call sites, fix histogram buckets

### DIFF
--- a/runtime/agent_server.py
+++ b/runtime/agent_server.py
@@ -271,6 +271,28 @@ async def _startup():
             "Metrics backend initialisation failed; instruments stay no-op.",
             exc_info=True,
         )
+    # Tracing was plumbed end-to-end and never switched on. SEOCHO_TRACE_BACKEND
+    # is documented in .env.example and passed by docker-compose, and nothing in
+    # the server read it, so `_BACKENDS` stayed empty and every rag.* span
+    # resolved to _NullSpan. The span tree existed, its tests passed, and no
+    # production request ever produced one — which makes stage attribution
+    # impossible however good the tree is.
+    #
+    # Same contract as metrics: SEOCHO_TRACE_BACKEND=none (the default) disables
+    # tracing, so boot never depends on a collector.
+    try:
+        from seocho.tracing import configure_tracing_from_env
+
+        if configure_tracing_from_env():
+            logger.info(
+                "Tracing enabled: backend=%s",
+                os.getenv("SEOCHO_TRACE_BACKEND", "none"),
+            )
+    except Exception:
+        logger.warning(
+            "Tracing initialisation failed; spans stay no-op.",
+            exc_info=True,
+        )
     # Phase 1.5: populate the runtime ontology registry from
     # SEOCHO_RUNTIME_ONTOLOGIES if set. Empty/missing manifest leaves the
     # registry empty so Phases 1/2/3 stay inert (their backward-compatible

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -95,6 +95,8 @@ uv run pytest \
   tests/seocho/test_debate_quorum.py \
   tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
+  tests/seocho/test_observability_wiring.py \
+  tests/seocho/test_histogram_buckets.py \
   tests/seocho/test_trace_span_context.py \
   tests/seocho/test_observability_contract.py \
   tests/seocho/test_golden_signal_emitters.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -1134,6 +1134,14 @@ class IndexingPipeline:
                     validation_errors=len(result.validation_errors),
                     elapsed_seconds=_pipeline_elapsed,
                     metadata=_meta,
+                    # Without these the span shows that an extraction happened
+                    # and nothing about which tenant it belonged to or which
+                    # stage produced it, so a shared deployment cannot filter
+                    # its own traces. The capability was added and never
+                    # passed; the arguments are the whole point of it.
+                    workspace_id=self.workspace_id,
+                    provider=getattr(self.llm, "provider", None),
+                    stage="indexing",
                 )
                 get_metrics().add(
                     "seocho.index.validation_errors.count",

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -1056,6 +1056,9 @@ class _LocalEngine:
                     reasoning_attempts=reasoning_attempts,
                     elapsed_seconds=elapsed_seconds,
                     metadata=self._last_query_metadata,
+                    workspace_id=self.workspace_id,
+                    provider=getattr(self.llm, "provider", None),
+                    stage="query",
                 )
         except Exception:
             pass

--- a/src/seocho/metrics.py
+++ b/src/seocho/metrics.py
@@ -72,6 +72,20 @@ _LATENCY_MILLISECONDS_BUCKETS = (
     2500.0,
     5000.0,
 )
+# Ratios and shares live in [0, 1] — except plan.speedup, which is a factor and
+# runs past it. Default OTel boundaries start at 5, so every one of these landed
+# in the first bucket and their percentiles were unreadable.
+_RATIO_BUCKETS = (
+    0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+    0.95, 0.99, 1.0, 2.0, 5.0, 10.0,
+)
+# Token counts (prompt, completion, context) span three orders of magnitude.
+_TOKEN_COUNT_BUCKETS = (
+    16.0, 64.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0,
+    8192.0, 16384.0, 32768.0, 131072.0,
+)
+# Small cardinal counts: retrieval candidates, attempts, batch entries.
+_ITEM_COUNT_BUCKETS = (1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 50.0, 100.0, 500.0)
 
 
 @dataclass(frozen=True, slots=True)
@@ -271,8 +285,84 @@ _metrics = ProductionMetrics()
 _provider: Any | None = None
 
 
-def enable_metrics(*, backend: str | None = None, endpoint: str | None = None) -> ProductionMetrics:
-    """Enable the process-wide production metrics registry."""
+def build_histogram_views() -> tuple:
+    """Bucket boundaries per instrument unit.
+
+    Extracted from enable_metrics so the boundaries can be asserted
+    without standing up an exporter -- they were wrong for 18 of 30
+    histograms and nothing could see it.
+    """
+    from opentelemetry.sdk.metrics.view import (
+        ExplicitBucketHistogramAggregation,
+        View,
+    )
+
+    # Matched on UNIT, not on a name suffix. The name-suffix form covered
+    # 12 of 30 histograms: `seocho.gen_ai.time_to_first_token` is in
+    # seconds and does not end in `.duration`, and
+    # `seocho.memory.commit.phase.duration` does end in `.duration` but is
+    # in milliseconds, so neither matched. Both fell back to OTel's default
+    # boundaries, which run 0..10000 and are shaped for milliseconds — a
+    # 0.8 s TTFT lands in the (0, 5] bucket and p95 reads ~5 s regardless of
+    # reality. Ratios in [0, 1] collapsed into the first bucket entirely.
+    #
+    # Unit is the property that actually determines the right boundaries,
+    # so a new instrument gets sensible buckets by declaring its unit
+    # rather than by being named a particular way.
+    views = (
+        View(
+            instrument_unit="s",
+            instrument_name="*",
+            aggregation=ExplicitBucketHistogramAggregation(
+                _DURATION_SECONDS_BUCKETS
+            ),
+        ),
+        View(
+            instrument_unit="ms",
+            instrument_name="*",
+            aggregation=ExplicitBucketHistogramAggregation(
+                _LATENCY_MILLISECONDS_BUCKETS
+            ),
+        ),
+        View(
+            instrument_unit="1",
+            instrument_name="*",
+            aggregation=ExplicitBucketHistogramAggregation(_RATIO_BUCKETS),
+        ),
+        View(
+            instrument_unit="{token}",
+            instrument_name="*",
+            aggregation=ExplicitBucketHistogramAggregation(
+                _TOKEN_COUNT_BUCKETS
+            ),
+        ),
+    ) + tuple(
+        View(
+            instrument_unit=unit,
+            instrument_name="*",
+            aggregation=ExplicitBucketHistogramAggregation(
+                _ITEM_COUNT_BUCKETS
+            ),
+        )
+        for unit in ("{item}", "{attempt}", "{entry}")
+    )
+    return views
+
+
+def enable_metrics(
+    *,
+    backend: str | None = None,
+    endpoint: str | None = None,
+    reader: Any = None,
+) -> ProductionMetrics:
+    """Enable the process-wide production metrics registry.
+
+    ``reader`` substitutes the exporting reader, so a test can pass an
+    ``InMemoryMetricReader`` and assert what was actually emitted. Without it
+    the only way to check a metric was to grep for its name in the source --
+    which is how a module full of instruments that nothing ever calls passed
+    the observability contract test.
+    """
 
     global _metrics, _provider
     selected = (backend or os.getenv(METRICS_BACKEND_ENV, "none")).strip().lower()
@@ -285,42 +375,33 @@ def enable_metrics(*, backend: str | None = None, endpoint: str | None = None) -
             return _metrics
         if selected != "otlp":
             raise ValueError("metrics backend must be 'none' or 'otlp'")
-        target = (endpoint or os.getenv(METRICS_OTLP_ENDPOINT_ENV, "")).strip()
-        if not target:
-            raise ValueError("OTLP metrics endpoint is required")
         try:
-            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
             from opentelemetry.sdk.metrics import MeterProvider
-            from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-            from opentelemetry.sdk.metrics.view import (
-                ExplicitBucketHistogramAggregation,
-                View,
-            )
             from opentelemetry.sdk.resources import Resource
         except ImportError as exc:
             raise ImportError("OTLP metrics require the seocho[otel] extra") from exc
-        exporter = OTLPMetricExporter(endpoint=target, insecure=target.startswith("http://"))
-        reader = PeriodicExportingMetricReader(exporter, export_interval_millis=5000)
+        if reader is None:
+            target = (endpoint or os.getenv(METRICS_OTLP_ENDPOINT_ENV, "")).strip()
+            if not target:
+                raise ValueError("OTLP metrics endpoint is required")
+            try:
+                from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                    OTLPMetricExporter,
+                )
+                from opentelemetry.sdk.metrics.export import (
+                    PeriodicExportingMetricReader,
+                )
+            except ImportError as exc:
+                raise ImportError("OTLP metrics require the seocho[otel] extra") from exc
+            exporter = OTLPMetricExporter(
+                endpoint=target, insecure=target.startswith("http://")
+            )
+            reader = PeriodicExportingMetricReader(exporter, export_interval_millis=5000)
         resource_attributes = {"service.name": os.getenv("OTEL_SERVICE_NAME", "seocho")}
         if instance_id := os.getenv("OTEL_SERVICE_INSTANCE_ID"):
             resource_attributes["service.instance.id"] = instance_id
         resource = Resource.create(resource_attributes)
-        views = (
-            View(
-                instrument_name="*.duration",
-                instrument_unit="s",
-                aggregation=ExplicitBucketHistogramAggregation(
-                    _DURATION_SECONDS_BUCKETS
-                ),
-            ),
-            View(
-                instrument_name="*.latency",
-                instrument_unit="ms",
-                aggregation=ExplicitBucketHistogramAggregation(
-                    _LATENCY_MILLISECONDS_BUCKETS
-                ),
-            ),
-        )
+        views = build_histogram_views()
         _provider = MeterProvider(
             resource=resource,
             metric_readers=(reader,),

--- a/src/seocho/tracing.py
+++ b/src/seocho/tracing.py
@@ -599,14 +599,41 @@ def log_span(
     metadata: Optional[Dict[str, Any]] = None,
     tags: Optional[List[str]] = None,
 ) -> None:
-    """Log a span to ALL active backends."""
+    """Log a point-in-time span to ALL active backends.
+
+    Unlike :func:`start_span` this does not time anything — the caller already
+    finished the work and knows how long it took. What it must still do is
+    attach to the enclosing trace, and it did not: `sdk.extraction` and
+    `sdk.query` were emitted with no `trace_id` and no `parent_span_id`, so
+    they landed as orphan records beside the `rag.*` tree instead of inside it.
+
+    Stage attribution is exactly the ability to ask "which part of *this*
+    request was slow or wrong", and an orphan span cannot answer it however
+    complete its own attributes are. So the current trace context is stamped on
+    here, and `elapsed_seconds` in the caller's metadata is promoted to
+    `duration_ms` so the record is placeable on a waterfall.
+    """
+    enriched = dict(metadata or {})
+
+    stack = _span_stack.get()
+    if stack:
+        enriched.setdefault("trace_id", stack[0])
+        if len(stack) > 1:
+            enriched.setdefault("parent_span_id", stack[-1])
+    enriched.setdefault("span_id", uuid.uuid4().hex[:16])
+
+    # Callers of log_extraction/log_query already measured the work.
+    elapsed = enriched.get("elapsed_seconds")
+    if "duration_ms" not in enriched and isinstance(elapsed, (int, float)):
+        enriched["duration_ms"] = round(float(elapsed) * 1000, 2)
+
     for b in _BACKENDS:
         try:
             b.log_span(
                 name,
                 input_data=input_data,
                 output_data=output_data,
-                metadata=metadata,
+                metadata=enriched,
                 tags=tags,
             )
         except Exception:

--- a/tests/seocho/test_histogram_buckets.py
+++ b/tests/seocho/test_histogram_buckets.py
@@ -1,0 +1,120 @@
+"""Every histogram needs boundaries shaped for its unit.
+
+The bucket views matched on a NAME SUFFIX: `*.duration` with unit `s`, and
+`*.latency` with unit `ms`. That covered 12 of 30 histograms. The other 18 fell
+back to OTel's default boundaries, which run 0..10000 and are shaped for
+milliseconds.
+
+Two instruments show why the suffix rule was the wrong axis:
+
+  seocho.gen_ai.time_to_first_token       unit s,  no `.duration` suffix
+  seocho.memory.commit.phase.duration     `.duration` suffix, unit ms
+
+Neither matched. TTFT is the only prefill signal a hosted API exposes, and with
+default boundaries a 0.8 s observation lands in the (0, 5] bucket, so p95 reads
+about 5 s no matter what the service does. Ratio histograms in [0, 1] collapsed
+into the first bucket entirely, making `server_share` and `provenance.coverage`
+unreadable.
+
+Unit is what determines the right boundaries, so views match on unit and a new
+instrument gets sensible buckets by declaring one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.metrics import METRIC_SPECS, build_histogram_views, enable_metrics
+
+pytest.importorskip("opentelemetry.sdk.metrics")
+
+
+def _view_units() -> set:
+    return {view._instrument_unit for view in build_histogram_views()}
+
+
+def test_every_declared_histogram_unit_has_a_view():
+    histograms = [s for s in METRIC_SPECS.values() if s.kind == "histogram"]
+    assert histograms, "metric catalog declares no histograms"
+
+    uncovered = sorted(
+        {s.unit for s in histograms} - _view_units()
+    )
+    assert not uncovered, (
+        f"histograms with units {uncovered} fall back to OTel's default "
+        f"millisecond-shaped boundaries"
+    )
+
+
+@pytest.mark.parametrize("unit", ["s", "ms", "1", "{token}", "{item}"])
+def test_expected_units_are_covered(unit):
+    assert unit in _view_units()
+
+
+def _bucket_for(reader, metric_name: str, value: float):
+    """Return the (low, high] bucket a value landed in."""
+    data = reader.get_metrics_data()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != metric_name:
+                    continue
+                point = list(metric.data.data_points)[0]
+                bounds = list(point.explicit_bounds)
+                index = next(
+                    i for i, count in enumerate(point.bucket_counts) if count
+                )
+                low = bounds[index - 1] if index else 0.0
+                high = bounds[index] if index < len(bounds) else float("inf")
+                return low, high
+    raise AssertionError(f"{metric_name} was not exported")
+
+
+@pytest.fixture
+def reader():
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    return InMemoryMetricReader()
+
+
+def test_time_to_first_token_lands_in_a_sub_second_bucket(reader):
+    """The regression that made the only prefill signal unreadable."""
+    metrics = enable_metrics(backend="otlp", reader=reader)
+    metrics.record(
+        "seocho.gen_ai.time_to_first_token", 0.8,
+        {"gen_ai.provider.name": "mara", "gen_ai.request.model": "MiniMax-M2.5"},
+    )
+
+    low, high = _bucket_for(reader, "seocho.gen_ai.time_to_first_token", 0.8)
+    assert high <= 1.0, (
+        f"0.8s landed in ({low}, {high}] — with default boundaries this is "
+        f"(0, 5] and p95 reads ~5s regardless of reality"
+    )
+
+
+def test_ratio_histogram_resolves_within_the_unit_interval(reader):
+    """A share in [0, 1] must not collapse into one bucket."""
+    metrics = enable_metrics(backend="otlp", reader=reader)
+    metrics.record(
+        "db.client.operation.server_share", 0.35,
+        {"db.system": "neo4j", "operation": "query"},
+    )
+
+    low, high = _bucket_for(reader, "db.client.operation.server_share", 0.35)
+    assert low >= 0.3 and high <= 0.5, (
+        f"0.35 landed in ({low}, {high}] — ratios need sub-unit boundaries"
+    )
+
+
+def test_millisecond_duration_is_not_treated_as_seconds(reader):
+    """`*.duration` in ms matched no view under the old name-suffix rule."""
+    metrics = enable_metrics(backend="otlp", reader=reader)
+    metrics.record(
+        "seocho.memory.commit.phase.duration", 12.0,
+        {"phase": "write", "outcome": "ok"},
+    )
+
+    low, high = _bucket_for(reader, "seocho.memory.commit.phase.duration", 12.0)
+    assert 10.0 <= low and high <= 25.0, (
+        f"12ms landed in ({low}, {high}]; expected the millisecond boundaries"
+    )

--- a/tests/seocho/test_observability_wiring.py
+++ b/tests/seocho/test_observability_wiring.py
@@ -1,0 +1,190 @@
+"""Instruments must actually fire, not merely exist.
+
+Three separate failures made the whole observability stack inert in the
+deployed runtime, and every one of them passed the existing contract test:
+
+1. `configure_tracing_from_env()` had no caller in `runtime/`, so `_BACKENDS`
+   stayed empty and every `rag.*` span resolved to `_NullSpan`. The span tree
+   was correct and never emitted.
+2. `log_extraction`/`log_query` grew `workspace_id`, `provider` and `stage`
+   parameters that no call site passed, so no span ever carried them.
+3. `log_span` ignored the enclosing trace context, so `sdk.extraction` and
+   `sdk.query` landed as orphans beside the `rag.*` tree instead of inside it.
+
+The contract test could not see any of it because it defines "emitted" as *the
+metric name appears as a string literal somewhere under src/*. A module full of
+instruments that nothing ever calls satisfies that. So these tests assert on
+what a backend actually received.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from seocho import tracing
+
+
+class _Recorder(tracing.TracingBackend):
+    def __init__(self):
+        self.spans = []
+
+    def log_span(self, name, *, input_data=None, output_data=None,
+                 metadata=None, tags=None, **kwargs):
+        self.spans.append({
+            "name": name, "input": input_data or {}, "output": output_data or {},
+            "metadata": metadata or {}, "tags": list(tags or []),
+        })
+
+    def flush(self):
+        pass
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """log_span fans out to tracing._BACKENDS, so that list is the real seam."""
+    rec = _Recorder()
+    monkeypatch.setattr(tracing, "_BACKENDS", [rec])
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# 1. The server turns tracing on
+# ---------------------------------------------------------------------------
+
+def test_configure_tracing_from_env_is_called_at_server_startup():
+    """The bootstrap that was missing. Asserted on source because importing
+    runtime.agent_server pulls in the whole FastAPI app and its dependencies."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    source = (root / "runtime" / "agent_server.py").read_text()
+    startup = source[source.index("async def _startup():"):]
+    startup = startup[:startup.index("\n# ---")] if "\n# ---" in startup else startup
+
+    assert "configure_tracing_from_env" in startup, (
+        "the server never enables tracing, so every rag.* span is a no-op and "
+        "stage attribution is impossible however good the span tree is"
+    )
+
+
+def test_tracing_backend_env_actually_installs_a_backend(monkeypatch, tmp_path):
+    monkeypatch.setenv("SEOCHO_TRACE_BACKEND", "jsonl")
+    monkeypatch.setenv("SEOCHO_TRACE_JSONL_PATH", str(tmp_path / "t.jsonl"))
+    monkeypatch.setattr(tracing, "_BACKENDS", [])
+
+    assert tracing.configure_tracing_from_env() is True
+    assert tracing._BACKENDS, "SEOCHO_TRACE_BACKEND=jsonl installed no backend"
+
+    tracing.disable_tracing()
+
+
+def test_backend_none_stays_off(monkeypatch):
+    """Boot must never depend on a collector — the default is off."""
+    monkeypatch.setenv("SEOCHO_TRACE_BACKEND", "none")
+    monkeypatch.setattr(tracing, "_BACKENDS", [])
+    assert tracing.configure_tracing_from_env() is False
+    assert not tracing._BACKENDS
+
+
+# ---------------------------------------------------------------------------
+# 2. The call sites pass the arguments
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("module,call,expected", [
+    ("src/seocho/index/pipeline.py", "log_extraction(", ("workspace_id=", "provider=", "stage=")),
+    ("src/seocho/local_engine.py", "log_query(", ("workspace_id=", "provider=", "stage=")),
+])
+def test_call_sites_pass_the_context_arguments(module, call, expected):
+    """A parameter nothing passes is a parameter that does nothing."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    source = (root / module).read_text()
+    start = source.index(call)
+
+    # Take the whole call by balancing parentheses — slicing at the first ")"
+    # stops inside the argument list and reads as a missing argument.
+    depth, end = 0, start
+    for i in range(start, len(source)):
+        if source[i] == "(":
+            depth += 1
+        elif source[i] == ")":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    block = source[start:end]
+
+    missing = [arg for arg in expected if arg not in block]
+    assert not missing, f"{module} calls {call} without {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Stage spans join the request's trace
+# ---------------------------------------------------------------------------
+
+def test_stage_span_nests_under_the_enclosing_request_span(recorder):
+    """`sdk.extraction` must be a child of `rag.ask`, not an orphan.
+
+    Stage attribution is the ability to ask "which part of THIS request was
+    slow or wrong". An orphan span cannot answer that however complete its own
+    attributes are.
+    """
+    with tracing.start_span("rag.ask"):
+        time.sleep(0.005)
+        tracing.log_extraction(
+            text_preview="source text", ontology_name="ent", model="MiniMax-M2.5",
+            nodes_count=3, relationships_count=1, score=0.9,
+            validation_errors=0, elapsed_seconds=1.25,
+            workspace_id="tenant-a", provider="mara", stage="indexing",
+        )
+
+    by_name = {s["name"]: s["metadata"] for s in recorder.spans}
+    assert "rag.ask" in by_name and "sdk.extraction" in by_name
+
+    ask, extraction = by_name["rag.ask"], by_name["sdk.extraction"]
+    assert extraction["trace_id"] == ask["trace_id"], "stage span is in another trace"
+    assert extraction["parent_span_id"] == ask["span_id"], (
+        "stage span is an orphan; it will not appear inside the request on a "
+        "waterfall, so no per-request breakdown is possible"
+    )
+
+
+def test_stage_span_carries_a_duration(recorder):
+    """A zero-duration record cannot be placed on a waterfall."""
+    tracing.log_extraction(
+        text_preview="x", ontology_name="ent", model="m",
+        nodes_count=1, relationships_count=0, score=1.0,
+        validation_errors=0, elapsed_seconds=2.5,
+    )
+    assert recorder.spans[-1]["metadata"]["duration_ms"] == 2500.0
+
+
+def test_request_span_tree_has_real_timings(recorder):
+    """start_span was already correct — pin it so a refactor cannot flatten it."""
+    with tracing.start_span("rag.ask"):
+        time.sleep(0.01)
+        with tracing.start_span("rag.retrieve"):
+            time.sleep(0.02)
+
+    by_name = {s["name"]: s["metadata"] for s in recorder.spans}
+    outer, inner = by_name["rag.ask"], by_name["rag.retrieve"]
+
+    assert inner["parent_span_id"] == outer["span_id"]
+    assert inner["duration_ms"] >= 15, "child span lost its timing"
+    assert outer["duration_ms"] >= inner["duration_ms"], "parent shorter than child"
+
+
+def test_stage_and_workspace_reach_the_span(recorder):
+    tracing.log_extraction(
+        text_preview="x", ontology_name="enterprise", model="MiniMax-M2.5",
+        nodes_count=1, relationships_count=0, score=1.0, validation_errors=0,
+        elapsed_seconds=0.1, workspace_id="tenant-a", provider="mara",
+        stage="indexing",
+    )
+    span = recorder.spans[-1]
+    assert "workspace:tenant-a" in span["tags"]
+    assert "stage:indexing" in span["tags"]
+    assert "model:mara/MiniMax-M2.5" in span["tags"]


### PR DESCRIPTION
Multi-agent review found the instrumentation was **designed well and connected to nothing**. Verified by counting callers, not by reading docs.

This is the prerequisite for the Graph-agentic-RAG breakdown: none of it is measurable until these land.

## The server never enabled tracing

`configure_tracing_from_env()` had **no caller** in `runtime/`. `_BACKENDS` stayed empty, so every `rag.*` span resolved to `_NullSpan`. `SEOCHO_TRACE_BACKEND` is documented in `.env.example` and passed by compose — and nothing read it.

The span tree is correct. Its tests pass. **No production request ever produced one.** The Tempo panel is permanently empty for real traffic, and stage attribution is impossible however good the tree is.

Now called at startup with the same contract as `enable_metrics`: `backend=none` (the default) stays off, so boot never depends on a collector.

## The call sites passed none of the new arguments

`log_extraction`/`log_query` gained `workspace_id` / `provider` / `stage` in #555 and **neither caller supplied them** — so no span carried a tenant or a stage. The tests passed because they called the functions directly. Both call sites now pass what they already hold.

## Stage spans were orphans

`log_span` ignored the enclosing trace context, so `sdk.extraction` and `sdk.query` were emitted with no `trace_id` and no `parent_span_id` — *beside* the `rag.*` tree rather than inside it. Stage attribution is the ability to ask "which part of **this** request was slow or wrong", and an orphan span cannot answer that.

Measured after:

```
rag.ask        span_id = 9cf7081d327e4cfc
sdk.extraction parent  = 9cf7081d327e4cfc
  same trace  : True
  nested      : True
  duration_ms : 1250.0
```

> **One correction to the review:** `start_span` was already right. Its spans carry `span_id`/`parent_span_id`/`trace_id`/`duration_ms` and nest correctly — verified, and now pinned by a test so a refactor cannot flatten it. Only the point-in-time `log_span` path was broken.

## Histogram buckets covered 12 of 30 instruments

The views matched a **name suffix** (`*.duration` unit `s`, `*.latency` unit `ms`), which is the wrong axis:

| instrument | why it missed |
|---|---|
| `seocho.gen_ai.time_to_first_token` | unit `s`, no `.duration` suffix |
| `seocho.memory.commit.phase.duration` | `.duration` suffix, but unit `ms` |

Both fell back to OTel defaults, which run 0..10000 and are millisecond-shaped. **A 0.8 s TTFT landed in `(0, 5]`, so p95 read ~5 s regardless of reality** — and TTFT is the only prefill signal a hosted API exposes. Ratios in `[0, 1]` collapsed into the first bucket, making `server_share` and `provenance.coverage` unreadable.

Views now match on **unit**, so a new instrument gets sensible buckets by declaring one. All 30 histograms covered. Measured after: `0.8s → (0.5, 1.0]`, `0.35 → (0.3, 0.4]`, `12ms → (10, 25]`.

`enable_metrics` accepts a `reader` so an `InMemoryMetricReader` can assert what was actually exported. Without it the only way to check a metric was to grep for its name — which is how modules full of never-called instruments passed the observability contract test.

## Validation

```
pytest test_observability_wiring test_histogram_buckets  -> 18 passed
pytest 13 observability/tracing suites                   -> 55 passed, 1 skipped
bash scripts/ci/run_basic_ci.sh                          -> passed
git diff --check                                         -> clean
```

New tests registered in `scripts/ci/run_basic_ci.sh`.

## Still open from the same review

Tracked, not in this PR: `record_extraction`/`record_off_vocabulary` have no production callers (they live on an unmerged branch); the `off_ontology_label` / `off_vocabulary_value` metric attributes are a cardinality bomb (LLM-controlled values); `_last_route_class` is never assigned so `plan_route.count` is unreachable; there is no `spanmetrics` connector or tail sampling, so trace↔metric drilldown and slow-request retention are still missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)