### PR TITLE
fix(graph): index the properties the write and read paths actually use

### DIFF
--- a/docs/decisions/ADR-0198-index-coverage.json
+++ b/docs/decisions/ADR-0198-index-coverage.json
@@ -1,0 +1,22 @@
+{
+  "adr": "ADR-0198",
+  "instance": "DozerDB 5.26.3 (graphstack/dozerdb), bolt://localhost:7687",
+  "ddl_accepted": "7/7",
+  "explain_probe": {
+    "merge_key  MATCH (n:L {id:$i})": [
+      "NodeIndexSeek",
+      "ProduceResults"
+    ],
+    "tenancy+anchor  n._workspace_id=$w AND n.name=$nm": [
+      "NodeIndexSeek",
+      "ProduceResults"
+    ],
+    "tenancy as generated  ($w='' OR coalesce(n._workspace_id,'')=$w) AND n.name=$nm": [
+      "NodeByLabelScan",
+      "Filter",
+      "ProduceResults"
+    ]
+  },
+  "finding": "The indexes are used. The predicate the builder currently generates is not index-eligible: coalesce() wraps the property and the OR disjunct is not a property predicate, so the planner falls back to a label scan plus a post-filter on every query.",
+  "not_changed": "The tenancy predicate shape. It is load-bearing for workspace isolation (verify_workspace_binding, _TAUTOLOGY_RE in store/graph.py), and changing it without review risks opening a tenancy hole."
+}

--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -118,6 +118,7 @@ uv run pytest \
   tests/seocho/test_finder_cache_synergy.py \
   tests/seocho/test_ontology_extraction_firewall.py \
   tests/seocho/test_ontology_lint.py \
+  tests/seocho/test_index_coverage.py \
   tests/seocho/test_shacl_enum_range.py \
   tests/seocho/test_ontology_merge_conflicts.py \
   tests/seocho/test_extraction_type_scoring.py \

--- a/src/seocho/ontology/core.py
+++ b/src/seocho/ontology/core.py
@@ -1827,6 +1827,18 @@ class Ontology:
             # uniqueness constraint over the identity members instead, and
             # skip the per-member UNIQUE.
             identity = set(nd.identity_keys)
+            if len(nd.identity_keys) == 1:
+                # A single identity key IS the identity, so it takes a plain
+                # UNIQUE. Previously the composite branch needed >1 key and the
+                # per-property branch skipped anything in `identity`, so a class
+                # with exactly one identity key got no constraint at all --
+                # silently, and precisely for the property the writer dedupes on.
+                (only,) = nd.identity_keys
+                if only in nd.properties:
+                    stmts.append(
+                        f"CREATE CONSTRAINT constraint_{label}_identity_unique "
+                        f"IF NOT EXISTS FOR (n:{label}) REQUIRE n.{only} IS UNIQUE"
+                    )
             if len(nd.identity_keys) > 1:
                 props = ", ".join(f"n.{k}" for k in nd.identity_keys)
                 cname = f"constraint_{label}_identity_unique"
@@ -1848,6 +1860,57 @@ class Ontology:
                         f"CREATE INDEX {iname} IF NOT EXISTS "
                         f"FOR (n:{label}) ON (n.{pname})"
                     )
+
+            # The three indexes below cover the properties the WRITE and READ
+            # paths actually use, which were disjoint from the properties this
+            # method indexed. Measured before adding them: the ontology indexed
+            # whatever was declared `unique`/`index`; the writer MERGEs on `id`;
+            # the retriever filters on the display property and `_workspace_id`.
+            # Three disjoint sets, so no index served any predicate a correct
+            # query would use — and a plan grader then reads that as "the LLM
+            # writes unsargable Cypher" when the truth is "no index exists".
+
+            # 1. The MERGE key. Every node write is `MERGE (n:L {id: ...})`, so
+            #    without this each write is a label scan plus a property filter,
+            #    and relationship writes do two. Ingest is quadratic.
+            stmts.append(
+                f"CREATE INDEX index_{label}_id IF NOT EXISTS "
+                f"FOR (n:{label}) ON (n.id)"
+            )
+
+            # 2. Tenancy first, then the anchor. `_workspace_id` alone is the
+            #    lowest-cardinality property in the store, so a seek on it
+            #    returns most of the label; composite with the identity key it
+            #    becomes O(this tenant's matching entities) instead of
+            #    O(all tenants' data) on every query in the system.
+            anchor = (nd.effective_identity_keys or [None])[0]
+            if anchor:
+                stmts.append(
+                    f"CREATE INDEX index_{label}_workspace_{anchor} IF NOT EXISTS "
+                    f"FOR (n:{label}) ON (n._workspace_id, n.{anchor})"
+                )
+
+        # 3. Entity-name resolution is a fuzzy substring match, which a RANGE
+        #    index (what CREATE INDEX gives you) cannot serve. FULLTEXT is the
+        #    only index type appropriate for it, and `graph_router.py` already
+        #    calls db.index.fulltext.queryNodes against exactly this index name
+        #    — nothing in the SDK created it, so that retrieval path failed and
+        #    was swallowed by a bare except, degrading to a keyword heuristic
+        #    with no signal.
+        display_props = sorted({
+            prop
+            for nd in self.nodes.values()
+            for prop in ((nd.effective_identity_keys or []) + ["name"])
+            if prop in nd.properties or prop == "name"
+        })
+        if self.nodes and display_props:
+            labels = "|".join(sorted(self.nodes))
+            props = ", ".join(f"n.{p}" for p in display_props)
+            stmts.append(
+                f"CREATE FULLTEXT INDEX entity_fulltext IF NOT EXISTS "
+                f"FOR (n:{labels}) ON EACH [{props}]"
+            )
+
         return stmts
 
     # ------------------------------------------------------------------

--- a/tests/seocho/test_index_coverage.py
+++ b/tests/seocho/test_index_coverage.py
@@ -1,0 +1,127 @@
+"""Indexes must cover the properties the write and read paths actually use.
+
+Before this, three property sets were disjoint:
+
+  the ontology indexed   whatever was declared `unique` / `index`
+  the writer MERGEd on   `id`            (store/graph.py: MERGE (n:L {id: row.id}))
+  the retriever filters  the display property and `_workspace_id`
+
+So no index served any predicate a correct query would use. The consequence is
+not only slowness: a plan grader reads that as "the LLM writes unsargable
+Cypher" when the truth is "no index exists for the predicate", which attributes
+a data-layer defect to the generation stage — the single biggest threat to a
+stage-attribution study.
+
+Every statement here was accepted by a live DozerDB 5.26.3 (7 of 7), and the
+planner was confirmed to use them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P
+
+
+@pytest.fixture
+def ontology() -> Ontology:
+    return Ontology(
+        name="t",
+        nodes={
+            "Person": NodeDef(
+                description="p",
+                properties={"name": P(str, unique=True), "age": P(int)},
+                identity_keys=["name"],
+            ),
+            "Step": NodeDef(
+                description="s",
+                properties={"name": P(str), "procedure": P(str)},
+                identity_keys=["name", "procedure"],
+            ),
+            "Decision": NodeDef(
+                description="d",
+                properties={"name": P(str), "status": P(str)},
+            ),
+        },
+    )
+
+
+def test_merge_key_is_indexed_for_every_label(ontology):
+    """`MERGE (n:L {id: ...})` without an index is a label scan per write, and
+    two per relationship — ingest is quadratic."""
+    statements = ontology.to_cypher_constraints()
+    for label in ontology.nodes:
+        assert any(
+            f"FOR (n:{label}) ON (n.id)" in s for s in statements
+        ), f"{label} has no index on the property the writer merges on"
+
+
+def test_tenancy_is_composite_with_the_anchor(ontology):
+    """`_workspace_id` alone is the lowest-cardinality property in the store, so
+    a seek on it returns most of the label. Composite with the identity key it
+    becomes O(this tenant's matching entities)."""
+    statements = ontology.to_cypher_constraints()
+    assert any(
+        "ON (n._workspace_id, n.name)" in s and "(n:Person)" in s
+        for s in statements
+    )
+    # Tenancy must come FIRST in the composite, or the prefix seek does not help.
+    composites = [s for s in statements if "_workspace_id" in s]
+    assert composites
+    for statement in composites:
+        assert "ON (n._workspace_id," in statement
+
+
+def test_single_identity_key_gets_a_unique_constraint(ontology):
+    """The pre-existing gap: the composite branch required >1 key and the
+    per-property branch skipped anything in `identity`, so a class with exactly
+    one identity key got no constraint at all — for the very property the writer
+    dedupes on."""
+    statements = ontology.to_cypher_constraints()
+    assert any(
+        "constraint_Person_identity_unique" in s and "REQUIRE n.name IS UNIQUE" in s
+        for s in statements
+    )
+
+
+def test_composite_identity_still_uses_a_tuple_constraint(ontology):
+    """seocho-uxs: a per-member UNIQUE would reject two distinct entities that
+    share one member. The tuple is the identity."""
+    statements = ontology.to_cypher_constraints()
+    assert any(
+        "REQUIRE (n.name, n.procedure) IS UNIQUE" in s for s in statements
+    )
+
+
+def test_fulltext_index_exists_and_uses_neo4j_5_label_syntax(ontology):
+    """Entity anchoring is a fuzzy substring match, which a RANGE index cannot
+    serve. `graph_router.py` already queries `entity_fulltext` and nothing in
+    the SDK created it, so that retrieval path failed and was swallowed by a
+    bare except — degrading to a keyword heuristic with no signal."""
+    statements = ontology.to_cypher_constraints()
+    fulltext = [s for s in statements if "FULLTEXT INDEX" in s]
+    assert fulltext, "no fulltext index; entity anchoring cannot use one"
+
+    statement = fulltext[0]
+    assert "entity_fulltext" in statement, "must match the name graph_router queries"
+    # Neo4j 5 separates labels with `|`. A comma is a syntax error.
+    assert "|" in statement and "n:Decision, " not in statement
+
+
+def test_no_index_for_an_empty_ontology():
+    """A fulltext index over no labels is a syntax error, not an empty index."""
+    assert Ontology(name="empty", nodes={}).to_cypher_constraints() == []
+
+
+def test_declared_index_and_unique_still_emitted():
+    """The new coverage must not displace what was already correct."""
+    onto = Ontology(
+        name="t",
+        nodes={"Co": NodeDef(
+            description="c",
+            properties={"ticker": P(str, index=True), "cik": P(str, unique=True)},
+        )},
+    )
+    statements = onto.to_cypher_constraints()
+    assert any("FOR (n:Co) ON (n.ticker)" in s for s in statements)
+    assert any("REQUIRE n.cik IS UNIQUE" in s for s in statements)


### PR DESCRIPTION
Found by a Neo4j/DozerDB engineer review. **Every statement here was accepted by a live DozerDB 5.26.3, and the planner was confirmed to use it.**

## Three property sets were disjoint

| what | indexed / used |
|---|---|
| the ontology **indexed** | whatever was declared `unique` / `index` |
| the writer **MERGEs on** | `id` — `MERGE (n:L {id: row.id})` |
| the retriever **filters on** | the display property and `_workspace_id` |

So **no index served any predicate a correct query would use.**

The cost is not only speed. A plan grader reads an unindexed predicate as *"the LLM writes unsargable Cypher"* when the truth is *"no index exists"* — attributing a data-layer defect to the generation stage. That is the single biggest threat to the stage-attribution study this work is for.

## Three indexes per label

- **`id`** — every node write was a label scan plus a property filter, and every relationship write two. Ingest was quadratic.
- **`(_workspace_id, anchor)`** — tenancy first. `_workspace_id` alone is the lowest-cardinality property in the store, so a seek on it returns most of the label; composite with the identity key it becomes O(this tenant's matching entities) instead of O(all tenants' data).
- **`entity_fulltext`** — entity anchoring is a fuzzy substring match, which a RANGE index cannot serve. `graph_router.py` already queries this exact index name and **nothing in the SDK created it**, so that retrieval path failed and was swallowed by a bare `except`, degrading to a keyword heuristic with no signal.

## A pre-existing constraint gap, found while writing the tests

A class with exactly **one** identity key got no uniqueness constraint at all: the composite branch required `len(identity_keys) > 1`, and the per-property branch skipped anything in `identity`. So the property the writer dedupes on was unconstrained — silently.

## Measured on a live instance

```
MATCH (n:L {id:$i})                          -> NodeIndexSeek
n._workspace_id=$w AND n.name=$nm            -> NodeIndexSeek
($w='' OR coalesce(n._workspace_id,'')=$w)
  AND n.name=$nm                             -> NodeByLabelScan + Filter
```

## ⚠️ Deliberately not changed: that third line

The tenancy predicate the builder generates today **is not index-eligible** — `coalesce()` wraps the property and the `OR` disjunct is not a property predicate, so the planner falls back to a label scan plus a post-filter on *every query in the system*.

Fixing it means changing the shape of a predicate that is load-bearing for workspace isolation (`verify_workspace_binding` and `_TAUTOLOGY_RE` in `store/graph.py` are tuned to it). Getting that wrong opens a tenancy hole rather than closing one, so it wants a deliberate review rather than being folded in here. The EXPLAIN evidence is recorded in `ADR-0198-index-coverage.json`.

## Validation

```
live DozerDB 5.26.3: 7/7 DDL accepted, EXPLAIN confirms seeks
pytest test_index_coverage                          -> 7 passed
pytest 7 ontology/graph suites                      -> 86 passed
bash scripts/ci/run_basic_ci.sh                     -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)