### PR TITLE
fix(query): the PROFILE path collected nothing and paid double for it

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -109,6 +109,7 @@ uv run pytest \
   tests/seocho/test_observability_contract.py \
   tests/seocho/test_golden_signal_emitters.py \
   tests/seocho/test_cypher_builder.py \
+  tests/seocho/test_plan_profile_harvest.py \
   tests/seocho/test_cypher_builder_ontology_aware.py \
   tests/seocho/test_extraction_engine.py \
   tests/seocho/test_graph_ensure_database.py \

--- a/src/seocho/query/plan_quality.py
+++ b/src/seocho/query/plan_quality.py
@@ -132,22 +132,48 @@ def summarize_profile(profile: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     operators: List[str] = []
     db_hits = 0
     rows = 0
+    cache_hits = 0
+    cache_misses = 0
+    worst_estimate_ratio = 0.0
 
     def walk(node: Dict[str, Any]) -> None:
-        nonlocal db_hits, rows
+        nonlocal db_hits, rows, cache_hits, cache_misses, worst_estimate_ratio
         operators.append(str(node.get("operatorType", "")))
         db_hits += int(node.get("dbHits", 0) or 0)
         rows += int(node.get("rows", 0) or 0)
+        cache_hits += int(node.get("pageCacheHits", 0) or 0)
+        cache_misses += int(node.get("pageCacheMisses", 0) or 0)
+
+        # Estimated vs actual, per operator. This is the single best signal for
+        # "the planner was wrong", which is a DIFFERENT root cause from "the
+        # query was wrong" — and the two were indistinguishable before.
+        estimated = (node.get("args") or {}).get("EstimatedRows")
+        actual = node.get("rows")
+        if isinstance(estimated, (int, float)) and isinstance(actual, (int, float)):
+            hi, lo = max(float(estimated), float(actual)), min(float(estimated), float(actual))
+            if lo >= 1.0:
+                worst_estimate_ratio = max(worst_estimate_ratio, hi / lo)
+
         for child in node.get("children", []) or []:
             walk(child)
 
     walk(profile)
     scans = [op for op in operators if any(s in op for s in SCAN_OPERATORS)]
     seeks = [op for op in operators if any(s in op for s in SEEK_OPERATORS)]
+    cache_total = cache_hits + cache_misses
     return {
         "available": True,
         "db_hits": db_hits,
+        # Summed across the whole tree, so this double-counts every pipeline
+        # stage and is neither result size nor total work. Named for what it is.
+        "intermediate_rows": rows,
         "rows": rows,
+        # Scale-free: raw db_hits is not comparable across questions.
+        "db_hits_per_row": (db_hits / rows) if rows else float(db_hits),
+        # Separates "the graph does not fit in the page cache" from "the query
+        # is bad". Without it an infra problem attributes to retrieval quality.
+        "page_cache_hit_ratio": (cache_hits / cache_total) if cache_total else None,
+        "worst_estimate_ratio": round(worst_estimate_ratio, 2) or None,
         "operator_count": len(operators),
         "scans": scans,
         "seeks": seeks,
@@ -163,12 +189,25 @@ def span_attributes(summary: Dict[str, Any]) -> Dict[str, Any]:
     """
     if not summary.get("available"):
         return {}
+    # .get(), not [] — summarize_plan (EXPLAIN) has no db_hits or rows at all,
+    # so indexing them raised KeyError for the caller this function exists to
+    # serve. Worse, record_metrics used `.get("db_hits") or 0` and silently
+    # recorded ZERO db hits for every explained plan, which is data corruption
+    # rather than a missing signal. EXPLAIN summaries now omit the field.
     attrs: Dict[str, Any] = {
-        "db.plan.db_hits": summary["db_hits"],
-        "db.plan.rows": summary["rows"],
-        "db.plan.operator_count": summary["operator_count"],
-        "db.plan.sargable": summary["sargable"],
+        "db.plan.operator_count": summary.get("operator_count", 0),
+        "db.plan.sargable": summary.get("sargable", False),
+        "db.plan.source": "profile" if "db_hits" in summary else "explain",
     }
+    for key, attr in (("db_hits", "db.plan.db_hits"),
+                      ("intermediate_rows", "db.plan.intermediate_rows"),
+                      ("db_hits_per_row", "db.plan.db_hits_per_row"),
+                      ("page_cache_hit_ratio", "db.plan.page_cache_hit_ratio"),
+                      ("worst_estimate_ratio", "db.plan.worst_estimate_ratio"),
+                      ("estimated_rows", "db.plan.estimated_rows")):
+        value = summary.get(key)
+        if value is not None:
+            attrs[attr] = value
     if summary.get("scans"):
         attrs["db.plan.scan_operators"] = ",".join(sorted(set(summary["scans"])))
     if summary.get("seeks"):
@@ -201,7 +240,12 @@ def record_metrics(summary: Dict[str, Any], *, route: Optional[str] = None,
         )
         # A counter carrying db hits lets a rate() show cost per query over time
         # without needing a histogram on every backend.
-        metrics.add("seocho.query.db_hits.count", float(summary.get("db_hits") or 0))
+        # Only from a PROFILE. An EXPLAIN summary has no db_hits, and
+        # `or 0` recorded a real zero for it — indistinguishable from a
+        # query that genuinely touched nothing, and wrong in the same
+        # direction every time.
+        if summary.get("db_hits") is not None:
+            metrics.add("seocho.query.db_hits.count", float(summary["db_hits"]))
         for operator in sorted(set(summary.get("scans") or []))[:3]:
             metrics.add("seocho.query.scan.count", 1, attributes={"operator": operator})
     if route:

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -747,6 +747,38 @@ class Neo4jGraphStore(GraphStore):
             logger.debug("EXPLAIN unavailable for query: %s", cypher[:120])
             return None
 
+    def profile_plan(
+        self,
+        cypher: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        database: str = "neo4j",
+    ) -> Optional[Dict[str, Any]]:
+        """Execute the query and return its profiled plan tree, with real counters.
+
+        Same reason `explain_plan` exists: the profile lives on the ResultSummary,
+        not in the result rows, and `query()` returns `[record.data() ...]` and
+        discards the summary. Sending `PROFILE <cypher>` through `query()` and
+        then scanning the rows for a `profile` key -- which is what the sampling
+        path did -- can never find one. It collected nothing while paying for a
+        second full execution of the query.
+
+        EXPLAIN gives estimates; this gives dbHits, rows and page-cache counters,
+        which is what separates "the planner was wrong" from "the query was
+        wrong". Executes, so callers must sample.
+        """
+        try:
+            with self._driver.session(
+                    database=database, default_access_mode="READ") as session:
+                result = session.run(f"PROFILE {cypher}",
+                                     parameters=dict(params or {}))
+                result.consume()  # drain before the summary is complete
+                profile = getattr(result.consume(), "profile", None)
+                return dict(profile) if profile else None
+        except Exception:  # noqa: BLE001 — profiling is advisory; never fail a caller
+            logger.debug("PROFILE unavailable for query: %s", cypher[:120])
+            return None
+
     def query(
         self,
         cypher: str,

--- a/tests/seocho/test_plan_profile_harvest.py
+++ b/tests/seocho/test_plan_profile_harvest.py
@@ -1,0 +1,149 @@
+"""The PROFILE path collected nothing while paying for a second execution.
+
+A graph-engineer review found the sampling path did this:
+
+    profiled = executor.execute(QueryPlan(cypher=f"PROFILE {cypher}", ...))
+    for row in profiled.records or []:
+        if isinstance(row, dict) and row.get("profile"):
+            profile = row["profile"]
+
+The PROFILE tree lives on the **ResultSummary**, not in the result rows, and
+`Neo4jGraphStore.query` returns `[record.data() for record in result]` — it
+discards the summary entirely. So `profile` was always None,
+`summarize_profile(None)` returned `{"available": False}`, and nothing was ever
+recorded. What it did cost was a full second execution of every sampled query.
+
+Verified against a live DozerDB 5.26.3:
+
+    OLD path — profile found in result rows: False
+    NEW path — profile on the summary:       True
+
+The test that "pinned" this behaviour faked `records = [{"profile": {...}}]`, a
+shape the real store cannot produce, so five tests passed against a fiction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.query.plan_quality import (
+    span_attributes,
+    summarize_plan,
+    summarize_profile,
+)
+
+
+def _profile_tree() -> dict:
+    """Driver-shaped profile: counters on the node, children nested."""
+    return {
+        "operatorType": "ProduceResults@neo4j",
+        "dbHits": 0, "rows": 10,
+        "pageCacheHits": 8, "pageCacheMisses": 2,
+        "args": {"EstimatedRows": 10},
+        "children": [{
+            "operatorType": "NodeByLabelScan@neo4j",
+            "dbHits": 500, "rows": 10,
+            "pageCacheHits": 40, "pageCacheMisses": 60,
+            "args": {"EstimatedRows": 1000},
+            "children": [],
+        }],
+    }
+
+
+# ---------------------------------------------------------------------------
+# The store grows a way to harvest a profile at all
+# ---------------------------------------------------------------------------
+
+def test_store_exposes_profile_plan():
+    """`query()` returns rows and drops the summary, so PROFILE needs its own
+    accessor — the same reason `explain_plan` exists."""
+    from seocho.store.graph import Neo4jGraphStore
+
+    assert hasattr(Neo4jGraphStore, "profile_plan")
+
+
+def test_profile_plan_does_not_route_through_query():
+    import inspect
+
+    from seocho.store.graph import Neo4jGraphStore
+
+    source = inspect.getsource(Neo4jGraphStore.profile_plan)
+    assert "session.run" in source, "must read the summary directly"
+    assert "self.query(" not in source, (
+        "query() discards the ResultSummary, which is where the profile lives"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The summary carries the signals that separate root causes
+# ---------------------------------------------------------------------------
+
+def test_page_cache_ratio_is_reported():
+    """Separates 'the graph does not fit in the page cache' from 'the query is
+    bad'. Without it an infra problem attributes to retrieval quality."""
+    summary = summarize_profile(_profile_tree())
+    assert summary["page_cache_hit_ratio"] == pytest.approx(48 / 110)
+
+
+def test_estimate_error_is_reported():
+    """Estimated vs actual per operator is the best signal for 'the planner was
+    wrong', which is a different root cause from 'the query was wrong'."""
+    summary = summarize_profile(_profile_tree())
+    assert summary["worst_estimate_ratio"] == pytest.approx(100.0)
+
+
+def test_db_hits_per_row_is_scale_free():
+    """Raw db_hits is not comparable across questions."""
+    summary = summarize_profile(_profile_tree())
+    assert summary["db_hits"] == 500
+    assert summary["db_hits_per_row"] == pytest.approx(500 / 20)
+
+
+def test_summed_rows_are_named_for_what_they_are():
+    """Summing rows across the tree double-counts every pipeline stage, so it is
+    neither result size nor total work — and it sat next to db_hits where it
+    read as result size."""
+    summary = summarize_profile(_profile_tree())
+    assert summary["intermediate_rows"] == 20
+
+
+def test_no_profile_is_reported_as_unavailable():
+    assert summarize_profile(None) == {"available": False}
+
+
+# ---------------------------------------------------------------------------
+# An EXPLAIN summary must not raise, and must not fabricate counters
+# ---------------------------------------------------------------------------
+
+def _explain_summary() -> dict:
+    return summarize_plan({
+        "operatorType": "NodeByLabelScan@neo4j",
+        "args": {"EstimatedRows": 1000},
+        "children": [],
+    })
+
+
+def test_span_attributes_accepts_an_explain_summary():
+    """It indexed summary["db_hits"], which summarize_plan never sets — a
+    KeyError for the exact caller the function exists to serve."""
+    attrs = span_attributes(_explain_summary())
+    assert attrs, "explain summaries produced no attributes"
+    assert "db.plan.db_hits" not in attrs
+
+
+def test_span_attributes_says_which_instrument_produced_it():
+    assert span_attributes(_explain_summary())["db.plan.source"] == "explain"
+    assert span_attributes(summarize_profile(_profile_tree()))["db.plan.source"] == "profile"
+
+
+def test_explain_summary_does_not_record_zero_db_hits():
+    """`.get("db_hits") or 0` recorded a real zero for every explained plan —
+    indistinguishable from a query that genuinely touched nothing, and wrong in
+    the same direction every time."""
+    import inspect
+
+    from seocho.query import plan_quality
+
+    source = inspect.getsource(plan_quality.record_metrics)
+    assert 'get("db_hits") or 0' not in source
+    assert 'summary.get("db_hits") is not None' in source


### PR DESCRIPTION
Found by a Neo4j/DozerDB engineer review. **Fixing the instrument before wiring it**, because every number it would have produced was going to be wrong.

## It could never find a profile

```python
profiled = executor.execute(QueryPlan(cypher=f"PROFILE {cypher}", ...))
for row in profiled.records or []:
    if isinstance(row, dict) and row.get("profile"):   # never true
```

The PROFILE tree lives on the **ResultSummary**, and `Neo4jGraphStore.query` returns `[record.data() for record in result]` — it discards the summary entirely. So `profile` was always `None`, `summarize_profile(None)` returned `{"available": False}`, and **nothing was ever recorded**.

What it *did* cost was a full second execution of every sampled query.

Verified against a live DozerDB 5.26.3:

```
OLD path — profile found in result rows: False
NEW path — profile on the summary:       True
           keys: dbHits, rows, pageCacheHits, pageCacheMisses,
                 pageCacheHitRatio, args.EstimatedRows
```

> The test that "pinned" this faked `records = [{"profile": {...}}]` — a shape the real store cannot produce. Five tests passed against a fiction.

## The two most diagnostic fields were being thrown away

Both separate root causes that were previously indistinguishable:

| field | separates |
|---|---|
| `page_cache_hit_ratio` | "the graph doesn't fit in the page cache" vs "the query is bad" — without it an **infra** problem attributes to **retrieval quality** |
| `worst_estimate_ratio` | estimated vs actual rows per operator — "the **planner** was wrong" vs "the **query** was wrong" |
| `db_hits_per_row` | scale-free; the raw sum isn't comparable across questions |
| `intermediate_rows` | the summed row count, **renamed** — it double-counts every pipeline stage, so it is neither result size nor total work, and it sat next to `db_hits` where it read as result size |

## Two latent bugs, live the moment EXPLAIN is wired to a span

- `span_attributes` indexed `summary["db_hits"]` and `summary["rows"]`, **neither of which `summarize_plan` sets** → `KeyError` for the exact caller it exists to serve.
- `record_metrics` used `.get("db_hits") or 0`, so an explained plan silently recorded **zero db hits** — indistinguishable from a query that genuinely touched nothing, and wrong in the same direction every time. That is data corruption, not a missing signal.

Now omitted, with `db.plan.source` on the attributes so a reader can tell which instrument produced them.

## ⚠️ Not in this change: the sampling wiring

`SEOCHO_PLAN_GATE` is a misnomer — **it gates nothing**. It widens the repair trigger from `not records` to `not records or plan_hint`, so a query that **returned correct rows** but planned a scan burns LLM repair budget. That is a behaviour question, not a bug fix, and belongs in its own change.

## Validation

```
live DozerDB 5.26.3: old path finds no profile, new path returns one
pytest test_plan_profile_harvest  -> 10 passed
pytest 3 query/graph suites       -> 33 passed
bash scripts/ci/run_basic_ci.sh   -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)