### PR TITLE
fix(vllm): pass response_format through; the guided translation disabled it (ADR-0192)

### DIFF
--- a/docs/decisions/ADR-0098-vllm-onprem-llm-profile.md
+++ b/docs/decisions/ADR-0098-vllm-onprem-llm-profile.md
@@ -1,7 +1,14 @@
 # ADR-0098: vLLM On-Prem LLM Profile
 
 Date: 2026-05-25
-Status: Proposed
+Status: Proposed (section 3 superseded by ADR-0192)
+
+> **Section 3 (guided-decoding translation) is superseded by ADR-0192.**
+> `guided_json` does not exist in vLLM 0.27; the translation silently
+> dropped the field *and* stripped the `response_format` that vLLM
+> handles natively, turning structured output off on self-hosted
+> deployments. The vLLM provider preset and agent-mode handling below
+> stand unchanged.
 
 ## Context
 

--- a/docs/decisions/ADR-0192-vllm-structured-output-passthrough.md
+++ b/docs/decisions/ADR-0192-vllm-structured-output-passthrough.md
@@ -1,0 +1,123 @@
+# ADR-0192: Pass `response_format` through to vLLM; drop the guided-decoding translation
+
+- Status: Accepted
+- Date: 2026-08-16
+- Supersedes: the guided-decoding translation in `ADR-0098` §3 (the rest of
+  ADR-0098 — the vLLM provider preset, agent-mode tool-call handling — stands)
+- Related: `ADR-0144` (observability), `seocho-fix` (unified cache)
+
+## Context
+
+ADR-0098 §3 specified that in pipeline mode against a vLLM endpoint, an OpenAI
+`response_format` is translated into a guided-decoding `extra_body` payload:
+
+    {"type":"json_object"}                  -> {"guided_json": {"type":"object"}}
+    {"type":"json_schema","json_schema":S}  -> {"guided_json": S}
+    {"type":"regex","pattern":P}            -> {"guided_regex": P}
+    {"type":"choice","options":[...]}       -> {"guided_choice": [...]}
+
+That was correct for the vLLM 0.4-era API. It is not correct for the version we
+deploy, and the failure is silent.
+
+**`guided_json` does not exist in vLLM 0.27.1.** Verified against the installed
+package rather than the docs: `grep -rl guided_json` over the whole distribution
+returns **zero** hits. The API is now `StructuredOutputsParams`, exposed on the
+OpenAI-compatible endpoint as `structured_outputs`.
+
+**The unknown field is accepted and dropped.** `OpenAIBaseModel` is
+`ConfigDict(extra="allow")`, so `guided_json` passes request validation and is
+discarded. The only notice is a `logger.debug` line, invisible at default log
+level.
+
+**And the translation removed the thing that worked.** The call site was an
+`elif`, so when the translation fired, `response_format` was not set on the
+request. vLLM handles `response_format` natively and correctly —
+`structured_outputs_from_response_format` maps `json_object` and `json_schema`
+itself, including the schema unwrap our translator got wrong (it took
+`response_format["json_schema"]`, which is `{"name":..., "schema":...}`: a JSON
+Schema with no `type` and no `properties`, matching any JSON — vLLM unwraps one
+level deeper).
+
+So on the exact deployment we are targeting, **the translation converted working
+structured output into no structured output**.
+
+### The blast radius is wider than one field
+
+Three JSON safety nets gate on `response_format` being present in the request
+kwargs, and all three therefore disabled themselves at the same time:
+
+- `_maybe_boost_json_budget` returns early when `response_format` is absent, so
+  the doubled-token retry for truncated JSON never ran.
+- `_completion_retry_variants` skips the `json_prompt_variant` branch, so the
+  `"Return ONLY valid JSON."` fallback was never appended.
+- The salvage parser (`extract_json_object`) absorbed the resulting prose and
+  counted it as `seocho.gen_ai.structured_output_repair.count`.
+
+The runaway thinking-in-content failure those were written for — measured at
+43k-character responses on MiniMax-M2.7 — was therefore *the default* on
+self-hosted vLLM, with every mitigation off.
+
+### The repair counter was reading as a model problem
+
+With guided decoding actually on, prose before JSON is untokenizable: the
+grammar forbids it. So a non-zero
+`seocho.gen_ai.structured_output_repair.count` from a vLLM-served model is not a
+model-quality signal at all — it is **a serving-configuration alarm**. It has
+been silently absorbing this bug and reporting it as "MiniMax emits
+chain-of-thought."
+
+### Capability was keyed on the wrong thing
+
+`capability_for()` resolved a profile from the **model name**, first-match-wins.
+Its `vllm` entry matches the literal string `vllm`, which is never a served
+model name. A self-hosted `MiniMax-M2.7` matched the `minimax` entry first and
+inherited `supports_guided_json=False`.
+
+So the one deployment where schema enforcement is *exact* — vLLM constrains the
+decoder with a grammar — was the one deployment that could never reach it.
+
+## Decision
+
+**Delete the translation.** Pass `response_format` through unchanged to every
+provider, vLLM included. This is a net deletion and it fixes the dropped field,
+the wrong schema level, and the three disarmed retries at once.
+
+**Make capability a function of `(server, model)`.** `capability_for(model,
+provider)` upgrades `supports_guided_json` when the *server* enforces a schema in
+the decoder, regardless of which model is loaded. `_SCHEMA_ENFORCING_PROVIDERS`
+currently holds `vllm`. A hosted OpenAI-compatible endpoint that merely accepts
+the parameter (MARA) stays conservative and keeps `json_object` plus robust
+parsing.
+
+Measured after:
+
+| model | provider | `supports_guided_json` |
+| --- | --- | --- |
+| MiniMax-M2.7 | *(none)* | False |
+| MiniMax-M2.7 | `vllm` | **True** |
+| MiniMax-M2.7 | `mara` | False |
+| gpt-4o | *(none)* | True |
+
+## Consequences
+
+- Structured output works on self-hosted vLLM. Every extraction and text2cypher
+  quality number measured against a vLLM endpoint before this change was
+  measured with structured output off, and should be re-run.
+- `seocho.gen_ai.structured_output_repair.count` becomes meaningful for vLLM: a
+  non-zero rate now indicates a serving misconfiguration, not model behaviour.
+  It is worth alerting on for that reason.
+- Agent mode is unchanged. ADR-0098's rule that the Agents SDK's tool-call
+  structure supersedes `response_format` still holds, and no `response_format`
+  is injected on that path.
+- One risk to name: a vLLM version that *stops* honouring `response_format` would
+  now fail open rather than being caught by our translation. The mitigation is a
+  live smoke assertion against a running server — post a deliberately
+  schema-violating request and assert a 400 or a constrained response — in the
+  shape of `scripts/serve_track/smoke_plugin.py`. Tracked separately; the unit
+  tests here pin the request shape but cannot see a server-side rename.
+
+## What was NOT changed
+
+ADR-0098's vLLM provider preset (`base_url`, blank `default_model`, optional API
+key), its agent-mode handling, and the `seocho-vllm-probe` stat-logger plugin
+distribution are all unaffected and remain in force.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1169,6 +1169,12 @@ Each entry must link to a full ADR when impact is non-trivial.
   - THIN (labels only) vs DECLARED (schema_for_prompt: rels+directions+cardinality+props+tenant scope), same 8 questions, same MARA model; deterministic conformance via validate_text2cypher_fallback
   - DECISIVE: conformance 0%->100%, hallucination 100%->0%, avg violations 2.62->0 across all 8; labels-only invents rel names/directions/props + omits tenant scope, declared schema eliminates it
   - ontology decisively useful to text2cypher (conformance = necessary condition; answer-quality + profile_gate loop + bolt-rs = remaining ia4.13)
+- [Accepted] ADR-0192 pass response_format through to vLLM; drop the guided-decoding translation
+  - guided_json does not exist in vLLM 0.27.1 (zero hits in the installed package); the field was accepted and dropped by extra="allow"
+  - the translation was an elif, so it stripped response_format -- which vLLM handles natively and correctly. Net: structured output was OFF on self-hosted vLLM
+  - three JSON retries gate on response_format being present and were disabled with it; the repair counter is a serving-config alarm, not a model signal
+  - capability_for now takes (model, provider): a self-hosted MiniMax reaches schema enforcement, MARA-hosted stays conservative
+  - supersedes ADR-0098 section 3 only; the vLLM preset, agent-mode handling and the probe plugin stand
 
 ## Template
 

--- a/src/seocho/llm_structured.py
+++ b/src/seocho/llm_structured.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Dict, Optional, Tuple
 
 
@@ -78,17 +78,48 @@ _REASONING_SUFFIX = (
 )
 
 
-def capability_for(model: Optional[str]) -> ModelCapability:
-    """Resolve a model name to its capability profile (first registry match).
-    Unknown models that *look* like reasoning models (``-r1``, ``think``,
-    ``reason``) get a reasoning profile; otherwise the conservative default."""
+#: Servers that enforce a JSON schema in the decoder itself, so schema support
+#: is a property of the server rather than of the model it happens to serve.
+_SCHEMA_ENFORCING_PROVIDERS = {"vllm"}
+
+
+def capability_for(
+    model: Optional[str], provider: Optional[str] = None
+) -> ModelCapability:
+    """Resolve a capability profile from the model and, when known, the server.
+
+    Capability is a function of *(server, model)*, and keying it on the model
+    alone made the vLLM entry dead code: it matches the literal name ``vllm``,
+    which is never a served model name. A self-hosted ``MiniMax-M2.7`` matched
+    the ``minimax`` entry first and inherited ``supports_guided_json=False``, so
+    the one deployment where schema enforcement is exact — vLLM constrains the
+    decoder with a grammar, and prose-before-JSON is untokenizable — could never
+    reach it.
+
+    ``provider`` upgrades schema support when the *server* enforces it,
+    regardless of which model is loaded. Unknown models that look like reasoning
+    models (``-r1``, ``think``, ``reason``) still get a reasoning profile.
+    """
     name = str(model or "").strip()
+    server = str(provider or "").strip().lower()
+
+    resolved: Optional[ModelCapability] = None
     for pattern, cap in _REGISTRY:
         if pattern.search(name):
-            return cap
-    if re.search(r"think|reason|-r\d|:r\d", name, re.I):
-        return ModelCapability("unknown-reasoner", emits_reasoning=True, supports_json_object=True, max_tokens_floor=4096)
-    return _DEFAULT
+            resolved = cap
+            break
+    if resolved is None:
+        if re.search(r"think|reason|-r\d|:r\d", name, re.I):
+            resolved = ModelCapability(
+                "unknown-reasoner", emits_reasoning=True,
+                supports_json_object=True, max_tokens_floor=4096,
+            )
+        else:
+            resolved = _DEFAULT
+
+    if server in _SCHEMA_ENFORCING_PROVIDERS and not resolved.supports_guided_json:
+        return replace(resolved, supports_guided_json=True)
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +225,12 @@ def structured_complete(
 
     ``schema`` (a JSON Schema) is used for guided decoding only when the model
     supports it; otherwise ``json_object`` + robust extraction is used."""
-    cap = capability_for(model or getattr(backend, "model", ""))
+    # The backend knows which server it is talking to; schema enforcement is
+    # a property of that server, not only of the model name.
+    cap = capability_for(
+        model or getattr(backend, "model", ""),
+        getattr(backend, "provider", None),
+    )
     mt = max(int(max_tokens or 0), cap.max_tokens_floor)
     temp = temperature if cap.temperature_clamp is None else cap.temperature_clamp
 

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -557,42 +557,6 @@ class OpenAICompatibleBackend(LLMBackend):
         model = self.model.strip().lower()
         return model.startswith(("o1", "o3", "o4", "gpt-5"))
 
-    @staticmethod
-    def _translate_response_format_to_guided(
-        response_format: Optional[Dict[str, Any]],
-    ) -> Optional[Dict[str, Any]]:
-        """Translate an OpenAI ``response_format`` into a vLLM guided-decoding
-        ``extra_body`` payload (ADR-0098). Returns None if the format is
-        not translatable so the caller leaves ``response_format`` in place.
-
-        Mapping per ADR-0098 §3:
-            {"type":"json_object"}             → {"guided_json": {"type":"object"}}
-            {"type":"json_schema","json_schema":S} → {"guided_json": S}
-            {"type":"regex","pattern":P}       → {"guided_regex": P}
-            {"type":"choice","options":[...]}  → {"guided_choice": [...]}
-        """
-        if not isinstance(response_format, dict):
-            return None
-        rf_type = str(response_format.get("type") or "").lower()
-        if rf_type == "json_object":
-            return {"guided_json": {"type": "object"}}
-        if rf_type == "json_schema":
-            schema = response_format.get("json_schema") or response_format.get("schema")
-            if schema is None:
-                return None
-            return {"guided_json": schema}
-        if rf_type == "regex":
-            pattern = response_format.get("pattern")
-            if pattern is None:
-                return None
-            return {"guided_regex": pattern}
-        if rf_type == "choice":
-            options = response_format.get("options")
-            if options is None:
-                return None
-            return {"guided_choice": list(options)}
-        return None
-
     def _completion_request_kwargs(
         self,
         *,
@@ -627,26 +591,26 @@ class OpenAICompatibleBackend(LLMBackend):
                 kwargs["max_tokens"] = max_tokens
 
         normalized_mode = (mode or "").strip().lower() or None
-        # ADR-0098 V3: in pipeline mode against vLLM, translate
-        # response_format into extra_body.guided_*. In agent mode the
-        # Agents SDK tool-call structure carries shape; leave response_format
-        # alone so we never JSON-force a tool-call response. For other
-        # providers, response_format flows through unchanged in every mode.
-        guided_kwargs: Optional[Dict[str, Any]] = None
-        if (
-            normalized_mode == "pipeline"
-            and self.provider == "vllm"
-            and response_format is not None
-        ):
-            guided_kwargs = self._translate_response_format_to_guided(response_format)
-
-        if guided_kwargs is not None:
-            # Guided decoding supersedes response_format on vLLM.
-            kwargs["extra_body"] = self._merge_extra_body(
-                kwargs.get("extra_body"),
-                guided_kwargs,
-            )
-        elif response_format is not None:
+        # ADR-0098 translated response_format into extra_body.guided_* for
+        # vLLM. That was correct for vLLM 0.4-era guided decoding and is now
+        # actively harmful: `guided_json` does not exist in vLLM 0.27 (grep of
+        # the installed package returns zero hits — the API is
+        # `structured_outputs`), and OpenAIBaseModel is ConfigDict(extra="allow"),
+        # so the unknown field is accepted and dropped with only a debug log.
+        #
+        # The translation was an `elif`, so when it fired `response_format` was
+        # stripped from the request. vLLM handles `response_format` natively and
+        # correctly — structured_outputs_from_response_format maps json_object
+        # and json_schema itself, including the schema unwrap our translator got
+        # wrong. So the net effect was to convert working structured output into
+        # none at all, on exactly the self-hosted deployment we target.
+        #
+        # Three JSON safety nets keyed off `response_format` being present and
+        # therefore also disabled themselves: the doubled-budget retry, the
+        # "Return ONLY valid JSON" prompt variant, and the salvage-parser
+        # accounting. Passing response_format straight through re-arms all of
+        # them. Deleting the translation is strictly better than fixing it.
+        if response_format is not None:
             kwargs["response_format"] = response_format
 
         if "extra_body" in reasoning_overrides:

--- a/tests/seocho/test_llm_backends.py
+++ b/tests/seocho/test_llm_backends.py
@@ -565,127 +565,86 @@ def test_vllm_complete_round_trip_against_mocked_endpoint(
     assert call["model"] == "Qwen2.5-7B-Instruct"
 
 
-def test_vllm_pipeline_mode_translates_json_object_to_guided_json(
+def test_vllm_pipeline_mode_passes_response_format_through(
     fake_openai: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """V3: pipeline-mode + response_format={'type':'json_object'} on vLLM
-    translates to extra_body.guided_json. response_format is dropped
-    because guided decoding supersedes it on the vLLM endpoint."""
-    monkeypatch.delenv("SEOCHO_VLLM_API_KEY", raising=False)
-    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    """response_format must reach vLLM unchanged.
 
+    ADR-0098 translated it into ``extra_body.guided_json``. That field does not
+    exist in vLLM 0.27 -- a grep of the installed package returns zero hits, the
+    API is ``structured_outputs`` -- and OpenAIBaseModel is
+    ``ConfigDict(extra="allow")``, so the unknown key was accepted and dropped
+    with only a debug log.
+
+    The translation was an ``elif``, so when it fired ``response_format`` was
+    stripped. vLLM maps ``response_format`` natively and correctly via
+    ``structured_outputs_from_response_format``. The net effect of the
+    translation was therefore to turn working structured output into none at
+    all, silently, on the deployment we target.
+    """
     backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
     backend.complete(
         system="reply json",
         user="ok",
-        temperature=0.0,
         response_format={"type": "json_object"},
         mode="pipeline",
-    )
-
-    call = backend._client.chat.completions.calls[0]
-    assert "response_format" not in call
-    assert call["extra_body"] == {"guided_json": {"type": "object"}}
-
-
-def test_vllm_pipeline_mode_translates_json_schema(
-    fake_openai: None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """V3: pipeline-mode + response_format={'type':'json_schema',...}
-    on vLLM translates to extra_body.guided_json with the schema."""
-    monkeypatch.delenv("SEOCHO_VLLM_API_KEY", raising=False)
-    monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
-    schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
-    backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
-    backend.complete(
-        system="reply json",
-        user="ok",
-        temperature=0.0,
-        response_format={"type": "json_schema", "json_schema": schema},
-        mode="pipeline",
-    )
-
-    call = backend._client.chat.completions.calls[0]
-    assert "response_format" not in call
-    assert call["extra_body"] == {"guided_json": schema}
-
-
-def test_vllm_pipeline_mode_translates_regex_and_choice(
-    fake_openai: None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """V3: regex and choice response_format types translate to the
-    corresponding guided_* extra_body keys."""
-    monkeypatch.delenv("SEOCHO_VLLM_API_KEY", raising=False)
-    monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
-    backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
-
-    backend.complete(
-        system="match",
-        user="ok",
-        response_format={"type": "regex", "pattern": r"^[A-Z]{3}$"},
-        mode="pipeline",
-    )
-    call = backend._client.chat.completions.calls[-1]
-    assert call["extra_body"] == {"guided_regex": r"^[A-Z]{3}$"}
-
-    backend.complete(
-        system="pick one",
-        user="ok",
-        response_format={"type": "choice", "options": ["yes", "no", "maybe"]},
-        mode="pipeline",
-    )
-    call = backend._client.chat.completions.calls[-1]
-    assert call["extra_body"] == {"guided_choice": ["yes", "no", "maybe"]}
-
-
-def test_vllm_agent_mode_does_not_translate_response_format(
-    fake_openai: None,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """V3: agent mode preserves the OpenAI response_format because the
-    Agents SDK's tool-call structure carries the shape — we must never
-    JSON-force a tool-call response."""
-    monkeypatch.delenv("SEOCHO_VLLM_API_KEY", raising=False)
-    monkeypatch.delenv("VLLM_API_KEY", raising=False)
-
-    backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
-    backend.complete(
-        system="agent mode",
-        user="ok",
-        response_format={"type": "json_object"},
-        mode="agent",
     )
 
     call = backend._client.chat.completions.calls[0]
     assert call["response_format"] == {"type": "json_object"}
-    assert "extra_body" not in call or "guided_json" not in (call.get("extra_body") or {})
+    assert "guided_json" not in (call.get("extra_body") or {})
 
 
-def test_vllm_default_mode_preserves_pre_adr_behavior(
+def test_vllm_pipeline_mode_passes_json_schema_through(
     fake_openai: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """V3 backward compat: when ``mode`` is unset, response_format flows
-    through unchanged — pre-ADR-0098 callers are unaffected."""
-    monkeypatch.delenv("SEOCHO_VLLM_API_KEY", raising=False)
-    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    """The schema must arrive intact, at the level vLLM expects.
 
+    The translator also unwrapped one level too few: it took
+    ``response_format["json_schema"]``, which is ``{"name": ..., "schema": ...}``
+    -- a JSON Schema with no ``type`` and no ``properties``, matching any JSON.
+    vLLM unwraps to ``json_schema.json_schema`` itself, so passing the whole
+    response_format through is both simpler and correct.
+    """
+    schema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "output",
+            "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+        },
+    }
+    backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
+    backend.complete(system="s", user="u", response_format=schema, mode="pipeline")
+
+    call = backend._client.chat.completions.calls[0]
+    assert call["response_format"] == schema
+    assert "extra_body" not in call or not (call.get("extra_body") or {})
+
+
+def test_json_safety_nets_stay_armed_on_vllm(
+    fake_openai: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three retries key off response_format being present in the request.
+
+    ``_maybe_boost_json_budget`` returns early without it, and the
+    "Return ONLY valid JSON" prompt variant is skipped. Stripping
+    response_format disabled both -- so on self-hosted vLLM the runaway
+    thinking-in-content failure they were written for was the default, with
+    every mitigation off.
+    """
     backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
     backend.complete(
-        system="default",
-        user="ok",
-        response_format={"type": "json_object"},
-        # no mode arg
+        system="s", user="u",
+        response_format={"type": "json_object"}, mode="pipeline",
     )
 
     call = backend._client.chat.completions.calls[0]
-    assert call["response_format"] == {"type": "json_object"}
-    assert "extra_body" not in call or "guided_json" not in (call.get("extra_body") or {})
+    assert "response_format" in call, (
+        "the JSON budget-boost and prompt-variant retries both gate on this key"
+    )
 
 
 def test_pipeline_mode_is_noop_on_non_vllm_provider(

--- a/tests/seocho/test_llm_structured.py
+++ b/tests/seocho/test_llm_structured.py
@@ -124,3 +124,53 @@ def test_structured_complete_falls_back_to_json_method():
         def complete(self, **kw):
             return _JsonOnlyResp({"ok": True})
     assert structured_complete(B(), system="s", user="u") == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Capability is a function of (server, model), not of the model name alone.
+# ---------------------------------------------------------------------------
+
+def test_self_hosted_reasoning_model_can_reach_schema_enforcement():
+    """The vLLM registry entry was dead code.
+
+    `_REGISTRY` is first-match-wins on the MODEL name, and its `vllm` entry
+    matches the literal string "vllm" — never a served model name. A self-hosted
+    `MiniMax-M2.7` matched `minimax` first and inherited
+    `supports_guided_json=False`, so the one deployment where enforcement is
+    exact (vLLM constrains the decoder with a grammar) could never reach it.
+    """
+    from seocho.llm_structured import capability_for
+
+    assert capability_for("MiniMax-M2.7").supports_guided_json is False
+    assert capability_for("MiniMax-M2.7", "vllm").supports_guided_json is True
+
+
+def test_hosted_provider_stays_conservative():
+    """The upgrade is for servers that enforce, not for every provider.
+
+    MARA serves MiniMax over an OpenAI-compatible API with no decoder-level
+    grammar, so it keeps json_object + robust parsing.
+    """
+    from seocho.llm_structured import capability_for
+
+    assert capability_for("MiniMax-M2.7", "mara").supports_guided_json is False
+
+
+def test_provider_upgrade_preserves_the_rest_of_the_profile():
+    """Only schema support changes; reasoning and token floor must survive."""
+    from seocho.llm_structured import capability_for
+
+    base = capability_for("MiniMax-M2.7")
+    upgraded = capability_for("MiniMax-M2.7", "vllm")
+
+    assert upgraded.family == base.family
+    assert upgraded.emits_reasoning == base.emits_reasoning is True
+    assert upgraded.max_tokens_floor == base.max_tokens_floor
+
+
+def test_provider_is_optional():
+    """Existing single-argument callers keep working."""
+    from seocho.llm_structured import capability_for
+
+    assert capability_for("gpt-4o").supports_guided_json is True
+    assert capability_for(None).family == "unknown"


### PR DESCRIPTION
Found by a vLLM-contributor review, verified against the **installed `vllm==0.27.1`** rather than the docs. ADR-0192 supersedes ADR-0098 §3.

## `guided_json` does not exist in vLLM 0.27.1

```
$ grep -rl "guided_json" <site-packages>/vllm --include=*.py | wc -l
0
$ grep -rn "structured_outputs_from_response_format" <site-packages>/vllm
entrypoints/openai/engine/protocol.py:179: def structured_outputs_from_response_format(
```

`OpenAIBaseModel` is `ConfigDict(extra="allow")`, so the unknown field was accepted and dropped with only a `logger.debug` line — invisible at default log level.

## The harm was not the dropped field

The call site was an **`elif`**, so when the translation fired, `response_format` was *not set on the request*:

```python
if guided_kwargs is not None:
    kwargs["extra_body"] = ...guided_kwargs      # dropped by vLLM
elif response_format is not None:
    kwargs["response_format"] = response_format  # never reached
```

vLLM handles `response_format` **natively and correctly**, including the schema unwrap our translator got wrong — it passed `{"name":..., "schema":...}`, which as a JSON Schema has no `type` and no `properties` and matches any JSON; vLLM unwraps one level deeper.

**Net effect on the deployment we target: working structured output became none at all, silently.**

## Three safety nets disarmed themselves at the same time

All gate on `response_format` being present in the request kwargs:

| net | what it does | state before this PR |
|---|---|---|
| `_maybe_boost_json_budget` | doubles tokens on truncated JSON | returned early |
| `json_prompt_variant` | appends "Return ONLY valid JSON." | skipped |
| repair accounting | counts salvage-parser hits | absorbed the bug |

So the runaway thinking-in-content failure they were written for — measured at **43k-character responses on MiniMax-M2.7** — was the *default* on self-hosted vLLM, with every mitigation off.

## A metric changes meaning

With guided decoding actually on, prose before JSON is untokenizable — the grammar forbids it. A non-zero `seocho.gen_ai.structured_output_repair.count` from a vLLM-served model is therefore a **serving-configuration alarm**, not a model-quality signal. It has been reporting this bug as "MiniMax emits chain-of-thought."

## Second fix, same root cause: capability was keyed on the model alone

`capability_for()` is first-match-wins on the **model name**, and its `vllm` entry matches the literal string `"vllm"` — never a served model name. Self-hosted `MiniMax-M2.7` matched `minimax` first and inherited `supports_guided_json=False`, so the one deployment where enforcement is *exact* could never reach it.

Capability is a function of *(server, model)*:

| model | provider | `supports_guided_json` |
|---|---|---|
| MiniMax-M2.7 | *(none)* | False |
| MiniMax-M2.7 | `vllm` | **True** |
| MiniMax-M2.7 | `mara` | False — hosted endpoint, no decoder grammar |
| gpt-4o | *(none)* | True |

## ⚠️ Measurement note

Extraction and text2cypher quality measured against a vLLM endpoint **before this change was measured with structured output off**.

## Tests

Four tests pinned the old behaviour and are replaced with the new contract — including one that pins the retry gating, so a future change cannot silently disarm it again.

```
pytest test_llm_backends          -> 38 passed
pytest test_llm_structured        -> 16 passed
bash scripts/ci/run_basic_ci.sh   -> passed
git diff --check                  -> clean
```

## Follow-up not in this PR

A live smoke assertion against a running server — post a deliberately schema-violating request, assert a 400 or constrained output — in the shape of `scripts/serve_track/smoke_plugin.py`. The unit tests pin the request shape but cannot see a server-side API rename, which is exactly how this failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)