### PR TITLE
fix(metrics): telemetry must never fail the work it measures

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -102,6 +102,7 @@ uv run pytest \
   tests/seocho/test_graph_loop_model_routing.py \
   tests/seocho/test_tracing.py \
   tests/seocho/test_observability_wiring.py \
+  tests/seocho/test_metrics_never_fail_the_work.py \
   tests/seocho/test_histogram_buckets.py \
   tests/seocho/test_trace_span_context.py \
   tests/seocho/test_observability_contract.py \

--- a/src/seocho/metrics.py
+++ b/src/seocho/metrics.py
@@ -7,11 +7,15 @@ request causality belongs in traces and auditable receipts, never metric labels.
 from __future__ import annotations
 
 import atexit
+import logging
 import os
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Mapping, Protocol
 
+
+logger = logging.getLogger(__name__)
 
 METRICS_BACKEND_ENV = "SEOCHO_METRICS_BACKEND"
 METRICS_OTLP_ENDPOINT_ENV = "SEOCHO_METRICS_OTLP_ENDPOINT"
@@ -259,25 +263,57 @@ class ProductionMetrics:
                 raise ValueError(f"metric attribute {key} exceeds 80 characters")
         return values
 
+    #: When true, a validation failure raises instead of being swallowed. Tests
+    #: and CI set it; production leaves it off. See _guard().
+    strict: bool = False
+
+    @contextmanager
+    def _guard(self, name: str):
+        """Never let telemetry fail the work it measures.
+
+        The emit calls in `store/llm.py` sit inside the same `try` as the
+        provider request, whose `except Exception` is the RETRY handler. So a
+        malformed attribute on a SUCCESSFUL completion was reclassified as an
+        LLM failure: it triggered a real retry at real cost, and recorded itself
+        as `seocho.gen_ai.retry.count{reason: "ValueError"}`. The retry metric
+        contained our own bugs, and the same shape in
+        `runtime/agent_server.py`'s bare `finally` turned a telemetry error into
+        a 500.
+
+        A monitoring system that can take down the thing it monitors, and that
+        misreports its own defects as vendor failures, fails the one job it has.
+        Guarding here rather than at each call site means a new emitter cannot
+        reintroduce it by forgetting to wrap.
+        """
+        try:
+            yield
+        except Exception as exc:  # noqa: BLE001 - telemetry must not escape
+            if self.strict:
+                raise
+            logger.debug("metric %s dropped: %s", name, exc)
+
     def add(self, name: str, amount: int | float = 1, attributes: Mapping[str, Any] | None = None) -> None:
-        spec = METRIC_SPECS[name]
-        if spec.kind not in {"counter", "up_down_counter"}:
-            raise TypeError(f"{name} is not an additive instrument")
-        self._instruments[name].add(amount, self._attributes(spec, attributes))
+        with self._guard(name):
+            spec = METRIC_SPECS[name]
+            if spec.kind not in {"counter", "up_down_counter"}:
+                raise TypeError(f"{name} is not an additive instrument")
+            self._instruments[name].add(amount, self._attributes(spec, attributes))
 
     def record(self, name: str, value: int | float, attributes: Mapping[str, Any] | None = None) -> None:
-        spec = METRIC_SPECS[name]
-        if spec.kind != "histogram":
-            raise TypeError(f"{name} is not a histogram")
-        if value < 0:
-            raise ValueError("histogram values must be non-negative")
-        self._instruments[name].record(value, self._attributes(spec, attributes))
+        with self._guard(name):
+            spec = METRIC_SPECS[name]
+            if spec.kind != "histogram":
+                raise TypeError(f"{name} is not a histogram")
+            if value < 0:
+                raise ValueError("histogram values must be non-negative")
+            self._instruments[name].record(value, self._attributes(spec, attributes))
 
     def set(self, name: str, value: int | float, attributes: Mapping[str, Any] | None = None) -> None:
-        spec = METRIC_SPECS[name]
-        if spec.kind != "gauge":
-            raise TypeError(f"{name} is not a gauge")
-        self._instruments[name].set(value, self._attributes(spec, attributes))
+        with self._guard(name):
+            spec = METRIC_SPECS[name]
+            if spec.kind != "gauge":
+                raise TypeError(f"{name} is not a gauge")
+            self._instruments[name].set(value, self._attributes(spec, attributes))
 
 
 _lock = threading.Lock()

--- a/tests/seocho/conftest.py
+++ b/tests/seocho/conftest.py
@@ -1,0 +1,31 @@
+"""Test-wide defaults for the SEOCHO SDK suite."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _strict_metrics():
+    """Make metric validation raise during tests.
+
+    In production a validation failure is swallowed: the emit calls in
+    `store/llm.py` sit inside the same `try` as the provider request, whose
+    `except Exception` is the retry handler, so a raising telemetry call turned
+    a successful completion into a retried "LLM failure" at real cost.
+
+    But swallowing by default would also make the validator's contract
+    unenforceable — a test asserting that a forbidden attribute is rejected
+    would pass whether or not the rejection happened. Tests therefore opt into
+    strict mode, so the guard protects production without hiding regressions
+    from us.
+    """
+    from seocho.metrics import get_metrics
+
+    metrics = get_metrics()
+    previous = getattr(metrics, "strict", False)
+    metrics.strict = True
+    try:
+        yield
+    finally:
+        metrics.strict = previous

--- a/tests/seocho/test_metrics_never_fail_the_work.py
+++ b/tests/seocho/test_metrics_never_fail_the_work.py
@@ -1,0 +1,97 @@
+"""Telemetry must never fail the work it measures.
+
+`ProductionMetrics` raises on an invalid attribute — correct as a contract, and
+placed where it could do real damage. The emit calls in `store/llm.py` sit
+inside the same `try` as the provider request, and that `try`'s
+`except Exception` is the **retry handler**:
+
+    try:
+        resp = self._client.chat.completions.create(**attempt_kwargs)
+        ...
+        metrics.record("gen_ai.client.operation.duration", ...)   # <-- here
+    except Exception as exc:
+        last_exc = exc
+        ...
+        metrics.add("seocho.gen_ai.retry.count", 1, {"reason": type(exc).__name__})
+
+So a malformed attribute on a **successful** completion was reclassified as an
+LLM failure: it triggered a real retry at real cost, and recorded itself as
+`seocho.gen_ai.retry.count{reason: "ValueError"}`. The retry metric contained
+our own bugs. The same shape in `runtime/agent_server.py`'s bare `finally`
+turned a telemetry error into a 500.
+
+A monitoring system that can take down the thing it monitors, and that
+misreports its own defects as vendor failures, fails the one job it has.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.metrics import METRIC_SPECS, ProductionMetrics, get_metrics
+
+
+@pytest.fixture
+def lenient():
+    """A registry in production mode — the autouse conftest fixture makes the
+    process-wide one strict, which is the opposite of what we test here."""
+    metrics = ProductionMetrics()
+    metrics.strict = False
+    return metrics
+
+
+def test_unknown_attribute_does_not_escape(lenient):
+    lenient.add("seocho.agent.request.count", 1, {"not_a_real_attribute": "x"})
+
+
+def test_forbidden_attribute_does_not_escape(lenient):
+    """Forbidden fragments are a cardinality/privacy control, not a reason to
+    fail a request that already succeeded."""
+    lenient.add("seocho.agent.request.count", 1, {"workspace_id": "tenant-a"})
+
+
+def test_oversized_attribute_does_not_escape(lenient):
+    lenient.add("seocho.agent.request.count", 1, {"operation": "x" * 200})
+
+
+def test_non_scalar_attribute_does_not_escape(lenient):
+    lenient.add("seocho.agent.request.count", 1, {"operation": {"nested": True}})
+
+
+def test_wrong_instrument_kind_does_not_escape(lenient):
+    """A counter recorded as a histogram is a wiring bug in our code, and still
+    must not take down the request."""
+    lenient.record("seocho.agent.request.count", 1.0, {"operation": "ask"})
+
+
+def test_unknown_metric_name_does_not_escape(lenient):
+    lenient.add("seocho.not.a.real.metric", 1)
+
+
+def test_negative_histogram_value_does_not_escape(lenient):
+    lenient.record("seocho.agent.request.duration", -1.0, {"operation": "ask"})
+
+
+def test_valid_emission_still_works(lenient):
+    """The guard must not swallow the measurement itself."""
+    spec = METRIC_SPECS["seocho.agent.request.count"]
+    attribute = sorted(spec.attributes)[0]
+    lenient.add("seocho.agent.request.count", 1, {attribute: "ask"})
+
+
+# ---------------------------------------------------------------------------
+# Strict mode keeps the contract enforceable
+# ---------------------------------------------------------------------------
+
+def test_strict_mode_still_raises():
+    """Swallowing by default would make the validator unenforceable — a test
+    asserting rejection would pass whether or not the rejection happened."""
+    metrics = ProductionMetrics()
+    metrics.strict = True
+    with pytest.raises(ValueError):
+        metrics.add("seocho.agent.request.count", 1, {"nope": "x"})
+
+
+def test_tests_run_strict_by_default():
+    """The autouse conftest fixture is what keeps the contract alive in CI."""
+    assert getattr(get_metrics(), "strict", False) is True


### PR DESCRIPTION
Found by an SRE review. `ProductionMetrics` raises on an invalid attribute — correct as a contract, **placed where it could do real damage**.

## The emit call sits inside the retry handler's `try`

```python
try:
    resp = self._client.chat.completions.create(**attempt_kwargs)
    ...
    metrics.record("gen_ai.client.operation.duration", ...)   # <-- here
except Exception as exc:
    last_exc = exc
    metrics.add("seocho.gen_ai.retry.count", 1, {"reason": type(exc).__name__})
```

So a malformed attribute on a **successful** completion was reclassified as an LLM failure: it triggered a **real retry at real cost**, and recorded itself as `seocho.gen_ai.retry.count{reason: "ValueError"}`.

**The retry metric contained our own bugs.**

The same shape in `runtime/agent_server.py`'s bare `finally` turned a telemetry error into a **500** — `outcome` there is a response-derived string, so an over-long one was enough.

A monitoring system that can take down the thing it monitors, and that misreports its own defects as vendor failures, fails the one job it has.

## The fix, and why it is at the metrics layer

Guarded inside `add`/`record`/`set` rather than at each call site, so a new emitter cannot reintroduce it by forgetting to wrap. Failures log at debug and drop the measurement.

## Swallowing by default would break the contract

A test asserting that a forbidden attribute is rejected would pass whether or not the rejection happened. So `ProductionMetrics` grows a `strict` flag and `tests/seocho/conftest.py` turns it on for the whole suite via an autouse fixture.

**The guard protects production; strict keeps the contract alive in CI.**

## Validation

```
pytest test_metrics_never_fail_the_work  -> 10 passed
pytest 4 observability suites (strict)   -> 30 passed
bash scripts/ci/run_basic_ci.sh          -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)