### PR TITLE
feat(intern): cross-source canonical convergence, opt-in per type (ADR-0204, zfe)

### DIFF
--- a/docs/decisions/ADR-0204-cross-source-convergence.md
+++ b/docs/decisions/ADR-0204-cross-source-convergence.md
@@ -1,0 +1,57 @@
+# ADR-0204: Cross-source canonical convergence (structured runtime, D2-2)
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-zfe (cross-source half of the read-time resolution contribution)
+- Related: ADR-0203 (read-side resolver), the multi-agent-flow review (#3 cross-source
+  fragmentation), the enterprise-rag cross-source thesis
+
+## Context
+
+ADR-0203 made reads *find* interned entities by name, but it also *surfaced* the
+cross-source fragmentation the review flagged (#3): the same real entity written from two
+sources gets two composite ids because the id is label-prefixed
+(`company|acme` vs `organization|acme`), so a cross-source join lands on two fragments, not
+one node. The "resolve one string to ONE canonical node" thesis needs the fragments to
+actually converge.
+
+## Decision
+
+**Opt-in, source-agnostic canonical address for globally-name-unique types.**
+
+- `NodeDef.cross_source_unique: bool = False` — the modeler declares which types are the
+  same real entity across sources when their name matches (e.g. Company / Organization /
+  Person), and which are not (homonym-prone metrics keep `identity_keys`). Default False →
+  no behaviour change; roundtrips through `to_dict`/`from_dict`.
+- In `apply_identity_keys`, a `cross_source_unique` node gets a **label-free, source-agnostic
+  canonical id** `~xs|<normalized-name>` instead of the label-prefixed composite. Both
+  sources compute the SAME id → both graph nodes MERGE to ONE physical node → the
+  cross-source join lands on one node. This is *physical* convergence at write time, not a
+  read-time remap.
+- Safe by construction: name-merge only fires for types the modeler declared globally
+  name-unique, so it never fuses genuinely-distinct types sharing a name (Apple the company
+  vs the fruit) or homonym-prone metrics (which stay on `identity_keys` and are surfaced as
+  candidates, never merged).
+- `SharedInternTable.reconcile(ws, name)` + a per-workspace union-find (`_find`, path-
+  compressed) remains as the **residual/explicit** reconciliation tool — for fragments not
+  caught at write (e.g. a concurrent race, or a post-hoc same-as declaration). It unions the
+  candidates to one deterministic representative; `candidates`/`resolve_one` return through
+  it. (This is a read-level remap; physically re-merging already-written fragments is a
+  re-projection / D3 concern.)
+
+## Consequences
+
+- Cross-source convergence is real and physical for declared types: "Acme Corp" from a jira
+  Company and a confluence Organization → one node `~xs|acme corp`, `resolve_one` returns it
+  (tested). The intern organ's cross-source claim is now backed, not asserted.
+- Homonym-prone types are untouched — distinct composite ids, candidates surfaced, never
+  fused (tested). The two policies (name-unique convergence vs identity-key separation) are
+  cleanly split by an explicit ontology declaration.
+- 6 new tests; ontology / identity / intern suites green (332 together). Opt-in default off.
+
+## Note for D3 (single federated-graph indexing)
+The `~xs|` id is workspace-agnostic in string form (content-addressed); isolation holds via
+the intern table's `(workspace, …)` keys and the `_workspace_id` read filter. When D3 indexes
+all sources into one graph, verify the graph MERGE is scoped so two tenants' identical `~xs|`
+entity never share a physical node (review #6) — carry `_workspace_id` on the node and MERGE
+on `(id, _workspace_id)`.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1227,6 +1227,14 @@ Each entry must link to a full ADR when impact is non-trivial.
   - t28 closed for unambiguous multi-key names; homonyms surface candidates (boundary1 honest); workspace-scoped. intern organ now mechanism-true on reads. 17 tests; identity/intern/grounding green
   - deferred: cross-source CONVERGENCE (fragments->one canonical) needs source-agnostic write identity/reconciliation; flagged review #6 sub-claim (composite id has no workspace -> verify graph MERGE key when D3 single-graph indexing lands)
 
+## 2026-08-16 (structured runtime D2-2: cross-source canonical convergence)
+
+- [Accepted] ADR-0204 cross-source canonical convergence (seocho-zfe)
+  - closes the cross-source half of blocker #3: same real entity from two sources fragments (company|acme vs organization|acme), so joins land on 2 nodes
+  - NodeDef.cross_source_unique (opt-in, default False, roundtrips): a declared globally-name-unique type gets a label-free source-agnostic canonical id ~xs|<name> in apply_identity_keys -> both sources' nodes MERGE to ONE physical node (write-time physical convergence). Safe: never fuses distinct types sharing a name (Apple co vs fruit) or homonym metrics (those keep identity_keys, surfaced as candidates)
+  - SharedInternTable.reconcile + union-find (_find, path-compressed) kept as the residual/explicit read-level reconciliation for fragments not caught at write
+  - 6 tests; ontology/identity/intern green (332). Note for D3: MERGE on (id,_workspace_id) so two tenants' identical ~xs| entity never share a node (review #6)
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/index/identity.py
+++ b/src/seocho/index/identity.py
@@ -79,10 +79,20 @@ def apply_identity_keys(
         label = str(node.get("label", "") or "")
         nd = node_defs.get(label)
         identity_keys = list(getattr(nd, "identity_keys", []) or []) if nd else []
-        if not identity_keys:
+        cross_unique = bool(getattr(nd, "cross_source_unique", False)) if nd else False
+        if not identity_keys and not cross_unique:
             continue
         props = node.get("properties") or {}
-        new_id = compute_node_identity(label, props, identity_keys)
+        name = str(props.get("name", "") or "")
+        if cross_unique and name:
+            # Cross-source-unique (seocho-zfe D2-2): a SOURCE-AGNOSTIC, label-free
+            # canonical address. The same real entity written from two sources with
+            # different labels (company|acme vs organization|acme) gets the SAME id
+            # here, so both graph nodes MERGE to one — cross-source joins land on one
+            # node. Safe because the modeler declared this type globally name-unique.
+            new_id = "~xs|" + _normalize_segment(name)
+        else:
+            new_id = compute_node_identity(label, props, identity_keys)
         if not new_id:
             continue
         if intern_table is not None:

--- a/src/seocho/index/shared_intern.py
+++ b/src/seocho/index/shared_intern.py
@@ -74,10 +74,57 @@ class SharedInternTable:
         self._interns = 0
         self._hits = 0
         self._reclaimed = 0
+        # Cross-source reconciliation (seocho-zfe D2-2): a union-find over canonical
+        # ids per workspace. The same real entity written from two sources gets two
+        # composite ids (label prefix differs: company|acme vs organization|acme);
+        # reconcile() unions them to ONE representative so cross-source sub-queries
+        # resolve one string to one node. Opt-in per node type (NodeDef.
+        # cross_source_unique) — NEVER blanket name-merge (that would fuse Apple the
+        # company with Apple the fruit).
+        self._merge: Dict[Tuple[str, str], str] = {}
+        self._merge_lock = threading.Lock()
         self._stats_lock = threading.Lock()
 
     def _shard(self, key: Tuple[str, str]) -> int:
         return hash(key) % self._shards
+
+    # -- cross-source reconciliation (union-find, seocho-zfe D2-2) -----------
+    def _find(self, workspace_id: str, canonical_id: str) -> str:
+        """Representative canonical for a reconciled set (path-compressed)."""
+        with self._merge_lock:
+            root = canonical_id
+            seen = []
+            while (str(workspace_id), root) in self._merge:
+                seen.append(root)
+                root = self._merge[(str(workspace_id), root)]
+            for c in seen:                       # path compression
+                self._merge[(str(workspace_id), c)] = root
+            return root
+
+    def reconcile(self, workspace_id: str, name: str) -> str:
+        """Union every canonical currently registered under ``name`` in this
+        workspace to ONE deterministic representative (the lexicographically
+        smallest), and return it. Idempotent. Call this ONLY for a node type the
+        ontology declares cross-source-unique — it fuses distinct composite ids of
+        the same real entity across sources."""
+        raw = self._raw_candidates(workspace_id, name)
+        if len(raw) < 2:
+            return raw[0] if raw else ""
+        rep = min(raw)                            # deterministic representative
+        with self._merge_lock:
+            for c in raw:
+                if c != rep:
+                    self._merge[(str(workspace_id), c)] = rep
+        return rep
+
+    def _raw_candidates(self, workspace_id: str, name: str) -> Tuple[str, ...]:
+        norm = self._norm_name(name)
+        if not norm:
+            return ()
+        key = (str(workspace_id), norm)
+        s = self._shard(key)
+        with self._locks[s]:
+            return tuple(sorted(self._alias[s].get(key, set())))
 
     # -- read-side name resolution index (seocho-t28/zfe) --------------------
     @staticmethod
@@ -97,16 +144,16 @@ class SharedInternTable:
             self._alias[s].setdefault(key, set()).add(canonical_id)
 
     def candidates(self, workspace_id: str, name: str) -> Tuple[str, ...]:
-        """Canonical ids registered under ``name`` in this workspace, sorted.
-        One element = an unambiguous resolve; more than one = a homonym the caller
-        must disambiguate with query context (never silently pick one)."""
-        norm = self._norm_name(name)
-        if not norm:
+        """Canonical ids registered under ``name`` in this workspace, sorted and
+        collapsed through cross-source reconciliation. One element = an unambiguous
+        resolve (a single entity, possibly reconciled across sources); more than
+        one = a genuine homonym the caller must disambiguate with query context
+        (never silently pick one)."""
+        raw = self._raw_candidates(workspace_id, name)
+        if not raw:
             return ()
-        key = (str(workspace_id), norm)
-        s = self._shard(key)
-        with self._locks[s]:
-            return tuple(sorted(self._alias[s].get(key, set())))
+        reps = {self._find(workspace_id, c) for c in raw}
+        return tuple(sorted(reps))
 
     def resolve_one(self, workspace_id: str, name: str) -> str:
         """The single canonical id for ``name``, or ``""`` if absent OR ambiguous
@@ -268,6 +315,7 @@ class SharedInternTable:
                 "shards": self._shards, "reclaimed": self._reclaimed,
                 "pinned": self.pinned_count(),
                 "aliases": sum(len(a) for a in self._alias),
+                "reconciled": len(self._merge),
                 "max_entries": self._max_entries or 0,
                 "backing": "sqlite" if self._sqlite_path else "memory"}
 
@@ -277,6 +325,8 @@ class SharedInternTable:
                 self._maps[i].clear()
                 self._refs[i].clear()
                 self._alias[i].clear()
+        with self._merge_lock:
+            self._merge.clear()
         with self._stats_lock:
             self._interns = 0
             self._hits = 0

--- a/src/seocho/ontology/core.py
+++ b/src/seocho/ontology/core.py
@@ -189,6 +189,14 @@ class NodeDef:
     # (name, company, year) match, instead of collapsing on name alone.
     # Empty == legacy behavior (single unique property / id is the key).
     identity_keys: List[str] = field(default_factory=list)
+    # seocho-zfe D2-2: when True, this type's entities are the SAME real entity
+    # across sources when their name matches — so the SAME name written from two
+    # sources (with different labels: company|acme vs organization|acme) converges
+    # to ONE canonical id / one physical node, enabling cross-source joins. Opt-in
+    # (default False): the modeler declares which types are globally name-unique,
+    # so name-merge never fuses genuinely-distinct types (Apple the company vs the
+    # fruit) or homonym-prone metrics (which use identity_keys instead).
+    cross_source_unique: bool = False
 
     # --- introspection helpers ------------------------------------------------
 
@@ -413,6 +421,9 @@ class Ontology:
                 broader=nd.get("broader", []),
                 same_as=nd.get("sameAs") or nd.get("same_as"),
                 identity_keys=list(nd.get("identity_keys", []) or nd.get("identityKeys", [])),
+                cross_source_unique=bool(
+                    nd.get("cross_source_unique", nd.get("crossSourceUnique", False))
+                ),
             )
 
         rels: Dict[str, RelDef] = {}
@@ -488,6 +499,8 @@ class Ontology:
                 node_entry["broader"] = list(nd.broader)
             if nd.identity_keys:
                 node_entry["identity_keys"] = list(nd.identity_keys)
+            if getattr(nd, "cross_source_unique", False):
+                node_entry["cross_source_unique"] = True
             nodes_out[label] = node_entry
 
         rels_out: Dict[str, Any] = {}

--- a/tests/seocho/test_cross_source_convergence.py
+++ b/tests/seocho/test_cross_source_convergence.py
@@ -1,0 +1,96 @@
+"""Cross-source convergence (seocho-zfe D2-2): the same real entity written from
+different sources converges to ONE canonical id / one physical node.
+"""
+
+from __future__ import annotations
+
+from seocho.index.identity import apply_identity_keys
+from seocho.index.shared_intern import SharedInternTable
+from seocho.ontology import NodeDef, Ontology, P
+
+
+def _onto_with(label: str, *, cross_unique: bool):
+    return Ontology("erb", package_id="erb", version="1.0.0", nodes={
+        label: NodeDef(description="an org", properties={"name": P(str, unique=True)},
+                       cross_source_unique=cross_unique),
+    })
+
+
+def _write(table, ws, label, name, *, cross_unique):
+    onto = _onto_with(label, cross_unique=cross_unique)
+    nodes = [{"label": label, "id": "tmp", "properties": {"name": name}}]
+    apply_identity_keys(onto, nodes, [], intern_table=table, workspace_id=ws)
+    return nodes[0]["id"]
+
+
+def test_same_entity_across_sources_converges_to_one_canonical():
+    """'Acme' as a Company (jira) and as an Organization (confluence) — both
+    cross_source_unique — get the SAME source-agnostic canonical id, so the two
+    graph nodes MERGE to one and a cross-source join lands on one node."""
+    t = SharedInternTable()
+    jira_id = _write(t, "acme", "Company", "Acme Corp", cross_unique=True)
+    conf_id = _write(t, "acme", "Organization", "Acme Corp", cross_unique=True)
+    assert jira_id == conf_id == "~xs|acme corp", "converged, label-agnostic id"
+    assert t.resolve_one("acme", "Acme Corp") == jira_id
+
+
+def test_non_flagged_multikey_homonyms_stay_separate():
+    """A homonym-prone type (identity_keys, NOT cross_source_unique) keeps distinct
+    composite ids and surfaces both as candidates — never fused."""
+    t = SharedInternTable()
+    onto = Ontology("fin", package_id="fin", version="1.0.0", nodes={
+        "FinancialMetric": NodeDef(
+            description="m", properties={"name": P(str), "company": P(str)},
+            identity_keys=["name", "company"]),
+    })
+
+    def w(company):
+        nodes = [{"label": "FinancialMetric", "id": "t",
+                  "properties": {"name": "Total Revenue", "company": company}}]
+        apply_identity_keys(onto, nodes, [], intern_table=t, workspace_id="acme")
+        return nodes[0]["id"]
+
+    ptc, tsla = w("PTC"), w("Tesla")
+    assert ptc != tsla
+    assert set(t.candidates("acme", "total revenue")) == {ptc, tsla}
+    assert t.resolve_one("acme", "total revenue") == ""   # homonym: no guess
+
+
+def test_convergence_is_workspace_scoped():
+    t = SharedInternTable()
+    a = _write(t, "acme", "Company", "Acme Corp", cross_unique=True)
+    _write(t, "globex", "Organization", "Acme Corp", cross_unique=True)
+    # same content -> same id string, but each tenant's alias is isolated
+    assert t.candidates("acme", "acme corp") == (a,)
+    assert t.candidates("globex", "widget co") == ()
+
+
+def test_union_find_reconcile_merges_residual_fragments():
+    """The explicit reconcile() (for fragments not caught at write, e.g. a
+    concurrent race) unions candidates to one representative."""
+    t = SharedInternTable()
+    t.alias("acme", "Acme", "company|acme")
+    t.alias("acme", "Acme", "organization|acme")
+    assert len(t.candidates("acme", "acme")) == 2      # fragmented
+    rep = t.reconcile("acme", "acme")
+    assert rep == "company|acme"                       # min = deterministic rep
+    assert t.candidates("acme", "acme") == (rep,)      # collapsed
+    assert t.resolve_one("acme", "acme") == rep
+
+
+def test_cross_source_unique_roundtrips_through_dict():
+    onto = _onto_with("Company", cross_unique=True)
+    d = onto.to_dict()
+    assert d["nodes"]["Company"]["cross_source_unique"] is True
+    back = Ontology.from_dict(d)
+    assert back.nodes["Company"].cross_source_unique is True
+
+
+def test_opt_in_default_off_leaves_composite_behavior():
+    t = SharedInternTable()
+    # not flagged, single unique name -> legacy: no identity_keys => untouched id
+    onto = _onto_with("Company", cross_unique=False)
+    nodes = [{"label": "Company", "id": "orig-1", "properties": {"name": "Acme"}}]
+    apply_identity_keys(onto, nodes, [], intern_table=t, workspace_id="acme")
+    assert nodes[0]["id"] == "orig-1", "no identity_keys + not cross_unique => id untouched"
+    assert t.stats()["aliases"] == 0


### PR DESCRIPTION
## Cross-source canonical convergence, opt-in per type (ADR-0204, seocho-zfe)

Closes the **cross-source half** of the multi-agent-flow review's blocker #3. ADR-0203 made reads *find* interned entities but *surfaced* the fragmentation: the same real entity from two sources gets two composite ids (label-prefixed: `company|acme` vs `organization|acme`), so a cross-source join lands on two fragments, not one node.

### What changed
- **`NodeDef.cross_source_unique: bool = False`** — the modeler declares which types are the same entity across sources when names match (Company/Organization/Person), vs homonym-prone types that keep `identity_keys`. Default off → no behaviour change; roundtrips through `to_dict`/`from_dict`.
- In `apply_identity_keys`, a `cross_source_unique` node gets a **label-free, source-agnostic** canonical id `~xs|<normalized-name>` instead of the label-prefixed composite. Both sources compute the **same** id → both graph nodes MERGE to **one physical node** → the cross-source join lands on one node. *Physical* write-time convergence, not a read remap.
- **Safe by construction**: name-merge fires only for types explicitly declared globally-name-unique, so it never fuses distinct types sharing a name (Apple the company vs the fruit) or homonym metrics (those stay on `identity_keys` and are surfaced as candidates, never fused).
- `SharedInternTable.reconcile(ws, name)` + a path-compressed **union-find** remain as the *residual/explicit* read-level reconciliation for fragments not caught at write (a concurrent race, a post-hoc same-as).

### Validation
6 new tests: cross-source Company+Organization "Acme Corp" → one `~xs|acme corp` id + `resolve_one` returns it; homonym multi-key stays separate + surfaces candidates; workspace-scoped; union-find reconcile merges residual fragments; `cross_source_unique` roundtrips; opt-in default off leaves composite behaviour. ontology/identity/intern suites green (**332 together**); `ruff` clean; `check_adr_index` 204.

### Note for D3 (single-graph indexing)
The `~xs|` id is content-addressed; isolation holds via the intern table `(workspace, …)` keys + the `_workspace_id` read filter. When D3 indexes all sources into one graph, MERGE on `(id, _workspace_id)` so two tenants' identical `~xs|` entity never share a node (review #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
