### PR TITLE
feat(runtime): per-request run-context spine + RCU version pin (ADR-0200)

### DIFF
--- a/docs/decisions/ADR-0200-run-context-spine.md
+++ b/docs/decisions/ADR-0200-run-context-spine.md
@@ -1,0 +1,54 @@
+# ADR-0200: Per-request run-context spine (structured multi-agent runtime, step 1)
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-ia4 (structured runtime), follows the structure investigation
+- Related: ADR-0188/0190/0194 (RCU B1/B2/B3), ADR-0164/0171 (tenant isolation)
+
+## Context
+
+A grounded investigation confirmed what the design review's #1 Major independently
+flagged: the local `Seocho.ask` path is a monolithic, agent-free function, and the
+runtime has **no structured per-request context object** delivered to its stages.
+`OntologyRunContext` — a fully-defined "typed middleware envelope … shared by SDK,
+runtime, agents, and tools" — was referenced **nowhere** in the runtime. Each stage
+re-derived ontology/schema/workspace ad hoc, and there was no notion of "this request
+reads ONE frozen ontology version," which multi-tenancy and the e2e's mutation-under-read
+probe both require. This is step 1 of structuring the multi-agent runtime: give it a
+spine.
+
+## Decision
+
+Build the per-request `OntologyRunContext` **once** in `ask`, workspace-scoped, and expose
+it via `_LocalEngine.last_run_context()`. When an RCU pin registry (+ active pointer) is
+configured on the engine, the request **pins one frozen ontology version** for its whole
+duration via the new `pinned_run_context(...)` context manager (RCU B2 read side, per
+`(workspace_id, package_id)`); the pin is released on exit, and the B3 gate cannot reclaim
+a version while a request pins it. The drift outcome the pipeline computes is folded back
+into the exposed context.
+
+- `OntologyRunContext.with_pinned_version(version, epoch, fingerprint)` + `pinned_epoch`
+  record/expose the pinned version immutably (frozen dataclass → a copy).
+- `pinned_run_context` reads the active pointer, stamps the pinned version, and holds the
+  pin for the request. With no active version it yields the context unchanged.
+- All new engine wiring defaults to **off** (`_ontology_pin_registry`/`_active_ontology_pointer`
+  = None): with nothing configured, behaviour is byte-for-byte the previous deterministic
+  path; the context is simply built and exposed. Pinning activates only when wired.
+
+## Consequences
+
+- The runtime now has ONE typed, workspace-scoped, per-request context object — the spine
+  the structured query orchestrator (step 2) will deliver to the query specialist and
+  synthesizer instead of each re-deriving from the raw `Ontology`. This closes the review's
+  "per-request ontology delivery doesn't exist" gap at the foundation.
+- Multi-tenancy is first-class in the spine (`workspace_id` carried explicitly; pins are
+  per `(workspace, package)` and isolated across tenants — tested).
+- The mutation-under-read guarantee is real and tested: a publish that swaps the active
+  version mid-request does not change what the already-pinned request reads. This is what
+  makes the e2e OS arm's mutation probe meaningful.
+- No behaviour change to the default path; 6 new spine tests + existing run-context /
+  drift / ontology-context suites green.
+
+Next (step 2): a structured query orchestrator that composes the schema-grounded query
+specialist (`build_graph_agent` + guardrail-as-tool-input-guardrail) and the synthesizer
+on the local runtime, consuming this context.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1196,6 +1196,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - network declared identically to root (graphrag-net -> name seocho-net, bridge, non-external) so include merges to ONE project-created network (no external-union breaking core network creation); make observability-up|down|logs drive root compose with an explicit 4-service list (core + volumes untouched)
   - verified live via the new path: 4 containers healthy, 8 dashboards, Prometheus+Tempo datasources, collector scrape target up; default config unchanged
 
+## 2026-08-16 (structured multi-agent runtime — step 1: run-context spine)
+
+- [Accepted] ADR-0200 per-request run-context spine (seocho-ia4 structured runtime)
+  - OntologyRunContext (defined but referenced nowhere in the runtime) is now built once per ask(), workspace-scoped, and exposed via _LocalEngine.last_run_context(); closes the review's "per-request ontology delivery doesn't exist" gap at the foundation
+  - pinned_run_context(...) + with_pinned_version/pinned_epoch: when an RCU pin registry+pointer are configured, the request pins ONE frozen ontology version for its whole duration (B2 read side, per (workspace,package)); a mid-request publish swap does not change what the pinned request reads (tested) -> the e2e mutation probe is meaningful
+  - all new wiring defaults OFF (behaviour identical until configured); multi-tenancy first-class (per-(ws,pkg) isolated pins); 6 new tests + run-context/drift/ontology-context suites green
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -76,6 +76,18 @@ class _LocalEngine:
 
         self._ontology_context_cache = OntologyContextCache()
         self._last_query_metadata: Dict[str, Any] = {}
+        # Per-request run-context spine (seocho structured-runtime, ADR-0200):
+        # the typed OntologyRunContext built once per ask() and exposed via
+        # last_run_context(). Optional RCU wiring (a VersionPinRegistry + active
+        # pointer) makes the request pin ONE frozen ontology version for its whole
+        # duration; all default to None so behaviour is unchanged until configured.
+        self._ontology_package_id = str(
+            getattr(ontology, "package_id", "") or getattr(ontology, "name", "") or "default"
+        )
+        self._ontology_pin_registry: Any = None
+        self._active_ontology_pointer: Any = None
+        self._current_run_context: Any = None
+        self._last_run_context: Any = None
         self._events = NullEventPublisher()
         self._ingest_request_cls = IngestRequest
 
@@ -599,6 +611,30 @@ class _LocalEngine:
         # nest as a tree in Tempo instead of one flat sdk.query event.
         from .tracing import start_span
 
+        # Build the per-request run context ONCE (workspace-scoped, typed) and,
+        # when an RCU pin registry is configured, pin ONE frozen ontology version
+        # for the whole request; the deterministic pipeline runs inside that pin.
+        from contextlib import nullcontext
+
+        from .ontology.run_context import build_local_ontology_run_context, pinned_run_context
+
+        run_context = build_local_ontology_run_context(
+            ontology_context,
+            workspace_id=self.workspace_id,
+            database=database,
+            reasoning_mode=bool(reasoning_mode),
+            repair_budget=int(repair_budget or 0),
+        )
+        pin_cm = (
+            pinned_run_context(
+                run_context,
+                pin_registry=self._ontology_pin_registry,
+                package_id=self._ontology_package_id,
+                active_pointer=self._active_ontology_pointer,
+            )
+            if self._ontology_pin_registry is not None
+            else nullcontext(run_context)
+        )
         with start_span(
             "rag.ask",
             input_data={"question": question[:200]},
@@ -608,16 +644,33 @@ class _LocalEngine:
                 "ontology": getattr(active_ontology, "name", ""),
             },
             tags=["rag"],
-        ):
-            return self._run_query_pipeline(
-                question,
-                database=database,
-                reasoning_mode=reasoning_mode,
-                repair_budget=repair_budget,
-                query_mode=query_mode,
-                active_ontology=active_ontology,
-                ontology_context=ontology_context,
-            )
+        ), pin_cm as pinned_context:
+            self._current_run_context = pinned_context
+            try:
+                return self._run_query_pipeline(
+                    question,
+                    database=database,
+                    reasoning_mode=reasoning_mode,
+                    repair_budget=repair_budget,
+                    query_mode=query_mode,
+                    active_ontology=active_ontology,
+                    ontology_context=ontology_context,
+                )
+            finally:
+                # Fold the drift outcome the pipeline computed into the exposed
+                # run context, then publish it as the last request's context.
+                ctx = self._current_run_context
+                mismatch = (self._last_query_metadata or {}).get("ontology_context_mismatch")
+                if mismatch:
+                    ctx = ctx.with_mismatch(mismatch)
+                self._last_run_context = ctx
+
+    def last_run_context(self) -> Any:
+        """The typed :class:`OntologyRunContext` built for the most recent ``ask``
+        — workspace-scoped, carrying the ontology identity/hash, the RCU-pinned
+        version (when pinning is configured), and the drift outcome. The single
+        per-request context object the structured runtime delivers downstream."""
+        return self._last_run_context
 
     @contextmanager
     def _traced_stage(

--- a/src/seocho/ontology/__init__.py
+++ b/src/seocho/ontology/__init__.py
@@ -155,6 +155,7 @@ _EXPORTS = {
     "OntologyRunContext": "run_context",
     "build_local_ontology_run_context": "run_context",
     "build_runtime_ontology_run_context": "run_context",
+    "pinned_run_context": "run_context",
     "CorpusProfile": "scorecard",
     "DimensionScore": "scorecard",
     "OntologyScorecard": "scorecard",

--- a/src/seocho/ontology/run_context.py
+++ b/src/seocho/ontology/run_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Iterable, Literal, Mapping, Sequence, Tuple
 
@@ -283,6 +284,32 @@ class OntologyRunContext:
     ) -> "OntologyRunContext":
         return replace(self, ontology_context_mismatch=_dict(ontology_context_mismatch))
 
+    def with_pinned_version(
+        self,
+        *,
+        version: str,
+        epoch: int,
+        fingerprint: str = "",
+    ) -> "OntologyRunContext":
+        """Record the RCU-pinned ontology version this request is reading — the
+        frozen (version, epoch, fingerprint) the whole request sees even if a
+        publish swaps the active pointer mid-run (RCU B1/B2)."""
+        md = dict(self.metadata)
+        md.update(
+            {
+                "pinned_ontology_version": _clean_str(version),
+                "pinned_ontology_epoch": int(epoch),
+                "pinned_ontology_fingerprint": _clean_str(fingerprint),
+            }
+        )
+        return replace(self, metadata=md)
+
+    @property
+    def pinned_epoch(self) -> int | None:
+        """The pinned RCU epoch for this request, or None when no version was pinned."""
+        value = self.metadata.get("pinned_ontology_epoch")
+        return int(value) if isinstance(value, int) else None
+
     def with_session_scope(
         self,
         *,
@@ -483,3 +510,37 @@ def build_runtime_ontology_run_context(
     """Build an `OntologyRunContext` from runtime graph target records."""
 
     return OntologyRunContext.from_runtime_graph_targets(graph_targets, **kwargs)
+
+
+@contextmanager
+def pinned_run_context(
+    context: OntologyRunContext,
+    *,
+    pin_registry: Any,
+    package_id: str,
+    active_pointer: Any = None,
+):
+    """Pin the active ontology version for a request's whole duration and yield a
+    run context stamped with the pinned version (RCU B2 read side, per
+    ``(workspace_id, package_id)``); unpin on exit.
+
+    This is what makes "the OS delivers ONE frozen ontology version per request"
+    real: the request reads a consistent version even if a publish swaps the active
+    pointer mid-run (RCU B1), and the B3 reclamation gate will not free a retired
+    version while a request still pins it. When there is no active pointer for the
+    ``(workspace, package)``, yields ``context`` unchanged (nothing to pin)."""
+    ws = context.workspace_id
+    epoch = pin_registry.pin(ws, package_id)
+    try:
+        if epoch is None:
+            yield context
+        else:
+            av = active_pointer.read(ws, package_id) if active_pointer is not None else None
+            yield context.with_pinned_version(
+                version=getattr(av, "version", "") or "",
+                epoch=epoch,
+                fingerprint=getattr(av, "fingerprint", "") or "",
+            )
+    finally:
+        if epoch is not None:
+            pin_registry.unpin(ws, package_id, epoch)

--- a/tests/seocho/test_run_context_spine.py
+++ b/tests/seocho/test_run_context_spine.py
@@ -1,0 +1,108 @@
+"""Per-request run-context spine + RCU pinning (structured runtime, ADR-0200).
+
+Increment 1 of the structured multi-agent runtime: OntologyRunContext is built
+once per request, workspace-scoped, and (when an RCU pin registry is configured)
+pins ONE frozen ontology version for the request's whole duration.
+"""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology.active_pointer import ActiveOntologyPointer
+from seocho.ontology.run_context import (
+    OntologyRunContext,
+    pinned_run_context,
+)
+from seocho.ontology.version_pin import VersionPinRegistry
+
+WS, PKG = "acme", "acme"
+
+
+def _ctx(ws: str = WS) -> OntologyRunContext:
+    return OntologyRunContext(workspace_id=ws, ontology_id=PKG)
+
+
+def _wire(tmp_path):
+    pointer = ActiveOntologyPointer(tmp_path / "active.db")
+    pins = VersionPinRegistry(pointer)
+    return pointer, pins
+
+
+def test_with_pinned_version_is_immutable_stamp():
+    base = _ctx()
+    stamped = base.with_pinned_version(version="2.0.0", epoch=3, fingerprint="abc")
+    assert base.metadata == {}, "original context is unchanged (frozen)"
+    assert stamped.metadata["pinned_ontology_version"] == "2.0.0"
+    assert stamped.pinned_epoch == 3
+    assert stamped.workspace_id == WS
+
+
+def test_pinned_run_context_holds_version_for_the_request(tmp_path):
+    pointer, pins = _wire(tmp_path)
+    ok, av = pointer.publish(WS, PKG, version="1.0.0", fingerprint="fp1", fencing_token=1)
+    assert ok and av.epoch == 0
+
+    with pinned_run_context(_ctx(), pin_registry=pins, package_id=PKG,
+                            active_pointer=pointer) as rc:
+        # the request is reading a pinned, stamped version...
+        assert rc.pinned_epoch == 0
+        assert rc.metadata["pinned_ontology_version"] == "1.0.0"
+        assert rc.metadata["pinned_ontology_fingerprint"] == "fp1"
+        # ...and the pin is live for the whole block
+        assert pins.pin_count(WS, PKG, 0) == 1
+    # released on exit
+    assert pins.min_pinned_epoch(WS, PKG) is None
+
+
+def test_pin_survives_a_mid_request_publish_swap(tmp_path):
+    """A publish that swaps the active version mid-request does NOT change what the
+    already-pinned request reads — the RCU guarantee the mutation probe relies on."""
+    pointer, pins = _wire(tmp_path)
+    ok, av0 = pointer.publish(WS, PKG, version="1.0.0", fingerprint="fp1", fencing_token=1)
+    with pinned_run_context(_ctx(), pin_registry=pins, package_id=PKG,
+                            active_pointer=pointer) as rc:
+        assert rc.metadata["pinned_ontology_version"] == "1.0.0"
+        # a writer swaps the active version to 2.0.0 mid-request
+        ok2, av1 = pointer.publish(WS, PKG, version="2.0.0", fingerprint="fp2",
+                                   fencing_token=2, expected=av0.expected())
+        assert ok2 and av1.epoch == 1
+        # the in-flight request still reads its pinned 1.0.0, and epoch 0 stays pinned
+        assert rc.metadata["pinned_ontology_version"] == "1.0.0"
+        assert pins.pin_count(WS, PKG, 0) == 1
+
+
+def test_no_active_pointer_yields_unpinned_context(tmp_path):
+    pointer, pins = _wire(tmp_path)  # nothing published -> no active version
+    with pinned_run_context(_ctx(), pin_registry=pins, package_id=PKG,
+                            active_pointer=pointer) as rc:
+        assert rc.pinned_epoch is None
+        assert "pinned_ontology_version" not in rc.metadata
+
+
+def test_two_workspaces_pin_in_isolation(tmp_path):
+    pointer, pins = _wire(tmp_path)
+    pointer.publish("acme", PKG, version="1.0.0", fingerprint="a", fencing_token=1)
+    pointer.publish("globex", PKG, version="9.0.0", fingerprint="g", fencing_token=1)
+    with pinned_run_context(_ctx("acme"), pin_registry=pins, package_id=PKG,
+                            active_pointer=pointer) as a:
+        with pinned_run_context(_ctx("globex"), pin_registry=pins, package_id=PKG,
+                                active_pointer=pointer) as g:
+            assert a.metadata["pinned_ontology_version"] == "1.0.0"
+            assert g.metadata["pinned_ontology_version"] == "9.0.0"
+            assert a.workspace_id == "acme" and g.workspace_id == "globex"
+
+
+def test_local_engine_exposes_a_run_context_after_ask():
+    """The wiring: _LocalEngine builds + exposes a workspace-scoped run context.
+    Exercised without a live DB by driving the engine with in-memory fakes."""
+    from seocho.ontology.run_context import build_local_ontology_run_context
+
+    onto = Ontology("acme", package_id=PKG, version="1.0.0", nodes={
+        "Company": NodeDef(description="c", properties={"name": P(str, unique=True)}),
+    })
+    compiled = onto.compile_context(workspace_id=WS) if hasattr(onto, "compile_context") else {}
+    rc = build_local_ontology_run_context(compiled, workspace_id=WS, database="neo4j")
+    assert rc.workspace_id == WS
+    # last_run_context() accessor exists on the engine class
+    from seocho.local_engine import _LocalEngine
+    assert hasattr(_LocalEngine, "last_run_context")


### PR DESCRIPTION
## Structured multi-agent runtime — step 1: the per-request run-context spine (ADR-0200)

A grounded investigation confirmed the design review's #1 Major: the local `Seocho.ask` path is a monolithic, agent-free function with **no structured per-request context delivered to its stages**. `OntologyRunContext` — a fully-defined "typed middleware envelope shared by SDK, runtime, agents, and tools" — was referenced **nowhere** in the runtime. This is step 1 of structuring it: give the runtime a spine.

### What changed
- `OntologyRunContext` is now built **once per `ask()`**, workspace-scoped, and exposed via `_LocalEngine.last_run_context()`.
- New `pinned_run_context(...)` + `OntologyRunContext.with_pinned_version/pinned_epoch`: when an RCU pin registry (+ active pointer) is configured, the request **pins ONE frozen ontology version** for its whole duration (RCU B2 read side, per `(workspace_id, package_id)`); released on exit; the B3 gate can't reclaim a version a request pins.
- The drift outcome the pipeline computes is folded back into the exposed context.
- **All new engine wiring defaults OFF** (`_ontology_pin_registry`/`_active_ontology_pointer = None`) → behaviour is byte-for-byte the previous deterministic path until configured.

### Why
- Closes the review's "per-request ontology delivery doesn't exist" gap **at the foundation** — the spine the step-2 query orchestrator will deliver to the query specialist + synthesizer instead of each re-deriving from the raw `Ontology`.
- **Multi-tenancy first-class**: `workspace_id` carried explicitly; pins are per `(workspace, package)` and isolated across tenants.
- **Mutation-under-read is real + tested**: a publish that swaps the active version mid-request does not change what the already-pinned request reads — what makes the e2e OS arm's mutation probe meaningful.

### Validation
- 6 new tests (`test_run_context_spine.py`): immutable pin stamp, pin held for the request + released, pin survives a mid-request publish swap, no-active-pointer yields unpinned, two-workspace isolation, engine accessor present.
- Existing `test_ontology_run_context` / `test_drift_barrier` / `test_ontology_context*` suites green (44 passed together); `ruff` clean; `check_adr_index` 200 ADRs, refs resolve.

Next (step 2): a structured query orchestrator composing the schema-grounded query specialist (`build_graph_agent` + guardrail-as-tool-input-guardrail) + synthesizer on the local runtime, consuming this context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
