### PR TITLE
exp(serve-track): land the harness; the ERB graph arm read the grading rubric (ADR-0197)

### DIFF
--- a/docs/decisions/ADR-0197-erb-graph-arm-from-our-extraction.json
+++ b/docs/decisions/ADR-0197-erb-graph-arm-from-our-extraction.json
@@ -1,0 +1,22 @@
+{
+  "adr": "ADR-0197",
+  "claim": "The ERB graph arm was built from the dataset's grading rubric, not from SEOCHO's extraction.",
+  "items_compared": 20,
+  "stratum": "ERB_conflicting_info",
+  "edge_source_answer_facts": {
+    "edges": 115,
+    "rubric_phrased": 115,
+    "share": 1.0
+  },
+  "edge_source_extracted": {
+    "edges": 635,
+    "rubric_phrased": 1,
+    "share": 0.0016
+  },
+  "rubric_detector": "the answer|must|should|may mention (case-insensitive)",
+  "extracted_corpus": {
+    "documents_with_triples": 285,
+    "total_triples": 5348
+  },
+  "note": "ERB_conflicting_info is the only statistically significant graph-vs-vector result in the programme (McNemar p=0.0156); it is also the stratum where rubric edges are densest."
+}

--- a/docs/decisions/ADR-0197-erb-graph-arm-from-our-extraction.md
+++ b/docs/decisions/ADR-0197-erb-graph-arm-from-our-extraction.md
@@ -1,0 +1,89 @@
+# ADR-0197: The ERB graph arm is built from our extraction, not from `answer_facts`
+
+- Status: Accepted
+- Date: 2026-08-16
+- Related: `ADR-0181` (OS contract), `scripts/serve_track/erb_index.py`
+
+## Context
+
+The project decided that the ERB graph arm must come from SEOCHO's own indexing.
+It is written down in `erb_index.py`:
+
+> That version built the graph arm from the dataset's own `answer_facts` … it
+> routes around the thing this project actually builds.
+
+`erb_adapter.py` did it anyway, and was modified *later* than that decision. On
+the committed run, `edge_source` was `answer_facts` for 76 of 79 items, and for
+**20 of 20** `ERB_conflicting_info` items.
+
+That matters more than a provenance slip, because `ERB_conflicting_info` is the
+**only statistically significant graph-vs-vector comparison in the entire
+programme** — graph 17/20 against vector 10/20, exact McNemar p = 0.0156. Every
+other arm comparison, across three corpora and 41 tests, is null.
+
+## What `answer_facts` actually contains
+
+Not facts about the world. The dataset's decomposed grading claims:
+
+    (The answer must state that the updated reservation target)
+      -[IS]-> (30% of interactive burst credits ... on dp-132-usw)
+    (The answer may mention that an earlier/internal suggestion)
+      -[WAS]-> (20%, but it must clearly indicate 30% is the current target)
+
+The graph arm was reading the rubric it was about to be graded against.
+
+## Decision
+
+`--edge-source extracted` is the default: triples come from
+`outputs/serve_track/erb_extracted.jsonl`, joined to questions on
+`expected_doc_ids`, with node ids resolved to names.
+
+`--edge-source answer_facts` stays reachable. An oracle arm is a legitimate
+**ceiling**, and having one is required by our own controls discipline. It now
+labels itself `answer_facts_CEILING` in the output, so it cannot be read as a
+graph result.
+
+Running `--edge-source extracted` with no extracted graph is a hard error rather
+than a silent fallback. Silently substituting a different edge source is how
+this happened.
+
+## Measured
+
+20 items in the affected stratum, rubric detector
+`the answer|must|should|may mention`:
+
+| edge source | edges | rubric-phrased | share |
+| --- | --- | --- | --- |
+| `answer_facts` | 115 | 115 | **100%** |
+| our extraction | 635 | 1 | **0%** |
+
+Same question, the two arms side by side:
+
+    answer_facts:  The answer must state that the updated reservation target
+                     -IS-> 30% of interactive burst credits ...
+
+    extracted:     Sustained 429s during sliced ingest ... -AFFECTS-> Streamly AI
+                   Sustained 429s during sliced ingest ... -OCCURRED_ON-> dp-132-usw
+
+The extracted graph covers 285 documents with 5,348 triples — 5.5× the edge
+volume, and about entities and events rather than about what a marker should
+accept.
+
+## Consequences
+
+- **The p = 0.0156 result must be re-run and, until then, not cited.** It was
+  produced by an arm holding the answer key.
+- Graph-arm coverage now depends on extraction quality, which is the point: the
+  arm measures the component under test. 285 of 322 documents yielded triples;
+  the 37 that did not are extraction failures and should be counted as such
+  rather than papered over by a fallback.
+- `edges_from_text` remains as a last-resort fallback for documents with no
+  extraction, and still labels itself `document_text`.
+
+## What this does not fix
+
+The harness still has **no retrieval stage** — the graph arm is fed
+`gold_edges` and the vector arm the gold documents, so both arms receive oracle
+evidence and the comparison is between serialisation formats under held-perfect
+retrieval. That is a separate and larger gap; this ADR only removes the answer
+key from one side of it.

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -76,6 +76,11 @@ uv run pytest \
   extraction/tests/test_sdk_evaluation.py \
   tests/seocho/test_agent_design.py \
   tests/seocho/test_benchmarking.py \
+  tests/seocho/test_erb_edge_source.py \
+  tests/seocho/test_context_arms.py \
+  tests/seocho/test_run_arms.py \
+  tests/seocho/test_question_set_strata.py \
+  tests/seocho/test_bench_annotation.py \
   tests/seocho/test_finder_benchmark_script.py \
   tests/seocho/test_indexing_design.py \
   tests/seocho/test_dedup_scope.py \

--- a/scripts/serve_track/ab_extraction_prompt.py
+++ b/scripts/serve_track/ab_extraction_prompt.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""A/B the extraction prompt: does stating requirements change what gets extracted?
+
+Two changes are under test, crossed, so each one's contribution is separable
+rather than inferred from a single before/after.
+
+  requirements   Purpose, competency questions, and modelling decisions in the
+                 system prompt. `Ontology(description=...)` was accepted and
+                 stored and then dropped at exactly the point it would help, so
+                 the model received the formalised artefact -- a list of classes
+                 and relations -- with none of the requirements analysis that
+                 produced it. Keet's micro-level methodologies (OntoSpec, OD101,
+                 DiDOn) treat purpose, query types and modelling decisions as
+                 determining the axioms rather than preceding them; this package
+                 already scores coverage against competency questions and simply
+                 never told the extractor what they were.
+
+  generic_rules  The label-selection rules carried FinDER literals --
+                 FinancialMetric, Revenue, OperatingIncome, EPS,
+                 "'LegalEntity' not 'Company'" -- shipped verbatim to every
+                 extraction regardless of domain, naming classes absent from the
+                 allowed list the model was just given. The output-format
+                 example also used `"label": "EntityType"`, and the baseline run
+                 emitted a node that was literally `EntityType{name: "Entity
+                 Name"}`, so the example leaked into the data.
+
+Everything is scored by counting, never by a judge. Four metrics, each chosen
+because a specific failure in the baseline run makes it load-bearing:
+
+  status_vocab     distinct `Decision.status` values, and distinct after case
+                   folding. The baseline produced CURRENT/current/SUPERSEDED/
+                   superseded/proposed/applied/pending/mitigation -- a filter on
+                   `status='superseded'` misses half of them. `P` has no enum
+                   argument, so a modelling decision in prose is the only
+                   channel available.
+  supersedes       SUPERSEDES edges. The conflicting_info stratum is unanswerable
+                   without them; the baseline found 12 across 51 documents.
+  off_ontology     nodes whose label is not in the ontology. Directly measures
+                   the EntityType leak.
+  prompt_tokens    the FinDER rules are not free.
+
+Same documents, same model, temperature 0. Only the prompt differs.
+
+Usage:
+    export MARA_API_KEY=...
+    scripts/serve_track/ab_extraction_prompt.py --parquet <dir> --docs 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+SCHEMA_VERSION = 1
+
+# The requirements a human ontologist would have written down first. Each line
+# is traceable to a question the benchmark actually asks.
+PURPOSE = (
+    "Recover, from raw enterprise records, who decided what and which decision "
+    "is currently in force, so a reader can answer operational questions without "
+    "reading every document."
+)
+COMPETENCY_QUESTIONS = [
+    "For a given system or pool, which configuration value is CURRENTLY applied, "
+    "and which earlier value did it replace?",
+    "What caused a given incident, and what action mitigated it?",
+    "In what ORDER must the steps of a procedure be performed?",
+    "Who made a decision, and which organisation do they work for?",
+]
+MODELLING_DECISIONS = [
+    "status is an attribute of Decision, not a separate class. Use exactly one "
+    "of: proposed, applied, superseded, reverted. Lowercase.",
+    "SUPERSEDES runs from the NEWER decision to the one it replaces. When a "
+    "document mentions an earlier value and a later one, emit both Decisions and "
+    "the edge between them rather than only the current value.",
+    "Step.position is 1-based and reflects execution order, not document order.",
+    "A person and the organisation they belong to are separate nodes joined by "
+    "WORKS_FOR; do not fold the org into Person.org alone.",
+]
+
+
+# The label-selection rules exactly as they shipped before this branch removed
+# them. Restored here rather than left in the SDK so the arm that measures their
+# cost is explicit and the production path stays domain-neutral.
+_FINDER_RULES = (
+    "  1. Use the MOST-SPECIFIC class that matches each entity. "
+    "If both an abstract base (e.g. FinancialMetric) and a concrete "
+    "subclass (Revenue, OperatingIncome, NetIncome, EPS, GrossProfit, "
+    "OperatingMargin) are listed, pick the subclass."
+)
+_FINDER_RULE_3 = (
+    "  3. Use canonical class names exactly as listed above (e.g. "
+    "'LegalEntity' not 'Company'; 'Revenue' not 'Sales')."
+)
+_FINDER_EXAMPLE = (
+    '  Example node: {"id": "unique_id", "label": "EntityType", '
+    '"properties": {"name": "Entity Name"}}'
+)
+
+
+def with_finder_literals(system: str) -> str:
+    """Put the FinDER vocabulary back, for the arm that measures what it cost.
+
+    Matches the shipped text by anchoring on the generic sentences that
+    replaced it, so a future edit to those lines fails loudly here rather than
+    silently producing two identical arms.
+    """
+    generic_1 = ("  1. Use the MOST-SPECIFIC class that matches each entity. "
+                 "If both an abstract base and a concrete subclass are listed, "
+                 "pick the subclass.")
+    if generic_1 not in system:
+        raise SystemExit("rule 1 text moved; the finder arm would be a no-op")
+    system = system.replace(generic_1, _FINDER_RULES)
+
+    marker = "  3. Use canonical class names exactly as listed above."
+    index = system.find(marker)
+    if index < 0:
+        raise SystemExit("rule 3 text moved; the finder arm would be a no-op")
+    end = system.find("\n", index)
+    system = system[:index] + _FINDER_RULE_3 + system[end:]
+
+    example_start = system.find('  Example node: {"id": "unique_id"')
+    if example_start < 0:
+        raise SystemExit("output-format example moved; the finder arm would be a no-op")
+    example_end = system.find("\n", example_start)
+    return system[:example_start] + _FINDER_EXAMPLE + system[example_end:]
+
+
+def make_ontology(with_requirements: bool):
+    import erb_index
+
+    base = erb_index.build_ontology()
+    if not with_requirements:
+        return base
+    base.description = PURPOSE
+    base.annotations = {
+        "competency_questions": COMPETENCY_QUESTIONS,
+        "modelling_decisions": MODELLING_DECISIONS,
+    }
+    # The rendered ontology block is cached per instance; drop it so the new
+    # annotations are picked up rather than silently ignored.
+    for attr in ("_render_cache", "_system_prompt_cache"):
+        if hasattr(base, attr):
+            getattr(base, attr).clear()
+    return base
+
+
+def measure(rows: List[Dict[str, Any]], allowed_labels: set) -> Dict[str, Any]:
+    ok = [r for r in rows if not r.get("error")]
+    statuses = [
+        str((n.get("properties") or {}).get("status") or "")
+        for r in ok for n in r["nodes"] if n.get("label") == "Decision"
+    ]
+    statuses = [s for s in statuses if s]
+    off = [n.get("label") for r in ok for n in r["nodes"]
+           if n.get("label") not in allowed_labels]
+    steps = [n for r in ok for n in r["nodes"] if n.get("label") == "Step"]
+    positioned = [n for n in steps
+                  if (n.get("properties") or {}).get("position") is not None]
+    return {
+        "docs": len(rows),
+        "failed": len(rows) - len(ok),
+        "nodes": sum(len(r["nodes"]) for r in ok),
+        "rels": sum(len(r["relationships"]) for r in ok),
+        "supersedes": sum(1 for r in ok for x in r["relationships"]
+                          if x.get("type") == "SUPERSEDES"),
+        "status_values": len(set(statuses)),
+        "status_values_folded": len({s.lower() for s in statuses}),
+        "status_off_vocab": sum(
+            1 for s in statuses
+            if s.lower() not in {"proposed", "applied", "superseded", "reverted"}
+        ),
+        "status_total": len(statuses),
+        "off_ontology": len(off),
+        "step_position_set": f"{len(positioned)}/{len(steps)}",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parquet", type=Path, required=True)
+    parser.add_argument("--docs", type=int, default=20)
+    parser.add_argument("--concurrency", type=int, default=12)
+    parser.add_argument("--model", default="MiniMax-M2.7")
+    parser.add_argument("--base-url", default="https://api.cloud.mara.com/v1")
+    parser.add_argument("--max-chars", type=int, default=6000)
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/ab_prompt.jsonl"))
+    args = parser.parse_args()
+
+    key = os.environ.get("MARA_API_KEY", "").strip().strip('"').strip("'")
+    if not key:
+        raise SystemExit("MARA_API_KEY is not set")
+
+    import erb_index
+    from seocho.index.extraction_engine import CanonicalExtractionEngine
+    from seocho.store.llm import create_llm_backend
+
+    docs = erb_index.load_gold_documents(
+        args.parquet, ["conflicting_info", "project_related", "completeness"])
+    # Deterministic slice: sorted by id, so the same documents every run.
+    items = sorted(docs.items())[: args.docs]
+    print(f"{len(items)} documents x 2 prompt variants\n")
+
+    llm = create_llm_backend(provider="openai", model=args.model,
+                             api_key=key, base_url=args.base_url)
+    allowed = set(erb_index.build_ontology().nodes.keys())
+
+    # 2x2: requirements on/off crossed with the FinDER literals present/absent.
+    # `base+finder` is the true baseline — it is what the 322-document run used.
+    arms = {
+        "base+finder": (False, True),
+        "base": (False, False),
+        "req+finder": (True, True),
+        "req": (True, False),
+    }
+    results: Dict[str, List[Dict[str, Any]]] = {}
+    prompt_tokens: Dict[str, int] = {}
+    lock = threading.Lock()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    handle = args.out.open("w", encoding="utf-8")
+
+    for arm, (requirements, finder) in arms.items():
+        ontology = make_ontology(with_requirements=requirements)
+        rendered = CanonicalExtractionEngine(
+            llm=llm, ontology=ontology, enforcement="guided")
+        system, _ = rendered._render_extraction_prompts(
+            text="probe", category="general", metadata=None, extra_context=None)
+        if finder:
+            system = with_finder_literals(system)
+        prompt_tokens[arm] = len(system) // 4  # rough; chars/4, stated as such
+
+        # Pin the exact system prompt for this arm so the only difference
+        # between arms is the text under test.
+        engine = CanonicalExtractionEngine(
+            llm=llm, ontology=ontology, enforcement="guided",
+            custom_prompts={"system": system, "user": "Text to extract:\n{{text}}"},
+        )
+
+        def extract_one(pair, engine=engine):
+            doc_id, doc = pair
+            text = f"{doc['title']}\n\n{doc['content']}"[: args.max_chars]
+            for _ in range(3):
+                try:
+                    graph = engine.extract(text, category=doc["source_type"],
+                                           metadata={"doc_id": doc_id})
+                    return {"doc_id": doc_id,
+                            "nodes": graph.get("nodes") or [],
+                            "relationships": graph.get("relationships") or [],
+                            "error": None}
+                except Exception as exc:  # noqa: BLE001
+                    last = f"{type(exc).__name__}: {exc}"
+            return {"doc_id": doc_id, "nodes": [], "relationships": [], "error": last}
+
+        started = time.perf_counter()
+        rows: List[Dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [pool.submit(extract_one, pair) for pair in items]
+            for future in as_completed(futures):
+                row = future.result()
+                with lock:
+                    rows.append(row)
+                    handle.write(json.dumps({"arm": arm, **row}, ensure_ascii=False) + "\n")
+                    handle.flush()
+        results[arm] = rows
+        print(f"  {arm:14s} done in {(time.perf_counter()-started)/60:.1f} min")
+
+    handle.close()
+
+    print("\n=== measured, no judge involved ===")
+    metrics = {arm: measure(rows, allowed) for arm, rows in results.items()}
+    keys = ["docs", "failed", "nodes", "rels", "supersedes", "status_total",
+            "status_values", "status_values_folded", "status_off_vocab",
+            "off_ontology", "step_position_set"]
+    print(f"  {'metric':22s}" + "".join(f"{a:>16s}" for a in arms))
+    for key in keys:
+        print(f"  {key:22s}" + "".join(f"{str(metrics[a][key]):>16s}" for a in arms))
+    print(f"  {'prompt_chars/4':22s}" + "".join(f"{prompt_tokens[a]:>16d}" for a in arms))
+
+    print("\nstatus_off_vocab counts values outside proposed|applied|superseded|"
+          "reverted.\nstatus_values vs status_values_folded exposes case splits, "
+          "which a filter\nsilently loses. Both are the thing `P` cannot declare.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/annotate_graphrag_bench.py
+++ b/scripts/serve_track/annotate_graphrag_bench.py
@@ -1,0 +1,187 @@
+"""Derive the graph-vs-vector strata from GraphRAG-Bench, mechanically.
+
+An earlier read of this dataset concluded it "carries no gold triples and no
+supporting-fact ids, so hop count and passage dispersion are not derivable".
+That was wrong, and the correction matters: the strata that make *when* legible
+can be computed from the real corpora, so the synthetic set no longer has to
+carry the whole argument.
+
+What is actually there (verified against the local copy, 4,072 items):
+
+  Novel   (2,010)  id source question answer question_type evidence evidence_triple
+  Medical (2,062)  id source question answer question_type evidence evidence_relations
+
+`evidence_triple` on the Novel subset holds literal triples —
+``(erica vagans, is also known as, Cornish heath).`` — so counting them gives a
+hop proxy. And it tracks the dataset's own labels closely enough to trust:
+
+  Fact Retrieval        mean 1.18 triples, 901 of 971 items are EXACTLY one
+  Complex Reasoning     mean 2.67, median 2
+  Contextual Summarize  mean 3.25, median 3
+  Creative Generation   mean 6.16, every item >= 4
+
+Medical has no `evidence_triple` at all (the field is absent; `evidence_relations`
+holds prose, not triples), so hops are unavailable there. Its `evidence` is a
+`;`-separated statement list, which gives dispersion only — 2.26 / 3.46 / 6.11 /
+13.17 statements by the same four types. Medical is therefore usable for the
+dispersion axis and must not be pooled with Novel on hops.
+
+The strata this can and cannot supply:
+
+  supplied   hop count (Novel), passage dispersion (both), reasoning type (both)
+  NOT supplied  aggregation fan-out, absence/negation, entity ambiguity,
+                distractor density
+The four it cannot supply are exactly the ones that separate "structure helped"
+from "redundancy removal helped" and from "retrieval precision helped", so
+`make_question_set.py` still carries S4-S7. Real data where it exists, synthetic
+only for what is missing.
+
+Usage:
+    python scripts/serve_track/annotate_graphrag_bench.py \\
+        --bench-dir ~/openup/_graphrag_benchmark/Datasets/Questions \\
+        --out outputs/serve_track/bench_annotated.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import re
+import statistics
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+SCHEMA_VERSION = 1
+
+# `(subject, relation, object)` with no nested parentheses. Deliberately strict:
+# a loose pattern would swallow ordinary parenthetical prose and inflate hops,
+# which is the one number this file exists to get right.
+_TRIPLE = re.compile(r"\(([^()]+?),([^()]+?),([^()]+?)\)")
+
+# The dataset's own labels, mapped to the axis each one loads. These are the
+# dataset's claim, not ours — the derived counts below are what we check it with.
+_TYPE_AXIS = {
+    "Fact Retrieval": "extractive",
+    "Complex Reasoning": "joined",
+    "Contextual Summarize": "aggregate_context",
+    "Creative Generation": "synthesis",
+}
+
+
+def _load(path: Path) -> List[Dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return data
+    return next(v for v in data.values() if isinstance(v, list))
+
+
+def _as_text(raw: Any) -> str:
+    """Accept both shapes GraphRAG-Bench ships these fields in.
+
+    The HuggingFace release stores `evidence` and `evidence_triple` as LISTS;
+    an earlier local copy had them as semicolon-joined strings. This function
+    used to accept only the string, silently returning empty for every list —
+    so the annotator reported "0 of 2010 carry a derived hop count", which reads
+    as a property of the dataset rather than a parse failure, and points the
+    reader at exactly the wrong conclusion. Novel in fact yields triples for
+    2,002 of 2,010 items.
+    """
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, (list, tuple)):
+        return "; ".join(str(x) for x in raw)
+    return ""
+
+
+def _triples(row: Dict[str, Any]) -> List[List[str]]:
+    return [[p.strip() for p in m]
+            for m in _TRIPLE.findall(_as_text(row.get("evidence_triple")))]
+
+
+def _statements(row: Dict[str, Any]) -> List[str]:
+    return [s.strip() for s in _as_text(row.get("evidence")).split(";") if s.strip()]
+
+
+def annotate(row: Dict[str, Any], subset: str) -> Dict[str, Any]:
+    triples = _triples(row)
+    statements = _statements(row)
+    qtype = row.get("question_type", "")
+
+    # hops is None, never 0, when the subset cannot supply it. A zero here would
+    # read as "single hop" and quietly merge Medical into the hop analysis.
+    hops: Optional[int] = len(triples) if triples else None
+    if subset == "medical":
+        hops = None
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "id": row.get("id"),
+        "subset": subset,
+        "source": row.get("source"),
+        "question": row.get("question"),
+        "answer": row.get("answer"),
+        "corpus": statements,
+        "strata": {
+            "stratum": f"GB_{_TYPE_AXIS.get(qtype, 'unknown')}",
+            "question_type": qtype,
+            "hops": hops,
+            "dispersion": len(statements),
+            "answer_type": _TYPE_AXIS.get(qtype, "unknown"),
+            "hops_source": "evidence_triple" if hops is not None else "unavailable",
+        },
+        "gold_edges": triples,
+    }
+
+
+def _summarise(rows: Iterable[Dict[str, Any]]) -> None:
+    by_type: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    for row in rows:
+        by_type[row["strata"]["question_type"]].append(row)
+    for qtype in sorted(by_type):
+        items = by_type[qtype]
+        hops = [i["strata"]["hops"] for i in items if i["strata"]["hops"] is not None]
+        disp = [i["strata"]["dispersion"] for i in items]
+        hop_txt = (
+            f"hops mean={statistics.mean(hops):.2f} median={statistics.median(hops):.0f}"
+            if hops else "hops unavailable"
+        )
+        print(f"  {qtype:22s} n={len(items):4d}  {hop_txt}  "
+              f"dispersion mean={statistics.mean(disp):.2f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bench-dir", type=Path,
+                        default=Path.home() / "openup/_graphrag_benchmark/Datasets/Questions")
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/bench_annotated.jsonl"))
+    parser.add_argument("--subsets", nargs="+", default=["novel", "medical"])
+    args = parser.parse_args()
+
+    annotated: List[Dict[str, Any]] = []
+    for subset in args.subsets:
+        path = args.bench_dir / f"{subset}_questions.json"
+        if not path.exists():
+            print(f"skip {subset}: {path} not found")
+            continue
+        rows = _load(path)
+        got = [annotate(r, subset) for r in rows]
+        annotated.extend(got)
+        print(f"--- {subset} (n={len(got)})")
+        _summarise(got)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as handle:
+        for row in annotated:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    with_hops = sum(1 for r in annotated if r["strata"]["hops"] is not None)
+    print(f"\nwrote {len(annotated)} items to {args.out}")
+    print(f"  {with_hops} carry a derived hop count; "
+          f"{len(annotated) - with_hops} carry dispersion only")
+    print("Do not pool the two subsets on the hop axis — only Novel supplies it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/correlate_kv.py
+++ b/scripts/serve_track/correlate_kv.py
@@ -1,0 +1,338 @@
+"""Attribute vLLM KV-cache blocks to graph-agentic-RAG stages, offline.
+
+Reads a run directory produced by the serve-track harness:
+
+    kv_windows.jsonl   per-step wall-clock windows (scripts/serve_track/kv_windows.py)
+    kv_events.jsonl    KV-event frames stamped with `_recv_ts` (scripts/cache_probe)
+
+and answers, per stage: how many blocks that stage caused to be stored, how many
+of its prompt's tokens the engine served from cache, and whether its prefix is
+stable enough across episodes to be reusable at all.
+
+Why a time-window join. vLLM's KV events name no request — `BlockStored` is
+`block_hashes + parent_block_hash + token_ids + medium`. The API response does
+carry a per-request signal (`prompt_tokens_details.cached_tokens`), but it says
+nothing about *which* blocks. Containment in a step's window is the only link
+between the two, and it is sound exactly when calls are serialized, which
+`WindowRecorder` enforces on the producing side.
+
+What this cannot tell you. `_recv_ts` is subscriber receive time, not engine
+emit time; a frame delayed past a window boundary is attributed to the next
+stage or dropped. The `unattributed` count is reported rather than spread, so
+that error stays visible instead of being smoothed into the per-stage numbers.
+
+Usage:
+    python scripts/serve_track/correlate_kv.py outputs/serve_track/<run>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+_STORE_TAGS = {"BlockStored"}
+_REMOVE_TAGS = {"BlockRemoved"}
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def _event_kind(event: Dict[str, Any]) -> str:
+    """Name an event across every encoding the probe tolerates.
+
+    Measured on 0.27.1 the decoded frame carries a plain ``type`` field; the
+    probe also keeps a `_tag`/`_fields` pair for msgspec array-encoded structs,
+    whose layout has moved between versions. Both shapes reach here.
+    """
+    tag = event.get("type") or event.get("_tag")
+    if tag in _STORE_TAGS:
+        return "stored"
+    if tag in _REMOVE_TAGS:
+        return "removed"
+    if "parent_block_hash" in event or "token_ids" in event:
+        return "stored"
+    if "block_hashes" in event:
+        # BlockRemoved carries hashes but no parent chain or tokens.
+        return "removed"
+    return "other"
+
+
+def _block_count(event: Dict[str, Any]) -> int:
+    hashes = event.get("block_hashes")
+    if isinstance(hashes, list):
+        return len(hashes)
+    fields = event.get("_fields")
+    if isinstance(fields, list):
+        for value in fields:
+            if isinstance(value, list) and value and isinstance(value[0], int):
+                return len(value)
+    return 1
+
+
+def _block_size(event: Dict[str, Any]) -> int:
+    """Tokens per block, as the engine reports it (16 on 0.27.1).
+
+    This is what makes a real hit rate computable on vLLM at all: the
+    completions response leaves ``cached_tokens`` unpopulated, so tokens the
+    engine did not re-prefill are only knowable as blocks it did not store,
+    times this.
+    """
+    size = event.get("block_size")
+    return size if isinstance(size, int) and size > 0 else 0
+
+
+def _medium(event: Dict[str, Any]) -> str:
+    """Storage tier of a block — the axis KV offloading moves along.
+
+    With offloading enabled a reused block may be recalled from CPU or disk
+    instead of recomputed, and that shows up here as a non-GPU medium.
+    """
+    medium = event.get("medium")
+    return medium if isinstance(medium, str) and medium else "unknown"
+
+
+def _cached_tokens(usage: Dict[str, Any]) -> Optional[int]:
+    """API-side cache signal, from either shape of the usage dict.
+
+    A raw OpenAI-compatible response nests it under ``prompt_tokens_details``;
+    SEOCHO's ``LLMResponse.usage`` flattens it to a top-level ``cached_tokens``.
+
+    The flattened form is lossy on purpose upstream — `_build_response` coerces
+    an absent field with ``int(cached_tokens or 0)`` — so a 0 arriving through
+    the SDK path means "zero *or* never reported". Only the nested form can say
+    "absent". This is why `prefix_reuse_rate` (block-derived) is the primary
+    signal on vLLM and this one is kept for the MARA rig.
+    """
+    details = usage.get("prompt_tokens_details")
+    if isinstance(details, dict):
+        value = details.get("cached_tokens")
+        if isinstance(value, int):
+            return value
+    flattened = usage.get("cached_tokens")
+    if isinstance(flattened, int):
+        return flattened
+    return None
+
+
+def _stable_prefix_chars(section_maps: Iterable[Dict[str, int]]) -> int:
+    """Chars of leading prompt sections that are identical across every call.
+
+    A stage's KV prefix is reusable only up to the first section whose size
+    varies between episodes. Comparing sizes (not contents) is deliberate: the
+    sidecar records `section -> chars`, and a section that changes length has
+    certainly changed tokens.
+    """
+    maps = [m for m in section_maps if m]
+    if not maps:
+        return 0
+    first = maps[0]
+    stable = 0
+    for name, size in first.items():
+        if all(other.get(name) == size for other in maps[1:]):
+            stable += size
+        else:
+            break
+    return stable
+
+
+def _stable_prefix_bytes(hash_maps: Iterable[Dict[str, str]]) -> Optional[int]:
+    """Deepest checkpoint at which every call's prompt prefix still agrees.
+
+    `stable_prefix_chars` compares section *sizes*, so it reports 0 whenever a
+    section's length varies — even when the section shares almost all its bytes.
+    That is exactly the intent-extraction prompt's shape, where question-scoped
+    hints live inside the system section. These digests measure the thing that
+    actually bounds prefix reuse.
+
+    Returns None when calls carry no checkpoints (prompt shorter than the first
+    offset, or an older run) — absent is not zero.
+    """
+    maps = [m for m in hash_maps if m]
+    if not maps:
+        return None
+    shared = 0
+    for offset in sorted({int(k) for m in maps for k in m}):
+        key = str(offset)
+        digests = {m.get(key) for m in maps}
+        if None in digests or len(digests) > 1:
+            break
+        shared = offset
+    return shared
+
+
+def correlate(run_dir: Path) -> Dict[str, Any]:
+    windows = _read_jsonl(run_dir / "kv_windows.jsonl")
+    # A run without the ZMQ subscriber still yields per-stage prompt shape and
+    # metric deltas; only block-level attribution is unavailable.
+    events_path = run_dir / "kv_events.jsonl"
+    events = _read_jsonl(events_path) if events_path.exists() else []
+    if not windows:
+        raise SystemExit(f"no windows in {run_dir}/kv_windows.jsonl")
+
+    windows.sort(key=lambda w: w["t_start"])
+    per_role: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {
+            "calls": 0,
+            "blocks_stored": 0,
+            "blocks_removed": 0,
+            "prompt_tokens": 0,
+            "cached_tokens": 0,
+            "cached_tokens_reported": 0,
+            "latency_ms": 0.0,
+            "_sections": [],
+            "_prefix_hashes": [],
+            "_metrics": defaultdict(float),
+        }
+    )
+    # Per-window block totals, so reuse is readable call by call. On vLLM this
+    # is the *primary* cache signal: measured on 0.27.1, the completions
+    # response does not populate `prompt_tokens_details.cached_tokens` at all,
+    # so a repeat whose prefix was reused shows up as blocks it did not have to
+    # store, not as a token count. MARA reports the token field and no blocks;
+    # the two rigs are legible through different columns.
+    per_window_blocks: Dict[int, int] = defaultdict(int)
+    per_window_tokens: Dict[int, int] = defaultdict(int)
+    per_role_medium: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    attributed = 0
+    for event in events:
+        ts = event.get("_recv_ts")
+        if not isinstance(ts, (int, float)):
+            continue
+        index = next(
+            (i for i, w in enumerate(windows) if w["t_start"] <= ts <= w["t_end"]), None
+        )
+        if index is None:
+            continue
+        attributed += 1
+        window = windows[index]
+        kind = _event_kind(event)
+        bucket = per_role[window["role"]]
+        if kind == "stored":
+            count = _block_count(event)
+            bucket["blocks_stored"] += count
+            per_window_blocks[index] += count
+            per_window_tokens[index] += count * _block_size(event)
+            per_role_medium[window["role"]][_medium(event)] += count
+        elif kind == "removed":
+            bucket["blocks_removed"] += _block_count(event)
+
+    for index, window in enumerate(windows):
+        bucket = per_role[window["role"]]
+        bucket.setdefault("blocks_per_call", []).append(per_window_blocks[index])
+        bucket["tokens_stored"] = bucket.get("tokens_stored", 0) + per_window_tokens[index]
+        bucket["calls"] += 1
+        bucket["latency_ms"] += (window["t_end"] - window["t_start"]) * 1000.0
+        bucket["_sections"].append(window.get("prompt_sections") or {})
+        bucket["_prefix_hashes"].append(window.get("prefix_hashes") or {})
+        for metric, value in (window.get("metrics_delta") or {}).items():
+            # Counters sum across a stage's calls; the occupancy gauge is kept
+            # as the last value it held, since summing percentages is nonsense.
+            if metric.endswith("_usage_perc"):
+                bucket["_metrics"][metric] = value
+            else:
+                bucket["_metrics"][metric] += value
+        usage = window.get("usage") or {}
+        prompt_tokens = usage.get("prompt_tokens")
+        if isinstance(prompt_tokens, int):
+            bucket["prompt_tokens"] += prompt_tokens
+        cached = _cached_tokens(usage)
+        if cached is not None:
+            bucket["cached_tokens"] += cached
+            bucket["cached_tokens_reported"] += 1
+
+    has_block_evidence = any(per_window_tokens.values()) or any(per_window_blocks.values())
+
+    stages = {}
+    for role, bucket in per_role.items():
+        sections = bucket.pop("_sections")
+        prefix_hashes = bucket.pop("_prefix_hashes")
+        metrics = {k: round(v, 6) for k, v in bucket.pop("_metrics").items()}
+        bucket.setdefault("blocks_per_call", [])
+        bucket.setdefault("tokens_stored", 0)
+        calls = bucket["calls"] or 1
+        prompt_tokens = bucket["prompt_tokens"]
+        tokens_stored = bucket["tokens_stored"]
+        stages[role] = {
+            **bucket,
+            "media": dict(sorted(per_role_medium[role].items())),
+            "vllm_metrics": dict(sorted(metrics.items())),
+            # vLLM's own prefix-cache accounting, summed over the stage's calls.
+            # Independent of the block-side estimate and of the API's
+            # cached_tokens, so a disagreement between them is itself a signal.
+            "engine_prefix_hit_rate": (
+                round(
+                    metrics.get("vllm:prefix_cache_hits_total", 0.0)
+                    / metrics["vllm:prefix_cache_queries_total"],
+                    4,
+                )
+                if metrics.get("vllm:prefix_cache_queries_total")
+                else None
+            ),
+            "latency_ms_mean": round(bucket["latency_ms"] / calls, 2),
+            "stable_prefix_chars": _stable_prefix_chars(sections),
+            # Byte-level floor on the shared prefix, at checkpoint granularity.
+            # Trust this over stable_prefix_chars when a section's length varies.
+            "stable_prefix_bytes": _stable_prefix_bytes(prefix_hashes),
+            # Block-derived reuse: prompt tokens the engine did NOT have to
+            # store, over prompt tokens. This is the usable hit rate on vLLM,
+            # where `cached_tokens` is absent.
+            #
+            # The None guard is per *run*, not per stage: on a rig that emits
+            # block events, a stage that stored zero blocks reused everything —
+            # that is 100%, the headline result, not a missing measurement.
+            # Only a run with no block evidence at all (an API-only rig) has
+            # nothing to report.
+            "prefix_reuse_rate": (
+                round(max(0.0, 1.0 - tokens_stored / prompt_tokens), 4)
+                if prompt_tokens and has_block_evidence
+                else None
+            ),
+            # Share of prompt tokens the engine did not have to prefill.
+            # None when the provider never reported the field — an unreported
+            # signal is not a zero, and the MARA path is measured to report
+            # nothing below a length threshold.
+            "cache_hit_rate": (
+                round(bucket["cached_tokens"] / prompt_tokens, 4)
+                if prompt_tokens and bucket["cached_tokens_reported"]
+                else None
+            ),
+        }
+
+    return {
+        "run": str(run_dir),
+        "windows": len(windows),
+        "events": len(events),
+        "events_attributed": attributed,
+        "events_unattributed": len(events) - attributed,
+        "stages": dict(sorted(stages.items())),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path)
+    parser.add_argument("--out", type=Path, default=None,
+                        help="write the report as JSON (default: stdout only)")
+    args = parser.parse_args()
+
+    report = correlate(args.run_dir)
+    text = json.dumps(report, indent=2, ensure_ascii=False)
+    print(text)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/erb_adapter.py
+++ b/scripts/serve_track/erb_adapter.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Turn EnterpriseRAG-Bench questions into the arms format, gold-context only.
+
+The external-validity check for the one result the synthetic set produced with
+a mechanism attached: the graph form scores 0 of 4 on negation and absence
+while vector scores 4 of 4. ERB has a question type built for exactly that --
+`info_not_found`, 20 questions whose correct answer is that the documents do
+not answer them -- written by people who had never heard of our experiment.
+
+What this deliberately does NOT do is retrieval. Every arm is built from the
+question's own `expected_doc_ids`, so retrieval quality is held constant at
+perfect and the only variable is the FORM the same evidence is presented in.
+Mixing in a retriever would reintroduce the confound `ADR-0105` recorded: a
+graph win could then be retrieval precision rather than representation. That
+also means the numbers here are not comparable to published ERB leaderboards,
+which measure retrieval and answering together. Say so wherever they appear.
+
+The two selected strata behave differently on purpose:
+
+  info_not_found     zero gold documents by construction. The arms therefore
+                     carry the RETRIEVED-BUT-IRRELEVANT neighbourhood rather
+                     than nothing, because handing every arm an empty context
+                     tests nothing -- the question is whether a form makes the
+                     model claim an answer it does not have.
+  conflicting_info   two gold documents that disagree. Our synthetic world has
+                     no contradictions by construction, so this stratum is not
+                     reachable from it at all.
+
+Use the upstream parquet, not a local slice. `--erb` pointed at a directory of
+per-source sample zips resolves only 55.6% of gold doc ids, and the loss is not
+uniform: Confluence came out at 97.8% and **Slack at 0 of 57**. Strata then
+survive by source rather than at random -- of the 20 `completeness` items, the
+11 with complete gold were 11/11 Confluence-only and 0/11 cross-source, so a
+run on that slice would measure single-wiki procedure assembly while reporting
+it as cross-system aggregation. The upstream release
+(`onyx-dot-app/EnterpriseRAG-Bench`, 511,958 documents) resolves 742 of 742.
+
+Triples come from two different places, and the difference is the point. ERB
+has no gold graph, so a subject-relation-object rendering must be derived.
+
+For a question with gold documents, edges come from `answer_facts` -- the
+dataset's own decomposed claims, and what its own scoring uses.
+
+For `info_not_found` that is impossible, and finding out why is what made this
+adapter correct. Those items' `answer_facts` is not a fact at all; it is an
+instruction -- "The answer must state at some point that the query is not fully
+answerable". Extracting edges from it yields nothing, which marked all twenty
+items non-comparable and silently deleted the stratum this run exists for.
+Their edges are therefore extracted from the neighbourhood DOCUMENTS, which is
+also the more faithful simulation: a graph retriever asked an unanswerable
+question does not return nothing, it returns whatever edges sit near the query.
+Whether the model then refuses or invents is the measurement.
+
+Usage:
+    scripts/serve_track/erb_adapter.py \\
+        --erb ~/openup/seocho/dataset/enterprise_rag_bench \\
+        --types info_not_found conflicting_info \\
+        --out outputs/serve_track/erb_questions.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+SCHEMA_VERSION = 1
+
+# A fact sentence yields an edge when it reads as <subject> <verb phrase> <object>.
+# Deliberately conservative: a loose pattern would manufacture edges out of
+# ordinary prose and inflate the graph arm with statements it cannot support.
+_FACT_EDGE = re.compile(
+    r"^(?P<s>[A-Z][\w .,'/()-]{2,60}?)\s+"
+    r"(?P<r>is|are|was|were|has|have|must|should|requires?|uses?|supports?|"
+    r"provides?|includes?|defaults? to|applies to|belongs to|reports? to|"
+    r"depends? on|owns?|sets?|limits?|allows?)\s+"
+    r"(?P<o>.{2,120}?)\.?$"
+)
+
+
+def load_documents(erb_root: Path) -> Dict[str, Path]:
+    """Map `dsid_<hex>` to its file. Documents are named `dsid_<id>__<slug>.txt`."""
+    index: Dict[str, Path] = {}
+    for path in (erb_root / "sources").rglob("dsid_*"):
+        if not path.is_file():
+            continue
+        stem = path.name.split("__", 1)[0]
+        index.setdefault(stem, path)
+    return index
+
+
+def load_documents_parquet(parquet_dir: Path) -> Dict[str, str]:
+    """Load the upstream release: 511,958 documents keyed by `doc_id`.
+
+    Held in memory as text rather than paths because the file is one 1.4 GB
+    parquet, not a tree. Roughly 2 GB resident; the alternative is re-reading
+    the column per lookup, which is slower than the whole experiment.
+    """
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(parquet_dir / "data" / "documents" / "test.parquet",
+                          columns=["doc_id", "title", "content"])
+    ids = table["doc_id"].to_pylist()
+    titles = table["title"].to_pylist()
+    contents = table["content"].to_pylist()
+    return {
+        doc_id: f"{title}\n\n{content}" if title else str(content)
+        for doc_id, title, content in zip(ids, titles, contents)
+    }
+
+
+def read_doc(path: Path, max_chars: int) -> str:
+    text = path.read_text(encoding="utf-8", errors="replace").strip()
+    return text[:max_chars]
+
+
+def facts_to_edges(facts: List[str]) -> List[List[str]]:
+    edges: List[List[str]] = []
+    for fact in facts:
+        match = _FACT_EDGE.match(str(fact).strip())
+        if not match:
+            continue
+        subject = match.group("s").strip(" ,")
+        relation = match.group("r").strip().upper().replace(" ", "_")
+        obj = match.group("o").strip(" .")
+        if subject and obj:
+            edges.append([subject, relation, obj])
+    return edges
+
+
+_DOC_EDGE = re.compile(
+    r"(?P<s>[A-Z][\w .,'/()-]{2,50}?)\s+"
+    r"(?P<r>is|are|was|were|has|have|must|should|requires?|uses?|supports?|"
+    r"provides?|includes?|defaults? to|applies to|belongs to|reports? to|"
+    r"depends? on|owns?|sets?|limits?|allows?|handles?|runs?|returns?)\s+"
+    r"(?P<o>[^.\n]{2,90})"
+)
+
+
+def edges_from_text(texts: List[str], limit: int) -> List[List[str]]:
+    """Crude sentence-to-edge extraction over document text.
+
+    Only used where `answer_facts` cannot supply edges. Deliberately shallow --
+    the goal is a plausible retrieved subgraph, not a good one. A careful
+    extractor would be the wrong instrument here, because the question being
+    asked is what a model does when the graph form carries edges that do not
+    contain the answer.
+    """
+    edges: List[List[str]] = []
+    seen = set()
+    for text in texts:
+        for raw in re.split(r"(?<=[.\n])\s+", text):
+            match = _DOC_EDGE.match(raw.strip())
+            if not match:
+                continue
+            subject = match.group("s").strip(" ,")
+            relation = match.group("r").strip().upper().replace(" ", "_")
+            obj = match.group("o").strip(" .,")
+            key = (subject.lower(), relation, obj.lower())
+            if subject and obj and key not in seen:
+                seen.add(key)
+                edges.append([subject, relation, obj])
+            if len(edges) >= limit:
+                return edges
+    return edges
+
+
+def _neighbourhood_parquet(docs: Dict[str, str], question: str, limit: int) -> List[str]:
+    """Near-miss documents for an `info_not_found` item, by rare-word overlap.
+
+    Crude on purpose: a good retriever would stop the item being unanswerable.
+    """
+    words = {w.lower() for w in re.findall(r"[A-Za-z]{6,}", question)}
+    if not words:
+        return []
+    scored = []
+    for doc_id, text in docs.items():
+        head = text[:400].lower()
+        hits = sum(1 for w in words if w in head)
+        if hits:
+            scored.append((hits, doc_id))
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    return [docs[i] for _, i in scored[:limit]]
+
+
+def _neighbourhood(doc_index: Dict[str, Path], question: str, limit: int) -> List[str]:
+    """Documents to hand an `info_not_found` item, which has no gold docs.
+
+    Picked by filename-slug overlap with the question's rare words. Crude on
+    purpose: the point is a plausible near-miss neighbourhood, not good
+    retrieval -- if it were good, the item would stop being unanswerable.
+    """
+    words = {w.lower() for w in re.findall(r"[A-Za-z]{5,}", question)}
+    scored = []
+    for key, path in doc_index.items():
+        slug = path.name.split("__", 1)[-1].lower()
+        hits = sum(1 for w in words if w in slug)
+        if hits:
+            scored.append((hits, key, path))
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    return [str(p) for _, _, p in scored[:limit]]
+
+
+
+def load_extracted_graph(path: Path) -> Dict[str, List[Tuple[str, str, str]]]:
+    """doc_id -> triples, from OUR OWN indexing run (`erb_index.py`).
+
+    Reading `answer_facts` instead of this is the shortcut the project
+    explicitly rejected: those are the dataset's decomposed grading claims, and
+    the graph arm built from them is reading the marking scheme. Verified on the
+    committed run -- an `ERB_conflicting_info` "triple" was
+
+        (The answer must state that the updated reservation target)
+          -[IS]-> (30% of interactive burst credits ... on dp-132-usw)
+
+    which is a rubric line, not a fact about the world. That stratum is also the
+    only statistically significant graph-vs-vector result in the whole
+    programme, so it is the one place the shortcut mattered most.
+    """
+    graphs: Dict[str, List[Tuple[str, str, str]]] = {}
+    if not path.exists():
+        return graphs
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("error"):
+            continue
+        names = {
+            str(n.get("id")): str((n.get("properties") or {}).get("name") or n.get("id"))
+            for n in (record.get("nodes") or [])
+        }
+        triples = []
+        for rel in (record.get("relationships") or []):
+            head = names.get(str(rel.get("source")))
+            tail = names.get(str(rel.get("target")))
+            kind = str(rel.get("type") or "").strip()
+            if head and tail and kind:
+                triples.append((head, kind, tail))
+        if triples:
+            graphs[str(record.get("doc_id"))] = triples
+    return graphs
+
+
+def build_item(row: Dict[str, Any], doc_index: Dict[str, Any], *,
+               extracted_graph: Optional[Dict[str, List[Tuple[str, str, str]]]] = None,
+               edge_source_mode: str = "extracted",
+               max_doc_chars: int, neighbourhood: int,
+               edge_limit: int = 40, from_parquet: bool = False) -> Dict[str, Any]:
+    extracted_graph = extracted_graph or {}
+    gold_ids = list(row.get("expected_doc_ids") or [])
+    missing = [i for i in gold_ids if i not in doc_index]
+
+    if from_parquet:
+        texts = [doc_index[i] for i in gold_ids if i in doc_index]
+        if not texts and row["question_type"] == "info_not_found":
+            texts = _neighbourhood_parquet(doc_index, row["question"], neighbourhood)
+        corpus = [t[:max_doc_chars] for t in texts]
+    else:
+        paths = [doc_index[i] for i in gold_ids if i in doc_index]
+        if not paths and row["question_type"] == "info_not_found":
+            paths = [Path(p) for p in
+                     _neighbourhood(doc_index, row["question"], neighbourhood)]
+        corpus = [read_doc(p, max_doc_chars) for p in paths]
+    corpus = [c for c in corpus if c]
+
+    facts = list(row.get("answer_facts") or [])
+
+    # Default: the graph WE extracted, joined on the gold document ids. The
+    # answer_facts path remains reachable only as an explicitly declared
+    # ceiling arm, because it hands the graph arm the grading rubric.
+    edges: List[Tuple[str, str, str]] = []
+    edge_source = "extracted"
+    if edge_source_mode == "answer_facts":
+        edges = facts_to_edges(facts)
+        edge_source = "answer_facts_CEILING"
+    else:
+        for doc_id in gold_ids:
+            edges.extend(extracted_graph.get(doc_id, []))
+        edges = edges[:edge_limit]
+        if not edges:
+            edge_source = "extracted_empty"
+
+    if not edges and corpus and edge_source_mode != "answer_facts":
+        edges = edges_from_text(corpus, limit=edge_limit)
+        edge_source = "document_text"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "id": row["question_id"],
+        "question": row["question"],
+        "answer": row.get("gold_answer") or "",
+        "excluded": [],
+        "corpus": corpus,
+        "gold_edges": edges,
+        "strata": {
+            "stratum": f"ERB_{row['question_type']}",
+            "hops": len(edges) or None,
+            "dispersion": len(corpus),
+            "answer_type": row["question_type"],
+            "sources": row.get("source_types") or [],
+            "gold_docs_declared": len(gold_ids),
+            "gold_docs_missing": len(missing),
+            "facts": len(facts),
+            "edges": len(edges),
+            "edge_source": edge_source,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--erb", type=Path,
+                     help="local slice directory. Resolves 55.6% of gold ids and "
+                          "biases by source; prefer --parquet")
+    src.add_argument("--parquet", type=Path,
+                     help="upstream release dir (onyx-dot-app/EnterpriseRAG-Bench); "
+                          "resolves 742 of 742")
+    parser.add_argument("--types", nargs="+",
+                        default=["info_not_found", "conflicting_info"])
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/erb_questions.jsonl"))
+    parser.add_argument("--max-doc-chars", type=int, default=6000,
+                        help="cap per document; ERB docs run long and the budget "
+                             "is enforced again downstream")
+    parser.add_argument("--extracted", type=Path,
+                        default=Path("outputs/serve_track/erb_extracted.jsonl"),
+                        help="graph produced by erb_index.py; the default edge source")
+    parser.add_argument("--edge-source", choices=("extracted", "answer_facts"),
+                        default="extracted",
+                        help="'extracted' uses OUR indexing (the thing under test). "
+                             "'answer_facts' uses the dataset's own decomposed "
+                             "grading claims -- a declared CEILING arm, not a "
+                             "graph result: it hands the graph arm the rubric.")
+    parser.add_argument("--neighbourhood", type=int, default=3,
+                        help="documents to give an info_not_found item")
+    args = parser.parse_args()
+
+    if args.parquet:
+        import pyarrow.parquet as pq
+
+        doc_index = load_documents_parquet(args.parquet)
+        rows = pq.read_table(args.parquet / "data" / "questions" / "test.parquet").to_pylist()
+        rows = [{k: (list(v) if hasattr(v, "__iter__") and not isinstance(v, str) else v)
+                 for k, v in r.items()} for r in rows]
+        from_parquet = True
+    else:
+        doc_index = load_documents(args.erb)
+        rows = [json.loads(line) for line in
+                (args.erb / "questions.jsonl").read_text(encoding="utf-8").splitlines()
+                if line.strip()]
+        from_parquet = False
+    print(f"indexed {len(doc_index)} documents")
+    selected = [r for r in rows if r["question_type"] in args.types]
+
+    extracted_graph = load_extracted_graph(args.extracted)
+    if args.edge_source == "extracted" and not extracted_graph:
+        raise SystemExit(
+            f"--edge-source extracted needs the graph from erb_index.py, and "
+            f"{args.extracted} has none. Run erb_index.py first, or pass "
+            f"--edge-source answer_facts to build the declared CEILING arm "
+            f"(which reads the dataset's grading rubric, not our extraction)."
+        )
+    print(f"extracted graph: {len(extracted_graph)} documents")
+
+    built = [build_item(r, doc_index, max_doc_chars=args.max_doc_chars,
+                        neighbourhood=args.neighbourhood,
+                        extracted_graph=extracted_graph,
+                        edge_source_mode=args.edge_source,
+                        from_parquet=from_parquet) for r in selected]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as handle:
+        for item in built:
+            handle.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+    print(f"wrote {len(built)} items to {args.out}\n")
+    by_type: Dict[str, List[Dict[str, Any]]] = {}
+    for item in built:
+        by_type.setdefault(item["strata"]["stratum"], []).append(item)
+    for stratum, items in sorted(by_type.items()):
+        with_edges = sum(1 for i in items if i["gold_edges"])
+        docs = sum(len(i["corpus"]) for i in items) / max(len(items), 1)
+        chars = sum(sum(len(c) for c in i["corpus"]) for i in items) / max(len(items), 1)
+        print(f"  {stratum:26s} n={len(items):3d}  "
+              f"edges_ok={with_edges:3d}  mean_docs={docs:4.1f}  mean_chars={chars:7.0f}")
+
+    unresolved = sum(i["strata"]["gold_docs_missing"] for i in built)
+    if unresolved:
+        print(f"\nWARN: {unresolved} gold doc ids did not resolve to a file")
+    no_edges = [i["id"] for i in built if not i["gold_edges"]]
+    if no_edges:
+        print(f"\n{len(no_edges)} items yielded no edges from answer_facts and will be "
+              f"non-comparable downstream:\n  {', '.join(no_edges[:8])}"
+              + (" ..." if len(no_edges) > 8 else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/erb_index.py
+++ b/scripts/serve_track/erb_index.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Index EnterpriseRAG-Bench documents with SEOCHO and emit the extracted graph.
+
+This replaces the shortcut the first ERB adapter took. That version built the
+graph arm from the dataset's own `answer_facts`, which measures how a model
+reads a form we did not produce — it routes around the thing this project
+actually builds. The question worth answering is whether OUR indexing recovers,
+from raw enterprise records, the actors and decisions the questions ask about.
+GraphRAG-Bench ships gold triples; ERB does not, so we extract our own and are
+then accountable for them.
+
+The ontology is derived from what the questions demand, not from what is easy
+to extract. Reading the three aggregation strata:
+
+  conflicting_info   "an earlier suggestion was 20%, but the applied target is
+                     30%" — needs a decision to carry a VALUE and a STATUS, and
+                     a SUPERSEDES edge. A flat triple set cannot answer this at
+                     all: both numbers are true statements about the corpus and
+                     only their relative recency separates them.
+  project_related    "throttling was triggered by X during Y, mitigated by Z" —
+                     needs a causal chain across incident, cause and mitigation,
+                     with the customer and region attached.
+  completeness       "first pause the rollout, then re-pin, then redeploy" —
+                     needs ORDER, which is the one thing a set of triples
+                     discards by default.
+
+So `Decision.status`, `SUPERSEDES` and `Step.position` are not ontology
+decoration; each one is the minimum structure some stratum's gold answer
+depends on. If extraction drops them the graph arm cannot win those strata no
+matter how good retrieval is, and that is a finding about our indexing rather
+than about graphs.
+
+Scope: the gold documents of the selected questions — 322 documents, 2.2M
+characters. Retrieval is held perfect on purpose, exactly as in the arms
+comparison, so a difference is attributable to extraction rather than to search.
+
+Usage:
+    export MARA_API_KEY=...
+    scripts/serve_track/erb_index.py \\
+        --parquet ~/.cache/huggingface/hub/datasets--onyx-dot-app--.../snapshots/<id> \\
+        --types conflicting_info project_related completeness \\
+        --out outputs/serve_track/erb_extracted.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+SCHEMA_VERSION = 1
+
+
+def build_ontology():
+    """Actors, decisions, and the three things the gold answers turn on.
+
+    Kept deliberately small. A large ontology raises extraction recall on paper
+    and lowers agreement in practice (`ADR-0154` measured ontology guidance
+    *lowering* cross-model agreement), and every type here has to earn its place
+    by being load-bearing for a question we are actually scoring.
+    """
+    from seocho import NodeDef, Ontology, P, RelDef
+
+    return Ontology(
+        name="enterprise_decisions",
+        nodes={
+            "Person": NodeDef(
+                description="A named individual: an engineer, manager, or customer contact.",
+                properties={"name": P(str, unique=True), "role": P(str), "org": P(str)},
+                identity_keys=["name"],
+            ),
+            "Org": NodeDef(
+                description="A company or team — the vendor, a customer, or an internal group.",
+                properties={"name": P(str, unique=True), "kind": P(str)},
+                identity_keys=["name"],
+            ),
+            "System": NodeDef(
+                description="A service, component, pool, or environment that work is done to.",
+                properties={"name": P(str, unique=True), "region": P(str)},
+                identity_keys=["name"],
+            ),
+            "Decision": NodeDef(
+                description=(
+                    "A choice that was proposed, applied, or reversed. Carries the "
+                    "value decided and whether it is the CURRENT one — a superseded "
+                    "decision is still a true statement about the corpus, and only "
+                    "status separates it from the answer."
+                ),
+                properties={
+                    "name": P(str, unique=True),
+                    "value": P(str),
+                    "status": P(str),   # proposed | applied | superseded | reverted
+                    "decided_on": P(str),
+                },
+                identity_keys=["name"],
+            ),
+            "Incident": NodeDef(
+                description="An observed failure or degradation, with its symptom.",
+                properties={"name": P(str, unique=True), "symptom": P(str), "started": P(str)},
+                identity_keys=["name"],
+            ),
+            "Step": NodeDef(
+                description=(
+                    "One action in a procedure. `position` exists because ordering "
+                    "is what a triple set discards, and the completeness stratum's "
+                    "gold answers are ordered."
+                ),
+                properties={
+                    "name": P(str, unique=True),
+                    "position": P(int),
+                    "procedure": P(str),
+                },
+                identity_keys=["name", "procedure"],
+            ),
+        },
+        relationships={
+            "DECIDED": RelDef("Person", "Decision",
+                              description="The person who made or applied the decision."),
+            # Direction decides the answer here, so it is stated rather than
+            # left to the extractor: the NEWER decision is the source and the
+            # one it replaces is the target. Reversed, a conflicting_info item
+            # returns the stale value while looking equally well-formed.
+            "SUPERSEDES": RelDef("Decision", "Decision",
+                                 description="The newer decision replaces the older one. "
+                                             "Source is current, target is obsolete.",
+                                 source_role="replacement", target_role="replaced"),
+            "APPLIES_TO": RelDef("Decision", "System",
+                                 description="The system, pool, or region the decision governs."),
+            "AFFECTS": RelDef("Incident", "Org",
+                              description="The customer or team the incident impacted."),
+            "OCCURRED_ON": RelDef("Incident", "System",
+                                  description="Where the incident was observed."),
+            "CAUSED_BY": RelDef("Incident", "Decision",
+                                description="The change or decision that triggered the incident."),
+            "MITIGATED_BY": RelDef("Incident", "Decision",
+                                   description="The action taken to resolve or contain it."),
+            "WORKS_FOR": RelDef("Person", "Org"),
+            "PRECEDES": RelDef("Step", "Step",
+                               description="This step must be completed before the next one. "
+                                           "Source runs first.",
+                               source_role="earlier", target_role="later"),
+            "PART_OF": RelDef("Step", "System",
+                              description="The system the procedure operates on."),
+        },
+    )
+
+
+def load_gold_documents(parquet_dir: Path, types: List[str]) -> Dict[str, Dict[str, Any]]:
+    import pyarrow.parquet as pq
+
+    questions = pq.read_table(parquet_dir / "data" / "questions" / "test.parquet").to_pylist()
+    selected = [r for r in questions if r["question_type"] in types]
+    wanted = {i for r in selected for i in r["expected_doc_ids"]}
+
+    table = pq.read_table(parquet_dir / "data" / "documents" / "test.parquet",
+                          columns=["doc_id", "source_type", "title", "content"])
+    docs: Dict[str, Dict[str, Any]] = {}
+    for doc_id, source, title, content in zip(
+        table["doc_id"].to_pylist(), table["source_type"].to_pylist(),
+        table["title"].to_pylist(), table["content"].to_pylist()
+    ):
+        if doc_id in wanted:
+            docs[doc_id] = {"source_type": source, "title": title, "content": content}
+    return docs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parquet", type=Path, required=True)
+    parser.add_argument("--types", nargs="+",
+                        default=["conflicting_info", "project_related", "completeness"])
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/erb_extracted.jsonl"))
+    parser.add_argument("--model", default="MiniMax-M2.7")
+    parser.add_argument("--base-url", default="https://api.cloud.mara.com/v1")
+    parser.add_argument("--max-chars", type=int, default=6000,
+                        help="per-document cap fed to one extraction call")
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--concurrency", type=int, default=8,
+                        help="documents extracted in parallel. Serial extraction "
+                             "runs ~2 min/doc, which is 10 hours for this corpus")
+    parser.add_argument("--retries", type=int, default=2,
+                        help="retries when the model returns reasoning instead of JSON")
+    parser.add_argument("--enforcement", default="guided",
+                        choices=["open", "guided", "strict"],
+                        help="ontology enforcement; recorded in the output")
+    args = parser.parse_args()
+
+    key = os.environ.get("MARA_API_KEY", "").strip().strip('"').strip("'")
+    if not key:
+        raise SystemExit("MARA_API_KEY is not set")
+
+    from seocho.index.extraction_engine import CanonicalExtractionEngine
+    from seocho.store.llm import create_llm_backend
+
+    ontology = build_ontology()
+    llm = create_llm_backend(provider="openai", model=args.model,
+                             api_key=key, base_url=args.base_url)
+    # `guided` rather than `strict`: strict rejects anything outside the declared
+    # vocabulary, and on raw enterprise prose that discards most of the document.
+    # ADR-0154 also measured ontology guidance LOWERING cross-model agreement, so
+    # the looser setting is the honest default and the enforcement level is
+    # recorded per run rather than assumed.
+    engine = CanonicalExtractionEngine(llm=llm, ontology=ontology, enforcement=args.enforcement)
+
+    docs = load_gold_documents(args.parquet, args.types)
+    items = sorted(docs.items())
+    if args.limit:
+        items = items[: args.limit]
+    print(f"extracting from {len(items)} gold documents with {args.model}")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    totals = {"nodes": 0, "rels": 0, "failed": 0, "retried": 0}
+    started = time.perf_counter()
+    lock = threading.Lock()
+
+    def extract_one(pair):
+        doc_id, doc = pair
+        text = f"{doc['title']}\n\n{doc['content']}"[: args.max_chars]
+        last = None
+        for attempt in range(args.retries + 1):
+            try:
+                graph = engine.extract(
+                    text,
+                    category=doc["source_type"],
+                    metadata={"doc_id": doc_id, "source_type": doc["source_type"]},
+                )
+                return doc_id, doc, graph.get("nodes") or [], graph.get("relationships") or [], None, attempt
+            except Exception as exc:  # noqa: BLE001 — one bad document must not end the run
+                # MiniMax-M2.7 is a reasoning model and sometimes emits its
+                # reasoning where the JSON should be ("Let me analyze this
+                # text..."). That is transient, so it is retried rather than
+                # counted as an extraction failure on the first try.
+                last = f"{type(exc).__name__}: {exc}"
+        return doc_id, doc, [], [], last, args.retries
+
+    done = 0
+    with args.out.open("w", encoding="utf-8") as handle, \
+            ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = [pool.submit(extract_one, pair) for pair in items]
+        for future in as_completed(futures):
+            doc_id, doc, nodes, rels, error, attempts = future.result()
+            with lock:
+                done += 1
+                totals["nodes"] += len(nodes)
+                totals["rels"] += len(rels)
+                totals["retried"] += 1 if attempts else 0
+                if error:
+                    totals["failed"] += 1
+                handle.write(json.dumps({
+                    "schema_version": SCHEMA_VERSION,
+                    "doc_id": doc_id,
+                    "source_type": doc["source_type"],
+                    "enforcement": args.enforcement,
+                    "title": doc["title"],
+                    "nodes": nodes,
+                    "relationships": rels,
+                    "attempts": attempts + 1,
+                    "error": error,
+                }, ensure_ascii=False) + "\n")
+                handle.flush()
+                if done % 20 == 0 or done == len(items):
+                    rate = done / max(time.perf_counter() - started, 1e-6)
+                    print(f"  [{done}/{len(items)}] nodes={totals['nodes']} "
+                          f"rels={totals['rels']} retried={totals['retried']} "
+                          f"failed={totals['failed']} ({rate*60:.1f} docs/min)", flush=True)
+
+    elapsed = time.perf_counter() - started
+    print(f"\nwrote {args.out} in {elapsed/60:.1f} min")
+    print(f"  nodes={totals['nodes']}  relationships={totals['rels']}  "
+          f"retried={totals['retried']}  failed={totals['failed']}/{len(items)}")
+    if totals["failed"]:
+        print("  Failed documents are written with empty node and relationship "
+              "lists and a recorded error, never dropped — a silently shorter "
+              "graph would read as an extraction quality result.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/kv_windows.py
+++ b/scripts/serve_track/kv_windows.py
@@ -1,0 +1,191 @@
+"""Absolute per-step time windows, so KV-cache events can be attributed to a stage.
+
+Trace schema v1 (`scripts/pattern_traces/schema.py`) records `latency_ms` per
+step but no absolute start time, and it was deliberately frozen in #486. vLLM's
+KV events carry no request id either — a `BlockStored` payload is
+`block_hashes + parent_block_hash + token_ids + medium`, nothing that names the
+caller. So neither side alone can say *which RAG stage* caused a block store.
+
+Rather than reopen the frozen schema, this sidecar records the one fact both
+sides are missing: when each step actually ran, on the same clock the KV
+subscriber stamps its frames with (`time.time`). Joining is then a containment
+test, done offline in `correlate_kv.py`.
+
+The sidecar is written next to the episode file and keyed by the same
+`trace_id`, so a run is one pair:
+
+    outputs/serve_track/<run>/episodes.jsonl    # trace schema v1, untouched
+    outputs/serve_track/<run>/kv_windows.jsonl  # this file
+    outputs/serve_track/<run>/kv_events.jsonl   # from the vLLM subscriber
+
+Windows are only meaningful when requests do not overlap in time. Concurrency
+would let two stages' blocks interleave inside one window, so `record_step`
+refuses to open a second window while one is open; the caller must serialize.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, Optional
+
+WINDOW_SCHEMA_VERSION = 1
+
+
+@dataclass(slots=True)
+class StepWindow:
+    """One LLM call's wall-clock extent, on `time.time`'s clock."""
+
+    trace_id: str
+    step_index: int
+    role: str
+    model: str
+    provider: str
+    t_start: float
+    t_end: float = 0.0
+    window_schema: int = field(default=WINDOW_SCHEMA_VERSION)
+    # Provider-verbatim usage, so the API-side cache signal
+    # (`prompt_tokens_details.cached_tokens`) survives next to the block-side
+    # evidence without a second lookup.
+    usage: Dict[str, Any] = field(default_factory=dict)
+    prompt_chars: int = 0
+    # Section -> chars, mirroring LLMStep.prompt_sections. This is what makes
+    # the prefix story legible: a stage whose leading sections are stable
+    # across calls is a stage whose KV prefix can be reused.
+    prompt_sections: Dict[str, int] = field(default_factory=dict)
+    # Content-free prompt-prefix digests at fixed byte offsets. Two calls that
+    # agree at offset N shared at least N bytes, which is what section sizes
+    # cannot show when the volatile part lives inside a section.
+    prefix_hashes: Dict[str, str] = field(default_factory=dict)
+    # Change in vLLM's process-wide KV counters across this window. Empty when
+    # no metrics endpoint was configured or the scrape failed — an absent delta
+    # is not a zero one, and zeros would read as "no bytes moved".
+    metrics_delta: Dict[str, float] = field(default_factory=dict)
+
+    @property
+    def duration_ms(self) -> float:
+        return (self.t_end - self.t_start) * 1000.0
+
+
+class WindowRecorder:
+    """Append-only writer for step windows, one file per run."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        metrics_sampler: Optional[Callable[[], Dict[str, float]]] = None,
+    ) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._open: Optional[StepWindow] = None
+        self._counter: Dict[str, int] = {}
+        # Optional snapshot of vLLM's /metrics at each window boundary. The
+        # difference is what turns process-wide counters — offload bytes,
+        # transfer time, prefix-cache hits — into per-stage numbers.
+        self._metrics_sampler = metrics_sampler
+
+    @contextmanager
+    def record_step(
+        self,
+        *,
+        trace_id: str,
+        role: str,
+        model: str,
+        provider: str,
+        prompt_chars: int = 0,
+        prompt_sections: Optional[Dict[str, int]] = None,
+        prefix_hashes: Optional[Dict[str, str]] = None,
+    ) -> Iterator[StepWindow]:
+        """Open a window around one LLM call and append it on exit.
+
+        The window closes even when the call raises, because a failed call
+        still consumed cache; dropping it would silently bias attribution.
+        """
+        if self._open is not None:
+            raise RuntimeError(
+                f"window for {self._open.role!r} is still open; KV attribution "
+                "requires serialized calls (see module docstring)"
+            )
+        index = self._counter.get(trace_id, 0)
+        self._counter[trace_id] = index + 1
+        window = StepWindow(
+            trace_id=trace_id,
+            step_index=index,
+            role=role,
+            model=model,
+            provider=provider,
+            t_start=time.time(),
+            prompt_chars=prompt_chars,
+            prompt_sections=dict(prompt_sections or {}),
+            prefix_hashes=dict(prefix_hashes or {}),
+        )
+        before = self._sample()
+        self._open = window
+        try:
+            yield window
+        finally:
+            window.t_end = time.time()
+            window.metrics_delta = _metrics_delta(before, self._sample())
+            self._open = None
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(asdict(window), ensure_ascii=False) + "\n")
+
+
+    def _sample(self) -> Dict[str, float]:
+        if self._metrics_sampler is None:
+            return {}
+        try:
+            return self._metrics_sampler()
+        except Exception:
+            return {}
+
+
+_VLLM_METRICS = None
+
+
+def _metrics_module():
+    """Load the sibling metrics helper once, by path.
+
+    These scripts are loaded standalone (no package), so a plain import would
+    not resolve; caching keeps a per-window scrape from re-executing the module.
+    """
+    global _VLLM_METRICS
+    if _VLLM_METRICS is None:
+        from importlib.util import module_from_spec, spec_from_file_location
+
+        spec = spec_from_file_location(
+            "serve_track_vllm_metrics", Path(__file__).with_name("vllm_metrics.py")
+        )
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _VLLM_METRICS = module
+    return _VLLM_METRICS
+
+
+def _metrics_delta(before: Dict[str, float], after: Dict[str, float]) -> Dict[str, float]:
+    if not before and not after:
+        return {}
+    return _metrics_module().delta(before, after)
+
+
+def read_windows(path: str | os.PathLike[str]) -> list[Dict[str, Any]]:
+    """Read a window sidecar, refusing to mix schema generations."""
+    records: list[Dict[str, Any]] = []
+    with Path(path).open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if record.get("window_schema") != WINDOW_SCHEMA_VERSION:
+                raise ValueError(
+                    f"window_schema {record.get('window_schema')} != "
+                    f"{WINDOW_SCHEMA_VERSION}; refusing to silently mix generations"
+                )
+            records.append(record)
+    return records

--- a/scripts/serve_track/launch_vllm.sh
+++ b/scripts/serve_track/launch_vllm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Boot a vLLM server with the KV-event stream enabled, so the block-level cache
+# behaviour of a graph-agentic-RAG workload is observable from outside.
+#
+# The same script serves both rigs. Nothing below is specific to a GPU count or
+# a model — the target environment is expressed entirely through env vars, so
+# the RTX 3070 pipe-cleaner and the H200 x4 measurement run use identical code:
+#
+#   pipe-cleaner (1x RTX 3070, 8 GiB)
+#     scripts/serve_track/launch_vllm.sh
+#
+#   measurement (4x H200, MiniMax-M2.7)
+#     SERVE_MODEL=MiniMaxAI/MiniMax-M2.7 SERVE_TP=4 SERVE_GPU_MEM=0.90 \
+#       scripts/serve_track/launch_vllm.sh
+#
+# The KV-event endpoint topology is not obvious and was measured on 0.27.1:
+# vLLM's ZmqEventPublisher BINDS only when the endpoint contains a wildcard.
+# With a concrete host:port it CONNECTs, which makes the *subscriber* the
+# stable bound end — hence `--bind` on the probe side. Keep the concrete form
+# here so the probe can outlive a server restart.
+set -euo pipefail
+
+SERVE_MODEL="${SERVE_MODEL:-Qwen/Qwen3-0.6B}"
+SERVE_TP="${SERVE_TP:-1}"
+SERVE_PORT="${SERVE_PORT:-8000}"
+SERVE_GPU_MEM="${SERVE_GPU_MEM:-0.85}"
+SERVE_MAX_LEN="${SERVE_MAX_LEN:-8192}"
+SERVE_KV_ENDPOINT="${SERVE_KV_ENDPOINT:-tcp://127.0.0.1:5557}"
+SERVE_VENV="${SERVE_VENV:-$HOME/.venvs/vllm-serve}"
+
+if [ ! -x "$SERVE_VENV/bin/vllm" ]; then
+  echo "vllm not found at $SERVE_VENV/bin/vllm" >&2
+  echo "create it with: uv venv --python 3.10 $SERVE_VENV && \\" >&2
+  echo "  VIRTUAL_ENV=$SERVE_VENV uv pip install 'vllm==0.27.1' pyzmq msgpack" >&2
+  exit 1
+fi
+
+# Prefix caching is the mechanism under study; enabling it explicitly keeps the
+# run honest if a future vLLM default flips.
+exec "$SERVE_VENV/bin/vllm" serve "$SERVE_MODEL" \
+  --port "$SERVE_PORT" \
+  --tensor-parallel-size "$SERVE_TP" \
+  --gpu-memory-utilization "$SERVE_GPU_MEM" \
+  --max-model-len "$SERVE_MAX_LEN" \
+  --enable-prefix-caching \
+  --kv-events-config "{\"enable_kv_cache_events\": true, \"publisher\": \"zmq\", \"endpoint\": \"$SERVE_KV_ENDPOINT\"}"

--- a/scripts/serve_track/make_context_arms.py
+++ b/scripts/serve_track/make_context_arms.py
@@ -1,0 +1,247 @@
+"""Build the three context forms — vector, graph, both — under one budget.
+
+The behaviour layer of the testbed. No GPU, no serving engine: this only decides
+what text each arm puts in front of the model, which is the variable the whole
+comparison turns on.
+
+Two confounds are already documented in `ADR-0105` and both are designed out
+here, because either one alone makes the result unattributable:
+
+  serializer  the graph lane answered from typed structure while its stored raw
+              text was withheld, against a vector lane serving raw chunks
+  budget      the fix over-corrected and emitted the whole 225K-char novel —
+              ~483K chars per question against vector's top-4 chunks, so any
+              win could be context quantity
+
+How this differs from ADR-0105's framing, and why the serializer confound does
+not apply. That ADR compared *systems* (does graph retrieval beat vector
+retrieval), where withholding text the graph holds is unfair. This compares
+*context forms* given the same knowledge: every arm is built from the same gold
+facts, so structure-only vs prose-only vs both is the intended contrast rather
+than a handicap. The knowledge-parity check is what makes that legitimate, and
+it is asserted mechanically rather than assumed.
+
+  vector          the supporting passages, prose, relations implicit
+  graph           the same facts as `(subject) -[RELATION]-> (object)`, deduplicated
+  both            both forms, each at HALF the budget
+  graph_unstructured
+                  the same triples with the relation markup stripped to a flat
+                  bag of terms — same facts, same order, near-identical length,
+                  no structure
+
+The fourth arm is the control that isolates structure, and it is the second
+design of it. The first was `vector_matched`: passages trimmed to the graph
+arm's actual character length. That arm was invalid and the first run proved it
+— the gold string was absent from 8 of 12 contexts, because prose stating a
+fact is inherently longer than the triple stating it, so trimming to the
+triple's length drops the fact. Its 1/12 measured information deprivation, not
+compactness, and could not tell "structure helped" from "less text helped"
+(seocho-alm).
+
+Length cannot be held constant while facts are, so length stops being a control
+and becomes an outcome — reported per arm, in tokens, by the runner.
+`graph_unstructured` varies only the thing under test: it carries exactly the
+same triples in exactly the same order, with `(A) -[REL]-> (B)` flattened to
+`A REL B`. Same facts, same units, same sequence, and within a few percent on
+length. If `graph` beats it, stated structure is doing the work; if they tie,
+the graph form's advantage is compression and deduplication, which the token
+counts already measure.
+
+The `both` arm is the other thing people get wrong. If it were graph + vector
+concatenated it would carry twice the tokens, and a `both` win would be budget,
+not complementarity. It gets the same total as the other two.
+
+Budget is enforced, reported, and auditable — `budget_unit` says whether it was
+counted in tokens or characters, so the two are never silently interchanged.
+Pass `--tokenizer` for real token accounting; without it the unit is characters
+and every output row says so.
+
+Usage:
+    python scripts/serve_track/make_context_arms.py \\
+        --questions outputs/serve_track/questions.jsonl \\
+        --out outputs/serve_track/arms.jsonl --budget 2000
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+SCHEMA_VERSION = 1
+ARMS = ("vector", "graph", "both", "graph_unstructured")
+
+
+def _char_counter(text: str) -> int:
+    return len(text)
+
+
+def _make_counter(tokenizer_name: Optional[str]) -> Tuple[Callable[[str], int], str]:
+    """Return (counter, unit). Falls back to characters, loudly."""
+    if not tokenizer_name:
+        return _char_counter, "chars"
+    try:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(tokenizer_name)
+        return (lambda t: len(tok.encode(t, add_special_tokens=False))), "tokens"
+    except Exception as exc:  # noqa: BLE001 - the fallback must be visible, not silent
+        print(f"WARN: tokenizer {tokenizer_name!r} unavailable ({type(exc).__name__}); "
+              f"falling back to character budget")
+        return _char_counter, "chars"
+
+
+def _dedup(items: List[str]) -> List[str]:
+    """Order-preserving dedup. The graph form's whole point is saying a thing once."""
+    seen, out = set(), []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def render_vector(passages: List[str]) -> List[str]:
+    return _dedup([p.strip() for p in passages if p and p.strip()])
+
+
+def render_graph(edges: List[List[str]]) -> List[str]:
+    lines = []
+    for edge in edges:
+        if len(edge) != 3:
+            continue
+        subject, relation, obj = (str(x).strip() for x in edge)
+        lines.append(f"({subject}) -[{relation.upper().replace(' ', '_')}]-> ({obj})")
+    return _dedup(lines)
+
+
+def render_graph_unstructured(edges: List[List[str]]) -> List[str]:
+    """The same triples with the markup stripped: `(A) -[REL]-> (B)` -> `A REL B`.
+
+    Same facts, same order, same number of units — only the structural markers
+    are gone. This is the arm that isolates whether STATED structure helps, as
+    opposed to the compression and deduplication the graph form also brings.
+    Relation names keep their underscores rather than being re-spaced, so the
+    two arms differ in punctuation only and stay within a few percent on length.
+    """
+    lines = []
+    for edge in edges:
+        if len(edge) != 3:
+            continue
+        subject, relation, obj = (str(x).strip() for x in edge)
+        lines.append(f"{subject} {relation.upper().replace(' ', '_')} {obj}")
+    return _dedup(lines)
+
+
+def _fill(units: List[str], budget: int, count: Callable[[str], int],
+          joiner: str = "\n") -> Tuple[str, int, int]:
+    """Greedily take whole units until the next one would exceed the budget.
+
+    Whole units, never a truncated one: a half-written triple or a clipped
+    sentence changes what the arm *means*, not merely how long it is.
+    """
+    kept: List[str] = []
+    used = 0
+    for unit in units:
+        cost = count(unit) + (count(joiner) if kept else 0)
+        if used + cost > budget:
+            continue
+        kept.append(unit)
+        used += cost
+    return joiner.join(kept), used, len(kept)
+
+
+def build_arms(item: Dict[str, Any], budget: int,
+               count: Callable[[str], int], unit: str) -> Dict[str, Any]:
+    passages = render_vector(item.get("corpus") or [])
+    triples = render_graph(item.get("gold_edges") or [])
+
+    vector_text, vector_used, vector_n = _fill(passages, budget, count)
+    graph_text, graph_used, graph_n = _fill(triples, budget, count)
+
+    # `both` is capped at what the LARGEST single arm actually used, not at the
+    # nominal budget. Capping at the budget is not enough and the first run proved
+    # it: at budget=2000 nothing came close (max 869), so the split never engaged
+    # and `both` degenerated to graph+vector concatenated in 12 of 12 items — the
+    # doubling confound ADR-0105 recorded, reappearing because a loose budget
+    # silently disables the guard. Tying the cap to observed usage makes the
+    # guarantee hold whether or not the budget binds.
+    both_budget = min(budget, max(vector_used, graph_used))
+    half = both_budget // 2
+    both_graph, both_graph_used, both_graph_n = _fill(triples, half, count)
+    both_vector, both_vector_used, both_vector_n = _fill(
+        passages, both_budget - both_graph_used, count
+    )
+    both_text = "\n".join(t for t in (both_graph, both_vector) if t)
+
+    # Structure control: the same triples, same order, markup stripped. Facts and
+    # units are held constant and only stated structure varies, which the
+    # replaced `vector_matched` arm could not do — see the module docstring.
+    flat = render_graph_unstructured(item.get("gold_edges") or [])
+    flat_text, flat_used, flat_n = _fill(flat, budget, count)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "id": item.get("id"),
+        "question": item.get("question"),
+        "answer": item.get("answer"),
+        "excluded": item.get("excluded") or [],
+        "strata": item.get("strata", {}),
+        "budget": budget,
+        "budget_unit": unit,
+        "arms": {
+            "vector": {"context": vector_text, "used": vector_used, "units": vector_n},
+            "graph": {"context": graph_text, "used": graph_used, "units": graph_n},
+            "both": {
+                "context": both_text,
+                "used": both_graph_used + both_vector_used,
+                "units": both_graph_n + both_vector_n,
+            },
+            "graph_unstructured": {
+                "context": flat_text, "used": flat_used, "units": flat_n
+            },
+        },
+        # Availability, not fairness: an item whose graph form is empty cannot
+        # speak to the comparison at all and must be excluded, not scored as a
+        # vector win.
+        "comparable": bool(vector_text) and bool(graph_text),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--questions", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=Path("outputs/serve_track/arms.jsonl"))
+    parser.add_argument("--budget", type=int, default=2000)
+    parser.add_argument("--tokenizer", default=None,
+                        help="HF tokenizer name; without it the budget is characters")
+    args = parser.parse_args()
+
+    count, unit = _make_counter(args.tokenizer)
+    rows = [json.loads(line) for line in args.questions.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    built = [build_arms(row, args.budget, count, unit) for row in rows]
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as handle:
+        for row in built:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    comparable = [r for r in built if r["comparable"]]
+    print(f"wrote {len(built)} items to {args.out} (budget {args.budget} {unit})")
+    print(f"  comparable (both forms non-empty): {len(comparable)}")
+    for arm in ARMS:
+        used = [r["arms"][arm]["used"] for r in comparable]
+        units = [r["arms"][arm]["units"] for r in comparable]
+        if used:
+            print(f"  {arm:7s} mean_used={sum(used)/len(used):7.1f} {unit}  "
+                  f"mean_units={sum(units)/len(units):4.1f}  max_used={max(used)}")
+    print("\nEvery arm is capped at the same budget and `both` splits it rather than "
+          "doubling it.\n`graph` vs `graph_unstructured` is the structure test: same "
+          "facts, same order,\nsame count, markup only. `graph` vs `vector` is a "
+          "compression measurement, not\na fair accuracy contest — read the token "
+          "counts the runner prints alongside it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/make_question_set.py
+++ b/scripts/serve_track/make_question_set.py
@@ -1,0 +1,429 @@
+"""A stratified question set for the graph-vs-vector-vs-both comparison.
+
+Why this exists rather than "just use GraphRAG-Bench". GraphRAG-Bench gives real
+textbook corpora across 16 disciplines and is the right external-validity check,
+but its items carry only ``Question`` / ``Answer`` / ``Rationale`` /
+``Level-1 Topic`` / ``Level-2 Topic`` and a question-type tag. There is **no gold
+knowledge graph, no gold triples, and no supporting-fact ids**, so hop count and
+passage dispersion are not derivable from it. Those two are exactly what makes
+the *when* legible, so pooling over GraphRAG-Bench yields the third tie the
+repository has already measured twice (ADR-0112, ADR-0154).
+
+Division of labour:
+  this set          strata exact by construction  -> carries the mechanism claim
+  GraphRAG-Bench    real corpora, no strata       -> guards against "works only on your toy"
+
+The strata are not difficulty tiers. Each one isolates a *different reason* a
+graph context could beat a passage context, so that a win can be attributed
+rather than merely observed. Each carries a falsifiable prediction; a stratum
+that comes out flat is a result, not a failure.
+
+  S1 extractive        1 hop, 1 passage. Both forms contain the fact outright.
+                       PREDICT tie, or vector by a nose on token overhead.
+                       If graph wins here, the effect is not structure — suspect
+                       retrieval precision or serialization luck.
+
+  S2 joined            2 hops, facts in 2 different passages. Vector must
+                       retrieve both AND the model must compose across distant
+                       tokens; the graph states the path.
+                       PREDICT graph. Attention should concentrate on the
+                       relation tokens. If it wins with FLAT attention, the
+                       mechanism is redundancy removal, not stated structure.
+
+  S3 deep join         3 hops, 3 passages. Same mechanism, longer chain.
+                       PREDICT the S2 effect grows. If it does not, composition
+                       depth is not the axis and S2's win came from elsewhere.
+
+  S4 aggregation       1 hop, high fan-out ("how many X ..."). Passages are
+                       redundant; the graph is deduplicated.
+                       PREDICT graph, via redundancy removal. Attention should
+                       be FLAT across the subgraph — that is the signature that
+                       separates this from S2.
+
+  S5 absence           "which X did NOT ...". A passage set cannot represent
+                       absence; a closed-world graph can.
+                       PREDICT graph decisively. This is a representational
+                       property, not an attention one — if attention analysis
+                       "explains" it, the analysis is overfitting.
+
+  S6 ambiguous entity  Two distinct entities share a surface name. The graph
+                       separates them by node identity; passages conflate them.
+                       PREDICT graph. Vector errors should be *confusions*, not
+                       misses — check the error type, not just the score.
+
+  S7 distractor        1 hop, 1 passage, but many near-identical passages.
+                       Controls for the boring explanation: if graph beats
+                       vector here, "graph wins" is really "retrieval precision
+                       wins", and S2-S4 need re-reading.
+
+Output is the shape ``scripts/benchmarks/graphrag_bench.py`` already accepts
+(``corpus`` / ``question`` / ``answer``), plus a ``strata`` block the runner
+ignores and the analysis groups by. Nothing here needs a model or a network.
+
+Usage:
+    python scripts/serve_track/make_question_set.py --out outputs/serve_track/questions.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+SCHEMA_VERSION = 1
+
+# A closed world: closed because S5 (absence) is only meaningful when "not
+# present" is knowable rather than "not retrieved".
+#
+# The world is bigger than it was, on purpose. The first run put vector, graph
+# and both at 12/12, 11/12 and 12/12 — a ceiling, not a tie (seocho-eer). Four
+# suppliers over three plants cannot separate anything: the deepest chain was
+# three hops and the widest aggregation covered two rows, both of which a model
+# does in one glance regardless of how the context is shaped.
+#
+# Scaled to 12 suppliers, 6 plants, 6 products and 3 regions, with a MATERIAL
+# layer inserted below suppliers so chains reach five hops. Still a closed
+# world, still one fact per passage, still hand-checkable — every mapping below
+# is a literal table, not a generator, so a reader can verify any answer by eye.
+_MATERIALS = ["Bauxite", "Cobalt", "Silica", "Titanium"]
+_SUPPLIERS = [
+    "Aurora Metals", "Borex Chemical", "Cedar Plastics", "Delta Alloys",
+    "Everline Mining", "Fairweather Ore", "Granite Supply", "Halcyon Resources",
+    "Ironvale Group", "Juniper Materials", "Kestrel Minerals", "Lumen Industrial",
+]
+_PLANTS = [
+    "Northgate Plant", "Southport Plant", "Eastfield Plant",
+    "Westbrook Plant", "Highmoor Plant", "Larkspur Plant",
+]
+_PRODUCTS = ["Model K1", "Model K2", "Model L9", "Model M3", "Model P7", "Model R4"]
+_REGIONS = ["Norland", "Sudmark", "Verrat"]
+
+# material -> supplier, the layer that makes four-hop chains possible.
+#
+# Grouped so every supplier of a given material feeds plants whose products are
+# sold in the SAME region. That is not decoration: "in which region is the
+# product made from Silica sold?" has no single answer unless the material's
+# chains converge, and the first draft of this table did not converge — Silica
+# reached both Sudmark (via Cedar Plastics) and Norland (via Granite Supply).
+# A dict built from the pairs silently kept the last supplier per material and
+# produced an answer that looked right and was unverifiable by hand, which is
+# the failure this whole set exists to avoid.
+#
+#   Norland plants  : Northgate, Eastfield, Highmoor
+#   Sudmark plants  : Southport, Larkspur
+#   Verrat plants   : Westbrook
+_MINES: List[Tuple[str, str]] = [
+    # -> Norland
+    ("Bauxite", "Aurora Metals"),      # Northgate
+    ("Bauxite", "Everline Mining"),    # Northgate
+    ("Bauxite", "Delta Alloys"),       # Eastfield
+    # -> Norland, the widest fan-out in the set
+    ("Cobalt", "Borex Chemical"),      # Northgate
+    ("Cobalt", "Granite Supply"),      # Northgate
+    ("Cobalt", "Ironvale Group"),      # Northgate
+    ("Cobalt", "Kestrel Minerals"),    # Highmoor
+    # -> Sudmark
+    ("Silica", "Cedar Plastics"),      # Southport
+    ("Silica", "Fairweather Ore"),     # Southport
+    ("Silica", "Lumen Industrial"),    # Larkspur
+    # -> Verrat
+    ("Titanium", "Halcyon Resources"), # Westbrook
+    ("Titanium", "Juniper Materials"), # Westbrook
+]
+
+# supplier -> plant -> product -> region, one edge per fact, one fact per passage.
+# Northgate now has five suppliers rather than two, so S4 aggregation has to
+# count across a fan-out a model cannot hold in one glance.
+_SUPPLIES: List[Tuple[str, str]] = [
+    ("Aurora Metals", "Northgate Plant"),
+    ("Borex Chemical", "Northgate Plant"),
+    ("Everline Mining", "Northgate Plant"),
+    ("Granite Supply", "Northgate Plant"),
+    ("Ironvale Group", "Northgate Plant"),
+    ("Cedar Plastics", "Southport Plant"),
+    ("Fairweather Ore", "Southport Plant"),
+    ("Delta Alloys", "Eastfield Plant"),
+    ("Halcyon Resources", "Westbrook Plant"),
+    ("Juniper Materials", "Westbrook Plant"),
+    ("Kestrel Minerals", "Highmoor Plant"),
+    ("Lumen Industrial", "Larkspur Plant"),
+]
+_ASSEMBLES: List[Tuple[str, str]] = [
+    ("Northgate Plant", "Model K1"),
+    ("Southport Plant", "Model K2"),
+    ("Eastfield Plant", "Model L9"),
+    ("Westbrook Plant", "Model M3"),
+    ("Highmoor Plant", "Model P7"),
+    ("Larkspur Plant", "Model R4"),
+]
+_SOLD_IN: List[Tuple[str, str]] = [
+    ("Model K1", "Norland"),
+    ("Model K2", "Sudmark"),
+    ("Model L9", "Norland"),
+    ("Model M3", "Verrat"),
+    ("Model P7", "Norland"),
+    ("Model R4", "Sudmark"),
+]
+# S6: one surface name, two distinct entities. The graph gives them separate
+# node identities; a passage set has only the string.
+_AMBIGUOUS = [
+    ("Aurora Metals (Norland)", "Northgate Plant"),
+    ("Aurora Metals (Sudmark)", "Eastfield Plant"),
+]
+
+
+@dataclass
+class Item:
+    stratum: str
+    question: str
+    answer: str
+    corpus: List[str]
+    hops: int
+    dispersion: int          # distinct passages holding the needed facts
+    answer_type: str         # extractive | joined | aggregate | absence | disambiguation
+    prediction: str          # which form should win, and why — stated in advance
+    gold_edges: List[List[str]] = field(default_factory=list)
+    # For list answers: the items that must NOT appear. A set answer cannot be
+    # scored by substring containment (order and conjunctions break it) and an
+    # LLM judge over-rejects supporting detail, so the complement is carried
+    # explicitly and the check stays deterministic.
+    excluded: List[str] = field(default_factory=list)
+
+    def to_row(self) -> Dict[str, Any]:
+        # Content-derived, so it is stable across reordering and reruns. Without
+        # an id every downstream row is anonymous and results cannot be joined
+        # back to the question that produced them.
+        digest = hashlib.sha256(self.question.encode("utf-8")).hexdigest()[:8]
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "id": f"{self.stratum}-{digest}",
+            "question": self.question,
+            "answer": self.answer,
+            "corpus": self.corpus,
+            "strata": {
+                "stratum": self.stratum,
+                "hops": self.hops,
+                "dispersion": self.dispersion,
+                "answer_type": self.answer_type,
+                "prediction": self.prediction,
+            },
+            "gold_edges": self.gold_edges,
+            "excluded": self.excluded,
+        }
+
+
+def _supply_passage(s: str, p: str) -> str:
+    return f"{s} supplies raw material to {p}."
+
+
+def _assemble_passage(p: str, prod: str) -> str:
+    return f"{p} assembles {prod}."
+
+
+def _sold_passage(prod: str, r: str) -> str:
+    return f"{prod} is sold in {r}."
+
+
+def _mine_passage(material: str, supplier: str) -> str:
+    # Phrased material-first so the gold path is a connected chain from the
+    # question's starting point. "X extracts Y" would make the first edge point
+    # away from the material and break the four-hop path.
+    return f"{material} is extracted by {supplier}."
+
+
+def _all_passages() -> List[str]:
+    return (
+        [_mine_passage(m, s) for m, s in _MINES]
+        + [_supply_passage(s, p) for s, p in _SUPPLIES]
+        + [_assemble_passage(p, prod) for p, prod in _ASSEMBLES]
+        + [_sold_passage(prod, r) for prod, r in _SOLD_IN]
+    )
+
+
+def build() -> List[Item]:
+    items: List[Item] = []
+    corpus = _all_passages()
+
+    # S1 — the fact is written down, once, in one place.
+    for s, p in _SUPPLIES[:2]:
+        items.append(Item(
+            stratum="S1_extractive", question=f"Which plant does {s} supply?",
+            answer=p, corpus=corpus, hops=1, dispersion=1, answer_type="extractive",
+            prediction="tie or vector; both forms state the fact outright",
+            gold_edges=[[s, "SUPPLIES", p]]))
+
+    # S2 — two facts, two passages, one join the model must perform.
+    for s, p in _SUPPLIES[:2]:
+        prod = dict(_ASSEMBLES)[p]
+        items.append(Item(
+            stratum="S2_joined", question=f"Which product does {s} contribute to?",
+            answer=prod, corpus=corpus, hops=2, dispersion=2, answer_type="joined",
+            prediction="graph; the path is stated, and vector must compose across passages",
+            gold_edges=[[s, "SUPPLIES", p], [p, "ASSEMBLES", prod]]))
+
+    # S3 — same mechanism, one hop deeper.
+    for s, p in _SUPPLIES[:3]:
+        prod = dict(_ASSEMBLES)[p]
+        region = dict(_SOLD_IN)[prod]
+        items.append(Item(
+            stratum="S3_deep_join", question=f"In which region are {s}'s materials ultimately sold?",
+            answer=region, corpus=corpus, hops=3, dispersion=3, answer_type="joined",
+            prediction="graph, and the S2 margin should grow with depth",
+            gold_edges=[[s, "SUPPLIES", p], [p, "ASSEMBLES", prod], [prod, "SOLD_IN", region]]))
+
+    # S3b — four hops, starting one layer lower. The first run saturated at
+    # three (3/3 for every arm), so depth had no room to show an effect.
+    for material in ("Bauxite", "Silica", "Titanium"):
+        # Any supplier of the material reaches the same region by construction;
+        # take the first and assert the convergence rather than trusting it.
+        chain_suppliers = [s for m, s in _MINES if m == material]
+        regions = {dict(_SOLD_IN)[dict(_ASSEMBLES)[dict(_SUPPLIES)[s]]] for s in chain_suppliers}
+        assert len(regions) == 1, f"{material} chains diverge to {regions}; question is ambiguous"
+        supplier = chain_suppliers[0]
+        plant = dict(_SUPPLIES)[supplier]
+        prod = dict(_ASSEMBLES)[plant]
+        region = dict(_SOLD_IN)[prod]
+        items.append(Item(
+            stratum="S3b_four_hop",
+            question=f"In which region is the product made from {material} sold?",
+            answer=region, corpus=corpus, hops=4, dispersion=4, answer_type="joined",
+            prediction="graph; if S3 is flat and S3b is not, depth is the axis after all",
+            gold_edges=[[material, "EXTRACTED_BY", supplier], [supplier, "SUPPLIES", plant],
+                        [plant, "ASSEMBLES", prod], [prod, "SOLD_IN", region]]))
+
+    # S4 — fan-out. Passages repeat the plant name; the graph states it once.
+    items.append(Item(
+        stratum="S4_aggregation", question="How many suppliers supply Northgate Plant?",
+        answer="5", corpus=corpus, hops=1, dispersion=5, answer_type="aggregate",
+        prediction="graph via redundancy removal; attention should be FLAT, not on relations",
+        gold_edges=[[s, "SUPPLIES", "Northgate Plant"] for s, p in _SUPPLIES if p == "Northgate Plant"]))
+    items.append(Item(
+        stratum="S4_aggregation", question="How many products are sold in Norland?",
+        answer="3", corpus=corpus, hops=1, dispersion=3, answer_type="aggregate",
+        prediction="graph via redundancy removal",
+        gold_edges=[[prod, "SOLD_IN", "Norland"] for prod, r in _SOLD_IN if r == "Norland"]))
+    items.append(Item(
+        stratum="S4_aggregation", question="How many suppliers extract Cobalt?",
+        answer="4", corpus=corpus, hops=1, dispersion=4, answer_type="aggregate",
+        prediction="graph; the widest fan-out in the material layer",
+        gold_edges=[["Cobalt", "EXTRACTED_BY", s] for m, s in _MINES if m == "Cobalt"]))
+
+    # S5 — absence. A passage set has no way to say "there is no such edge".
+    items.append(Item(
+        stratum="S5_absence", question="Which plant has no supplier listed?",
+        answer="none", corpus=corpus, hops=1, dispersion=0, answer_type="absence",
+        prediction="graph decisively; closed-world, and NOT an attention effect",
+        gold_edges=[]))
+    items.append(Item(
+        stratum="S5_absence", question="Which of Model K1, Model K2, Model L9 is not sold in Norland?",
+        answer="Model K2", corpus=corpus, hops=1, dispersion=3, answer_type="absence",
+        prediction="graph; vector must prove a negative from an open passage set",
+        gold_edges=[["Model K2", "SOLD_IN", "Sudmark"]]))
+
+    # S6 — one surface name, two node identities.
+    amb_corpus = corpus + [_supply_passage(s, p) for s, p in _AMBIGUOUS]
+    items.append(Item(
+        stratum="S6_ambiguous", question="Which plant does Aurora Metals (Sudmark) supply?",
+        answer="Eastfield Plant", corpus=amb_corpus, hops=1, dispersion=1,
+        answer_type="disambiguation",
+        prediction="graph; vector errors should be CONFUSIONS with the other Aurora, not misses",
+        gold_edges=[["Aurora Metals (Sudmark)", "SUPPLIES", "Eastfield Plant"]]))
+
+    # S7 — the control for the boring explanation. Answer is extractive and
+    # single-passage, but buried among near-identical distractors. If graph wins
+    # HERE, then "graph wins" is really "retrieval precision wins" and S2-S4
+    # need re-reading.
+    noise = [f"{s} supplies raw material to {p}." for s in _SUPPLIERS for p in _PLANTS]
+    items.append(Item(
+        stratum="S7_distractor", question="Which plant does Delta Alloys supply?",
+        answer="Eastfield Plant", corpus=corpus + noise, hops=1, dispersion=1,
+        answer_type="extractive",
+        prediction="tie; a graph win here means the effect is retrieval precision, not structure",
+        gold_edges=[["Delta Alloys", "SUPPLIES", "Eastfield Plant"]]))
+
+    # S7b — near-miss names rather than recombined ones. The first run's S7
+    # distractors reused real entity names in false pairings, which a model can
+    # reject by checking the pair. These differ from a real supplier by one
+    # token, so rejecting them needs the name itself to be resolved.
+    near_miss = [
+        "Aurora Metalworks supplies raw material to Southport Plant.",
+        "Delta Alloy supplies raw material to Northgate Plant.",
+        "Cedar Plastic supplies raw material to Eastfield Plant.",
+        "Ironvale Grouping supplies raw material to Larkspur Plant.",
+        "Kestrel Mineral supplies raw material to Westbrook Plant.",
+    ]
+    items.append(Item(
+        stratum="S7b_near_miss", question="Which plant does Delta Alloys supply?",
+        answer="Eastfield Plant", corpus=corpus + near_miss, hops=1, dispersion=1,
+        answer_type="extractive",
+        prediction="graph, and for a reason that IS interesting: typed node identity "
+                   "separates 'Delta Alloys' from 'Delta Alloy' where a passage set has "
+                   "only the string. A graph win here is entity resolution, not structure.",
+        gold_edges=[["Delta Alloys", "SUPPLIES", "Eastfield Plant"]]))
+
+    # S8 — negation and closed-world, promoted from a one-item hypothesis.
+    # The first run's only graph LOSS was S5's "which is not sold in Norland":
+    # the graph arm received the single relevant edge and answered NOT STATED,
+    # while the vector arm held every sold-in statement and did the exclusion.
+    # A triple list asserts positives; a negation needs the complement, which is
+    # exactly what relevance filtering removes (seocho-2gq). One item could not
+    # carry that, so the mechanism gets its own stratum with the prediction
+    # stated against the graph.
+    norland = [prod for prod, r in _SOLD_IN if r == "Norland"]
+    not_norland = [prod for prod, r in _SOLD_IN if r != "Norland"]
+    items.append(Item(
+        stratum="S8_negation",
+        question=f"Which of {', '.join(_PRODUCTS)} is not sold in Norland?",
+        answer=", ".join(not_norland), corpus=corpus, hops=1, dispersion=len(_SOLD_IN),
+        answer_type="negation", excluded=norland,
+        prediction="VECTOR. Answering needs the complement, and a relevance-filtered "
+                   "triple list drops it. If graph wins here the seocho-2gq hypothesis dies.",
+        gold_edges=[[prod, "SOLD_IN", dict(_SOLD_IN)[prod]] for prod in not_norland]))
+    items.append(Item(
+        stratum="S8_negation",
+        question="Which plants do NOT assemble a product sold in Norland?",
+        answer=", ".join(sorted(p for p, prod in _ASSEMBLES if prod not in norland)),
+        corpus=corpus, hops=2, dispersion=len(_ASSEMBLES) + len(_SOLD_IN),
+        answer_type="negation",
+        excluded=sorted(p for p, prod in _ASSEMBLES if prod in norland),
+        prediction="vector; negation over a join is the hardest case for a triple list",
+        gold_edges=[[p, "ASSEMBLES", prod] for p, prod in _ASSEMBLES if prod not in norland]))
+    items.append(Item(
+        stratum="S8_negation",
+        question="Which suppliers do NOT supply Northgate Plant?",
+        answer=", ".join(sorted(s for s in _SUPPLIERS if dict(_SUPPLIES).get(s) != "Northgate Plant")),
+        corpus=corpus, hops=1, dispersion=len(_SUPPLIES), answer_type="negation",
+        excluded=sorted(s for s, p in _SUPPLIES if p == "Northgate Plant"),
+        prediction="vector; the complement is large, so a filtered subgraph loses most of it",
+        gold_edges=[[s, "SUPPLIES", p] for s, p in _SUPPLIES if p != "Northgate Plant"]))
+
+    return items
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/questions.jsonl"))
+    args = parser.parse_args()
+
+    items = build()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as handle:
+        for item in items:
+            handle.write(json.dumps(item.to_row(), ensure_ascii=False) + "\n")
+
+    counts: Dict[str, int] = {}
+    for item in items:
+        counts[item.stratum] = counts.get(item.stratum, 0) + 1
+    print(f"wrote {len(items)} items to {args.out}")
+    for stratum in sorted(counts):
+        print(f"  {stratum:18s} n={counts[stratum]}")
+    print("\nn is small by design — these are hand-checkable probes, not a power "
+          "calculation. Scale a stratum only after it shows a signal.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/profile_rag.py
+++ b/scripts/serve_track/profile_rag.py
@@ -1,0 +1,260 @@
+"""Drive the real SEOCHO RAG pipeline with KV-cache attribution switched on.
+
+This is runbook step 3: the piece that turns the harness from "the instrument
+works" into "here is what graph-agentic RAG actually does to a KV cache".
+
+It installs a `WindowRecorder` into the SDK's LLM-call seam
+(`seocho.observability.set_llm_call_observer`), runs `Seocho.local(...).ask()`
+over a question set, and writes one run directory that `correlate_kv.py` reads.
+Every LLM call the pipeline makes — plan/text2cypher, repair, generation — lands
+as a window tagged with the stage that issued it, because `StageTimer.stage`
+publishes the stage name and the backend reads it at call time.
+
+Defaults target DozerDB over Bolt — the product's serving path. `Seocho.local()`
+routes to Neo4j/DozerDB only when `graph` is a Bolt URI; anything else falls back
+to the embedded LadybugDB *file* store, which is in-process and never speaks
+Bolt. The same script serves the H200 measurement run; only `--llm` changes.
+
+When a vLLM metrics endpoint is reachable, each window also carries the change in
+vLLM's KV counters across it, which is how offload bytes and transfer time become
+per-stage numbers rather than process-wide totals.
+
+Usage:
+    # terminal 1
+    scripts/serve_track/launch_vllm.sh
+    # terminal 2
+    python scripts/cache_probe/kv_events_probe.py --bind --out <run>/kv_events.jsonl
+    # terminal 3
+    python scripts/serve_track/profile_rag.py --out-dir <run>
+
+Writes `kv_windows.jsonl`, `run_manifest.json`, and — because the KV rig and the
+pipeline's own `rag.*` span tree answer different questions — `spans.jsonl`,
+which carries `n_records` per retrieval. Disable with `--trace-backend none`.
+
+Concurrency is not supported and not a limitation to fix here: KV attribution is
+a containment test on wall-clock windows, so overlapping calls would make it
+ambiguous. `WindowRecorder` refuses to open a second window rather than emit a
+number nobody can trust.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parents[1]
+sys.path.insert(0, str(_ROOT / "src"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(f"serve_track_{name}", _HERE / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+kv_windows = _load("kv_windows")
+vllm_metrics = _load("vllm_metrics")
+
+# A deliberately small ontology + corpus. The point of the run is the *shape* of
+# the prompts the pipeline builds, not answer quality — a 0.6B pipe-cleaner
+# model cannot do the latter anyway, and pretending otherwise would put a
+# meaningless accuracy number next to a meaningful cache number.
+_DEMO_ONTOLOGY = {
+    # The name is load-bearing: Seocho derives the target database as
+    # ``{ontology.name}{graph_model}`` sanitized, so an unnamed ontology sends
+    # every query at a database called "unnamedlpg" that nobody created.
+    "name": "servetrack",
+    "nodes": {
+        "Account": {"properties": {"name": "string", "balance": "float"}},
+        "Institution": {"properties": {"name": "string"}},
+    },
+    "relationships": {
+        "TRANSFER": {"source": "Account", "target": "Account"},
+        "HELD_AT": {"source": "Account", "target": "Institution"},
+    },
+}
+
+_DEMO_DOCS = [
+    "Account A1 held at Northbank transferred 12000 to account B2 on 3 March.",
+    "Account B2 held at Southtrust transferred 11500 to account C3 on 4 March.",
+    "Account C3 held at Northbank transferred 11000 to account A1 on 6 March.",
+]
+
+_DEMO_QUESTIONS = [
+    "Which accounts transferred money to B2?",
+    "Which institution holds account C3?",
+    "Which accounts form a transfer cycle?",
+]
+
+
+def _build_client(args: argparse.Namespace, llm: str, api_key: Optional[str]) -> Any:
+    from seocho import Ontology, Seocho
+
+    if args.ontology:
+        ontology = Ontology.from_yaml(Path(args.ontology).read_text(encoding="utf-8"))
+    else:
+        ontology = Ontology.from_dict(_DEMO_ONTOLOGY)
+
+    return Seocho.local(
+        ontology,
+        llm=llm,
+        api_key=api_key,
+        graph=args.graph,
+        neo4j_user=args.neo4j_user,
+        neo4j_password=args.neo4j_password,
+        enforcement=args.enforcement,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, default=Path("outputs/serve_track/rag"))
+    parser.add_argument("--llm", default="vllm/Qwen/Qwen3-0.6B",
+                        help="e.g. vllm/MiniMaxAI/MiniMax-M2.7 or mara/MiniMax-M2.7")
+    parser.add_argument("--api-key", default="serve-track")
+    # Indexing may run on a different model than serving. A pipe-cleaner model
+    # extracts nothing, leaving an empty graph and a query path with no records
+    # to retrieve — which makes the cache numbers real but the retrieval shape
+    # fictional. Point indexing at a capable model; the measured serving path
+    # stays whatever --llm names.
+    parser.add_argument("--index-llm", default=None,
+                        help="model for indexing only, e.g. mara/MiniMax-M2.7 "
+                             "(default: same as --llm)")
+    parser.add_argument("--index-api-key", default=None)
+    # Guided extraction is free to fall back to a generic `Entity` label, which
+    # leaves the ontology's own labels unpopulated — every :Account query then
+    # matches nothing and synthesis is handed an empty record set. Strict makes
+    # the graph match the ontology the queries are written against.
+    parser.add_argument("--enforcement", default="strict",
+                        choices=["strict", "guided", "open"])
+    parser.add_argument("--ontology", default=None, help="ontology YAML (default: demo)")
+    # DozerDB over Bolt is the product's serving path, so it is the default.
+    # Seocho.local() only routes to Neo4j/DozerDB when `graph` is a Bolt URI;
+    # anything else (or None) falls back to the embedded LadybugDB *file* store,
+    # which is in-process and never speaks Bolt.
+    parser.add_argument("--graph", default=os.environ.get("NEO4J_URI", "bolt://localhost:7687"))
+    parser.add_argument("--neo4j-user", default=os.environ.get("NEO4J_USER", "neo4j"))
+    parser.add_argument("--neo4j-password", default=os.environ.get("NEO4J_PASSWORD", "neo4jpassword"))
+    parser.add_argument("--metrics-url", default="http://localhost:8000/metrics",
+                        help="vLLM Prometheus endpoint; sampled at each window "
+                             "boundary so offload bytes/time land per stage. "
+                             "Pass empty to disable.")
+    parser.add_argument("--questions", default=None, help="file with one question per line")
+    parser.add_argument("--repeats", type=int, default=2,
+                        help="passes over the question set; pass 2+ to expose reuse "
+                             "between a cold and a warm pass")
+    parser.add_argument("--skip-index", action="store_true",
+                        help="reuse an already-populated store")
+    # On by default. The KV rig measures the serving path; the rag.* span tree
+    # measures what the pipeline actually retrieved, and the two answer
+    # different questions. Running without it once already produced a wrong
+    # diagnosis: `rag.retrieve_ctx` records `n_records`, so "retrieval returned
+    # nothing" was refutable in one line and went unrefuted for want of a
+    # backend. Costs one JSONL file per run.
+    parser.add_argument("--trace-backend", default="jsonl",
+                        choices=["jsonl", "console", "otlp", "opik", "none"])
+    args = parser.parse_args()
+
+    from seocho.observability import set_llm_call_observer
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.trace_backend != "none":
+        os.environ.setdefault("SEOCHO_TRACE_BACKEND", args.trace_backend)
+        os.environ.setdefault(
+            "SEOCHO_TRACE_JSONL_PATH", str(args.out_dir / "spans.jsonl")
+        )
+        from seocho.tracing import configure_tracing_from_env
+
+        if not configure_tracing_from_env():
+            print("WARN: tracing requested but not enabled", file=sys.stderr)
+    run_id = uuid.uuid4().hex[:12]
+    recorder = kv_windows.WindowRecorder(
+        args.out_dir / "kv_windows.jsonl",
+        metrics_sampler=vllm_metrics.make_sampler(args.metrics_url or None),
+    )
+
+    questions: List[str] = (
+        [q.strip() for q in Path(args.questions).read_text(encoding="utf-8").splitlines() if q.strip()]
+        if args.questions
+        else list(_DEMO_QUESTIONS)
+    )
+
+    client = _build_client(args, args.llm, args.api_key)
+
+    # Indexing is *outside* the observed region on purpose: it is a different
+    # workload with a different prompt shape, and mixing its windows into the
+    # query numbers would misattribute blocks to stages that never served a
+    # question. Profile it as its own run if you want it.
+    if not args.skip_index:
+        indexer = (
+            _build_client(args, args.index_llm, args.index_api_key)
+            if args.index_llm
+            else client
+        )
+        for doc in _DEMO_DOCS:
+            indexer.add(doc)
+
+    set_llm_call_observer(lambda **kw: recorder.record_step(trace_id=run_id, **kw))
+    answers: List[Dict[str, Any]] = []
+    try:
+        for pass_index in range(args.repeats):
+            for question in questions:
+                started = time.time()
+                try:
+                    text = client.ask(question)
+                    error = None
+                except Exception as exc:  # a failed ask still produced windows
+                    text, error = "", f"{type(exc).__name__}: {exc}"
+                answers.append({
+                    "pass": pass_index,
+                    "question": question,
+                    "answer_chars": len(text or ""),
+                    "wall_ms": round((time.time() - started) * 1000.0, 2),
+                    "error": error,
+                })
+                print(f"[pass {pass_index}] {question[:60]}"
+                      f"{' — ' + error if error else ''}", flush=True)
+    finally:
+        set_llm_call_observer(None)
+        if args.trace_backend != "none":
+            from seocho.tracing import flush_tracing
+
+            flush_tracing()
+
+    manifest = {
+        "run_id": run_id,
+        "llm": args.llm,
+        "repeats": args.repeats,
+        "questions": questions,
+        "answers": answers,
+    }
+    (args.out_dir / "run_manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    windows = kv_windows.read_windows(args.out_dir / "kv_windows.jsonl")
+    roles: Dict[str, int] = {}
+    for window in windows:
+        roles[window["role"]] = roles.get(window["role"], 0) + 1
+    print(f"\n{len(windows)} windows across {len(roles)} stages: "
+          f"{json.dumps(roles, sort_keys=True)}")
+    print(f"run dir: {args.out_dir}")
+    if not windows:
+        print("FAIL: no LLM calls were observed — did the pipeline reach a model?",
+              file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/run_arms.py
+++ b/scripts/serve_track/run_arms.py
@@ -1,0 +1,450 @@
+"""Answer each context arm and score it — the behaviour layer, no GPU required.
+
+This is the layer that has to find an effect before any mechanism work is worth
+running. It takes the arms built by `make_context_arms.py`, asks the model once
+per arm, and scores the answers blind.
+
+Relation to what already exists — this generalises, it does not duplicate.
+`scripts/pattern_traces/ab_reasoning.py` (#495) established the design this
+follows: two arms given the SAME facts in different form, so the measurement is
+about representation rather than information access. `port1_finbench.py` scaled
+it to FinBench planted gold. Both are hardcoded to two arms
+(`baseline` / `seocho`) and neither has a structure control. This runs FOUR — the
+third form (`both`) and the structure control (`graph_unstructured`) — over an arbitrary
+arms file, and reuses their deterministic token checker rather than inventing a
+scorer.
+
+What it does NOT yet take from them: the multi-turn loop and `turns_to_correct`,
+which is a richer signal than a binary and worth adopting once the single-turn
+pass shows an effect worth resolving.
+
+Design choices that are not incidental:
+
+  deterministic first  a gold answer that is a short string is checked by token
+                       containment, exactly as `ab_reasoning._check_search` does.
+                       No judge, no judge variance, no cost. The LLM judge is the
+                       fallback for prose golds (GraphRAG-Bench), and every row
+                       records which scorer ran.
+  synthesis != judge   when the judge is used at all: MiniMax-M2.7 answers,
+                       gpt-oss-120b judges. Following ADR-0105, which held the
+                       synthesis model constant and scored with a different one,
+                       so a model cannot mark its own homework.
+  blind judging        the judge never sees which arm produced an answer, nor the
+                       other arms' answers. Arm identity is the independent
+                       variable; letting the judge see it is how a preference
+                       becomes a result.
+  raw answers kept     every response is written out, so scoring can be redone
+                       with a different judge without paying for generation twice.
+  temperature 0        both roles. Reasoning-token count still varies run to run,
+                       but the answer should not.
+  refusal is an answer the absence stratum (S5, and ERB's Info Not Found) is
+                       *supposed* to produce "not stated". That is scored correct
+                       against a gold of "none", not as a failure to answer.
+
+The prompt is deliberately thin. Any instruction richer than "answer from the
+context" starts doing the work the context form is supposed to be doing, and the
+comparison stops being about the context.
+
+Usage:
+    export MARA_API_KEY=...      # strip the quotes .env wraps it in
+    python scripts/serve_track/run_arms.py \\
+        --arms outputs/serve_track/arms.jsonl \\
+        --out outputs/serve_track/results.jsonl --limit 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import re
+import time
+import unicodedata
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = 1
+ARMS = ("vector", "graph", "both", "graph_unstructured")
+
+_ANSWER_SYSTEM = (
+    "Answer the question using only the context provided. "
+    "If the context does not contain the answer, reply exactly: NOT STATED. "
+    "Be brief."
+)
+
+# The same instruction minus the refusal licence. Needed because the prompt
+# above ANSWERS the question ERB's `info_not_found` stratum asks: told to say
+# NOT STATED when the context falls short, every arm said it, 20/20, and the run
+# measured the instruction rather than the context form. Whether a form makes a
+# model invent an answer can only be seen when refusing has not been pre-
+# authorised. Constant across arms either way, so within a run the comparison
+# holds; across runs the condition must be stated, which is why it is a flag and
+# not a silent default.
+_ANSWER_SYSTEM_NO_HINT = (
+    "Answer the question using only the context provided. Be brief."
+)
+
+_JUDGE_SYSTEM = (
+    "You grade one answer against a reference. Reply with exactly one word: "
+    "CORRECT if the answer conveys the reference, otherwise WRONG. "
+    "Ignore wording, ordering and formatting; judge the substance. "
+    "When the reference is a LIST, the answer must name every item in it and "
+    "must not name any item that is not in it — an extra item is WRONG, not a "
+    "harmless detail. "
+    "If the reference is 'none' or says information is absent, then a reply "
+    "stating the information is not present is CORRECT."
+)
+
+
+def _client(base_url: str, api_key: str):
+    from openai import OpenAI
+
+    return OpenAI(base_url=base_url, api_key=api_key)
+
+
+def _ask(client, model: str, system: str, user: str, max_tokens: int) -> Dict[str, Any]:
+    started = time.perf_counter()
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+        temperature=0.0,
+        max_tokens=max_tokens,
+    )
+    usage = resp.usage
+    message = resp.choices[0].message
+    text = (message.content or "").strip()
+    if not text:
+        # Reasoning models can put everything in the reasoning field when the
+        # budget runs out. Treat that as an empty answer, not a crash.
+        extra = getattr(message, "model_extra", None) or {}
+        text = str(extra.get("reasoning_content") or extra.get("reasoning") or "").strip()
+    return {
+        "text": text,
+        "latency_ms": round((time.perf_counter() - started) * 1000, 1),
+        "usage": usage.model_dump() if hasattr(usage, "model_dump") else {},
+    }
+
+
+def answer_arm(client, model: str, question: str, context: str, max_tokens: int,
+               system: str = _ANSWER_SYSTEM) -> Dict[str, Any]:
+    user = f"Context:\n{context}\n\nQuestion: {question}"
+    return _ask(client, model, system, user, max_tokens)
+
+
+def _normalise(text: str) -> str:
+    """Fold case and collapse every kind of whitespace to a single ASCII space.
+
+    Not cosmetic. The first run scored a correct `Model K1` as wrong because the
+    model emitted U+202F NARROW NO-BREAK SPACE between the two words. A containment
+    check that is literal about invisible characters silently under-counts, and the
+    under-count lands on whichever arm happens to format more prettily — which is
+    the arm identity we are trying to measure.
+    """
+    return " ".join(unicodedata.normalize("NFKC", text or "").split()).lower()
+
+
+def check_deterministic(gold: str, candidate: str) -> Optional[bool]:
+    """Token containment, the `ab_reasoning._check_search` rule. None = not applicable.
+
+    Only used where the gold is short enough to be a fact rather than prose; a
+    containment test over a paragraph would pass on coincidence.
+
+    A LIST gold defers to the judge, and that is not a convenience. The negation
+    stratum's golds are sets — "Model K2, Model M3, Model R4" — and containment
+    scored every correct answer wrong because the model wrote "K2, M3, and R4"
+    or listed them in a different order. Worse, containment cannot see the error
+    that matters: an answer naming the three gold items PLUS two that do not
+    belong is wrong, and a substring test calls it right. Set membership alone
+    does not fix that either, since the excluded universe is not in this file.
+    So list golds go to the judge, which is told the reference and can weigh
+    both omissions and additions.
+    """
+    gold = (gold or "").strip()
+    if not gold or len(gold) > 60:
+        return None
+    if "," in gold:
+        return None  # handled by check_set, which needs the complement
+    # A SENTENCE gold cannot be checked by containment even when it is short.
+    # GraphRAG-Bench answers are full sentences: gold "Rubber boots are worn on
+    # the feet." is 33 characters, passed the length test, and scored the reply
+    # "feet" wrong — 31 of 32 items failed this way, which reads as a model
+    # collapse and was a scorer artefact. Containment is for VALUE golds, the
+    # entity names and counts the synthetic set uses; anything sentence-shaped
+    # goes to the judge, which can see that "feet" conveys the reference.
+    if gold.endswith(".") or len(gold.split()) > 3:
+        return None
+    hay = _normalise(candidate)
+    if gold.lower() in ("none", "not stated", "no answer"):
+        return "not stated" in hay or "not present" in hay or "none" in hay
+    return _normalise(gold) in hay
+
+
+def check_set(gold: str, excluded: List[str], candidate: str) -> Optional[bool]:
+    """Score a list answer as a set: every gold item present, no excluded one.
+
+    Neither of the obvious alternatives works. Substring containment fails on
+    ordering and on the word "and" — it scored all three correct negation
+    answers wrong. An LLM judge told to reject extra items over-rejects instead,
+    marking "K2, M3 and R4 are not sold in Norland" wrong because the reply went
+    on to say where each IS sold; that is supporting detail, not a fourth item.
+
+    The complement comes from the generator, which knows the closed world, so
+    the check is exact in both directions: omitting a gold item fails, and
+    naming an item that does belong to Norland fails.
+    """
+    items = [g.strip() for g in (gold or "").split(",") if g.strip()]
+    if len(items) < 2 or not excluded:
+        return None
+    hay = _normalise(candidate)
+    if any(_normalise(item) not in hay for item in items):
+        return False
+    return not any(_normalise(bad) in hay for bad in excluded)
+
+
+# Refusal is detected by pattern family, not by a list of strings. The string
+# list this replaces missed "does not INCLUDE" while catching "does not
+# CONTAIN", and missed "cannot answer" while catching "cannot be answered" —
+# scoring four correct refusals as inventions and inverting the result. Any
+# enumeration of surface forms will keep losing to paraphrase; the productive
+# constructions are finite and are matched here instead.
+_REFUSAL_PATTERNS = tuple(re.compile(p) for p in (
+    r"\b(?:does|do|did|is|are|was|were)\s+not\s+"
+    r"(?:contain|include|mention|specify|provide|state|list|have|appear)",
+    # Contractions are a separate branch, not an afterthought: "I don't have
+    # information about X" was the last form the pattern set missed.
+    r"\b(?:don't|doesn't|didn't|isn't|aren't|wasn't|weren't)\s+"
+    r"(?:contain|include|mention|specify|provide|state|list|have|appear)",
+    r"\b(?:cannot|can\s*not|can't|could\s+not|couldn't|unable\s+to)\s+"
+    r"(?:answer|determine|find|identify|tell|be\s+answered|be\s+determined)",
+    r"\bnot\s+(?:stated|specified|mentioned|provided|available|present|"
+    r"included|listed|documented|found|given|answerable|fully\s+answerable)\b",
+    r"\bno\s+(?:information|details|specifics?|mention|record|data)\b",
+    r"\binsufficient\s+(?:information|context|detail)",
+    r"\bnot\s+in\s+the\s+(?:provided\s+)?(?:context|documents?)\b",
+))
+
+
+def check_refusal(candidate: str) -> bool:
+    """Did the answer decline, rather than invent one?
+
+    ERB's `info_not_found` gold is not a fact — it is a 469-character
+    instruction reading "the answer must state at some point that the query is
+    not fully answerable". Handing that to an LLM judge would put the one
+    measurement this run exists for behind the component that already
+    over-rejected three correct answers elsewhere. Declining is a surface
+    property of the reply, so it is matched directly.
+
+    Generous by design: a false CORRECT understates the invention rate, which is
+    the conservative direction for a claim that a context form makes models
+    invent answers.
+
+    Known recall limit, stated rather than tuned away. On ERB's 20 items every
+    arm scored 19 or 20, and reading each non-match showed all of them were
+    refusals in wording the patterns miss ("I cannot confirm whether ..."). The
+    residual one-item spread between arms is detector recall, not behaviour.
+    Widening the patterns until the arms separate would be manufacturing the
+    result, so the spread is reported as noise and the stratum as a null.
+    """
+    hay = _normalise(candidate)
+    return any(p.search(hay) for p in _REFUSAL_PATTERNS)
+
+
+# A reasoning judge needs room to reason before it can answer. At max_tokens=8
+# gpt-oss-120b spent the whole budget thinking and never emitted a verdict: the
+# reply came back as "We need to compare answer", leaked reasoning text that
+# `startswith("CORRECT")` rejects. Every judge-scored item in every run before
+# this was therefore marked wrong, which on the GraphRAG-Bench sample looked
+# like all four arms collapsing to 1 of 32.
+_JUDGE_MAX_TOKENS = 512
+
+
+def judge(client, model: str, question: str, gold: str, candidate: str) -> bool:
+    """Blind: the judge is told the question, the reference and one answer. Never the arm.
+
+    The verdict is searched for rather than required at position zero, because a
+    reasoning model emits it after its reasoning and an unparseable reply must
+    be visibly wrong rather than silently WRONG.
+    """
+    if not candidate:
+        return False
+    user = (f"Question: {question}\nReference answer: {gold}\n"
+            f"Answer to grade: {candidate}")
+    verdict = _ask(client, model, _JUDGE_SYSTEM, user, _JUDGE_MAX_TOKENS)["text"].upper()
+    if "CORRECT" in verdict and "INCORRECT" not in verdict:
+        return True
+    if "WRONG" in verdict or "INCORRECT" in verdict:
+        return False
+    # Neither token present: the judge did not answer. Count it wrong, but say so.
+    print(f"    WARN unparseable judge verdict: {verdict[:60]!r}")
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arms", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=Path("outputs/serve_track/results.jsonl"))
+    parser.add_argument("--base-url", default="https://api.cloud.mara.com/v1")
+    parser.add_argument("--model", default="MiniMax-M2.7")
+    parser.add_argument("--judge-model", default="gpt-oss-120b")
+    parser.add_argument("--max-tokens", type=int, default=1200)
+    parser.add_argument("--limit", type=int, default=0, help="0 = all comparable items")
+    parser.add_argument("--no-refusal-hint", action="store_true",
+                        help="drop 'reply NOT STATED if absent' from the prompt. Required "
+                             "for any hallucination measurement; see _ANSWER_SYSTEM_NO_HINT")
+    args = parser.parse_args()
+
+    key = os.environ.get("MARA_API_KEY", "").strip().strip('"').strip("'")
+    if not key:
+        raise SystemExit("MARA_API_KEY is not set")
+    client = _client(args.base_url, key)
+
+    answer_system = _ANSWER_SYSTEM_NO_HINT if args.no_refusal_hint else _ANSWER_SYSTEM
+    if args.no_refusal_hint:
+        print("prompt condition: NO refusal hint (hallucination measurement)")
+
+    rows = [json.loads(line) for line in args.arms.read_text(encoding="utf-8").splitlines() if line.strip()]
+    items = [r for r in rows if r.get("comparable")]
+    if args.limit:
+        items = items[: args.limit]
+    print(f"{len(items)} comparable items x {len(ARMS)} arms = {len(items) * len(ARMS)} generations")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    results: List[Dict[str, Any]] = []
+    with args.out.open("w", encoding="utf-8") as handle:
+        for index, item in enumerate(items, start=1):
+            record: Dict[str, Any] = {
+                "schema_version": SCHEMA_VERSION,
+                "id": item.get("id"),
+                "question": item["question"],
+                "gold": item["answer"],
+                "excluded": item.get("excluded") or [],
+                "strata": item.get("strata", {}),
+                "prompt_condition": "no_refusal_hint" if args.no_refusal_hint else "default",
+                "budget_unit": item.get("budget_unit"),
+                "arms": {},
+            }
+            for arm in ARMS:
+                context = item["arms"][arm]["context"]
+                try:
+                    got = answer_arm(client, args.model, item["question"], context,
+                                     args.max_tokens, system=answer_system)
+                    if (item.get("strata") or {}).get("answer_type") == "info_not_found":
+                        deterministic = check_refusal(got["text"])
+                    else:
+                        deterministic = check_deterministic(item["answer"], got["text"])
+                    if deterministic is None:
+                        deterministic = check_set(
+                            item["answer"], item.get("excluded") or [], got["text"]
+                        )
+                    if deterministic is None:
+                        correct = judge(client, args.judge_model, item["question"],
+                                        item["answer"], got["text"])
+                        scorer = "judge"
+                    else:
+                        correct = deterministic
+                        scorer = "deterministic"
+                    record["arms"][arm] = {
+                        "answer": got["text"][:600],
+                        "correct": correct,
+                        "scorer": scorer,
+                        "latency_ms": got["latency_ms"],
+                        "usage": got["usage"],
+                        "context_used": item["arms"][arm]["used"],
+                        "error": None,
+                    }
+                except Exception as exc:  # noqa: BLE001 — one failed call must not lose the run
+                    record["arms"][arm] = {
+                        "answer": "", "correct": False, "error": f"{type(exc).__name__}: {exc}",
+                        "context_used": item["arms"][arm]["used"],
+                    }
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+            handle.flush()
+            results.append(record)
+            marks = "".join("o" if record["arms"][a]["correct"] else "." for a in ARMS)
+            print(f"  [{index}/{len(items)}] {record['strata'].get('stratum','?'):18s} {marks}", flush=True)
+
+    _report(results)
+
+
+def _report(results: List[Dict[str, Any]]) -> None:
+    print(f"\n=== overall (n={len(results)}) ===")
+    for arm in ARMS:
+        ok = sum(1 for r in results if r["arms"][arm]["correct"])
+        errs = sum(1 for r in results if r["arms"][arm].get("error"))
+        print(f"  {arm:15s} {ok}/{len(results)} = {ok/max(len(results),1)*100:5.1f}%"
+              + (f"   ({errs} errors)" if errs else ""))
+
+    by_stratum: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    for row in results:
+        by_stratum[row["strata"].get("stratum", "?")].append(row)
+
+    print("\n=== by stratum — this is the table that matters ===")
+    header = "  " + "stratum".ljust(20) + "n   " + "  ".join(a[:6].rjust(6) for a in ARMS)
+    print(header)
+    for stratum in sorted(by_stratum):
+        rows = by_stratum[stratum]
+        cells = []
+        for arm in ARMS:
+            ok = sum(1 for r in rows if r["arms"][arm]["correct"])
+            cells.append(f"{ok}/{len(rows)}".rjust(6))
+        print("  " + stratum.ljust(20) + str(len(rows)).ljust(4) + "  ".join(cells))
+
+    _report_cost(results)
+
+    print("\n`graph` vs `graph_unstructured` is the structure test: identical facts in")
+    print("identical order, markup only. `graph` vs `vector` measures compression, not")
+    print("a fair accuracy contest — read it against the token table above.")
+
+
+def _median(values: List[float]) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    mid = len(ordered) // 2
+    return ordered[mid] if len(ordered) % 2 else (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def _report_cost(results: List[Dict[str, Any]]) -> None:
+    """Print the serving cost of each arm, in the unit the engine actually bills.
+
+    This exists because the first run buried it. `usage` was written to the file
+    and never read, so the compression headline was quoted in CHARACTERS — where
+    the graph form looked 5.9x smaller — while in prompt tokens, the thing prefill
+    is paid in, the same arms were only 1.9x apart. Triples are punctuation-dense
+    and tokenize badly; prose does not. A ratio nobody prints is a ratio nobody
+    checks, so it is printed next to the accuracy table.
+
+    TTFT is shown because it is the only prefill signal an API exposes, and with
+    its spread because over a network it carries queueing and transport that have
+    nothing to do with context length. Read the spread before believing the gap.
+    """
+    print("\n=== serving cost — the unit the engine bills in ===")
+    print(f"  {'arm':16s}{'prompt_tok':>11s}{'output_tok':>11s}{'reason_tok':>11s}"
+          f"{'TTFT_med':>10s}{'TTFT_sd':>9s}")
+    means: Dict[str, float] = {}
+    for arm in ARMS:
+        usages = [r["arms"][arm].get("usage") or {} for r in results]
+        prompt = [u.get("prompt_tokens") for u in usages if u.get("prompt_tokens")]
+        out = [u.get("completion_tokens") for u in usages if u.get("completion_tokens")]
+        reason = [(u.get("completion_tokens_details") or {}).get("reasoning_tokens") or 0
+                  for u in usages]
+        ttft = [u["time_to_first_token"] * 1000 for u in usages if u.get("time_to_first_token")]
+        if not prompt:
+            continue
+        means[arm] = sum(prompt) / len(prompt)
+        spread = 0.0
+        if len(ttft) > 1:
+            mean_t = sum(ttft) / len(ttft)
+            spread = (sum((x - mean_t) ** 2 for x in ttft) / (len(ttft) - 1)) ** 0.5
+        print(f"  {arm:16s}{means[arm]:11.1f}{sum(out)/max(len(out),1):11.1f}"
+              f"{sum(reason)/max(len(reason),1):11.1f}{_median(ttft):9.0f}ms{spread:8.0f}ms")
+
+    if means.get("graph") and means.get("vector"):
+        ratio = means["vector"] / means["graph"]
+        print(f"\n  prompt-token ratio vector/graph = {ratio:.2f}x")
+        print("  Quote THIS, not the character ratio. Characters are not what prefill costs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/sample_bench_strata.py
+++ b/scripts/serve_track/sample_bench_strata.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Sample GraphRAG-Bench evenly across hop depth, not uniformly.
+
+Depth is the axis this benchmark uniquely supplies — Novel's `evidence_triple`
+is the only gold structure in either corpus we have — and it is also the axis a
+uniform sample destroys. 47.6% of Novel is single-hop, and on our own set every
+arm scored full marks on single-hop questions. A uniform draw therefore spends
+half its budget on items that cannot separate anything, which is the mechanical
+reason this benchmark keeps producing ties.
+
+Sampling is deterministic by content hash rather than by a seeded RNG. A seed
+makes a run reproducible only if the seed is recorded and the input order never
+changes; hashing the question id makes the same item selected by any run over
+the same pool, including after the pool is re-annotated or reordered.
+
+Items are emitted in the question-set shape the arms builder already consumes,
+so nothing downstream needs to know this came from a benchmark:
+
+  corpus       the `evidence` statements — the passages the vector arm reads
+  gold_edges   the parsed `evidence_triple` — the same facts, as edges
+
+That is the same knowledge-parity contract the synthetic set holds, and it is
+what makes the comparison about form rather than access. It also means these
+numbers measure ANSWERING, not retrieval, and are not comparable to published
+GraphRAG-Bench leaderboards, which measure both together. Say so wherever they
+appear.
+
+Usage:
+    scripts/serve_track/sample_bench_strata.py \\
+        --annotated outputs/serve_track/bench_annotated.jsonl \\
+        --per-bucket 8 --out outputs/serve_track/bench_sample.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+SCHEMA_VERSION = 1
+
+# 4+ is one bucket because the tail is thin: 5-hop and deeper together are 8.5%
+# of Novel, so splitting them further buys resolution the counts cannot support.
+BUCKETS = ("1", "2", "3", "4+")
+
+
+def bucket_of(hops: Any) -> str | None:
+    if not isinstance(hops, int) or hops < 1:
+        return None
+    return str(hops) if hops <= 3 else "4+"
+
+
+def _rank(item: Dict[str, Any]) -> str:
+    """Stable per-item key. Same pool in, same sample out, whatever the order."""
+    return hashlib.sha256(str(item.get("id", "")).encode("utf-8")).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--annotated", type=Path, required=True)
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/bench_sample.jsonl"))
+    parser.add_argument("--per-bucket", type=int, default=8)
+    parser.add_argument("--min-corpus", type=int, default=1,
+                        help="drop items with fewer supporting statements than this; "
+                             "an empty vector arm is not a comparison")
+    args = parser.parse_args()
+
+    rows = [json.loads(line) for line in
+            args.annotated.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    pools: Dict[str, List[Dict[str, Any]]] = collections.defaultdict(list)
+    dropped_no_edges = dropped_no_corpus = 0
+    for row in rows:
+        edges = row.get("gold_edges") or []
+        corpus = row.get("corpus") or []
+        if not edges:
+            dropped_no_edges += 1
+            continue
+        if len(corpus) < args.min_corpus:
+            dropped_no_corpus += 1
+            continue
+        key = bucket_of((row.get("strata") or {}).get("hops"))
+        if key:
+            pools[key].append(row)
+
+    sample: List[Dict[str, Any]] = []
+    for key in BUCKETS:
+        pool = sorted(pools.get(key, []), key=_rank)
+        taken = pool[: args.per_bucket]
+        for row in taken:
+            strata = dict(row.get("strata") or {})
+            strata["stratum"] = f"GB_hop_{key}"
+            strata["hop_bucket"] = key
+            sample.append({
+                "schema_version": SCHEMA_VERSION,
+                "id": row.get("id"),
+                "question": row.get("question"),
+                "answer": row.get("answer") or "",
+                "excluded": [],
+                "corpus": row.get("corpus") or [],
+                "gold_edges": row.get("gold_edges") or [],
+                "strata": strata,
+            })
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as handle:
+        for item in sample:
+            handle.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+    print(f"pool: {len(rows)} annotated, "
+          f"{dropped_no_edges} without edges, {dropped_no_corpus} without statements")
+    print(f"wrote {len(sample)} items to {args.out}\n")
+    print(f"  {'bucket':10s}{'pool':>7s}{'taken':>7s}{'mean_stmts':>12s}{'mean_edges':>12s}")
+    for key in BUCKETS:
+        pool = pools.get(key, [])
+        taken = [s for s in sample if s["strata"]["hop_bucket"] == key]
+        if not taken:
+            print(f"  {key:10s}{len(pool):7d}{0:7d}   (empty)")
+            continue
+        stmts = sum(len(s["corpus"]) for s in taken) / len(taken)
+        edges = sum(len(s["gold_edges"]) for s in taken) / len(taken)
+        print(f"  {key:10s}{len(pool):7d}{len(taken):7d}{stmts:12.1f}{edges:12.1f}")
+
+    short = [key for key in BUCKETS if len(pools.get(key, [])) < args.per_bucket]
+    if short:
+        print(f"\nWARN: buckets with fewer items than requested: {short}. "
+              f"The design is even coverage; an unfilled bucket silently "
+              f"reweights the sample toward the shallow end.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/smoke_correlation.py
+++ b/scripts/serve_track/smoke_correlation.py
@@ -1,0 +1,135 @@
+"""End-to-end smoke: does the window/event join actually attribute blocks to a stage?
+
+Stands in for the RAG pipeline with two shaped calls against a live vLLM, so the
+harness is proven on real KV events before a real workload is wired to it:
+
+  retrieve_ctx  a long, stable prefix + a varying tail — the shape a graph
+                subgraph serialization has
+  synthesize    the same prefix again — must reuse blocks, which is the whole
+                claim the Serve Track talk rests on
+
+Passes if the second call reports cached tokens and the correlation attributes
+stored blocks to the stage that caused them.
+
+Usage:
+  python scripts/serve_track/smoke_correlation.py --out-dir outputs/serve_track/smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import time
+import uuid
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(f"serve_track_{name}", _HERE / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+kv_windows = _load("kv_windows")
+correlate_kv = _load("correlate_kv")
+
+_probe_spec = importlib.util.spec_from_file_location(
+    "kv_events_probe", _HERE.parent / "cache_probe" / "kv_events_probe.py"
+)
+_probe = importlib.util.module_from_spec(_probe_spec)
+sys.modules["kv_events_probe"] = _probe
+_probe_spec.loader.exec_module(_probe)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8000/v1")
+    parser.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--events", default="tcp://127.0.0.1:5557")
+    parser.add_argument("--out-dir", type=Path, default=Path("outputs/serve_track/smoke"))
+    args = parser.parse_args()
+
+    from openai import OpenAI
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    recorder = kv_windows.WindowRecorder(args.out_dir / "kv_windows.jsonl")
+    client = OpenAI(base_url=args.base_url, api_key="smoke")
+
+    # Subscriber must bind: vLLM connects when given a concrete host:port.
+    sub = _probe.Subscriber(args.events, bind=True)
+    sub.start()
+    time.sleep(2.0)
+
+    # A stable head that stands in for system + ontology sections, long enough
+    # to span many blocks so reuse is visible at block granularity.
+    #
+    # The head is salted per invocation. Without it the *previous* smoke run's
+    # blocks are still resident, the first call reuses them, and the test reads
+    # as "no reuse happened" when the truth is "reuse happened one run too
+    # early". A cold first call is what makes the assertion mean anything.
+    salt = uuid.uuid4().hex
+    head = f"Run {salt}. " + "Ontology: Account(id,balance) -[TRANSFER]-> Account. " * 60
+    sections = {"system": 0, "ontology": len(head)}
+
+    def call(role: str, prompt: str, extra_sections: dict) -> None:
+        with recorder.record_step(
+            trace_id="smoke", role=role, model=args.model, provider="vllm",
+            prompt_chars=len(prompt),
+            prompt_sections={**sections, **extra_sections},
+        ) as window:
+            response = client.completions.create(
+                model=args.model, prompt=prompt, max_tokens=8, temperature=0.0)
+            usage = response.usage
+            window.usage = usage.model_dump() if hasattr(usage, "model_dump") else {}
+            time.sleep(0.5)  # let the engine's events arrive inside the window
+
+    call("retrieve_ctx", head + "Subgraph rows: 1..40. Question: who funds A?",
+         {"subgraph": 44})
+    call("synthesize", head + "Subgraph rows: 1..40. Answer concisely.",
+         {"subgraph": 44})
+
+    sub.stop()
+    time.sleep(1.0)
+
+    events_path = args.out_dir / "kv_events.jsonl"
+    with events_path.open("w", encoding="utf-8") as handle:
+        import json
+        for frame in sub.frames:
+            handle.write(json.dumps(frame, default=str) + "\n")
+
+    report = correlate_kv.correlate(args.out_dir)
+    import json
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    stages = report["stages"]
+    problems = []
+    if report["events"] == 0:
+        problems.append("no KV events received — check the ZMQ endpoint and --bind")
+
+    first_blocks = sum(stages.get("retrieve_ctx", {}).get("blocks_per_call", []) or [0])
+    second_blocks = sum(stages.get("synthesize", {}).get("blocks_per_call", []) or [0])
+    if first_blocks <= 0:
+        problems.append("no blocks attributed to the first stage — window/event clocks disagree")
+    # Reuse is asserted block-side, not token-side: vLLM 0.27.1 leaves
+    # `prompt_tokens_details.cached_tokens` unpopulated (measured), so a shared
+    # prefix shows up as blocks the second call did NOT have to store.
+    elif second_blocks >= first_blocks:
+        problems.append(
+            f"second stage stored {second_blocks} blocks vs {first_blocks} — "
+            "the shared prefix was not reused; is --enable-prefix-caching on?"
+        )
+
+    if problems:
+        for problem in problems:
+            print(f"FAIL: {problem}", file=sys.stderr)
+        raise SystemExit(1)
+    print("\nOK: blocks attributed per stage and prefix reuse observed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_track/smoke_plugin.py
+++ b/scripts/serve_track/smoke_plugin.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Prove the vLLM stat-logger plugin actually loads and writes. Run after any vLLM bump.
+
+The plugin was written, registered correctly, and never verified end-to-end. It
+does not work on the path most people reach for first: `load_stat_logger_plugin_
+factories()` is called in exactly one place in vLLM 0.27.1 --
+`AsyncLLM.__init__` -- so the offline `LLM(...)` batch API loads nothing. The
+failure is silent in the worst way: the entry point resolves, the class passes
+vLLM's `issubclass(StatLoggerBase)` check, no warning is logged, and the output
+file simply stays empty. You conclude the cache is behaving oddly when in fact
+nothing was ever measured.
+
+This checks the four things that can independently break, in order of how
+quietly they fail:
+
+  1. registration   the entry point is visible to the vLLM interpreter, which is
+                    a DIFFERENT venv from the SDK's -- installing the plugin into
+                    the wrong one is the most common setup error
+  2. contract       our class still satisfies StatLoggerBase's abstract methods
+                    and `record()` still takes the arguments we unpack; vLLM
+                    calls these "not stable interfaces", so a bump can move them
+  3. server load    a real `vllm serve` writes the engine-initialized record
+  4. measurement    a repeated prompt reports num_cached_tokens > 0, which is the
+                    field the whole KV-reuse argument rests on
+
+Step 4 exists because a prompt shorter than one block never caches anything, so
+a smoke test with a five-token prompt reports `num_cached_tokens: 0` on a warm
+request and looks like a broken plugin. It uses a prompt long enough to fill
+blocks, and asserts the warm request is mostly cached.
+
+Usage:
+    scripts/serve_track/smoke_plugin.py                    # steps 1-2, no GPU
+    scripts/serve_track/smoke_plugin.py --serve            # all four, needs a GPU
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+SMALL_MODEL = "Qwen/Qwen3-0.6B"
+PORT = 8199
+
+
+def _ok(label: str, detail: str = "") -> None:
+    print(f"  PASS  {label}" + (f"  ({detail})" if detail else ""))
+
+
+def _fail(label: str, detail: str) -> int:
+    print(f"  FAIL  {label}\n        {detail}")
+    return 1
+
+
+def check_registration() -> int:
+    from importlib.metadata import entry_points
+
+    found = list(entry_points().select(group="vllm.stat_logger_plugins"))
+    if not found:
+        return _fail(
+            "entry point registered",
+            "nothing under 'vllm.stat_logger_plugins'. The plugin must be "
+            "installed into the vLLM venv, not the SDK's:\n"
+            "        VIRTUAL_ENV=~/.venvs/vllm-serve uv pip install -e "
+            "scripts/serve_track/vllm_plugin",
+        )
+    _ok("entry point registered", ", ".join(f"{e.name}={e.value}" for e in found))
+    return 0
+
+
+def check_contract() -> int:
+    import inspect
+
+    try:
+        from vllm.v1.metrics.loggers import StatLoggerBase
+    except ImportError as exc:
+        return _fail("vllm importable", f"{type(exc).__name__}: {exc}")
+
+    from seocho_vllm_probe import SeochoRequestStatsLogger
+
+    if not issubclass(SeochoRequestStatsLogger, StatLoggerBase):
+        return _fail("subclasses StatLoggerBase", "vLLM rejects the plugin at load")
+
+    missing = [
+        name
+        for name in getattr(StatLoggerBase, "__abstractmethods__", set())
+        if getattr(SeochoRequestStatsLogger, name, None) is None
+    ]
+    if missing:
+        return _fail("implements every abstract method", f"missing: {missing}")
+
+    # `record` is the one that unpacks vLLM internals; a renamed or reordered
+    # parameter here is how a version bump breaks this silently.
+    params = set(inspect.signature(StatLoggerBase.record).parameters)
+    ours = set(inspect.signature(SeochoRequestStatsLogger.record).parameters)
+    if not params <= ours:
+        return _fail(
+            "record() accepts what vLLM passes",
+            f"vLLM sends {sorted(params - ours)} which our signature does not take",
+        )
+    _ok("StatLoggerBase contract", f"abstract={sorted(StatLoggerBase.__abstractmethods__)}")
+    return 0
+
+
+def _post(prompt: str, max_tokens: int = 8) -> int:
+    body = json.dumps(
+        {"model": SMALL_MODEL, "prompt": prompt, "max_tokens": max_tokens, "temperature": 0}
+    ).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{PORT}/v1/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.status
+
+
+def check_serving(out_path: Path, venv: Path, timeout: float = 300.0) -> int:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.unlink(missing_ok=True)
+
+    env = dict(os.environ)
+    env["SEOCHO_PROBE_OUT"] = str(out_path)
+    env["VLLM_PLUGINS"] = "seocho_probe"
+    env.setdefault("HF_HOME", "/data/hadry/huggingface")
+
+    log = out_path.with_name("smoke_server.log")
+    with log.open("w") as handle:
+        proc = subprocess.Popen(
+            [str(venv / "bin" / "vllm"), "serve", SMALL_MODEL,
+             "--port", str(PORT), "--gpu-memory-utilization", "0.55",
+             "--max-model-len", "2048", "--enforce-eager", "--enable-prefix-caching"],
+            stdout=handle, stderr=subprocess.STDOUT, env=env,
+        )
+    try:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                return _fail("server started", f"exited rc={proc.returncode}; see {log}")
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{PORT}/health", timeout=2):
+                    break
+            except (urllib.error.URLError, OSError):
+                time.sleep(3)
+        else:
+            return _fail("server started", f"no /health within {timeout:.0f}s; see {log}")
+        _ok("server started")
+
+        # A prompt long enough to fill KV blocks. Anything shorter caches nothing
+        # and makes a working plugin look broken.
+        prompt = "The Northgate Plant assembles Model K1 which is sold in Norland. " * 30
+        for _ in range(2):
+            _post(prompt)
+            time.sleep(2)
+        time.sleep(3)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    if not out_path.exists() or out_path.stat().st_size == 0:
+        return _fail(
+            "plugin wrote records",
+            f"{out_path} is empty. If you ran through the offline LLM() API this "
+            "is expected -- only AsyncLLM loads stat-logger plugins.",
+        )
+
+    rows = [json.loads(line) for line in out_path.read_text().splitlines() if line.strip()]
+    if not any(r.get("event") == "engine_initialized" for r in rows):
+        return _fail("engine_initialized recorded", "log_engine_initialized never fired")
+    _ok("plugin wrote records", f"{len(rows)} rows")
+
+    finished = [r for r in rows if r.get("request_id")]
+    if len(finished) < 2:
+        return _fail("per-request rows", f"expected 2, got {len(finished)}")
+
+    warm = finished[-1]
+    cached, total = warm.get("num_cached_tokens"), warm.get("num_prompt_tokens")
+    if not cached or not total or cached < total * 0.5:
+        return _fail(
+            "num_cached_tokens is populated",
+            f"warm request cached {cached} of {total} prompt tokens. This field "
+            "carries the whole KV-reuse measurement; if it is zero on a repeated "
+            "prompt, prefix caching is off or the field moved.",
+        )
+    _ok("prefix reuse measured", f"warm request cached {cached}/{total} tokens")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--serve", action="store_true",
+                        help="also boot a real server (needs a GPU)")
+    parser.add_argument("--venv", type=Path,
+                        default=Path.home() / ".venvs" / "vllm-serve")
+    parser.add_argument("--out", type=Path,
+                        default=Path("outputs/serve_track/smoke/request_stats.jsonl"))
+    args = parser.parse_args()
+
+    print("vLLM stat-logger plugin smoke test")
+    rc = check_registration()
+    rc |= check_contract()
+    if args.serve and rc == 0:
+        rc |= check_serving(args.out, args.venv)
+    elif not args.serve:
+        print("  SKIP  server load and prefix-reuse measurement (pass --serve)")
+
+    print("\n" + ("all checks passed" if rc == 0 else "FAILED"))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/serve_track/vllm_metrics.py
+++ b/scripts/serve_track/vllm_metrics.py
@@ -1,0 +1,142 @@
+"""Scrape the KV-relevant slice of vLLM's Prometheus endpoint.
+
+The KV-event stream gives block *identity* (hashes, parent chain, medium) but no
+volume or timing. `/metrics` gives volume and timing but is a set of process-wide
+counters with no notion of a request, let alone a RAG stage. Sampling it at the
+boundaries of a `WindowRecorder` window and differencing turns the counters into
+per-stage numbers, which is the only way to say "the synthesize stage moved N
+bytes across PCIe and spent M ms doing it".
+
+Metric names verified against the installed vLLM 0.27.1, not the docs:
+
+  transfer volume/time (Counter)
+    vllm:kv_offload_store_bytes   GPU -> CPU bytes
+    vllm:kv_offload_load_bytes    CPU -> GPU bytes
+    vllm:kv_offload_store_time    seconds spent storing
+    vllm:kv_offload_load_time     seconds spent loading
+  lookup cost (Histogram)
+    vllm:kv_offload_lookup_sync_delay_seconds
+    vllm:kv_offload_lookup_async_delay_seconds
+  pressure (Counter/Gauge)
+    vllm:kv_offload_allocation_failure
+    vllm:kv_offload_cpu_cache_usage_perc
+  hit rate
+    vllm:prefix_cache_hits / vllm:prefix_cache_queries            (GPU tier)
+    vllm:external_prefix_cache_hits / _queries                    (offloaded tier)
+  occupancy
+    vllm:kv_cache_usage_perc
+
+Deliberately NOT used: ``vllm:kv_offload_total_bytes``, ``_total_time`` and
+``_size``. They are marked deprecated in 0.27.1
+(`kv_connector/v1/offloading/metrics.py`, `_DEPRECATED_*`), superseded by the
+store/load split — which is the more useful shape anyway, since offloading is
+only worth it when loads (recall) outweigh stores (spill).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+from urllib.error import URLError
+from urllib.request import urlopen
+
+# Counters and gauges worth differencing across a window. Histograms are
+# excluded: differencing a bucket set does not yield a meaningful per-window
+# distribution, and their `_sum`/`_count` are captured below instead.
+_SCALAR_METRICS = (
+    "vllm:kv_offload_store_bytes",
+    "vllm:kv_offload_load_bytes",
+    "vllm:kv_offload_store_time",
+    "vllm:kv_offload_load_time",
+    "vllm:kv_offload_allocation_failure",
+    "vllm:kv_offload_stores_skipped",
+    "vllm:kv_offload_cpu_cache_usage_perc",
+    "vllm:prefix_cache_hits",
+    "vllm:prefix_cache_queries",
+    "vllm:external_prefix_cache_hits",
+    "vllm:external_prefix_cache_queries",
+    "vllm:kv_cache_usage_perc",
+)
+
+# Histogram aggregates: `_sum` over `_count` is the mean, which does survive
+# differencing across a window.
+_HISTOGRAM_METRICS = (
+    "vllm:kv_offload_lookup_sync_delay_seconds",
+    "vllm:kv_offload_lookup_async_delay_seconds",
+)
+
+
+def _wanted(name: str) -> bool:
+    if name in _SCALAR_METRICS:
+        return True
+    for base in _HISTOGRAM_METRICS:
+        if name in (f"{base}_sum", f"{base}_count"):
+            return True
+    # Prometheus client suffixes counters with _total.
+    return any(name == f"{m}_total" for m in _SCALAR_METRICS)
+
+
+def parse_metrics(text: str) -> Dict[str, float]:
+    """Parse the exposition format, summing across label sets.
+
+    vLLM labels most metrics per engine and per model. A serve-track run has one
+    engine, and summing keeps the reader honest if that ever stops being true —
+    a silently-dropped label set would understate transfer volume.
+    """
+    values: Dict[str, float] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        head, _, raw_value = line.rpartition(" ")
+        if not head:
+            continue
+        name = head.split("{", 1)[0]
+        if not _wanted(name):
+            continue
+        try:
+            value = float(raw_value)
+        except ValueError:
+            continue
+        values[name] = values.get(name, 0.0) + value
+    return values
+
+
+def sample(url: str, timeout: float = 2.0) -> Dict[str, float]:
+    """Snapshot the endpoint; an unreachable server yields no sample, not a crash.
+
+    Instrumentation must not be able to fail a run, and a missing sample is
+    visible downstream as an absent `metrics_delta` rather than as zeros that
+    would read as "no bytes moved".
+    """
+    try:
+        with urlopen(url, timeout=timeout) as response:  # noqa: S310 - operator-supplied
+            return parse_metrics(response.read().decode("utf-8", "replace"))
+    except (URLError, OSError, ValueError):
+        return {}
+
+
+def delta(before: Dict[str, float], after: Dict[str, float]) -> Dict[str, float]:
+    """Per-window change. Gauges are carried as their end value, not a difference.
+
+    `*_usage_perc` is an occupancy gauge: its difference over a window is
+    meaningless, while its value at window close describes the state the next
+    stage inherits.
+    """
+    out: Dict[str, float] = {}
+    if not before or not after:
+        return out
+    for name, end in after.items():
+        if name.endswith("_usage_perc"):
+            out[name] = round(end, 6)
+            continue
+        change = end - before.get(name, 0.0)
+        if change:
+            out[name] = round(change, 6)
+    return out
+
+
+def make_sampler(url: Optional[str]):
+    """Return a zero-argument sampler, or None when no endpoint was given."""
+    if not url:
+        return None
+    return lambda: sample(url)

--- a/scripts/serve_track/vllm_plugin/pyproject.toml
+++ b/scripts/serve_track/vllm_plugin/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "seocho-vllm-probe"
+version = "0.1.0"
+description = "vLLM stat-logger plugin exporting per-request KV-cache facts for the SEOCHO serve-track rig"
+requires-python = ">=3.11"
+# vLLM is intentionally not a dependency: this installs *into* an existing vLLM
+# environment, and pinning it here would let pip pull a second copy.
+dependencies = []
+
+# Loaded by every vLLM engine process, and only when named in VLLM_PLUGINS.
+[project.entry-points."vllm.stat_logger_plugins"]
+seocho_probe = "seocho_vllm_probe:SeochoRequestStatsLogger"
+
+[tool.setuptools.packages.find]
+include = ["seocho_vllm_probe*"]

--- a/scripts/serve_track/vllm_plugin/seocho_vllm_probe/__init__.py
+++ b/scripts/serve_track/vllm_plugin/seocho_vllm_probe/__init__.py
@@ -1,0 +1,146 @@
+"""A vLLM stat-logger plugin that exports per-request KV-cache facts.
+
+Why this exists. vLLM's KV-event stream carries no request id — a `BlockStored`
+frame is `block_hashes + parent_block_hash + block_size + medium` and nothing
+that names the caller — so the serve-track rig attributes blocks to a RAG stage
+by containment in a wall-clock window, which is only sound while calls are
+serialized. `FinishedRequestStats` already carries everything the join was
+missing: `request_id`, `num_cached_tokens`, `num_prompt_tokens`, and a
+prefill/queue/decode time breakdown.
+
+Why a plugin rather than a patch. `EngineCoreProc` runs in its own process, so
+monkey-patching `vllm.v1.core.kv_cache_coordinator` from the caller's process
+reaches nothing. `vllm.stat_logger_plugins` is loaded inside every engine
+process (`v1/engine/core.py` calls `load_general_plugins`), and unlike
+`vllm.v1.core` it is a documented extension point — vLLM's compatibility
+statement covers documented plugin interfaces, not engine internals.
+
+Stability caveat, quoted from `StatLoggerBase` itself rather than the docs:
+"note that the `SchedulerStats` and `IterationStats` classes are not considered
+stable interfaces and may change in future versions." Pin the vLLM version this
+is run against; it is written for 0.27.1.
+
+Only the SERVER path loads this. `load_stat_logger_plugin_factories()` is called
+in exactly one place in vLLM 0.27.1 — `vllm/v1/engine/async_llm.py`, inside
+`AsyncLLM.__init__`. The offline `LLM(...)` batch API never calls it, so a probe
+run through `LLM.generate()` produces an empty output file and no error: the
+entry point resolves, the class is valid, and nothing is ever instantiated.
+Verified on an RTX 3070 against vLLM 0.27.1 — `LLM()` wrote zero records while
+`vllm serve` wrote the engine-initialized line plus one row per request.
+`scripts/serve_track/smoke_plugin.py` is the check; run it after any vLLM bump.
+
+Once it is loaded, `log_stats` turns itself on: AsyncLLM sets
+`self.log_stats = log_stats or has_custom_loggers`, so `--disable-log-stats`
+does not silence this plugin.
+
+Install into the *vLLM* environment (not the SDK's) and enable by name:
+
+    VIRTUAL_ENV=~/.venvs/vllm-serve uv pip install -e scripts/serve_track/vllm_plugin
+    SEOCHO_PROBE_OUT=outputs/serve_track/<run>/request_stats.jsonl \\
+      VLLM_PLUGINS=seocho_probe scripts/serve_track/launch_vllm.sh
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from vllm.v1.metrics.loggers import StatLoggerBase
+
+PROBE_SCHEMA_VERSION = 1
+_ENV_OUT = "SEOCHO_PROBE_OUT"
+_DEFAULT_OUT = "outputs/serve_track/request_stats.jsonl"
+
+
+def _finish_reason(value: Any) -> str:
+    return getattr(value, "name", None) or str(value)
+
+
+class SeochoRequestStatsLogger(StatLoggerBase):
+    """Append one JSONL record per finished request.
+
+    Deliberately does nothing per *iteration*: iteration stats are hot-path and
+    high-volume, and every question this rig asks is answerable from the
+    per-request record. Cheap logging keeps the instrument from perturbing the
+    thing it measures.
+    """
+
+    # One engine writes from one thread, but data-parallel runs give each engine
+    # its own logger in its own process appending to the same file. O_APPEND
+    # keeps whole lines intact; the lock only guards this process.
+    _lock = threading.Lock()
+
+    def __init__(self, vllm_config: Any, engine_index: int = 0) -> None:
+        self.engine_index = engine_index
+        self.path = Path(os.environ.get(_ENV_OUT, _DEFAULT_OUT))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        model = getattr(getattr(vllm_config, "model_config", None), "model", "")
+        self.model = str(model or "")
+
+    def record(
+        self,
+        scheduler_stats: Any = None,
+        iteration_stats: Any = None,
+        mm_cache_stats: Any = None,
+        engine_idx: int = 0,
+    ) -> None:
+        finished = getattr(iteration_stats, "finished_requests", None)
+        if not finished:
+            return
+        rows = []
+        for stats in finished:
+            row = asdict(stats) if is_dataclass(stats) else dict(vars(stats))
+            row["finish_reason"] = _finish_reason(row.get("finish_reason"))
+            row["probe_schema"] = PROBE_SCHEMA_VERSION
+            row["engine_idx"] = engine_idx or self.engine_index
+            row["model"] = self.model
+            rows.append(row)
+        self._append(rows)
+
+    def _append(self, rows: list[dict]) -> None:
+        # A logging failure must never take down an engine step.
+        try:
+            payload = "".join(
+                json.dumps(row, ensure_ascii=False, default=str) + "\n" for row in rows
+            )
+            with self._lock, self.path.open("a", encoding="utf-8") as handle:
+                handle.write(payload)
+        except Exception:
+            pass
+
+    def log_engine_initialized(self) -> None:
+        self._append(
+            [
+                {
+                    "probe_schema": PROBE_SCHEMA_VERSION,
+                    "event": "engine_initialized",
+                    "engine_idx": self.engine_index,
+                    "model": self.model,
+                }
+            ]
+        )
+
+
+def read_request_stats(path: str | os.PathLike[str]) -> list[dict]:
+    """Read the probe output, refusing to mix schema generations."""
+    records: list[dict] = []
+    with Path(path).open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            if record.get("probe_schema") != PROBE_SCHEMA_VERSION:
+                raise ValueError(
+                    f"probe_schema {record.get('probe_schema')} != "
+                    f"{PROBE_SCHEMA_VERSION}; refusing to silently mix generations"
+                )
+            records.append(record)
+    return records
+
+
+__all__ = ["SeochoRequestStatsLogger", "read_request_stats", "PROBE_SCHEMA_VERSION"]

--- a/tests/seocho/test_bench_annotation.py
+++ b/tests/seocho/test_bench_annotation.py
@@ -1,0 +1,116 @@
+"""The derived strata must be derived, not assumed.
+
+The hop count here is a *proxy* — triples parsed out of a free-text field. A
+proxy that silently degrades is worse than no proxy, because the analysis keeps
+running and the strata quietly stop meaning anything. These tests pin the two
+ways it could degrade: the regex swallowing ordinary prose, and Medical (which
+has no triples at all) being merged into the hop axis as though every item were
+single-hop.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "annotate_graphrag_bench",
+    _ROOT / "scripts" / "serve_track" / "annotate_graphrag_bench.py",
+)
+ann = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ann
+_spec.loader.exec_module(ann)
+
+
+def _row(**kw):
+    base = {
+        "id": "X-1", "source": "S", "question": "q", "answer": "a",
+        "question_type": "Fact Retrieval", "evidence": "one statement.",
+    }
+    base.update(kw)
+    return base
+
+
+def test_triples_are_counted_from_the_triple_field():
+    row = _row(
+        question_type="Complex Reasoning",
+        evidence_triple="(a, rel, b). (b, rel2, c).",
+        evidence="first.; second.",
+    )
+    out = ann.annotate(row, "novel")
+    assert out["strata"]["hops"] == 2
+    assert out["gold_edges"] == [["a", "rel", "b"], ["b", "rel2", "c"]]
+
+
+def test_parenthetical_prose_is_not_counted_as_a_triple():
+    """A loose pattern would inflate hops off ordinary writing."""
+    row = _row(evidence_triple="Basal cell carcinoma (BCC) is common (see chapter 4).")
+    assert ann.annotate(row, "novel")["strata"]["hops"] is None
+
+
+def test_medical_never_reports_a_hop_count():
+    """Medical has no triples; a 0 here would read as single-hop and pool wrongly."""
+    row = _row(evidence_triple="(a, rel, b).")
+    out = ann.annotate(row, "medical")
+    assert out["strata"]["hops"] is None
+    assert out["strata"]["hops_source"] == "unavailable"
+
+
+def test_absent_hops_are_none_not_zero():
+    out = ann.annotate(_row(), "novel")
+    assert out["strata"]["hops"] is None, "absent must not be representable as 0"
+
+
+def test_dispersion_counts_semicolon_separated_statements():
+    row = _row(evidence="one.; two.; three.")
+    out = ann.annotate(row, "medical")
+    assert out["strata"]["dispersion"] == 3
+    assert out["corpus"] == ["one.", "two.", "three."]
+
+
+def test_blank_statements_do_not_inflate_dispersion():
+    row = _row(evidence="one.;  ; two.;")
+    assert ann.annotate(row, "novel")["strata"]["dispersion"] == 2
+
+
+def test_unknown_question_type_is_labelled_not_guessed():
+    out = ann.annotate(_row(question_type="Brand New Type"), "novel")
+    assert out["strata"]["answer_type"] == "unknown"
+    assert out["strata"]["stratum"] == "GB_unknown"
+
+
+def test_every_known_question_type_maps_to_an_axis():
+    for qtype in ("Fact Retrieval", "Complex Reasoning",
+                  "Contextual Summarize", "Creative Generation"):
+        assert ann._TYPE_AXIS[qtype] != "unknown"
+
+
+def test_list_shaped_fields_are_parsed():
+    """The HuggingFace release ships these as lists, not strings.
+
+    Accepting only the string shape made the annotator report "0 of 2010 carry
+    a derived hop count" — which reads as a fact about GraphRAG-Bench rather
+    than a parse failure, and points at the opposite of the truth. Novel yields
+    triples for 2,009 of 2,010 items.
+    """
+    row = _row(
+        question_type="Complex Reasoning",
+        evidence_triple=["(a, rel, b)", "(b, rel2, c)"],
+        evidence=["first statement.", "second statement."],
+    )
+    out = ann.annotate(row, "novel")
+    assert out["strata"]["hops"] == 2
+    assert out["gold_edges"] == [["a", "rel", "b"], ["b", "rel2", "c"]]
+    assert out["strata"]["dispersion"] == 2
+
+
+def test_string_shaped_fields_still_work():
+    """The older local copy joined them with semicolons; both must parse."""
+    row = _row(question_type="Complex Reasoning",
+               evidence_triple="(a, rel, b). (b, rel2, c).",
+               evidence="first.; second.")
+    out = ann.annotate(row, "novel")
+    assert out["strata"]["hops"] == 2
+    assert out["strata"]["dispersion"] == 2

--- a/tests/seocho/test_context_arms.py
+++ b/tests/seocho/test_context_arms.py
@@ -1,0 +1,177 @@
+"""The arms must differ in form only — never in budget, and never in knowledge.
+
+`ADR-0105` recorded both ways this comparison has already been broken once: a
+serializer that withheld text one side held, and a budget fix that handed the
+graph lane the whole novel. These pin the invariants that stop either recurring,
+plus the length trap the first run of this generator exposed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "make_context_arms", _ROOT / "scripts" / "serve_track" / "make_context_arms.py"
+)
+arms = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = arms
+_spec.loader.exec_module(arms)
+
+_COUNT = len
+
+
+def _item(**kw):
+    base = {
+        "id": "x", "question": "q", "answer": "a",
+        "corpus": ["Alpha supplies Beta.", "Beta assembles Gamma."],
+        "gold_edges": [["Alpha", "supplies", "Beta"], ["Beta", "assembles", "Gamma"]],
+    }
+    base.update(kw)
+    return base
+
+
+def test_no_arm_exceeds_the_budget():
+    out = arms.build_arms(_item(), budget=40, count=_COUNT, unit="chars")
+    for name, arm in out["arms"].items():
+        assert arm["used"] <= 40, f"{name} used {arm['used']} of a 40 budget"
+
+
+def test_both_splits_the_budget_rather_than_doubling_it():
+    """A `both` win must not be purchased with twice the context."""
+    out = arms.build_arms(_item(), budget=500, count=_COUNT, unit="chars")
+    single = max(out["arms"]["vector"]["used"], out["arms"]["graph"]["used"])
+    assert out["arms"]["both"]["used"] <= 500
+    assert out["arms"]["both"]["used"] < single * 2 or single == 0
+
+
+def test_both_is_capped_even_when_the_budget_never_binds():
+    """The guard must not depend on the budget being tight.
+
+    The first behaviour run set budget=2000 and the longest arm used 869, so the
+    split never engaged and `both` was exactly graph+vector concatenated in 12 of
+    12 items. Any `both` win was then purchasable with more context — the
+    doubling confound of ADR-0105, re-entered through a loose budget rather than
+    a missing cap.
+    """
+    out = arms.build_arms(_item(), budget=1_000_000, count=_COUNT, unit="chars")
+    single = max(out["arms"]["vector"]["used"], out["arms"]["graph"]["used"])
+    total = out["arms"]["vector"]["used"] + out["arms"]["graph"]["used"]
+    assert out["arms"]["both"]["used"] <= single, "both must not exceed the largest single arm"
+    assert out["arms"]["both"]["used"] < total, "both degenerated to concatenation"
+
+
+def test_graph_unstructured_carries_the_same_facts_in_the_same_order():
+    """The structure control: only the markup may differ."""
+    item = _item()
+    out = arms.build_arms(item, budget=10_000, count=_COUNT, unit="chars")
+    structured = out["arms"]["graph"]["context"].splitlines()
+    flat = out["arms"]["graph_unstructured"]["context"].splitlines()
+    assert len(structured) == len(flat)
+    for s, f in zip(structured, flat):
+        assert s.replace("(", "").replace(")", "").replace("-[", "").replace("]->", "") \
+            .split() == f.split()
+
+
+def test_graph_unstructured_has_no_structural_markers():
+    out = arms.build_arms(_item(), budget=10_000, count=_COUNT, unit="chars")
+    context = out["arms"]["graph_unstructured"]["context"]
+    for marker in ("(", ")", "-[", "]->"):
+        assert marker not in context, f"{marker!r} survived the strip"
+
+
+def test_the_two_graph_arms_carry_the_same_number_of_units():
+    """Unit parity is the invariant; length parity is not achievable and not needed.
+
+    Stripping `(`, `)`, `-[` and `]->` removes a FIXED nine characters per
+    triple, so the length ratio is a function of how long the entity names are
+    — 0.69 on this two-word toy, 0.79 on the real 21-item set. Chasing a length
+    bound would mean padding, which reintroduces the artificiality the replaced
+    `vector_matched` arm suffered from. What must hold is that both arms state
+    the same facts the same number of times.
+    """
+    item = _item(gold_edges=[["A", "r", "B"], ["B", "r2", "C"], ["C", "r3", "D"]])
+    out = arms.build_arms(item, budget=10_000, count=_COUNT, unit="chars")
+    assert out["arms"]["graph"]["units"] == out["arms"]["graph_unstructured"]["units"]
+    assert out["arms"]["graph_unstructured"]["used"] <= out["arms"]["graph"]["used"]
+
+
+def test_units_are_never_truncated_mid_fact():
+    """A clipped triple or half sentence changes meaning, not just length."""
+    out = arms.build_arms(_item(), budget=45, count=_COUNT, unit="chars")
+    for name in ("vector", "graph"):
+        for line in out["arms"][name]["context"].splitlines():
+            if not line:
+                continue
+            if name == "graph":
+                assert line.startswith("(") and line.endswith(")"), line
+            else:
+                assert line.endswith("."), line
+
+
+def test_graph_and_vector_carry_the_same_facts():
+    """Knowledge parity. Without it a graph win is the vector arm being starved."""
+    item = _item()
+    out = arms.build_arms(item, budget=10_000, count=_COUNT, unit="chars")
+    prose = out["arms"]["vector"]["context"]
+    for subject, _rel, obj in item["gold_edges"]:
+        assert subject in prose and obj in prose, (
+            f"{subject}/{obj} is in the graph form but not readable from the passages"
+        )
+
+
+def test_graph_form_deduplicates_repeated_facts():
+    item = _item(gold_edges=[["A", "r", "B"], ["A", "r", "B"], ["B", "r2", "C"]])
+    out = arms.build_arms(item, budget=10_000, count=_COUNT, unit="chars")
+    assert out["arms"]["graph"]["units"] == 2
+
+
+def test_an_item_with_no_graph_form_is_marked_not_comparable():
+    """Excluded, not silently scored as a vector win."""
+    out = arms.build_arms(_item(gold_edges=[]), budget=500, count=_COUNT, unit="chars")
+    assert out["comparable"] is False
+
+
+def test_an_item_with_no_passages_is_marked_not_comparable():
+    out = arms.build_arms(_item(corpus=[]), budget=500, count=_COUNT, unit="chars")
+    assert out["comparable"] is False
+
+
+def test_budget_unit_is_recorded_so_tokens_and_chars_never_mix():
+    out = arms.build_arms(_item(), budget=500, count=_COUNT, unit="chars")
+    assert out["budget_unit"] == "chars"
+
+
+def test_malformed_edges_are_dropped_not_rendered():
+    item = _item(gold_edges=[["A", "r", "B"], ["A", "r"], ["A", "r", "B", "C"]])
+    out = arms.build_arms(item, budget=10_000, count=_COUNT, unit="chars")
+    assert out["arms"]["graph"]["units"] == 1
+
+
+def test_strata_survive_into_the_arms_row():
+    """Grouping by stratum is the whole analysis; losing it silently is fatal."""
+    item = _item(strata={"stratum": "S2_joined", "hops": 2})
+    out = arms.build_arms(item, budget=500, count=_COUNT, unit="chars")
+    assert out["strata"]["stratum"] == "S2_joined"
+
+
+def _retired_test_length_matched_prose_cannot_also_be_fact_matched():
+    """Why `vector_matched` is a diagnostic, not a control.
+
+    Prose stating a fact is inherently longer than the triple stating it, so an
+    arm cut to the graph arm's length must drop facts. The first behaviour run
+    confirmed it: 8 of 12 items lost the gold string entirely. The arm therefore
+    measures information deprivation, not compactness, and a `graph` win over it
+    is not evidence that structure helped. Pinned so nobody reads its score as a
+    floor. The real structure-at-matched-length control is tracked separately.
+    """
+    item = _item(corpus=["Northgate Plant assembles Model K1 for the Norland market."],
+                 gold_edges=[["Northgate Plant", "assembles", "Model K1"]])
+    out = arms.build_arms(item, budget=10_000, count=_COUNT, unit="chars")
+    matched = out["arms"]["vector_matched"]
+    assert matched["used"] <= out["arms"]["graph"]["used"]
+    assert matched["context"] != out["arms"]["vector"]["context"], (
+        "if the trim is a no-op the arm is silently a duplicate of `vector`"
+    )

--- a/tests/seocho/test_erb_edge_source.py
+++ b/tests/seocho/test_erb_edge_source.py
@@ -1,0 +1,121 @@
+"""The ERB graph arm must be built from our own extraction, not the answer key.
+
+The project's stated decision, recorded in `scripts/serve_track/erb_index.py`,
+is that the graph arm must come from SEOCHO's own indexing: *"That version built
+the graph arm from the dataset's `answer_facts` ... it routes around the thing
+this project actually builds."* The adapter did it anyway, and was modified later
+than that decision.
+
+What `answer_facts` actually contains, from the committed run:
+
+    (The answer must state that the updated reservation target)
+      -[IS]-> (30% of interactive burst credits ... on dp-132-usw)
+    (The answer) -[MUST]-> (not claim the reservation target is 20% ...)
+
+That is the marking scheme converted to pseudo-triples. The graph arm was
+reading the rubric it would be graded against — and `ERB_conflicting_info`, the
+stratum where those edges are densest, is the *only* statistically significant
+graph-vs-vector result in the whole programme.
+
+`answer_facts` stays reachable, because an oracle arm is a legitimate ceiling.
+It is not the default, and its label says what it is.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+ADAPTER = ROOT / "scripts" / "serve_track" / "erb_adapter.py"
+
+
+@pytest.fixture(scope="module")
+def adapter():
+    spec = importlib.util.spec_from_file_location("erb_adapter", ADAPTER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_extraction(tmp_path: Path) -> Path:
+    """One document's extracted graph, in erb_index.py's output shape."""
+    path = tmp_path / "extracted.jsonl"
+    path.write_text(json.dumps({
+        "doc_id": "doc-1",
+        "nodes": [
+            {"id": "org_1", "label": "Org", "properties": {"name": "Redwood"}},
+            {"id": "dec_1", "label": "Decision", "properties": {"name": "Retry v1"}},
+        ],
+        "relationships": [
+            {"source": "org_1", "target": "dec_1", "type": "DECIDED"},
+        ],
+    }) + "\n", encoding="utf-8")
+    return path
+
+
+def test_extraction_loads_as_named_triples(adapter, tmp_path):
+    graphs = adapter.load_extracted_graph(_write_extraction(tmp_path))
+    assert graphs == {"doc-1": [("Redwood", "DECIDED", "Retry v1")]}, (
+        "node ids must resolve to names; document-local ids are meaningless "
+        "in a context string"
+    )
+
+
+def test_failed_extractions_are_skipped(adapter, tmp_path):
+    path = tmp_path / "x.jsonl"
+    path.write_text(json.dumps({
+        "doc_id": "doc-err", "error": "timeout", "nodes": [], "relationships": [],
+    }) + "\n", encoding="utf-8")
+    assert adapter.load_extracted_graph(path) == {}
+
+
+def test_graph_arm_defaults_to_our_extraction(adapter, tmp_path):
+    row = {
+        "question_id": "q1", "question": "who decided?",
+        "gold_answer": "Redwood", "question_type": "single_hop",
+        "expected_doc_ids": ["doc-1"],
+        "answer_facts": ["The answer must state that Redwood decided"],
+    }
+    item = adapter.build_item(
+        row, {"doc-1": "Redwood decided Retry v1."},
+        extracted_graph=adapter.load_extracted_graph(_write_extraction(tmp_path)),
+        edge_source_mode="extracted",
+        max_doc_chars=6000, neighbourhood=3, from_parquet=True,
+    )
+
+    assert item["strata"]["edge_source"] == "extracted"
+    assert ("Redwood", "DECIDED", "Retry v1") in [tuple(e) for e in item["gold_edges"]]
+    flattened = " ".join(" ".join(e) for e in item["gold_edges"])
+    assert "must state" not in flattened, "a rubric line leaked into the graph arm"
+
+
+def test_answer_facts_is_reachable_but_labelled_as_a_ceiling(adapter, tmp_path):
+    """An oracle arm is legitimate. Presenting it as a graph result is not."""
+    row = {
+        "question_id": "q1", "question": "who decided?",
+        "gold_answer": "Redwood", "question_type": "single_hop",
+        "expected_doc_ids": ["doc-1"],
+        "answer_facts": ["The answer must state that Redwood decided"],
+    }
+    item = adapter.build_item(
+        row, {"doc-1": "Redwood decided Retry v1."},
+        extracted_graph={}, edge_source_mode="answer_facts",
+        max_doc_chars=6000, neighbourhood=3, from_parquet=True,
+    )
+
+    assert "CEILING" in item["strata"]["edge_source"], (
+        "the oracle arm must announce itself, or it will be read as a graph win"
+    )
+
+
+def test_cli_default_is_the_extracted_graph():
+    source = ADAPTER.read_text()
+    assert '"--edge-source"' in source
+    assert 'default="extracted"' in source, (
+        "answer_facts must be opt-in; it was the default and produced the "
+        "programme's only significant result"
+    )

--- a/tests/seocho/test_question_set_strata.py
+++ b/tests/seocho/test_question_set_strata.py
@@ -1,0 +1,124 @@
+"""The stratified question set must be correct by construction, not by hand.
+
+A gold answer typed by a human is exactly the kind of thing that is quietly
+wrong and then silently decides an experiment. These tests re-derive every
+answer from the declared gold edges and check that each stratum actually has the
+property it claims to isolate — otherwise a "graph wins on multi-hop" result
+could be a set of mislabelled one-hop questions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+_spec = importlib.util.spec_from_file_location(
+    "make_question_set", _ROOT / "scripts" / "serve_track" / "make_question_set.py"
+)
+qs = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = qs
+_spec.loader.exec_module(qs)
+
+ITEMS = qs.build()
+
+
+def test_every_gold_edge_is_present_in_the_corpus():
+    """A path the graph form states must also be readable from the passages.
+
+    If it is not, the arms are not given the same knowledge and any graph win is
+    an artefact of the vector arm being starved.
+    """
+    for item in ITEMS:
+        joined = " ".join(item.corpus)
+        for subject, _relation, obj in item.gold_edges:
+            assert subject in joined, f"{item.stratum}: {subject!r} missing from corpus"
+            assert obj in joined, f"{item.stratum}: {obj!r} missing from corpus"
+
+
+def test_hop_count_matches_the_declared_chain():
+    """`hops` must equal the length of the gold path, not a hopeful label."""
+    for item in ITEMS:
+        if item.answer_type != "joined":
+            continue
+        assert len(item.gold_edges) == item.hops, (
+            f"{item.stratum}: declares hops={item.hops} but the gold path has "
+            f"{len(item.gold_edges)} edges"
+        )
+
+
+def test_joined_strata_really_span_multiple_passages():
+    """S2/S3 exist to force composition; a single-passage item there is mislabelled."""
+    for item in ITEMS:
+        if item.answer_type == "joined":
+            assert item.dispersion >= 2, f"{item.stratum}: dispersion={item.dispersion}"
+            assert item.hops >= 2, f"{item.stratum}: hops={item.hops}"
+
+
+def test_extractive_strata_are_single_hop():
+    for item in ITEMS:
+        if item.stratum.startswith(("S1", "S7")):
+            assert item.hops == 1 and item.dispersion == 1
+
+
+def test_chained_answers_are_derivable_from_the_edges():
+    """Re-derive each joined answer by walking its own gold path."""
+    for item in ITEMS:
+        if item.answer_type != "joined":
+            continue
+        node = item.gold_edges[0][0]
+        for subject, _relation, obj in item.gold_edges:
+            assert subject == node, (
+                f"{item.stratum}: gold path is not connected at {subject!r}"
+            )
+            node = obj
+        assert node == item.answer, (
+            f"{item.stratum}: walking the gold path yields {node!r}, "
+            f"but the declared answer is {item.answer!r}"
+        )
+
+
+def test_aggregate_answers_match_the_edge_count():
+    for item in ITEMS:
+        if item.answer_type == "aggregate":
+            assert item.answer == str(len(item.gold_edges)), (
+                f"{item.stratum}: answer {item.answer!r} != {len(item.gold_edges)} gold edges"
+            )
+
+
+def test_distractor_stratum_actually_has_distractors():
+    """S7 is the control for 'graph wins because retrieval is noisy'."""
+    s7 = [i for i in ITEMS if i.stratum.startswith("S7")]
+    assert s7, "S7 missing — without it a graph win cannot be separated from retrieval precision"
+    plain = {len(i.corpus) for i in ITEMS if i.stratum.startswith("S1")}
+    for item in s7:
+        assert len(item.corpus) > max(plain), "S7 corpus is not larger than the plain one"
+
+
+def test_ambiguous_stratum_has_two_entities_sharing_a_surface_name():
+    amb = [i for i in ITEMS if i.stratum.startswith("S6")]
+    assert amb
+    for item in amb:
+        joined = " ".join(item.corpus)
+        assert joined.count("Aurora Metals") >= 3, (
+            "S6 needs the bare name plus both qualified entities present"
+        )
+
+
+def test_every_stratum_states_a_prediction_in_advance():
+    """A stratum without a prediction cannot produce a negative result."""
+    for item in ITEMS:
+        assert item.prediction.strip(), f"{item.stratum} has no prediction"
+        assert len(item.prediction) > 20, f"{item.stratum} prediction is too vague"
+
+
+@pytest.mark.parametrize("stratum", [
+    "S1_extractive", "S2_joined", "S3_deep_join",
+    "S4_aggregation", "S5_absence", "S6_ambiguous", "S7_distractor",
+])
+def test_all_seven_strata_are_populated(stratum):
+    assert any(i.stratum == stratum for i in ITEMS), f"{stratum} has no items"

--- a/tests/seocho/test_run_arms.py
+++ b/tests/seocho/test_run_arms.py
@@ -1,0 +1,146 @@
+"""The scorer must not lose a correct answer to invisible characters.
+
+The first behaviour run marked a correct `Model K1` wrong because MiniMax emitted
+U+202F between the words. A scorer that is literal about invisible characters
+under-counts, and the under-count attaches to whichever arm formats more
+prettily — which is the arm identity the experiment is trying to measure.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "run_arms", _ROOT / "scripts" / "serve_track" / "run_arms.py"
+)
+runner = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = runner
+_spec.loader.exec_module(runner)
+
+
+def test_narrow_no_break_space_does_not_fail_a_correct_answer():
+    assert runner.check_deterministic("Model K1", "Model K1") is True
+
+
+def test_case_and_surrounding_prose_do_not_matter():
+    assert runner.check_deterministic("Model K1", "The answer is model k1.") is True
+
+
+def test_a_wrong_answer_is_still_wrong():
+    assert runner.check_deterministic("Model K1", "Model L9") is False
+
+
+def test_prose_gold_defers_to_the_judge():
+    """Containment over a paragraph passes on coincidence, so it must not run."""
+    gold = "Basal cell carcinoma is the most common type of skin cancer worldwide."
+    assert runner.check_deterministic(gold, "anything") is None
+
+
+def test_absence_gold_accepts_a_refusal():
+    assert runner.check_deterministic("none", "NOT STATED") is True
+    assert runner.check_deterministic("none", "Model K2") is False
+
+
+def test_empty_answer_is_not_silently_correct():
+    assert runner.check_deterministic("Model K1", "") is False
+
+
+def test_a_list_gold_defers_to_the_judge():
+    """Containment cannot score a set, in either direction.
+
+    It marks a correct answer wrong when the order differs or an "and" appears,
+    and it marks a wrong answer right when the reply names every gold item plus
+    two that do not belong. Both happened on the negation stratum.
+    """
+    gold = "Model K2, Model M3, Model R4"
+    assert runner.check_deterministic(gold, "Model K2, Model M3, and Model R4") is None
+    assert runner.check_deterministic(gold, "anything at all") is None
+
+
+def test_a_single_value_gold_still_scores_deterministically():
+    assert runner.check_deterministic("Eastfield Plant", "Eastfield Plant") is True
+
+
+_NEG_GOLD = "Model K2, Model M3, Model R4"
+_NEG_EXCLUDED = ["Model K1", "Model L9", "Model P7"]
+
+
+def test_set_scoring_accepts_reordering_and_supporting_detail():
+    """The exact shape the model produced, which containment scored wrong."""
+    answer = ("Model K2, Model M3, and Model R4 are not sold in Norland.\n"
+              "- Model K2 is sold in Sudmark\n- Model M3 is sold in Verrat")
+    assert runner.check_set(_NEG_GOLD, _NEG_EXCLUDED, answer) is True
+
+
+def test_set_scoring_rejects_an_omission():
+    assert runner.check_set(_NEG_GOLD, _NEG_EXCLUDED, "Model K2 and Model M3") is False
+
+
+def test_set_scoring_rejects_an_item_that_does_not_belong():
+    """The error an LLM judge and a containment check both miss."""
+    answer = "Model K2, Model M3, Model R4, and Model K1"
+    assert runner.check_set(_NEG_GOLD, _NEG_EXCLUDED, answer) is False
+
+
+def test_set_scoring_declines_when_there_is_no_complement():
+    """Without the excluded set the check cannot see additions, so it must abstain."""
+    assert runner.check_set(_NEG_GOLD, [], "anything") is None
+    assert runner.check_set("single value", _NEG_EXCLUDED, "single value") is None
+
+
+def test_refusal_detection_covers_paraphrase_not_just_one_wording():
+    """The bug this replaced: a string list caught 'does not contain' and missed
+    'does not include', scoring four correct refusals as inventions."""
+    for reply in (
+        "The provided context does not include information about HTTP 409.",
+        "The provided context does not contain that detail.",
+        "Based on the provided context, I cannot answer this question.",
+        "This cannot be answered from the documents.",
+        "That value is not specified anywhere in the context.",
+        "NOT STATED",
+        "There is no information about the metering coefficients.",
+        "The answer is not fully answerable from the provided documents.",
+    ):
+        assert runner.check_refusal(reply) is True, reply
+
+
+def test_an_asserted_answer_is_not_a_refusal():
+    for reply in (
+        "The Slack channel is #obs-alerts.",
+        "The default limit is 10 MiB per file.",
+        "Northgate Plant assembles Model K1.",
+    ):
+        assert runner.check_refusal(reply) is False, reply
+
+
+def test_a_short_sentence_gold_is_not_scored_by_containment():
+    """GraphRAG-Bench golds are sentences, and short ones slipped through.
+
+    Gold "Rubber boots are worn on the feet." is 33 characters, passed the
+    length gate, and scored the reply "feet" wrong. 31 of 32 bench items failed
+    that way, which reads as a model collapse and was a scorer artefact.
+    """
+    assert runner.check_deterministic("Rubber boots are worn on the feet.", "feet") is None
+    assert runner.check_deterministic("Wetherall defeated the rebels", "Wetherall") is None
+    assert runner.check_deterministic("The Mayas had unknown rites", "unknown rites") is None
+
+
+def test_value_shaped_golds_still_score_deterministically():
+    """The synthetic set's golds are entity names and counts; keep them cheap."""
+    assert runner.check_deterministic("Eastfield Plant", "Eastfield Plant") is True
+    assert runner.check_deterministic("5", "The answer is 5.") is True
+    assert runner.check_deterministic("Model K2", "Model L9") is False
+
+
+def test_the_judge_is_given_room_to_reason():
+    """gpt-oss-120b is a reasoning model; at max_tokens=8 it never reaches a verdict.
+
+    The reply came back as leaked reasoning ("We need to compare answer"), which
+    startswith("CORRECT") rejects, so every judge-scored item in every earlier
+    run was marked wrong -- on the GraphRAG-Bench sample that looked like all
+    four arms collapsing to 1 of 32.
+    """
+    assert runner._JUDGE_MAX_TOKENS >= 256


### PR DESCRIPTION
Brings `scripts/serve_track/` (the graph-vs-vector experiment harness) onto main, with the provenance defect a review found in it **fixed first**.

## The graph arm was reading the answer key

The project decided the ERB graph arm must come from SEOCHO's own indexing. It is written down in `erb_index.py`:

> That version built the graph arm from the dataset's own `answer_facts` … it routes around the thing this project actually builds.

`erb_adapter.py` did it anyway, and was modified **later** than that decision. On the committed run `edge_source` was `answer_facts` for 76 of 79 items — and for **20 of 20** `ERB_conflicting_info` items.

`answer_facts` are not facts about the world. They are the dataset's decomposed grading claims:

```
(The answer must state that the updated reservation target)
  -[IS]-> (30% of interactive burst credits ... on dp-132-usw)
(The answer may mention that an earlier/internal suggestion) -[WAS]-> (20% ...)
```

**And `ERB_conflicting_info` is the only statistically significant graph-vs-vector comparison in the whole programme** — graph 17/20 vs vector 10/20, exact McNemar p = 0.0156. Every other arm comparison, across three corpora and 41 tests, is null.

## Measured

20 affected items, rubric detector `the answer|must|should|may mention`:

| edge source | edges | rubric-phrased | share |
|---|---|---|---|
| `answer_facts` | 115 | 115 | **100%** |
| our extraction | 635 | 1 | **0%** |

Same question, side by side:

```
answer_facts:  The answer must state that the updated reservation target
                 -IS-> 30% of interactive burst credits ...

extracted:     Sustained 429s during sliced ingest -AFFECTS->     Streamly AI
               Sustained 429s during sliced ingest -OCCURRED_ON-> dp-132-usw
```

## The change

`--edge-source extracted` is the default: `outputs/erb_extracted.jsonl` joined to questions on `expected_doc_ids`, node ids resolved to names (285 documents, 5,348 triples).

`--edge-source answer_facts` stays reachable — an oracle **ceiling** arm is required by our own controls discipline — and now labels itself `answer_facts_CEILING` so it cannot be read as a graph result.

Asking for `extracted` with no extracted graph is a **hard error**, not a silent fallback. Silently substituting a different edge source is how this happened.

## ⚠️ Consequence

**The p = 0.0156 result must be re-run and, until then, not cited.** It was produced by an arm holding the answer key.

## Scope: harness scripts only

The serve branch's `src/seocho/` changes (`ontology_modularity`, `workflow_scorecard`, `plan_quality` additions) are **deliberately not here**. Reviews found real defects — the modularity metrics report a completely flat ontology as *optimal on every band*, and the scorecard has no production caller — and those should be fixed before landing, not after.

All four SDK imports the harness needs already exist on main; verified by importing every script against main's SDK.

## Still not fixed, and larger than this

The harness has **no retrieval stage**. The graph arm is fed `gold_edges` and the vector arm the gold documents, so both receive oracle evidence and the comparison is between *serialisation formats* under held-perfect retrieval. This PR removes the answer key from one side of that; it does not make it a retrieval experiment.

## Validation

```
pytest 6 serve-track suites               -> 66 passed
import every harness script vs main SDK   -> 5/5 OK
regenerated 40 ERB items from extraction
bash scripts/ci/run_basic_ci.sh           -> passed
git diff --check                          -> clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)