### PR TITLE
fix(query): an unnamed endpoint is an unknown to solve for, not a wildcard

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -131,6 +131,7 @@ uv run pytest \
   tests/seocho/test_ontology_iso704_cq.py \
   tests/seocho/test_relationship_direction.py \
   tests/seocho/test_anchor_orientation.py \
+  tests/seocho/test_unbound_slot.py \
   tests/seocho/test_prompt_prefix_stability.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \

--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -130,6 +130,7 @@ class CypherBuilder:
         # Cleared per build: a builder is constructed per plan, but `build` may
         # be called more than once on one (repair paths do).
         self.anchor_role = ""
+        self.unbound_slots: List[str] = []
         if anchor_label and anchor_label not in self.ontology.nodes:
             anchor_label = ""
         if target_label and target_label not in self.ontology.nodes:
@@ -639,7 +640,24 @@ class CypherBuilder:
         an identifier or prose?" — governs plan shape everywhere. Applying it to only
         one template is what left `_list_all` doing 86M dbHits at SF1000 while the
         repaired `_count` did 105.
+
+        An EMPTY mention is a third case, and it was being handled as the second.
+        "Which decisions apply to the Payments API?" names one endpoint and asks
+        the system to find the other, so the unnamed slot is an unknown to solve
+        for, not a mention to match. Falling through to the text anchor produced
+        ``toLower(...) CONTAINS toLower('')``, which is true for every node in
+        the database — an accidental wildcard that reads as a filter. It also
+        forces a scan, since a CONTAINS over a coalesce chain cannot use an
+        index, so the plan cost is paid for a predicate that excludes nothing.
+
+        An unbound slot is now constrained by its LABEL alone, which the caller
+        has already put in the MATCH pattern. `is_bound=False` tells the caller
+        the slot is open, so it can distinguish "no constraint" from "constraint
+        that happens to match everything".
         """
+        if not str(entity or "").strip():
+            self.unbound_slots = sorted(set(getattr(self, "unbound_slots", set())) | {alias})
+            return "true", {}
         sargable = self._sargable_anchor(alias, label, entity)
         if sargable is not None:
             return sargable
@@ -840,6 +858,51 @@ class CypherBuilder:
         # Self-referential (Account->Account) or a single consistent orientation.
         return ">" if len(pairs) == 1 else ""
 
+    def _connecting_relationship_types(
+        self, start_label: str, end_label: str, *, max_hops: int = 4,
+    ) -> List[str]:
+        """Declared relationship types on any chain from start_label to end_label.
+
+        Used when the model names a relationship that cannot on its own reach the
+        target ("which decision applies to the Payments API, and what did it
+        supersede" names SUPERSEDES, declared Decision -> Decision, while the
+        anchor is a System). The previous relaxation dropped the restriction
+        entirely, which admits every edge in the store -- including the
+        provenance layer this pipeline writes. Measured on a live graph: the
+        unrestricted form returned 20 paths, most of them Chunk MENTIONS
+        detours, for a question with two relevant edges.
+
+        Widening to the types that CAN connect the endpoints keeps the chain the
+        question needs and leaves the provenance edges out.
+        """
+        rels = self.ontology.relationships or {}
+        adjacency: Dict[str, List[Tuple[str, str]]] = {}
+        for name, rel in rels.items():
+            source, target = rel.source, rel.target
+            if not source or not target:
+                continue
+            adjacency.setdefault(source, []).append((target, name))
+            adjacency.setdefault(target, []).append((source, name))
+
+        used: Set[str] = set()
+        # Breadth-first over label space, recording the types on any chain that
+        # reaches the end label within the hop bound.
+        frontier: List[Tuple[str, List[str]]] = [(start_label, [])]
+        for _ in range(max(1, int(max_hops))):
+            nxt: List[Tuple[str, List[str]]] = []
+            for label, path in frontier:
+                for neighbour, rel_name in adjacency.get(label, []):
+                    if rel_name in path:
+                        continue  # do not repeat a type within one chain
+                    chain = path + [rel_name]
+                    if neighbour == end_label:
+                        used.update(chain)
+                    nxt.append((neighbour, chain))
+            frontier = nxt
+            if not frontier:
+                break
+        return sorted(used)
+
     def _path(
         self,
         from_entity: str,
@@ -875,12 +938,20 @@ class CypherBuilder:
                 if target_label in widened:
                     # Reachable, just not over the relationship the model named:
                     # drop the restriction rather than return a wrong empty answer.
+                    # Widen to the types that can actually connect the two
+                    # endpoints, rather than to everything. Dropping the
+                    # restriction entirely admits the provenance layer
+                    # (Chunk MENTIONS, HAS_SECTION), which floods the answer
+                    # context with document-structure detours.
+                    connecting = self._connecting_relationship_types(
+                        anchor_label, target_label, max_hops=bounded_hops)
                     self.last_path_pruning = {
                         "action": "relaxed_relationship_type",
                         "requested": relationship_type,
+                        "widened_to": connecting,
                         "reason": "target_label_unreachable_over_requested_relationship",
                     }
-                    rel_types = []
+                    rel_types = connecting
                 else:
                     # Provably empty per the schema: answer immediately instead of
                     # exhaustively searching for something that cannot exist.
@@ -899,8 +970,14 @@ class CypherBuilder:
 
         a_label = f":{quote_identifier(anchor_label)}" if anchor_label else ""
         b_label = f":{quote_identifier(target_label)}" if target_label else ""
-        rel_name = self._rel_name(rel_types[0]) if rel_types else ""
-        rel_clause = f":{quote_identifier(rel_name)}" if rel_name else ""
+        # All resolved types, not just the first. A widened set describes a chain
+        # (APPLIES_TO then SUPERSEDES); keeping only rel_types[0] would restrict
+        # the traversal to one leg of it and return nothing.
+        rel_names = [n for n in (self._rel_name(r) for r in rel_types) if n]
+        rel_clause = (
+            ":" + "|".join(quote_identifier(n) for n in dict.fromkeys(rel_names))
+            if rel_names else ""
+        )
         # Only orient the pattern when the target is genuinely reachable following
         # declared directions; otherwise the question needs undirected traversal and
         # forcing an arrow would return nothing.
@@ -916,10 +993,29 @@ class CypherBuilder:
             "b", target_label, to_entity, value_param="to_e", norm_param="to_e_norm")
         params: Dict[str, Any] = {**from_params, **to_params,
                                   "workspace_id": workspace_id, "limit": limit}
+        # Drop a `true` from an unbound endpoint rather than emitting `AND true`.
+        # It is harmless to the planner but it is noise in an EXPLAIN, and the
+        # plan grader reads operator shape from exactly that.
+        endpoint_preds = " AND ".join(
+            pred for pred in (from_pred, to_pred) if pred != "true"
+        ) or "true"
+        # shortestPath answers "how are THESE TWO connected" -- one path per
+        # endpoint pair. When an endpoint is unbound the question is "what is
+        # connected", and shortestPath answers it wrongly by construction: a
+        # 1-hop edge between the same pair hides every longer chain. Measured on
+        # a live graph, asking which decision applies to a system and what it
+        # superseded, shortestPath returned only the two APPLIES_TO edges and
+        # the model correctly reported that no SUPERSEDES relationship was in
+        # its results.
+        #
+        # Enumerating all paths is only safe because the relationship set is now
+        # constrained: unrestricted it returned 20 paths, mostly Chunk MENTIONS
+        # detours through the provenance layer. Constrained it returns 4, which
+        # are exactly the APPLIES_TO edges and the two SUPERSEDES chains.
+        primitive = "shortestPath" if not self.unbound_slots else ""
         return (
-            f"MATCH path = shortestPath((a{a_label})-[{rel_clause}*..{bounded_hops}]-{arrow}(b{b_label}))\n"
-            f"WHERE {from_pred}\n"
-            f"  AND {to_pred}\n"
+            f"MATCH path = {primitive}((a{a_label})-[{rel_clause}*..{bounded_hops}]-{arrow}(b{b_label}))\n"
+            f"WHERE {endpoint_preds}\n"
             "  AND ($workspace_id = '' OR all(n IN nodes(path) WHERE coalesce(n._workspace_id, '') = $workspace_id))\n"
             f"RETURN [n IN nodes(path) | {self._display_expr('n', anchor_label)}] AS nodes,\n"
             "       [r IN relationships(path) | type(r)] AS relationships\n"

--- a/tests/seocho/test_unbound_slot.py
+++ b/tests/seocho/test_unbound_slot.py
@@ -1,0 +1,178 @@
+"""An unnamed endpoint is an unknown to solve for, not a wildcard to match.
+
+"Which retry standard is currently applied to the Payments API, and what did it
+supersede?" names one endpoint and asks the system to find the other. The
+planner extracted that correctly — `anchor='Payments API'` (System),
+`target=''` (Decision), `relationship='SUPERSEDES'`. Three separate pieces of
+machinery then mishandled the empty slot, and the end-to-end answer was
+"I cannot answer this question" from a graph that contained the answer.
+
+1. `_anchor_predicate` fell through to the text anchor, producing
+   `toLower(...) CONTAINS toLower('')` — true for every node in the database.
+   An accidental wildcard that reads as a filter, and one that forces a scan,
+   since CONTAINS over a coalesce chain cannot use an index.
+
+2. The relationship restriction was dropped entirely. `SUPERSEDES` is declared
+   `Decision -> Decision` and cannot on its own reach a System anchor, so the
+   pruning logic relaxed it to *everything*. Measured on a live graph: 20 paths,
+   most of them `Chunk MENTIONS` detours through the provenance layer this
+   pipeline writes itself.
+
+3. `shortestPath` returns one path per endpoint pair, so a 1-hop `APPLIES_TO`
+   edge hid every 2-hop `APPLIES_TO`/`SUPERSEDES` chain. The model said so:
+   "the query results do not include any SUPERSEDES relationships".
+
+Measured end to end after all three, same question and model:
+
+    before: "Based on the query results, I cannot answer this question."
+    after:  "Current retry standard: Retry Standard v2.
+             What it superseded: Retry Standard v1."
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+from seocho.query.cypher_builder import CypherBuilder
+
+
+@pytest.fixture
+def ontology() -> Ontology:
+    return Ontology(
+        name="incident",
+        nodes={
+            "Org": NodeDef(description="o", properties={"name": P(str, unique=True)},
+                           identity_keys=["name"]),
+            "System": NodeDef(description="s", properties={"name": P(str, unique=True)},
+                              identity_keys=["name"]),
+            "Decision": NodeDef(description="d",
+                                properties={"name": P(str, unique=True), "status": P(str)},
+                                identity_keys=["name"]),
+        },
+        relationships={
+            "DECIDED": RelDef(source="Org", target="Decision", description=""),
+            "APPLIES_TO": RelDef(source="Decision", target="System", description=""),
+            "SUPERSEDES": RelDef(source="Decision", target="Decision", description=""),
+        },
+    )
+
+
+def _unbound(ontology):
+    builder = CypherBuilder(ontology)
+    cypher, params = builder.build(
+        intent="path", anchor_entity="Payments API", anchor_label="System",
+        target_entity="", target_label="Decision", relationship_type="SUPERSEDES",
+        workspace_id="w", limit=20,
+    )
+    return builder, cypher, params
+
+
+# ---------------------------------------------------------------------------
+# 1. No accidental wildcard
+# ---------------------------------------------------------------------------
+
+def test_empty_slot_does_not_become_a_contains_wildcard(ontology):
+    _, cypher, params = _unbound(ontology)
+    assert "$to_e" not in cypher, (
+        "CONTAINS '' is true for every node — a wildcard that reads as a filter"
+    )
+    assert "to_e" not in params
+
+
+def test_empty_slot_is_reported_as_unbound(ontology):
+    """The caller must be able to tell 'no constraint' from 'constraint that
+    happens to match everything'."""
+    builder, _, _ = _unbound(ontology)
+    assert builder.unbound_slots == ["b"]
+
+
+def test_bound_slots_still_constrain(ontology):
+    builder = CypherBuilder(ontology)
+    cypher, params = builder.build(
+        intent="path", anchor_entity="Payments API", anchor_label="System",
+        target_entity="Retry Standard v2", target_label="Decision",
+        relationship_type="APPLIES_TO", workspace_id="w", limit=20,
+    )
+    assert "$to_e" in cypher
+    assert params["to_e"] == "Retry Standard v2"
+    assert builder.unbound_slots == []
+
+
+def test_unbound_slots_do_not_leak_between_builds(ontology):
+    builder = CypherBuilder(ontology)
+    builder.build(intent="path", anchor_entity="Payments API", anchor_label="System",
+                  target_entity="", target_label="Decision",
+                  relationship_type="SUPERSEDES", workspace_id="w", limit=20)
+    builder.build(intent="path", anchor_entity="Payments API", anchor_label="System",
+                  target_entity="Retry Standard v2", target_label="Decision",
+                  relationship_type="APPLIES_TO", workspace_id="w", limit=20)
+    assert builder.unbound_slots == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Relaxation widens to what can connect, not to everything
+# ---------------------------------------------------------------------------
+
+def test_relaxation_keeps_a_relationship_restriction(ontology):
+    _, cypher, _ = _unbound(ontology)
+    assert "*..4]" in cypher
+    assert "[:" in cypher, (
+        "dropping the restriction admits every edge, including the Chunk/Section "
+        "provenance layer this pipeline writes itself"
+    )
+
+
+def test_relaxation_includes_the_connecting_chain(ontology):
+    builder, cypher, _ = _unbound(ontology)
+    widened = builder.last_path_pruning["widened_to"]
+    assert "APPLIES_TO" in widened, "the leg that reaches the anchor is missing"
+    assert "SUPERSEDES" in widened, "the relationship the question named is missing"
+    assert "APPLIES_TO" in cypher and "SUPERSEDES" in cypher
+
+
+def test_connecting_types_exclude_unrelated_relationships(ontology):
+    """DECIDED connects Org to Decision and is not on any System->Decision chain
+    of interest; it must not be pulled in just because it touches Decision."""
+    builder = CypherBuilder(ontology)
+    connecting = builder._connecting_relationship_types("System", "Decision", max_hops=1)
+    assert connecting == ["APPLIES_TO"]
+
+
+def test_unsatisfiable_pattern_is_still_pruned(ontology):
+    """The guardrail that prevents an exhaustive search for something the schema
+    forbids must survive."""
+    onto = Ontology(
+        name="t",
+        nodes={"A": NodeDef(description="a", properties={"name": P(str)}),
+               "B": NodeDef(description="b", properties={"name": P(str)})},
+        relationships={},
+    )
+    builder = CypherBuilder(onto)
+    cypher, _ = builder.build(intent="path", anchor_entity="x", anchor_label="A",
+                              target_entity="", target_label="B",
+                              relationship_type="", workspace_id="w", limit=20)
+    assert "LIMIT 0" in cypher
+
+
+# ---------------------------------------------------------------------------
+# 3. shortestPath is for bound pairs only
+# ---------------------------------------------------------------------------
+
+def test_unbound_endpoint_does_not_use_shortest_path(ontology):
+    """One path per pair means a 1-hop edge hides every longer chain — which is
+    exactly the chain an unbound question is asking to enumerate."""
+    _, cypher, _ = _unbound(ontology)
+    assert "shortestPath" not in cypher
+
+
+def test_bound_pair_still_uses_shortest_path(ontology):
+    """"How are these two connected" is what shortestPath is for, and
+    enumerating all paths between two named nodes is expensive for no gain."""
+    builder = CypherBuilder(ontology)
+    cypher, _ = builder.build(
+        intent="path", anchor_entity="Payments API", anchor_label="System",
+        target_entity="Retry Standard v2", target_label="Decision",
+        relationship_type="APPLIES_TO", workspace_id="w", limit=20,
+    )
+    assert "shortestPath" in cypher


### PR DESCRIPTION
*"Which retry standard is currently applied to the Payments API, and what did it supersede?"* names one endpoint and asks the system to **find** the other.

The planner extracted that correctly — `anchor='Payments API'` (System), `target=''` (Decision), `relationship='SUPERSEDES'`. Three pieces of machinery then mishandled the empty slot, and the end-to-end answer was *"I cannot answer this question"* — **from a graph that contained the answer**.

## 1. The empty slot became an accidental wildcard

`_anchor_predicate` fell through to the text anchor:

```cypher
toLower(coalesce(b.name, b.uri, '')) CONTAINS toLower('')   -- true for every node
```

A filter in shape, no filter in effect. And one that **forces a scan** — `CONTAINS` over a `coalesce` chain cannot use an index — so the plan cost was paid for a predicate that excluded nothing.

Unbound slots are now constrained by label alone, and recorded in `unbound_slots` so a caller can tell *"no constraint"* from *"constraint that matches everything"*.

## 2. The relationship restriction was dropped rather than widened

`SUPERSEDES` is declared `Decision → Decision` and cannot on its own reach a System anchor, so the pruning logic relaxed it to **everything**.

Measured on a live graph: **20 paths**, most of them `Chunk MENTIONS` detours through the provenance layer this pipeline writes itself.

Relaxation now widens to the types that can *actually connect* the two endpoint labels — here `APPLIES_TO|SUPERSEDES` — keeping the chain the question needs and leaving provenance edges out. The path builder also uses **every** resolved type rather than `rel_types[0]`, since a widened set describes a chain and one leg of it matches nothing.

## 3. `shortestPath` answered the wrong question

It returns **one path per endpoint pair**, so the 1-hop `APPLIES_TO` edge hid every 2-hop `APPLIES_TO`/`SUPERSEDES` chain. The model said so itself: *"the query results do not include any SUPERSEDES relationships"*.

`shortestPath` is for *"how are **these two** connected"*. When an endpoint is unbound the question is *"what is connected"*, and enumerating paths is the answer — which is only safe because of fix 2. Unrestricted it was 20 noisy paths; constrained it is 4.

## Measured end to end — same question, same model

| | answer |
|---|---|
| before | *"Based on the query results, I cannot answer this question."* |
| after fix 1+2 | *"Both v1 and v2 are applied … results do not include any SUPERSEDES"* |
| **after all three** | **"Current retry standard: Retry Standard v2. What it superseded: Retry Standard v1."** |

Builder rows went **2 → 4**, and the two added rows are exactly the `SUPERSEDES` chains.

## Validation

```
live DozerDB 5.26.3 + MARA MiniMax-M2.7: full answer, correct in both parts
pytest test_unbound_slot          -> 10 passed
pytest 7 query/builder suites     -> 59 passed
bash scripts/ci/run_basic_ci.sh   -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)