### PR TITLE
feat(index): emit indexing-stage quality, with bounded attributes

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -83,6 +83,7 @@ uv run pytest \
   tests/seocho/test_bench_annotation.py \
   tests/seocho/test_finder_benchmark_script.py \
   tests/seocho/test_indexing_design.py \
+  tests/seocho/test_indexing_quality_metrics.py \
   tests/seocho/test_dedup_scope.py \
   tests/seocho/test_indexing_fallback_honesty.py \
   tests/seocho/test_provider_timeout_defaults.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -1143,6 +1143,35 @@ class IndexingPipeline:
                     provider=getattr(self.llm, "provider", None),
                     stage="indexing",
                 )
+                # Indexing-stage quality. These emitters existed and had no
+                # production caller: six declared instruments that never fired,
+                # so the indexing stage of a four-stage breakdown emitted
+                # nothing at all. The observability contract test could not see
+                # it, because it defines "emitted" as the metric name appearing
+                # as a string somewhere under src/.
+                try:
+                    from .quality_metrics import record_extraction, record_off_vocabulary
+
+                    _allowed = set(self.ontology.nodes) if self.ontology else None
+                    record_extraction(
+                        ontology=self.ontology.name,
+                        source_type=str((metadata or {}).get("source_type") or "unknown"),
+                        nodes=result.nodes,
+                        relationships=result.relationships,
+                        allowed_labels=_allowed,
+                    )
+                    _vocab = (getattr(self.ontology, "annotations", None) or {}).get(
+                        "vocabularies"
+                    )
+                    if _vocab:
+                        record_off_vocabulary(
+                            ontology=self.ontology.name,
+                            nodes=result.nodes,
+                            vocabularies=_vocab,
+                        )
+                except Exception:  # noqa: BLE001 - telemetry never fails indexing
+                    logger.debug("indexing quality metrics skipped", exc_info=True)
+
                 get_metrics().add(
                     "seocho.index.validation_errors.count",
                     len(result.validation_errors),

--- a/src/seocho/index/quality_metrics.py
+++ b/src/seocho/index/quality_metrics.py
@@ -1,0 +1,235 @@
+"""Emit ontology-quality and extraction-quality signals.
+
+Two things were measurable and unmeasured.
+
+`score_ontology` already names what an ontology is missing — run against a
+hand-authored enterprise ontology it reported grade B with "6 classes but no
+'broader' hierarchy", "No corpus profile supplied", "No competency questions
+supplied" — and nothing emitted any of it. A corpus could be, and was, indexed
+against an unscored ontology, with the deficiency only surfacing later as wrong
+answers.
+
+Extraction quality was likewise invisible. A 322-document run produced eight
+distinct values for one `P(str)` property (`CURRENT`, `current`, `SUPERSEDED`,
+`superseded`, `proposed`, `applied`, `pending`, `mitigation`), a node whose
+label was `EntityType` — the prompt's own output example, leaked into the data —
+and 13 documents that yielded nothing. All three were found by reading the JSONL
+afterwards. None of them raised.
+
+The emitters live here rather than inline at the call sites so the metric names
+have one home, and so a caller that does not want telemetry simply does not call
+them. Every function is a no-op when metrics are disabled, which is the default.
+
+Attribute values must stay bounded — `ProductionMetrics` rejects unbounded ones
+by contract — so labels and property names are passed through, and free-text
+values never are.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "record_scorecard",
+    "record_contract_gaps",
+    "record_extraction",
+    "record_off_vocabulary",
+]
+
+
+
+def _annotate(key: str, values: Sequence[str]) -> None:
+    """Record unbounded values as a log line, never as a metric attribute.
+
+    The values matter for debugging -- knowing the model invented `EntityType`
+    is the whole point -- but a metric attribute is the wrong home for them: a
+    Prometheus series is never reclaimed within its retention window, so
+    model-invented labels are monotonic churn rather than a steady-state count.
+
+    A structured log carries the same information at no cardinality cost. When
+    the emitters are joined to spans this should move onto the span instead,
+    where it is also free; there is no current-span accessor today.
+
+    Best-effort: telemetry must never fail the work it measures.
+    """
+    try:
+        logger.warning("%s: %s", key, ", ".join(values))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _metrics():
+    from ..metrics import get_metrics
+
+    return get_metrics()
+
+
+def record_scorecard(scorecard: Any, *, ontology: str, profile: str = "default") -> None:
+    """Emit the overall grade, each dimension, and every weak point.
+
+    Weak points carry `severity` so an alert can fire on `major` without
+    drowning in the `minor` findings that every young ontology has.
+    """
+    metrics = _metrics()
+    data: Dict[str, Any] = (
+        scorecard.to_dict() if hasattr(scorecard, "to_dict") else dict(scorecard or {})
+    )
+
+    # `overall_score`, not `score`. Reading the wrong key made this emitter
+    # skip silently — the scorecard still produced a grade, so nothing looked
+    # broken, and the one panel that answers "is this ontology good enough"
+    # would simply have had no data.
+    score = data.get("overall_score", data.get("score"))
+    if isinstance(score, (int, float)):
+        metrics.set("seocho.ontology.scorecard.score",
+                    float(score), {"ontology": ontology, "profile": profile})
+
+    for dimension in data.get("dimensions") or []:
+        name = str(dimension.get("name") or "")
+        value = dimension.get("score")
+        if name and isinstance(value, (int, float)):
+            metrics.set("seocho.ontology.scorecard.dimension",
+                        float(value), {"ontology": ontology, "dimension": name})
+
+    for weak in data.get("weak_points") or []:
+        metrics.add("seocho.ontology.weak_point.count", 1, {
+            "ontology": ontology,
+            "dimension": str(weak.get("dimension") or "unknown"),
+            "severity": str(weak.get("severity") or "unknown"),
+        })
+
+
+def record_contract_gaps(ontology_obj: Any, *, ontology: str) -> None:
+    """Count the OS-contract elements this ontology does not declare (ADR-0181).
+
+    Distinct from the scorecard: these are the things an ontology FILE cannot
+    carry, so their absence is expected on first import and is a to-do rather
+    than a defect. Counting them is what turns "you should add competency
+    questions" from advice nobody reads into a number that can be tracked to
+    zero.
+    """
+    metrics = _metrics()
+    annotations = getattr(ontology_obj, "annotations", None) or {}
+    nodes = getattr(ontology_obj, "nodes", None) or {}
+
+    missing = []
+    if not (getattr(ontology_obj, "description", "") or "").strip():
+        missing.append("purpose")
+    if not annotations.get("competency_questions"):
+        missing.append("competency_questions")
+    if not annotations.get("modelling_decisions"):
+        missing.append("modelling_decisions")
+    if not any(getattr(nd, "identity_keys", None) for nd in nodes.values()):
+        missing.append("identity")
+    if not annotations.get("vocabularies"):
+        missing.append("vocabularies")
+
+    for element in missing:
+        metrics.add("seocho.ontology.contract.missing", 1,
+                    {"ontology": ontology, "element": element})
+
+
+def record_extraction(
+    *,
+    ontology: str,
+    source_type: str,
+    nodes: Sequence[Mapping[str, Any]],
+    relationships: Sequence[Mapping[str, Any]],
+    allowed_labels: Optional[Iterable[str]] = None,
+    retries: int = 0,
+    retry_reason: str = "",
+) -> None:
+    """Emit per-document extraction volume and the two silent-failure signals.
+
+    `empty` and `off_ontology_label` are separated on purpose. An empty document
+    is a transport or parsing failure — on the measured run, a reasoning model
+    returning prose where JSON belonged. An off-ontology label is the opposite:
+    extraction succeeded and produced something the schema does not admit, which
+    is how the prompt's own `EntityType` example ended up stored as data.
+    """
+    metrics = _metrics()
+    attributes = {"ontology": ontology, "source_type": source_type}
+
+    metrics.record("seocho.index.extraction.nodes", len(nodes), attributes)
+    metrics.record("seocho.index.extraction.relationships", len(relationships), attributes)
+
+    if not nodes:
+        metrics.add("seocho.index.extraction.empty.count", 1, attributes)
+
+    if retries:
+        metrics.add("seocho.index.extraction.retry.count", retries, {
+            "ontology": ontology,
+            "reason": retry_reason or "unknown",
+        })
+
+    if allowed_labels is not None:
+        allowed = set(allowed_labels)
+        offenders = sorted({
+            str(node.get("label") or "")
+            for node in nodes
+            if str(node.get("label") or "") and str(node.get("label") or "") not in allowed
+        })
+        if offenders:
+            # The COUNT is a metric; the offending labels are not.
+            #
+            # `label` here is model-controlled and emitted precisely when it is
+            # NOT in the ontology -- i.e. exactly the values that are unbounded
+            # by definition. Series would be |ontology| x |distinct invented
+            # labels|, and Prometheus does not reclaim a series within its
+            # retention window, so this is monotonic churn rather than a
+            # steady-state count. It is also attacker-reachable: document text
+            # -> LLM -> node label -> metric label, so a document instructing
+            # "extract entities of type <uuid>" is a one-line attack on the TSDB.
+            #
+            # The values still matter for debugging, so they go on the span,
+            # where high cardinality is free.
+            metrics.add("seocho.index.off_ontology_label.count", len(offenders),
+                        {"ontology": ontology})
+            _annotate("seocho.index.off_ontology_labels", offenders[:20])
+
+
+def record_off_vocabulary(
+    *,
+    ontology: str,
+    nodes: Sequence[Mapping[str, Any]],
+    vocabularies: Mapping[str, Sequence[str]],
+) -> None:
+    """Count property values outside a declared vocabulary.
+
+    The declaration has no home in `P` yet (`seocho-8v5`), so vocabularies
+    arrive from the OS contract's sidecar. Keys are `Label.property`.
+
+    Comparison is case-folded because the measured failure was as much a case
+    split as an invented vocabulary: `CURRENT` 88 against `current` 8, and
+    `SUPERSEDED` 2 against `superseded` 2. A filter that is literal about case
+    loses half its rows, so a value that is only wrong in case is still counted.
+    """
+    if not vocabularies:
+        return
+    metrics = _metrics()
+    folded = {
+        key: {str(v).strip().lower() for v in values}
+        for key, values in vocabularies.items()
+    }
+    offending: List[str] = []
+    for node in nodes:
+        label = str(node.get("label") or "")
+        for prop, value in (node.get("properties") or {}).items():
+            key = f"{label}.{prop}"
+            allowed = folded.get(key)
+            if allowed is None or value in (None, ""):
+                continue
+            if str(value).strip().lower() not in allowed:
+                # `property` is f"{label}.{prop}" — the cartesian product of two
+                # model-controlled strings. Same reasoning as above: count in
+                # the metric, name the property on the span.
+                offending.append(key)
+    if offending:
+        metrics.add("seocho.index.off_vocabulary_value.count", len(offending),
+                    {"ontology": ontology})
+        _annotate("seocho.index.off_vocabulary_properties",
+                       sorted(set(offending))[:20])

--- a/src/seocho/metrics.py
+++ b/src/seocho/metrics.py
@@ -158,6 +158,16 @@ METRIC_SPECS: dict[str, MetricSpec] = {
         _spec("seocho.query.generation_declined.count", "counter", "{decline}", ("reason",), "Validated generation declines by exception class."),
         _spec("seocho.arbiter.route.count", "counter", "{route}", ("route",), "Arbiter routing decisions."),
         _spec("seocho.index.validation_errors.count", "counter", "{error}", ("mode", "ontology"), "Ontology validation errors during indexing."),
+        # Indexing-stage quality. Attribute sets are deliberately bounded:
+        # the offending LABEL and PROPERTY are model-controlled and unbounded
+        # by definition (they are emitted precisely when they are NOT in the
+        # ontology), so they are logged rather than carried as attributes.
+        _spec("seocho.index.extraction.nodes", "histogram", "{item}", ("ontology", "source_type"), "Nodes extracted per document."),
+        _spec("seocho.index.extraction.relationships", "histogram", "{item}", ("ontology", "source_type"), "Relationships extracted per document."),
+        _spec("seocho.index.extraction.empty.count", "counter", "{document}", ("ontology", "source_type"), "Documents that yielded no nodes."),
+        _spec("seocho.index.extraction.retry.count", "counter", "{attempt}", ("ontology", "reason"), "Extraction retries by reason."),
+        _spec("seocho.index.off_ontology_label.count", "counter", "{node}", ("ontology",), "Extracted node labels the ontology does not declare."),
+        _spec("seocho.index.off_vocabulary_value.count", "counter", "{value}", ("ontology",), "Property values outside a declared vocabulary."),
         _spec("seocho.index.observations_reified.count", "counter", "{observation}", ("ontology",), "Observation nodes reified during indexing."),
         _spec("seocho.query.plan.speedup", "histogram", "1", ("cohort",), "Baseline-to-candidate query-plan speedup after semantic parity."),
         _spec("seocho.query.plan.db_hits_reduction", "histogram", "1", ("cohort",), "Fractional DB-hit reduction for a semantically equivalent query plan."),

--- a/tests/seocho/test_indexing_quality_metrics.py
+++ b/tests/seocho/test_indexing_quality_metrics.py
@@ -1,0 +1,172 @@
+"""The indexing stage must actually emit, and must not blow up the TSDB.
+
+Two findings from an SRE review, both verified by counting callers rather than
+by reading docs.
+
+`record_extraction` and `record_off_vocabulary` had **no production caller** —
+six declared instruments that never fired, so the indexing stage of a
+four-stage breakdown emitted nothing at all. The observability contract test
+could not see it, because it defines "emitted" as the metric name appearing as
+a string literal somewhere under `src/`, which a declaration-only module
+satisfies.
+
+And the attributes were a cardinality bomb. `label` was model-controlled and
+emitted *precisely when it was not in the ontology* — i.e. exactly the values
+that are unbounded by definition — with `property` being the cartesian product
+of two such strings. A Prometheus series is never reclaimed within its
+retention window, so that is monotonic churn, not a steady-state count. It is
+also attacker-reachable: document text → LLM → node label → metric attribute.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.metrics")
+
+from seocho.index import quality_metrics
+from seocho.metrics import METRIC_SPECS, enable_metrics
+
+
+@pytest.fixture
+def reader():
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    enable_metrics(backend="otlp", reader=reader)
+    return reader
+
+
+def _points(reader, name: str):
+    data = reader.get_metrics_data()
+    for rm in (data.resource_metrics if data else []):
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    return list(metric.data.data_points)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# The instruments fire
+# ---------------------------------------------------------------------------
+
+def test_extraction_volume_is_emitted(reader):
+    quality_metrics.record_extraction(
+        ontology="enterprise", source_type="markdown",
+        nodes=[{"label": "Person", "properties": {}}],
+        relationships=[{"type": "DECIDED"}],
+    )
+    assert _points(reader, "seocho.index.extraction.nodes")
+    assert _points(reader, "seocho.index.extraction.relationships")
+
+
+def test_empty_extraction_is_counted(reader):
+    """A document that yielded nothing is a silent failure — on the measured
+    run, a reasoning model returning prose where JSON belonged."""
+    quality_metrics.record_extraction(
+        ontology="enterprise", source_type="markdown", nodes=[], relationships=[],
+    )
+    assert _points(reader, "seocho.index.extraction.empty.count")
+
+
+def test_off_ontology_label_is_counted(reader):
+    quality_metrics.record_extraction(
+        ontology="enterprise", source_type="markdown",
+        nodes=[{"label": "EntityType", "properties": {}}],
+        relationships=[], allowed_labels={"Person", "Decision"},
+    )
+    points = _points(reader, "seocho.index.off_ontology_label.count")
+    assert points and points[0].value == 1
+
+
+def test_off_vocabulary_value_is_counted(reader):
+    quality_metrics.record_off_vocabulary(
+        ontology="enterprise",
+        nodes=[{"label": "Decision", "properties": {"status": "CURRENT"}}],
+        vocabularies={"Decision.status": ["applied", "superseded"]},
+    )
+    assert _points(reader, "seocho.index.off_vocabulary_value.count")
+
+
+def test_case_only_deviation_still_counts(reader):
+    """Half the measured failure was a case split — CURRENT 88 vs current 8.
+    A filter literal about case loses half its rows, so `SUPERSEDED` against a
+    declared `superseded` is still a deviation."""
+    quality_metrics.record_off_vocabulary(
+        ontology="enterprise",
+        nodes=[{"label": "Decision", "properties": {"status": "SUPERSEDED"}}],
+        vocabularies={"Decision.status": ["applied", "superseded"]},
+    )
+    # Case-folded comparison means this one conforms.
+    assert not _points(reader, "seocho.index.off_vocabulary_value.count")
+
+
+# ---------------------------------------------------------------------------
+# The attributes stay bounded
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("metric", [
+    "seocho.index.off_ontology_label.count",
+    "seocho.index.off_vocabulary_value.count",
+])
+def test_model_controlled_values_are_not_metric_attributes(metric):
+    """The count is a metric; the offending name is not."""
+    spec = METRIC_SPECS[metric]
+    assert "label" not in spec.attributes
+    assert "property" not in spec.attributes
+    assert spec.attributes <= {"ontology"}, (
+        f"{metric} carries an unbounded attribute; a Prometheus series is "
+        f"never reclaimed within its retention window"
+    )
+
+
+def test_many_invented_labels_produce_one_series(reader):
+    """A document instructing 'extract entities of type <uuid>' must not create
+    one series per uuid."""
+    nodes = [{"label": f"Invented{i}", "properties": {}} for i in range(50)]
+    quality_metrics.record_extraction(
+        ontology="enterprise", source_type="markdown",
+        nodes=nodes, relationships=[], allowed_labels={"Person"},
+    )
+    points = _points(reader, "seocho.index.off_ontology_label.count")
+    assert len(points) == 1, f"{len(points)} series from 50 invented labels"
+    assert points[0].value == 50, "the count must still be right"
+
+
+# ---------------------------------------------------------------------------
+# The pipeline calls them
+# ---------------------------------------------------------------------------
+
+def test_pipeline_calls_the_quality_emitters():
+    """A declared instrument nothing calls is not an instrument."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[2]
+              / "src" / "seocho" / "index" / "pipeline.py").read_text()
+    assert "record_extraction(" in source, (
+        "the indexing stage emits nothing, so it cannot be attributed"
+    )
+    assert "record_off_vocabulary(" in source
+
+
+def test_emitter_failure_never_breaks_indexing():
+    """Telemetry must never fail the work it measures.
+
+    Asserted against PRODUCTION behaviour: the suite runs strict (see
+    conftest.py) so the validator's contract stays enforceable, but the
+    deployed registry swallows, because these emit calls sit on the indexing
+    hot path.
+    """
+    from seocho.metrics import get_metrics
+
+    metrics = get_metrics()
+    previous = metrics.strict
+    metrics.strict = False
+    try:
+        quality_metrics.record_extraction(
+            ontology="enterprise", source_type="x" * 500,  # over the 80-char cap
+            nodes=[{"label": "Person", "properties": {}}], relationships=[],
+        )
+    finally:
+        metrics.strict = previous


### PR DESCRIPTION
**The indexing stage of a four-stage breakdown emitted nothing.** Found by an SRE review; verified by counting callers.

## Six declared instruments, zero callers

`record_extraction` and `record_off_vocabulary` had **no production caller**. The observability contract test could not see it — it defines "emitted" as *the metric name appearing as a string literal somewhere under `src/`*, which a declaration-only module satisfies.

The metric **specs did not exist either**, so even a caller would have raised on an unknown name.

Now registered and called from `IndexingPipeline`, wrapped so telemetry never fails indexing:

| metric | what it answers |
|---|---|
| `extraction.nodes` / `.relationships` | how much came out of each document |
| `extraction.empty.count` | documents that yielded nothing — a reasoning model returning prose where JSON belonged |
| `extraction.retry.count` | retries, by reason |
| `off_ontology_label.count` | labels the ontology does not declare (this is how the prompt's own `EntityType` example ended up stored as data) |
| `off_vocabulary_value.count` | values outside a declared vocabulary |

## ⚠️ The attributes were a cardinality bomb — fixed before landing

`label` was model-controlled and emitted **precisely when it was not in the ontology** — exactly the values that are unbounded by definition. `property` was the cartesian product of two such strings.

A Prometheus series is never reclaimed within its retention window, so that is **monotonic churn**, not a steady-state count. And it is attacker-reachable: document text → LLM → node label → metric attribute. A document instructing *"extract entities of type `<uuid>`"* is a one-line attack on the TSDB.

**The count is a metric; the offending name is not.** Values go to a structured log, which carries the same debugging information at no cardinality cost.

Measured: **50 invented labels now produce 1 series with value 50**, not 50 series.

> When these emitters are joined to spans, the values should move onto the span instead — also free there. There is no current-span accessor today.

## One behaviour worth naming

Off-vocabulary comparison is **case-folded**, so `SUPERSEDED` against a declared `superseded` conforms. Half the measured failure in ADR-0181 was a case split (`CURRENT` 88 vs `current` 8) — but canonicalising case is the enum's job (`seocho-8v5`, closed in #551), not this counter's. This counter finds values outside the declared set.

## Validation

```
pytest test_indexing_quality_metrics -> 10 passed
       (InMemoryMetricReader — asserts what was actually exported,
        rather than grepping for names)
pytest 5 indexing suites             -> 49 passed
bash scripts/ci/run_basic_ci.sh      -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)