### PR TITLE
fix(security): serving image shipped tokenless root RCE on port 8888

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,18 @@ SEOCHO_LLM=openai/gpt-4o-mini
 # Miscellaneous
 TIMEZONE=UTC
 HF_TOKEN=
+
+# Serving image: opt-in extras (extraction/entrypoint.sh)
+# The image serves the API. Jupyter and the batch pipeline used to run beside it
+# unconditionally; both are now off by default.
+#   SEOCHO_ENABLE_JUPYTER=1 requires SEOCHO_JUPYTER_TOKEN. A tokenless notebook
+#   server is remote code execution for anyone who can reach the port, with
+#   every secret below in its environment.
+SEOCHO_ENABLE_JUPYTER=0
+# SEOCHO_JUPYTER_TOKEN=
+#   A full extraction run on every container start becomes N concurrent ingests
+#   at N replicas, racing the same graph.
+SEOCHO_RUN_BATCH_ON_START=0
+# Access control. runtime/identity.py defaults to "none" (anonymous); compose
+# now requires you to state the choice rather than inherit it.
+SEOCHO_AUTH_MODE=none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,27 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - SEOCHO_TRACE_BACKEND=${SEOCHO_TRACE_BACKEND:-none}
       - SEOCHO_TRACE_JSONL_PATH=${SEOCHO_TRACE_JSONL_PATH:-/tmp/seocho-runtime.jsonl}
+      # Auth defaults to "none" in runtime/identity.py, so the stack shipped
+      # unauthenticated and nothing made the operator notice. Compose already
+      # guards NEO4J_PASSWORD this way; the access-control decision deserves
+      # the same treatment. Set it to "none" explicitly to keep the old
+      # behaviour.
+      - SEOCHO_AUTH_MODE=${SEOCHO_AUTH_MODE:?Set SEOCHO_AUTH_MODE (none|token) in .env -- the default was anonymous access}
+      # Opt-in, and off by default. See extraction/entrypoint.sh.
+      - SEOCHO_ENABLE_JUPYTER=${SEOCHO_ENABLE_JUPYTER:-0}
+      - SEOCHO_JUPYTER_TOKEN=${SEOCHO_JUPYTER_TOKEN:-}
+      - SEOCHO_RUN_BATCH_ON_START=${SEOCHO_RUN_BATCH_ON_START:-0}
+    # Without these a dead API server left the container "up" indefinitely:
+    # uvicorn was backgrounded behind `tail -f /dev/null`, there was no probe,
+    # and no restart policy. /health/runtime is used rather than /health/batch
+    # because the latter reports on a batch that no longer runs by default.
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8001/health/runtime', timeout=4).status==200 else 1)\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
     depends_on:
       neo4j:
         condition: service_healthy
@@ -87,8 +108,12 @@ services:
     environment:
       - EXTRACTION_SERVICE_URL=http://extraction-service:8001
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    restart: unless-stopped
+    # Wait for readiness, not just start order. Bare `depends_on` only orders
+    # container creation, so the UI came up against an API that was not serving.
     depends_on:
-      - extraction-service
+      extraction-service:
+        condition: service_healthy
     networks:
       - graphrag-net
 

--- a/evaluation/Dockerfile
+++ b/evaluation/Dockerfile
@@ -7,4 +7,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Non-root, same reasoning as extraction/Dockerfile. This tier is the
+# internet-facing one and is the most likely thing to be exploited.
+RUN useradd --create-home --uid 10001 seocho \
+    && chown -R seocho:seocho /app
+USER seocho
+
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8501"]

--- a/extraction/Dockerfile
+++ b/extraction/Dockerfile
@@ -18,4 +18,12 @@ COPY src/seocho/ /app/seocho/
 
 RUN chmod +x /app/extraction/entrypoint.sh
 
+# Run as a non-root user. Nothing here needs root, and the image previously ran
+# every process as root -- including, until it was gated, a tokenless notebook
+# server. `USER` is the difference between a container escape being a privileged
+# one and an unprivileged one.
+RUN useradd --create-home --uid 10001 seocho \
+    && chown -R seocho:seocho /app
+USER seocho
+
 CMD ["/bin/bash", "./extraction/entrypoint.sh"]

--- a/extraction/entrypoint.sh
+++ b/extraction/entrypoint.sh
@@ -1,26 +1,53 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Start Jupyter Lab in background
-echo "Starting Jupyter Lab..."
-jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root --NotebookApp.token='' &
+# The API server is this image's job. Jupyter and the batch pipeline used to run
+# alongside it unconditionally, and both were problems:
+#
+#   Jupyter ran as `--allow-root --NotebookApp.token=''` on 0.0.0.0:8888. Anyone
+#   reaching that port got arbitrary code execution as root, and once compose
+#   started injecting `.env` into the container that shell held MARA_API_KEY,
+#   NEO4J_PASSWORD, SEOCHO_AUTH_SECRET and every other secret. The only control
+#   was SEOCHO_BIND_HOST defaulting to 127.0.0.1 -- and our own docs tell
+#   operators to set it to 0.0.0.0.
+#
+#   `python -m extraction.main` ran a full extraction pipeline with graph writes
+#   on every container start. At one replica that is a surprise; at N replicas it
+#   is N concurrent ingests racing the same graph and applying DDL concurrently.
+#
+# Both are now opt-in and default to off. Turning Jupyter on requires a token.
 
-# Start Agent Server (Uvicorn)
-echo "Starting Agent Server..."
-echo "Starting Agent Server..."
-uvicorn extraction.agent_server:app --host 0.0.0.0 --port 8001 &
+JUPYTER_ENABLED="${SEOCHO_ENABLE_JUPYTER:-0}"
+BATCH_ENABLED="${SEOCHO_RUN_BATCH_ON_START:-0}"
 
-BATCH_STATUS_FILE="${SEOCHO_BATCH_STATUS_FILE:-/tmp/seocho_batch_status}"
-echo "running" > "${BATCH_STATUS_FILE}"
-
-echo "Running Pipeline (extraction.main)..."
-if python -m extraction.main; then
-  echo "success" > "${BATCH_STATUS_FILE}"
-else
-  echo "failed" > "${BATCH_STATUS_FILE}"
-  echo "extraction.main failed or finished"
+if [ "${JUPYTER_ENABLED}" = "1" ]; then
+  if [ -z "${SEOCHO_JUPYTER_TOKEN:-}" ]; then
+    echo "SEOCHO_ENABLE_JUPYTER=1 requires SEOCHO_JUPYTER_TOKEN to be set." >&2
+    echo "A tokenless notebook server is remote code execution for anyone who" >&2
+    echo "can reach the port, with every secret in .env in its environment." >&2
+    exit 1
+  fi
+  echo "Starting Jupyter Lab (token required)..."
+  jupyter lab --ip=0.0.0.0 --port=8888 --no-browser \
+    --ServerApp.token="${SEOCHO_JUPYTER_TOKEN}" &
 fi
 
-# Keep the container alive (if main.py finishes, we still want Jupyter running)
-echo "Pipeline finished. Keeping container alive for Jupyter..."
-tail -f /dev/null
+if [ "${BATCH_ENABLED}" = "1" ]; then
+  BATCH_STATUS_FILE="${SEOCHO_BATCH_STATUS_FILE:-/tmp/seocho_batch_status}"
+  echo "running" > "${BATCH_STATUS_FILE}"
+  echo "Running Pipeline (extraction.main)..."
+  if python -m extraction.main; then
+    echo "success" > "${BATCH_STATUS_FILE}"
+  else
+    echo "failed" > "${BATCH_STATUS_FILE}"
+    echo "extraction.main failed" >&2
+  fi
+fi
+
+# exec, so uvicorn becomes PID 1. Previously it was backgrounded behind
+# `tail -f /dev/null`, and `set -e` does not apply to background jobs -- so a
+# dead API server left the container "up" forever, with no healthcheck and no
+# restart policy to notice. As PID 1 its exit is the container's exit, which is
+# what makes `restart:` and k8s liveness probes work at all.
+echo "Starting Agent Server..."
+exec uvicorn extraction.agent_server:app --host 0.0.0.0 --port 8001

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -71,6 +71,7 @@ uv run pytest \
   tests/seocho/test_ontology_import.py \
   tests/seocho/test_memory_sharing_contract.py \
   tests/seocho/test_operating_layer.py \
+  tests/seocho/test_serving_image_hardening.py \
   tests/seocho/test_semantic_query_phase_a.py \
   extraction/tests/test_sdk_evaluation.py \
   tests/seocho/test_agent_design.py \

--- a/tests/seocho/test_serving_image_hardening.py
+++ b/tests/seocho/test_serving_image_hardening.py
@@ -1,0 +1,124 @@
+"""The serving image must not ship remote code execution.
+
+`extraction/entrypoint.sh` started Jupyter Lab with `--allow-root` and
+`--NotebookApp.token=''` on `0.0.0.0:8888`, in the same image that serves the
+API. Anyone who reached that port got arbitrary code execution as root, with
+`MARA_API_KEY`, `NEO4J_PASSWORD` and `SEOCHO_AUTH_SECRET` in the shell's
+environment. The only control was `SEOCHO_BIND_HOST` defaulting to `127.0.0.1`,
+and the repo's own guides tell operators to set it to `0.0.0.0`.
+
+Two more properties of the same file were wrong for different reasons:
+
+  - `python -m extraction.main` ran a full extraction pipeline with graph writes
+    on every container start. At one replica that is a surprise; at N replicas
+    it is N concurrent ingests racing the same graph.
+  - uvicorn was backgrounded behind `tail -f /dev/null`, and `set -e` does not
+    apply to background jobs, so a dead API server left the container "up"
+    forever — with no healthcheck and no restart policy to notice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = ROOT / "extraction" / "entrypoint.sh"
+
+
+@pytest.fixture(scope="module")
+def entrypoint() -> str:
+    """Executable lines only — the comments in this file *describe* the flags
+    that were removed, so scanning raw text finds them in the prose."""
+    return "\n".join(
+        line for line in ENTRYPOINT.read_text().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def test_no_tokenless_notebook_server(entrypoint):
+    assert "--NotebookApp.token=''" not in entrypoint
+    assert '--NotebookApp.token=""' not in entrypoint
+    assert "--allow-root" not in entrypoint, (
+        "a root notebook server in the serving image is remote code execution "
+        "for anyone who can reach the port"
+    )
+
+
+def test_jupyter_is_opt_in_and_requires_a_token(entrypoint):
+    assert "SEOCHO_ENABLE_JUPYTER" in entrypoint, "Jupyter must be opt-in"
+    assert "SEOCHO_JUPYTER_TOKEN" in entrypoint, (
+        "enabling the notebook server must require a token, or the opt-in just "
+        "moves the same hole behind a flag"
+    )
+    # The guard must precede the launch, not follow it.
+    assert entrypoint.index("SEOCHO_JUPYTER_TOKEN") < entrypoint.index("jupyter lab")
+
+
+def test_batch_pipeline_does_not_run_on_every_start(entrypoint):
+    assert "SEOCHO_RUN_BATCH_ON_START" in entrypoint, (
+        "a full ingest on container start becomes N concurrent ingests at N "
+        "replicas, racing the same graph"
+    )
+
+
+def test_api_server_is_pid_one(entrypoint):
+    """A backgrounded server cannot fail the container, so nothing restarts it."""
+    assert "exec uvicorn" in entrypoint
+    assert "tail -f /dev/null" not in entrypoint, (
+        "keeping PID 1 alive independently of the server is what made a dead "
+        "API look healthy"
+    )
+
+
+@pytest.mark.parametrize("dockerfile", [
+    "extraction/Dockerfile",
+    "evaluation/Dockerfile",
+])
+def test_images_do_not_run_as_root(dockerfile):
+    text = (ROOT / dockerfile).read_text()
+    assert "USER " in text, f"{dockerfile} runs every process as root"
+    # USER must come after the COPY/RUN steps it protects.
+    assert text.index("USER ") > text.rindex("COPY ")
+
+
+@pytest.fixture(scope="module")
+def compose() -> dict:
+    return yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+
+
+def test_app_service_has_a_healthcheck_and_restart_policy(compose):
+    service = compose["services"]["extraction-service"]
+    assert service.get("healthcheck"), (
+        "without a probe a crashed API server is indistinguishable from a "
+        "healthy one"
+    )
+    assert service.get("restart") == "unless-stopped"
+
+
+def test_healthcheck_does_not_depend_on_the_batch_pipeline(compose):
+    """`/health/batch` reports on a batch that no longer runs by default."""
+    probe = str(compose["services"]["extraction-service"]["healthcheck"]["test"])
+    assert "/health/batch" not in probe
+    assert "/health/runtime" in probe
+
+
+def test_ui_waits_for_readiness_not_start_order(compose):
+    depends = compose["services"]["evaluation-interface"]["depends_on"]
+    assert isinstance(depends, dict), "bare depends_on only orders creation"
+    assert depends["extraction-service"]["condition"] == "service_healthy"
+
+
+def test_auth_mode_must_be_stated_explicitly(compose):
+    """The default is anonymous; compose should make the operator choose."""
+    env = compose["services"]["extraction-service"]["environment"]
+    entries = env if isinstance(env, list) else [f"{k}={v}" for k, v in env.items()]
+    auth = [e for e in entries if e.startswith("SEOCHO_AUTH_MODE=")]
+    assert auth, "SEOCHO_AUTH_MODE is not passed at all"
+    assert ":?" in auth[0], (
+        "compose guards NEO4J_PASSWORD this way; the access-control decision "
+        "deserves the same forcing function"
+    )


### PR DESCRIPTION
Found by a platform-engineering review, ranked **CRITICAL** there. The `.env` work landing alongside it made the consequence worse, not better.

## The hole

`extraction/entrypoint.sh`:

```bash
jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root --NotebookApp.token=''
```

In the **same image that serves the API**, published by `docker-compose.yml`. Neither Dockerfile had a `USER` directive, so every process ran as root.

Anyone reaching that port got arbitrary root code execution. And once compose began injecting `.env` into the container, that shell held `MARA_API_KEY`, `NEO4J_PASSWORD`, `SEOCHO_AUTH_SECRET` and every other secret.

The only control was `SEOCHO_BIND_HOST` defaulting to `127.0.0.1` — and **this repo's own guides instruct operators to set it to `0.0.0.0`** (`examples/finder/PROJECT_GUIDE.md`, ADR-0076). On the H200 box that one character is full compromise.

## Fixes

| what | before | after |
|---|---|---|
| Jupyter | always on, root, no token | opt-in (`SEOCHO_ENABLE_JUPYTER`, default `0`), **refuses to start without `SEOCHO_JUPYTER_TOKEN`** |
| image user | root | uid 10001, both images |
| batch pipeline | full ingest on every container start | opt-in (`SEOCHO_RUN_BATCH_ON_START`, default `0`) |
| API process | backgrounded behind `tail -f /dev/null` | `exec uvicorn` as PID 1 |
| health | none | `/health/runtime` probe + `restart: unless-stopped` |
| UI dependency | start order only | `condition: service_healthy` |
| auth mode | silently defaults to anonymous | `${SEOCHO_AUTH_MODE:?}` guard |

An opt-in *without* the token requirement would just move the same hole behind a flag, so the entrypoint exits non-zero if the flag is set and the token is not.

## Two more bugs in the same file

**The batch pipeline ran on every container start.** `python -m extraction.main` performs graph writes. At one replica that is a surprise; at N replicas it is N concurrent ingests racing the same graph and applying DDL concurrently — a hard blocker for ever running a second replica.

**A dead API server looked healthy.** uvicorn was backgrounded and `set -e` does not apply to background jobs, so `tail -f /dev/null` kept PID 1 alive regardless. There was no healthcheck and no restart policy to notice. `exec`ing uvicorn as PID 1 makes its exit the container's exit — which is what makes `restart:` and a k8s liveness probe work at all.

## ⚠️ One deliberate behaviour change

`SEOCHO_AUTH_MODE` is now a required variable in compose. `runtime/identity.py` defaults it to `"none"`, so the stack shipped **unauthenticated** and nothing made the operator notice. Compose already guards `NEO4J_PASSWORD` this way. Setting `SEOCHO_AUTH_MODE=none` explicitly preserves the old behaviour — the change is that you have to say so.

## Validation

```
pytest test_serving_image_hardening  -> 10 passed
docker compose config                -> valid
bash scripts/ci/run_basic_ci.sh      -> passed
git diff --check                     -> clean
```

New test registered in `scripts/ci/run_basic_ci.sh`.

## Related, not in this PR

Secrets should move out of the environment entirely (Docker secrets → k8s Secret via the `_FILE` convention), and the UI tier reads exactly **one** variable (`EXTRACTION_SERVICE_URL`) while being handed the whole `.env` — both tracked with the `.env`/compose work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)