### PR TITLE
feat(observability): make the OTel stack a first-class root-compose profile (ADR-0199)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,21 +165,17 @@ memory-down: ## Stop PostgreSQL memory without deleting its volume
 
 ##@ Observability
 
-observability-up: ## Start the lightweight OTel + Tempo + Prometheus + Grafana stack
-	@COMPOSE_PROJECT_NAME=seocho-observability docker compose \
-		-f examples/observability/docker-compose.observability.yml \
-		--profile observability up -d --wait --remove-orphans
+OBS_SERVICES := tempo prometheus otel-collector grafana
+
+observability-up: ## Start the local OTel + Tempo + Prometheus + Grafana stack (root compose, `observability` profile, alongside the core stack)
+	docker compose --profile observability up -d --wait $(OBS_SERVICES)
 	@echo "📊 Grafana: http://$${SEOCHO_BIND_HOST:-127.0.0.1}:$${GRAFANA_PORT:-3000}"
 
-observability-down: ## Stop the lightweight observability stack
-	@COMPOSE_PROJECT_NAME=seocho-observability docker compose \
-		-f examples/observability/docker-compose.observability.yml \
-		--profile observability down
+observability-down: ## Stop and remove ONLY the observability containers (core stack + named volumes untouched)
+	docker compose --profile observability rm -fs $(OBS_SERVICES)
 
 observability-logs: ## Tail Collector, Tempo, Prometheus, and Grafana logs
-	@COMPOSE_PROJECT_NAME=seocho-observability docker compose \
-		-f examples/observability/docker-compose.observability.yml \
-		--profile observability logs -f --tail=100
+	docker compose --profile observability logs -f --tail=100 $(OBS_SERVICES)
 
 ##@ FinDER Tutorials
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,10 @@
+# Optional local observability stack (ADR-0144): OTel Collector + Tempo +
+# Prometheus + Grafana. Gated behind the `observability` profile, so it is OFF
+# by default and only starts with `docker compose --profile observability up`.
+# The stack definition lives with its dashboards under examples/observability/.
+include:
+  - path: examples/observability/docker-compose.observability.yml
+
 services:
   # --- Core Local Stack: graph DB + runtime API + thin UI proxy ---
   apoc-extended-init:

--- a/docs/decisions/ADR-0199-observability-stack-root-compose-profile.md
+++ b/docs/decisions/ADR-0199-observability-stack-root-compose-profile.md
@@ -1,0 +1,54 @@
+# ADR-0199: Observability stack as a first-class root-compose profile
+
+- Status: accepted
+- Date: 2026-08-16
+- Related: ADR-0144 (local OTel observability + span/trace structure),
+  ADR-0146 (production observability profiles + metric contract)
+
+## Context
+
+The local OTel stack (Collector + Tempo + Prometheus + Grafana + the SEOCHO
+dashboards, ADR-0144) lived in `examples/observability/` as a standalone compose
+file, brought up via `make observability-up` under its own project name
+(`seocho-observability`) and joining the core stack's `seocho-net` as an
+`external` network.
+
+Two problems: (1) filing the stack under `examples/` framed observability as a
+demo, when the AgenticOS thesis treats observability/provenance/auditability as a
+first-class governance pillar; (2) a separate project + `external` network is
+brittle — a pre-existing or foreign-labelled `seocho-net` makes bring-up fail,
+and there was no single `docker compose` entry point that included it.
+
+## Decision
+
+Pull the observability stack into the **root `docker-compose.yml`** via Compose
+`include:`, gated behind the existing **`observability` profile** (OFF by
+default — a plain `docker compose up` starts nothing observability-related).
+
+- The definition and the eight Grafana dashboards **stay** in
+  `examples/observability/`; only the entry point moved. The root compose
+  `include:`s the file.
+- The included network is declared **identically** to the root network
+  (`graphrag-net` → name `seocho-net`, `driver: bridge`, non-external), so
+  `include` merges the two into ONE project-created network instead of unioning
+  `external: true` into the core definition (which would have stopped the core
+  stack from creating its own network). The four services attach to it.
+- `make observability-up|down|logs` now drive the root compose with
+  `--profile observability` and an explicit service list, so they bring up /
+  tear down ONLY the four observability containers, leaving the core stack and
+  the named data volumes untouched.
+
+## Consequences
+
+- One entry point: `docker compose --profile observability up -d …` (or
+  `make observability-up`) from the repo root, alongside the core stack in the
+  same project. Bringing the core stack up first is no longer required — the
+  profile creates/attaches `seocho-net` itself.
+- Observability reads as part of how you operate SEOCHO, not a side example,
+  while the profile keeps it opt-in and the README's dev-grade caveats
+  (anonymous Grafana, local-disk retention) intact. Opik stays the separate
+  cloud/team backend (its own profile).
+- Verified live via the new path: all four containers healthy, eight dashboards
+  provisioned, Prometheus + Tempo datasources present, the Collector scrape
+  target `up`. Default `docker compose config` still excludes the observability
+  services and creates `seocho-net` exactly as before.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1189,6 +1189,13 @@ Each entry must link to a full ADR when impact is non-trivial.
 - [Accepted] ADR-0196 freshness real read-time repair, not a serve stub (seocho-ia4.6)
   - repair_read drops soft-deleted rows + strips deprecated props so a drifted-but-within-bound read conforms to the active contract; wired into local_engine after the drift barrier (gated on proceeding mismatch, O(records) self-describing scan = no ontology reasoning on hot path); plan_read_repair derives deprecated-prop set off hot path + marks destructive changes non-repairable (-> refuse). Closes the soft-delete read-leak. 6 tests; drift/context suites unchanged
 
+## 2026-08-16 (observability stack -> root compose profile)
+
+- [Accepted] ADR-0199 observability stack as a first-class root-compose profile
+  - root docker-compose.yml `include:`s examples/observability/docker-compose.observability.yml behind the existing `observability` profile (OFF by default); definition + 8 Grafana dashboards stay in examples/, only the entry point moved
+  - network declared identically to root (graphrag-net -> name seocho-net, bridge, non-external) so include merges to ONE project-created network (no external-union breaking core network creation); make observability-up|down|logs drive root compose with an explicit 4-service list (core + volumes untouched)
+  - verified live via the new path: 4 containers healthy, 8 dashboards, Prometheus+Tempo datasources, collector scrape target up; default config unchanged
+
 ## Template
 
 Use this block for new entries:

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -22,13 +22,27 @@ Flow: `SEOCHO → OTLP gRPC → Collector → Tempo (traces) + Prometheus (metri
 
 ## Run
 
-The stack joins the **external** `seocho-net` network created by the repo's main
-`docker-compose.yml`, so bring the main stack up first, then use the repository
-entry point:
+This stack is a first-class **`observability` profile** of the repo's root
+`docker-compose.yml` (pulled in via `include:`), so it shares the core stack's
+`seocho-net` network and project. It is OFF by default — nothing here starts on a
+plain `docker compose up`. Start it either way:
 
 ```bash
-make observability-up
+make observability-up                          # the four services only
+# or, directly, from the repo root:
+docker compose --profile observability up -d tempo prometheus otel-collector grafana
 ```
+
+Stopping removes only the four observability containers (the core stack and the
+named data volumes are left alone):
+
+```bash
+make observability-down
+```
+
+The definition and dashboards still live in this directory; only the entry point
+moved to the root compose. Bringing the core stack up first is no longer required
+— the profile creates/attaches `seocho-net` on its own.
 
 Point SEOCHO at the collector:
 

--- a/examples/observability/docker-compose.observability.yml
+++ b/examples/observability/docker-compose.observability.yml
@@ -33,7 +33,7 @@ services:
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${OTLP_GRPC_PORT:-4317}:4317"
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${OTLP_HTTP_PORT:-4318}:4318"
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${OTEL_METRICS_PORT:-8889}:8889"
-    networks: [seocho-net]
+    networks: [graphrag-net]
     depends_on: [tempo]
 
   tempo:
@@ -46,7 +46,7 @@ services:
       - tempo-data:/var/tempo
     ports:
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${TEMPO_PORT:-3200}:3200"
-    networks: [seocho-net]
+    networks: [graphrag-net]
 
   prometheus:
     image: prom/prometheus:v2.55.1
@@ -61,7 +61,7 @@ services:
       - prometheus-data:/prometheus
     ports:
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${PROMETHEUS_PORT:-9091}:9090"
-    networks: [seocho-net]
+    networks: [graphrag-net]
 
   grafana:
     image: grafana/grafana:11.5.1
@@ -77,13 +77,18 @@ services:
       - grafana-data:/var/lib/grafana
     ports:
       - "${SEOCHO_BIND_HOST:-127.0.0.1}:${GRAFANA_PORT:-3000}:3000"
-    networks: [seocho-net]
+    networks: [graphrag-net]
     depends_on: [prometheus, tempo]
 
 networks:
-  seocho-net:
-    external: true
+  # Declared IDENTICALLY to the root compose's network so that, when this file is
+  # pulled in via `include:` from the root docker-compose.yml, the two definitions
+  # merge cleanly into one (project-created) `seocho-net` — no external/driver
+  # union that would stop the core stack from creating its own network. The 4
+  # services attach to it; the profile keeps them off unless requested.
+  graphrag-net:
     name: seocho-net
+    driver: bridge
 
 volumes:
   tempo-data:


### PR DESCRIPTION
## Make the local observability stack a first-class root-compose profile (Option A, ADR-0199)

Follow-up to the recent observability merges (#555/#556). The OTel stack (Collector + Tempo + Prometheus + Grafana + 8 SEOCHO dashboards, ADR-0144) was a standalone compose file under `examples/`, run under its own project with `seocho-net` declared `external`. This promotes it to a first-class **`observability` profile** of the **root** `docker-compose.yml` via `include:` — observability is a governance pillar of the AgenticOS thesis, not a demo.

### What changed
- Root `docker-compose.yml` `include:`s `examples/observability/docker-compose.observability.yml`, behind the existing `observability` profile — **OFF by default** (a plain `docker compose up` starts nothing observability-related).
- The included network is declared **identically** to the root network (`graphrag-net` → name `seocho-net`, `driver: bridge`, non-external), so `include` merges the two into **one project-created network** rather than unioning `external: true` into the core definition (which would stop the core stack creating its own network).
- `make observability-up|down|logs` now drive the root compose with `--profile observability` + an explicit 4-service list, so they touch **only** the four observability containers (core stack + named volumes untouched).
- Definition + the 8 Grafana dashboards **stay** in `examples/observability/`; only the entry point moved. README updated.

### Verified (live, via the new path)
- `docker compose --profile observability up -d tempo prometheus otel-collector grafana`: all 4 containers **healthy**, attached to the project-created `seocho-net`.
- Grafana: **8 dashboards** provisioned; **Prometheus + Tempo** datasources present.
- Prometheus: Collector scrape target **up**.
- Default `docker compose config` (no profile): observability services **absent**, `seocho-net` created exactly as before.
- Contracts pass: root-hierarchy, doc-contracts, `check_adr_index` (199 ADRs, refs resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
