### PR TITLE
fix(query): project what the ontology declares, not the whole node

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -132,6 +132,7 @@ uv run pytest \
   tests/seocho/test_relationship_direction.py \
   tests/seocho/test_anchor_orientation.py \
   tests/seocho/test_unbound_slot.py \
+  tests/seocho/test_query_projection.py \
   tests/seocho/test_prompt_prefix_stability.py \
   tests/seocho/test_run_spec.py \
   tests/seocho/test_e2e_runner.py \

--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -739,7 +739,7 @@ class CypherBuilder:
             "       type(r) AS relationship,\n"
             "       coalesce(endNode(r).name, endNode(r).uri) AS target,\n"
             "       labels(b) AS target_labels,\n"
-            "       properties(b) AS target_properties,\n"
+            f"       {self._declared_props_expr('b', target_label)} AS target_properties,\n"
             "       coalesce(b.content_preview, b.description, b.content, '') AS supporting_fact\n"
             "LIMIT $limit",
             params,
@@ -1018,6 +1018,7 @@ class CypherBuilder:
             f"WHERE {endpoint_preds}\n"
             "  AND ($workspace_id = '' OR all(n IN nodes(path) WHERE coalesce(n._workspace_id, '') = $workspace_id))\n"
             f"RETURN [n IN nodes(path) | {self._display_expr('n', anchor_label)}] AS nodes,\n"
+            f"       [n IN nodes(path) | {self._path_props_expr('n')}] AS node_properties,\n"
             "       [r IN relationships(path) | type(r)] AS relationships\n"
             "LIMIT $limit",
             params,
@@ -1080,6 +1081,68 @@ class CypherBuilder:
             "RETURN count(n) AS count",
             {"workspace_id": workspace_id},
         )
+
+    def _declared_props_expr(self, alias: str, label: str = "") -> str:
+        """Project the properties the ontology declares, not the whole node.
+
+        `properties(n)` returns everything the writer put there, and most of it
+        is this pipeline's own bookkeeping: _workspace_id, _sources, _source_id,
+        _writer_agent, _writer_ts, and eight _ontology_* fields. Measured on a
+        two-row answer against a live graph, 23 keys were returned of which the
+        ontology declared 2 -- 80% of the answer context was provenance the
+        model cannot use and must still read.
+
+        Cost is the smaller half. The larger half is that a model given twenty
+        internal keys alongside two meaningful ones has to guess which carry the
+        answer, and `status` -- the property the question was about -- arrives
+        with the same weight as `_ontology_glossary_hash`.
+
+        Falls back to the whole map when the label is unknown, because returning
+        nothing is worse than returning too much.
+        """
+        node = self.ontology.nodes.get(label) if label else None
+        declared = list(getattr(node, "properties", {}) or {}) if node is not None else []
+        if not declared:
+            return f"properties({alias})"
+        pairs = ", ".join(
+            f"{quote_identifier(name)}: {alias}.{quote_identifier(name)}"
+            for name in declared
+        )
+        # Plain Cypher rather than apoc.map.clean: a projection is not worth a
+        # procedure dependency, and the read path refuses procedure calls
+        # (enforce_read_workspace_scope) precisely so it does not have to reason
+        # about what they can do. An unset optional property comes back null,
+        # which the answer layer already handles.
+        return f"{{{pairs}}}"
+
+    def _path_props_expr(self, alias: str, *, max_keys: int = 12) -> str:
+        """Map projection over every property name the ontology declares.
+
+        A path crosses several labels, so a per-label projection is not
+        available statically. The union of declared names is, and it is bounded
+        by the ontology rather than by what the writer happened to store -- which
+        is the property that matters, since the alternative (`properties(n)`)
+        returns this pipeline's _workspace_id/_sources/_ontology_* bookkeeping on
+        every node of every path.
+
+        Identity properties come first so the cap, if it binds, keeps the keys
+        that identify a node over the ones that describe it.
+        """
+        identity: List[str] = []
+        rest: List[str] = []
+        for node in (self.ontology.nodes or {}).values():
+            keys = list(getattr(node, "properties", {}) or {})
+            for key in getattr(node, "effective_identity_keys", None) or []:
+                if key in keys and key not in identity:
+                    identity.append(key)
+            for key in keys:
+                if key not in identity and key not in rest:
+                    rest.append(key)
+        names = (identity + rest)[:max_keys]
+        if not names:
+            return self._display_expr(alias)
+        projection = ", ".join(f".{quote_identifier(name)}" for name in names)
+        return f"{alias}{{{projection}}}"
 
     def _display_expr(self, alias: str, label: str = "") -> str:
         """Ontology-aware display expression for a node.

--- a/tests/seocho/test_query_projection.py
+++ b/tests/seocho/test_query_projection.py
@@ -1,0 +1,182 @@
+"""Project what the ontology declares, not the whole node.
+
+`properties(n)` returns everything the writer stored, and most of it is this
+pipeline's own bookkeeping. Measured against a live graph on a two-row answer,
+23 keys came back:
+
+    _ontology_artifact_hash  _ontology_context_hash  _ontology_glossary_hash
+    _ontology_graph_model    _ontology_id            _ontology_name
+    _ontology_profile        _ontology_schema_fingerprint
+    _ontology_version        _ontology_version_valid _source_id  _sources
+    _workspace_id            _writer_agent           _writer_ts
+    category  id  memory_id  name  source_id  source_type  status
+    updated_at  workspace_id
+
+The ontology declared **two** of them. 2213 characters of answer context, of
+which 435 carried information: **80% provenance**.
+
+Cost is the smaller half. The larger half is that a model handed twenty internal
+keys alongside two meaningful ones has to guess which carry the answer, and
+`status` — the property the question was about — arrives with exactly the same
+weight as `_ontology_glossary_hash`.
+
+The path template had the opposite defect: it projected node *names* and
+relationship types and no properties at all, so a question about `status` could
+not be answered from its rows however correct the traversal was.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.ontology import NodeDef, Ontology, P, RelDef
+
+from seocho.query.cypher_builder import CypherBuilder
+
+INTERNAL = (
+    "_workspace_id", "_sources", "_source_id", "_writer_agent", "_writer_ts",
+    "_ontology_version", "_ontology_schema_fingerprint",
+)
+
+
+
+def _return_clause(cypher: str) -> str:
+    """Only the projection. `_workspace_id` legitimately appears in the WHERE —
+    it is the tenancy filter — so scanning the whole query is a false positive."""
+    index = cypher.upper().rindex("RETURN")
+    return cypher[index:]
+
+
+@pytest.fixture
+def ontology() -> Ontology:
+    return Ontology(
+        name="incident",
+        nodes={
+            "System": NodeDef(description="s",
+                              properties={"name": P(str, unique=True)},
+                              identity_keys=["name"]),
+            "Decision": NodeDef(description="d",
+                                properties={"name": P(str, unique=True),
+                                            "status": P(str)},
+                                identity_keys=["name"]),
+        },
+        relationships={
+            "APPLIES_TO": RelDef(source="Decision", target="System", description=""),
+        },
+    )
+
+
+def _lookup(ontology):
+    return CypherBuilder(ontology).build(
+        intent="relationship_lookup", anchor_entity="Payments API",
+        anchor_label="System", target_label="Decision",
+        relationship_type="APPLIES_TO", workspace_id="w", limit=20,
+    )[0]
+
+
+# ---------------------------------------------------------------------------
+# relationship_lookup
+# ---------------------------------------------------------------------------
+
+def test_declared_properties_are_projected(ontology):
+    cypher = _lookup(ontology)
+    assert "`status`: b.`status`" in cypher, (
+        "the property the question is about must reach the answer context"
+    )
+    assert "`name`: b.`name`" in cypher
+
+
+def test_whole_node_is_not_projected(ontology):
+    cypher = _lookup(ontology)
+    assert "properties(b)" not in cypher, (
+        "properties() returns the pipeline's own _ontology_*/_workspace_id "
+        "bookkeeping on every row"
+    )
+
+
+@pytest.mark.parametrize("internal", INTERNAL)
+def test_internal_properties_are_not_named(ontology, internal):
+    assert internal not in _return_clause(_lookup(ontology))
+
+
+def test_unknown_label_still_returns_something(ontology):
+    """Returning nothing is worse than returning too much."""
+    cypher = CypherBuilder(ontology).build(
+        intent="relationship_lookup", anchor_entity="x",
+        anchor_label="System", target_label="",
+        relationship_type="APPLIES_TO", workspace_id="w", limit=20,
+    )[0]
+    assert "target_properties" in cypher
+
+
+def test_projection_uses_no_procedure_call(ontology):
+    """The read path refuses procedure calls (enforce_read_workspace_scope), so
+    a projection must not need apoc."""
+    cypher = _lookup(ontology)
+    assert "apoc." not in cypher
+    assert "CALL" not in cypher.upper()
+
+
+# ---------------------------------------------------------------------------
+# path
+# ---------------------------------------------------------------------------
+
+def _path(ontology, **kw):
+    params = dict(intent="path", anchor_entity="Payments API",
+                  anchor_label="System", target_entity="",
+                  target_label="Decision", relationship_type="APPLIES_TO",
+                  workspace_id="w", limit=20)
+    params.update(kw)
+    return CypherBuilder(ontology).build(**params)[0]
+
+
+def test_path_projects_properties(ontology):
+    """A correct traversal whose rows carry only names cannot answer a question
+    about a property."""
+    cypher = _path(ontology)
+    assert "node_properties" in cypher
+    assert ".`status`" in cypher
+
+
+def test_path_projection_is_bounded_by_the_ontology(ontology):
+    cypher = _path(ontology)
+    assert "properties(n)" not in cypher
+    projection = _return_clause(cypher)
+    for internal in INTERNAL:
+        assert internal not in projection
+
+
+def test_path_projection_is_capped():
+    """A wide ontology must not put an unbounded key list on every path node."""
+    onto = Ontology(
+        name="wide",
+        nodes={"Thing": NodeDef(
+            description="t",
+            properties={f"p{i}": P(str) for i in range(40)} | {"name": P(str, unique=True)},
+            identity_keys=["name"],
+        )},
+        relationships={},
+    )
+    expr = CypherBuilder(onto)._path_props_expr("n")
+    assert expr.count(".") <= 13, "projection grew with the ontology without bound"
+
+
+def test_identity_keys_survive_the_cap():
+    """If the cap binds, keep the keys that identify a node over the ones that
+    merely describe it."""
+    onto = Ontology(
+        name="wide",
+        nodes={"Thing": NodeDef(
+            description="t",
+            properties={f"p{i}": P(str) for i in range(40)} | {"code": P(str, unique=True)},
+            identity_keys=["code"],
+        )},
+        relationships={},
+    )
+    assert ".`code`" in CypherBuilder(onto)._path_props_expr("n")
+
+
+def test_empty_ontology_falls_back_to_a_display_expression():
+    onto = Ontology(name="empty", nodes={}, relationships={})
+    expr = CypherBuilder(onto)._path_props_expr("n")
+    assert expr and "coalesce" in expr


### PR DESCRIPTION
Two **opposite** projection defects, both measured against a live graph.

## `relationship_lookup` returned everything

`properties(b)` returns everything the writer stored. On a two-row answer that was **23 keys**, of which the ontology declared **2**:

```
_ontology_artifact_hash  _ontology_context_hash  _ontology_glossary_hash
_ontology_graph_model    _ontology_id            _ontology_name
_ontology_profile        _ontology_schema_fingerprint
_ontology_version        _ontology_version_valid _source_id  _sources
_workspace_id            _writer_agent           _writer_ts
category  id  memory_id  name  source_id  source_type  status
updated_at  workspace_id
```

**2213 characters of answer context, 435 of them informative — 80% provenance.**

Cost is the smaller half. The larger half is that a model handed twenty internal keys alongside two meaningful ones has to guess which carry the answer, and `status` — the property the question was about — arrived with exactly the same weight as `_ontology_glossary_hash`.

## The path template returned nothing

Node names and relationship types, **no properties at all**. So a correct traversal could not answer a question about a property, however right the path was.

## The fix

Both project the ontology's declared properties. **Pure Cypher map projection, not `apoc.map.clean`** — the read path refuses procedure calls (`enforce_read_workspace_scope`) precisely so it does not have to reason about what they can do, and a projection is not worth a procedure dependency.

A path crosses several labels, so a per-label projection isn't available statically. The **union of declared names** is, and it's bounded by the ontology rather than by what the writer happened to store. Capped at 12 keys with **identity properties first**, so if the cap binds it keeps the keys that identify a node over the ones that describe it. An unknown label falls back to the whole map — returning nothing is worse than returning too much.

## Measured end to end

Same question and model, live DozerDB + MiniMax-M2.7. The answer now **cites the data** rather than inferring from names:

> "Retry Standard v2 has an **'applied'** status and is actively associated with the Payments API, while Retry Standard v1 has a **'superseded'** status. The SUPERSEDES relationship confirms that v2 replaced v1."

```
relationship_lookup: 2213 -> 435 chars, status preserved
path rows:           node_properties with status on every node
pytest test_query_projection    -> 16 passed
pytest 6 query/builder suites   -> 55 passed
bash scripts/ci/run_basic_ci.sh -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)