### PR TITLE
fix(index): render declared vocabularies, and count the ones we declare

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -84,6 +84,7 @@ uv run pytest \
   tests/seocho/test_finder_benchmark_script.py \
   tests/seocho/test_indexing_design.py \
   tests/seocho/test_indexing_quality_metrics.py \
+  tests/seocho/test_declared_vocabulary_reaches_extraction.py \
   tests/seocho/test_dedup_scope.py \
   tests/seocho/test_indexing_fallback_honesty.py \
   tests/seocho/test_provider_timeout_defaults.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -1152,21 +1152,50 @@ class IndexingPipeline:
                 try:
                     from .quality_metrics import record_extraction, record_off_vocabulary
 
+                    # Only the EXTRACTED graph is checked against the ontology.
+                    # result.nodes also carries the provenance layer this
+                    # pipeline writes itself -- Document, DocumentVersion,
+                    # Section, Chunk -- which the ontology does not and should
+                    # not declare. Counting those as violations reported a
+                    # constant 4 on every document forever, which would have
+                    # made the signal useless in exactly the way that is hard to
+                    # notice: a metric that is always wrong by the same amount
+                    # still moves correctly, so nobody questions the baseline.
+                    _extracted = [
+                        n for n in result.nodes
+                        if not self._system_layer_label(n.get("label"))
+                    ]
                     _allowed = set(self.ontology.nodes) if self.ontology else None
                     record_extraction(
                         ontology=self.ontology.name,
                         source_type=str((metadata or {}).get("source_type") or "unknown"),
-                        nodes=result.nodes,
+                        nodes=_extracted,
                         relationships=result.relationships,
                         allowed_labels=_allowed,
                     )
-                    _vocab = (getattr(self.ontology, "annotations", None) or {}).get(
-                        "vocabularies"
+                    # Vocabularies come from BOTH declaration sites. `P(enum=)`
+                    # is the SDK-native one; the OS-contract sidecar writes
+                    # `annotations["vocabularies"]`. Reading only the sidecar
+                    # meant an ontology declaring `P(str, enum=[...])` had its
+                    # vocabulary enforced by SHACL and never counted here -- so
+                    # the metric reported zero deviations for a property that
+                    # was deviating. Verified e2e: a declared
+                    # [proposed|applied|superseded|reverted] came back as
+                    # "active" on every node, silently.
+                    _vocab = dict(
+                        (getattr(self.ontology, "annotations", None) or {}).get(
+                            "vocabularies"
+                        ) or {}
                     )
+                    for _label, _nd in (self.ontology.nodes or {}).items():
+                        for _pname, _prop in (_nd.properties or {}).items():
+                            if getattr(_prop, "enum", None):
+                                _vocab.setdefault(f"{_label}.{_pname}",
+                                                  list(_prop.enum))
                     if _vocab:
                         record_off_vocabulary(
                             ontology=self.ontology.name,
-                            nodes=result.nodes,
+                            nodes=_extracted,
                             vocabularies=_vocab,
                         )
                 except Exception:  # noqa: BLE001 - telemetry never fails indexing

--- a/src/seocho/ontology/core.py
+++ b/src/seocho/ontology/core.py
@@ -2269,6 +2269,23 @@ class Ontology:
                     lines.append(f"- {label}.{pname}: {p.constraint.value}")
                 if p.property_type != PropertyType.STRING:
                     lines.append(f"- {label}.{pname}: datatype={p.property_type.value}")
+                # A declared vocabulary that never reaches the extractor is a
+                # constraint the model cannot honour: it can only be rejected
+                # after the fact, for a rule it was never told. ADR-0181's own
+                # finding was that what has a declarative home in the prompt is
+                # obeyed (Step.position, 175/175) and what does not is invented
+                # (Decision.status, 8 values across 51 documents) -- so the enum
+                # has to be rendered, not only validated.
+                if p.enum:
+                    allowed = ", ".join(str(v) for v in p.enum)
+                    lines.append(
+                        f"- {label}.{pname}: MUST be exactly one of [{allowed}]"
+                    )
+                if p.value_range:
+                    low, high = p.value_range
+                    lines.append(
+                        f"- {label}.{pname}: numeric, between {low} and {high} inclusive"
+                    )
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/tests/seocho/test_declared_vocabulary_reaches_extraction.py
+++ b/tests/seocho/test_declared_vocabulary_reaches_extraction.py
@@ -1,0 +1,122 @@
+"""A declared vocabulary must reach the extractor, and the counter must see it.
+
+Found by running the pipeline end to end against a live DozerDB and MiniMax-M2.7,
+not by reading code. Two independent gaps, both silent:
+
+**The enum never reached the prompt.** `P(str, enum=[...])` was emitted as
+`sh:in` and enforced by `validate_with_shacl`, and rendered nowhere. So the
+model was rejected after the fact for a rule it was never told. ADR-0181's own
+finding was that what has a declarative home in the prompt is obeyed
+(`Step.position`, 175/175) and what does not is invented (`Decision.status`,
+eight values across 51 documents) — so rendering is the half that does the work.
+
+**The counter read the wrong declaration site.** `record_off_vocabulary` was
+wired to `annotations["vocabularies"]` (the OS-contract sidecar) only, so an
+ontology declaring `P(str, enum=[...])` had a vocabulary the metric could not
+see. It reported zero deviations for a property that was deviating on every
+node.
+
+Measured, same document and same model, before and after:
+
+    status='active'      'active'        <- enum declared, not rendered
+    status='superseded'  'applied'       <- enum rendered
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P
+
+
+VOCAB = ["proposed", "applied", "superseded", "reverted"]
+
+
+@pytest.fixture
+def ontology() -> Ontology:
+    return Ontology(
+        name="incident",
+        nodes={
+            "Decision": NodeDef(
+                description="A decision taken",
+                properties={
+                    "name": P(str, unique=True),
+                    "status": P(str, enum=VOCAB),
+                    "confidence": P(float, value_range=(0.0, 1.0)),
+                },
+                identity_keys=["name"],
+            ),
+        },
+    )
+
+
+def test_enum_is_rendered_into_the_extraction_context(ontology):
+    """The model cannot honour a constraint it is never shown."""
+    rendered = " ".join(ontology.to_extraction_context().values())
+    assert "Decision.status" in rendered
+    for value in VOCAB:
+        assert value in rendered, f"{value} never reaches the extractor"
+
+
+def test_range_is_rendered_too(ontology):
+    rendered = " ".join(ontology.to_extraction_context().values())
+    assert "Decision.confidence" in rendered
+    assert "0.0" in rendered and "1.0" in rendered
+
+
+def test_plain_property_is_not_given_a_vocabulary(ontology):
+    """Only declared constraints render; a bare P(str) must stay unconstrained."""
+    rendered = " ".join(ontology.to_extraction_context().values())
+    assert "Decision.name: MUST be exactly one of" not in rendered
+
+
+def test_pipeline_derives_vocabularies_from_property_enum():
+    """The counter must read the SDK-native declaration site, not only the
+    sidecar. Reading one of two homes made the metric report zero deviations
+    for a property deviating on every node."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[2]
+              / "src" / "seocho" / "index" / "pipeline.py").read_text()
+    assert 'getattr(_prop, "enum", None)' in source, (
+        "P(enum=...) is invisible to the off-vocabulary counter"
+    )
+    assert '"vocabularies"' in source, "the sidecar site must still be read"
+
+
+def test_both_declaration_sites_compose():
+    """Sidecar and P(enum=) must merge, not replace one another."""
+    onto = Ontology(
+        name="t",
+        nodes={
+            "Decision": NodeDef(description="d",
+                                properties={"status": P(str, enum=VOCAB)}),
+            "Step": NodeDef(description="s", properties={"phase": P(str)}),
+        },
+    )
+    onto.annotations = {"vocabularies": {"Step.phase": ["start", "end"]}}
+
+    merged = dict(onto.annotations.get("vocabularies") or {})
+    for label, node in onto.nodes.items():
+        for name, prop in node.properties.items():
+            if getattr(prop, "enum", None):
+                merged.setdefault(f"{label}.{name}", list(prop.enum))
+
+    assert merged == {
+        "Step.phase": ["start", "end"],
+        "Decision.status": VOCAB,
+    }
+
+
+def test_provenance_layer_is_not_an_ontology_violation():
+    """The pipeline writes Document / DocumentVersion / Section / Chunk itself.
+    Counting those as off-ontology reported a constant 4 on every document
+    forever — a metric always wrong by the same amount still moves correctly,
+    so nobody questions the baseline."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[2]
+              / "src" / "seocho" / "index" / "pipeline.py").read_text()
+    assert "_system_layer_label(n.get(\"label\"))" in source, (
+        "the provenance layer is still counted against the ontology"
+    )


### PR DESCRIPTION
Three defects found by **running the pipeline end to end** against a live DozerDB and MiniMax-M2.7. None was visible from the code alone.

## 1. A declared enum never reached the extractor

`P(str, enum=[...])` landed in #551 as `sh:in`, enforced by `validate_with_shacl` — and **rendered nowhere**. So the model was rejected after the fact for a rule it was never told.

ADR-0181's own finding is that what has a declarative home *in the prompt* is obeyed (`Step.position`, 175/175) and what does not is invented (`Decision.status`, eight values across 51 documents). **Rendering is the half that does the work, and it was the half missing.**

Same document, same model, before and after:

```
status='active'      'active'        <- enum declared, not rendered
status='superseded'  'applied'       <- enum rendered
```

Both values are now inside the declared set, from a model that had been putting `"active"` on every node. `value_range` renders the same way.

## 2. The off-vocabulary counter read only one of two declaration sites

`record_off_vocabulary` was wired to `annotations["vocabularies"]` — the OS-contract sidecar — only. So an ontology declaring `P(str, enum=[...])` had a vocabulary **the metric could not see**, and it reported zero deviations for a property deviating on every node.

The two sites now merge, sidecar first.

## 3. `off_ontology_label` counted this pipeline's own provenance nodes

`result.nodes` carries `Document`, `DocumentVersion`, `Section`, `Chunk` — written by the layered-graph machinery, not extracted, and the ontology neither declares them nor should.

The e2e run reported `off_ontology_label.count = 4` for a document whose extraction was in fact **perfect**. A metric that is always wrong by the same amount still moves correctly, so the baseline goes unquestioned — the hard kind to notice. `_system_layer_label` already existed; the check now uses it. The count drops to zero, and `extraction.nodes` reports 4 entities instead of 8 rows.

## The e2e also confirmed the breakdown works

```
- e2e.run             12007.76ms
   - sdk.extraction    12000.00ms  stage:indexing model:mara/MiniMax-M2.7 workspace:e2e-tenant
   - gen_ai.chat        5845.08ms
   - gen_ai.chat        5539.31ms
```

Stage attribution is real: of 12s, 11.4s is attributable to two LLM calls. And the extracted graph was correct — `(Retry Standard v2) -[SUPERSEDES]-> (Retry Standard v1)`, `-[APPLIES_TO]-> (Payments API)`.

## Validation

```
live e2e (DozerDB 5.26.3 + MARA MiniMax-M2.7), re-indexed from clean:
    status went active/active -> superseded/applied
pytest test_declared_vocabulary_reaches_extraction -> 6 passed
pytest 4 index/ontology suites                     -> 64 passed
bash scripts/ci/run_basic_ci.sh                    -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)