### PR TITLE
fix(query): an anchor on a relationship's target end must flip the traversal

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -130,6 +130,7 @@ uv run pytest \
   tests/seocho/test_ontology_reasoner.py \
   tests/seocho/test_ontology_iso704_cq.py \
   tests/seocho/test_relationship_direction.py \
+  tests/seocho/test_anchor_orientation.py \
   tests/seocho/test_prompt_prefix_stability.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \

--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -127,6 +127,9 @@ class CypherBuilder:
         schema_hints: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, Dict[str, Any]]:
         hint_payload = dict(schema_hints or {})
+        # Cleared per build: a builder is constructed per plan, but `build` may
+        # be called more than once on one (repair paths do).
+        self.anchor_role = ""
         if anchor_label and anchor_label not in self.ontology.nodes:
             anchor_label = ""
         if target_label and target_label not in self.ontology.nodes:
@@ -173,7 +176,12 @@ class CypherBuilder:
         # a template kwarg so every registered PatternSpec factory keeps its signature —
         # the same approach ``last_orientation_repair`` already uses, and safe because a
         # builder is constructed per plan.
-        self.anchor_role = str(hint_payload.get("anchor_role", "") or "")
+        # _orient_relationship above may already have determined the role from
+        # the ontology's declared direction. The ontology is authoritative about
+        # direction and the hint is a model guess, so the derived role wins;
+        # otherwise fall back to the hint.
+        _derived_role = getattr(self, "anchor_role", "")
+        self.anchor_role = _derived_role or str(hint_payload.get("anchor_role", "") or "")
 
         # ADR-0097 G3: dispatch via externalized PatternSpec catalog.
         # Behavior is bit-identical to the pre-G3 inline if/elif chain;
@@ -1398,13 +1406,29 @@ class CypherBuilder:
             self.last_orientation_repair = None
             return anchor_label, target_label
 
+        # The anchor sits on the relationship's TARGET end. That is not an error
+        # -- "Which decisions apply to the Payments API?" legitimately anchors on
+        # the System, and the ontology says APPLIES_TO runs Decision -> System.
+        #
+        # Swapping the labels was the wrong repair, because the anchor ENTITY
+        # filter does not move with them: the generated query became
+        # `MATCH (a:Decision)-[:APPLIES_TO]-(b:System) WHERE a.name CONTAINS
+        # "Payments API"` -- a Decision named "Payments API", which does not
+        # exist. Measured on a live graph containing the answer: 0 rows, and the
+        # model then reported no data for a question the graph could answer.
+        #
+        # The labels the model gave are consistent with the entity it named. It
+        # is the TRAVERSAL that has to run backwards, which is exactly what
+        # anchor_role expresses and what every pattern builder already honours.
         self.last_orientation_repair = {
             "relationship_type": relationship_type,
             "from": {"anchor_label": anchor_label, "target_label": target_label},
-            "to": {"anchor_label": source, "target_label": target},
-            "reason": "reversed_endpoints_vs_ontology",
+            "to": {"anchor_label": anchor_label or target,
+                   "target_label": source, "anchor_role": "target"},
+            "reason": "anchor_on_relationship_target_end",
         }
-        return source, target
+        self.anchor_role = "target"
+        return (anchor_label or target), source
 
     def _match_relationship(self, rel_type: str, *, anchor_label: str, target_label: str) -> str:
         # 1. Exact or alias match

--- a/tests/seocho/test_anchor_orientation.py
+++ b/tests/seocho/test_anchor_orientation.py
@@ -1,0 +1,152 @@
+"""An anchor on the relationship's target end must flip the traversal, not the labels.
+
+Found by running a query end to end against a live graph that contained the
+answer, and getting "no data" back.
+
+`_orient_relationship` detects that the model's (anchor_label, target_label)
+pair contradicts the ontology's declared direction, and repaired it by swapping
+the two labels. The anchor **entity** filter does not move with them, so the
+generated query became:
+
+    MATCH (a:Decision)-[:APPLIES_TO]-(b:System)
+    WHERE toLower(a.name) CONTAINS toLower($anchor)     -- $anchor = "Payments API"
+
+— a `Decision` named "Payments API", which does not exist. Measured: **0 rows**
+on a graph holding both matching decisions, and the model then honestly reported
+that it could not answer.
+
+The premise was wrong. "Which decisions apply to the Payments API?" legitimately
+anchors on the System; the ontology declares `APPLIES_TO: Decision -> System`, so
+what has to run backwards is the **traversal**, not the labelling. That is what
+`anchor_role` expresses, and every pattern builder already honours it.
+
+After: 2 rows, carrying `status='applied'` and `status='superseded'` — the
+property the question was actually about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.query.cypher_builder import CypherBuilder
+
+
+@pytest.fixture
+def ontology() -> Ontology:
+    return Ontology(
+        name="incident",
+        nodes={
+            "System": NodeDef(description="s",
+                              properties={"name": P(str, unique=True)},
+                              identity_keys=["name"]),
+            "Decision": NodeDef(description="d",
+                                properties={"name": P(str, unique=True),
+                                            "status": P(str)},
+                                identity_keys=["name"]),
+        },
+        relationships={
+            "APPLIES_TO": RelDef(source="Decision", target="System", description=""),
+        },
+    )
+
+
+def _build(ontology, **kw):
+    builder = CypherBuilder(ontology)
+    cypher, params = builder.build(workspace_id="w", limit=20, **kw)
+    return builder, cypher, params
+
+
+def test_anchor_label_survives_the_repair(ontology):
+    """The label the model gave is consistent with the entity it named."""
+    builder, cypher, _ = _build(
+        ontology, intent="relationship_lookup", anchor_entity="Payments API",
+        anchor_label="System", target_label="Decision",
+        relationship_type="APPLIES_TO",
+    )
+    assert "(a:`System`)" in cypher, (
+        "the anchor variable lost the label of the entity bound to it, so the "
+        "filter searches the wrong node type and matches nothing"
+    )
+
+
+def test_traversal_runs_backwards_instead(ontology):
+    _, cypher, _ = _build(
+        ontology, intent="relationship_lookup", anchor_entity="Payments API",
+        anchor_label="System", target_label="Decision",
+        relationship_type="APPLIES_TO",
+    )
+    assert "<-[r:`APPLIES_TO`]-" in cypher, (
+        "the ontology declares Decision -> System, so an anchor on System must "
+        "traverse the edge in reverse"
+    )
+
+
+def test_repair_is_recorded_for_measurement(ontology):
+    builder, _, _ = _build(
+        ontology, intent="relationship_lookup", anchor_entity="Payments API",
+        anchor_label="System", target_label="Decision",
+        relationship_type="APPLIES_TO",
+    )
+    repair = builder.last_orientation_repair
+    assert repair is not None
+    assert repair["reason"] == "anchor_on_relationship_target_end"
+    assert repair["to"]["anchor_role"] == "target"
+
+
+def test_anchor_on_the_source_end_is_left_alone(ontology):
+    """The common case must not acquire a spurious repair."""
+    builder, cypher, _ = _build(
+        ontology, intent="relationship_lookup", anchor_entity="Retry Standard v2",
+        anchor_label="Decision", target_label="System",
+        relationship_type="APPLIES_TO",
+    )
+    assert "(a:`Decision`)" in cypher
+    assert builder.last_orientation_repair is None
+    assert "<-[" not in cypher, "a forward traversal was reversed"
+
+
+def test_missing_anchor_label_is_filled_from_the_ontology(ontology):
+    """The original case this guardrail was written for: the model names the
+    relationship and the wrong end, with no target label to disambiguate."""
+    _, cypher, _ = _build(
+        ontology, intent="relationship_lookup", anchor_entity="Payments API",
+        anchor_label="System", target_label="",
+        relationship_type="APPLIES_TO",
+    )
+    assert "(a:`System`)" in cypher
+    assert "(b:`Decision`)" in cypher, "the counterpart label was not derived"
+
+
+def test_self_referential_relationship_is_not_reoriented():
+    """A relationship whose ends share a label cannot be reversed."""
+    onto = Ontology(
+        name="t",
+        nodes={"Decision": NodeDef(description="d",
+                                   properties={"name": P(str, unique=True)},
+                                   identity_keys=["name"])},
+        relationships={"SUPERSEDES": RelDef(source="Decision", target="Decision",
+                                            description="")},
+    )
+    builder, cypher, _ = _build(
+        onto, intent="relationship_lookup", anchor_entity="Retry Standard v2",
+        anchor_label="Decision", target_label="Decision",
+        relationship_type="SUPERSEDES",
+    )
+    assert builder.last_orientation_repair is None
+
+
+def test_role_does_not_leak_between_builds(ontology):
+    """`build` may be called more than once on one builder (repair paths do)."""
+    builder = CypherBuilder(ontology)
+    builder.build(intent="relationship_lookup", anchor_entity="Payments API",
+                  anchor_label="System", target_label="Decision",
+                  relationship_type="APPLIES_TO", workspace_id="w", limit=20)
+    _, second = builder.build(intent="relationship_lookup",
+                              anchor_entity="Retry Standard v2",
+                              anchor_label="Decision", target_label="System",
+                              relationship_type="APPLIES_TO",
+                              workspace_id="w", limit=20), None
+    assert builder.anchor_role != "target", (
+        "a derived role from an earlier build leaked into a later one"
+    )


### PR DESCRIPTION
First step of the retrieval work. Found by running a query end to end against a live graph **that contained the answer**, and getting "no data" back.

## The repair made it worse

`_orient_relationship` detects that the model's `(anchor_label, target_label)` pair contradicts the ontology's declared direction, and repaired it by **swapping the two labels**. The anchor *entity* filter does not move with them:

```cypher
MATCH (a:Decision)-[:APPLIES_TO]-(b:System)
WHERE toLower(a.name) CONTAINS toLower($anchor)   -- $anchor = "Payments API"
```

A `Decision` named "Payments API" — which does not exist. Measured on a live DozerDB holding **both** matching decisions: **0 rows**. The model then honestly reported it could not answer a question the graph could answer.

## The premise was wrong

*"Which decisions apply to the Payments API?"* **legitimately** anchors on the System. The ontology declares `APPLIES_TO: Decision → System`, so what has to run backwards is the **traversal**, not the labelling.

`anchor_role` already expresses exactly that, and every pattern builder already honours it. The repair now sets the role and leaves the labels alone.

## Measured after — same query, same live graph

```
MATCH (a:`System`)<-[r:`APPLIES_TO`]-(b:`Decision`)
rows: 2
  Retry Standard v1 -> Payments API | status: superseded
  Retry Standard v2 -> Payments API | status: applied
```

**0 rows → 2 rows**, carrying the `status` property the question was actually about.

`anchor_role` is now cleared at the top of `build()`, and the ontology-derived role takes precedence over the model's hint — the ontology is authoritative about direction, the hint is a guess. Clearing matters because `build()` is called more than once on one builder by the repair paths.

## Two findings from the same run, deliberately not fixed here

**The planner routes this question to `path`, not `relationship_lookup`.** Both endpoints are not named — the question asks the system to *find* one. An unbound slot is not the same as a missing one, and treating it as a wildcard `CONTAINS ''` is a separate design question.

**`shortestPath` returns exactly one path per `(a, b)` pair**, so a 2-hop `APPLIES_TO`/`SUPERSEDES` chain is structurally excluded whenever a 1-hop edge exists between the same endpoints. The answer said so itself: *"the query results do not include any SUPERSEDES relationships"*.

## Validation

```
live DozerDB 5.26.3: 0 rows -> 2 rows with status
pytest test_anchor_orientation   -> 7 passed
pytest 5 builder/direction suites -> 42 passed
bash scripts/ci/run_basic_ci.sh  -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)