### PR TITLE
feat(runtime): engine=structured axis wires orchestrator into Seocho.ask (ADR-0205)

### DIFF
--- a/docs/decisions/ADR-0205-structured-engine-axis.md
+++ b/docs/decisions/ADR-0205-structured-engine-axis.md
@@ -1,0 +1,54 @@
+# ADR-0205: engine="structured" axis — wire the orchestrator into Seocho.ask (Step 2c/1)
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-ia4 (structured runtime)
+- Related: ADR-0200/0201 (run-context + resolver), ADR-0202 (orchestrator),
+  ADR-0203/0204 (read-side resolver + convergence), the multi-agent-flow review (D1/D5)
+
+## Context
+
+The organ-flagged `StructuredQueryOrchestrator` (ADR-0202) existed as a composable unit but
+was not reachable from `Seocho.ask` — the default path was still the monolithic,
+agent-free `_run_query_pipeline`. The orchestrator review's major asked for an **orthogonal
+engine axis** (not overloading `query_mode`, which carries reasoning semantics), governed
+reads (D1), honest abstain (D5), and a **per-request** GuardrailLedger.
+
+## Decision
+
+Add an `engine` parameter — `"deterministic"` (default, unchanged) or `"structured"` — to
+`Seocho.ask` / `ask_response` and `_LocalEngine.ask`, orthogonal to `query_mode`.
+
+- `engine="structured"` routes, inside the existing per-request pin + ContextVar wrapper, to
+  `_run_structured_pipeline`, which builds a `StructuredQueryOrchestrator` over the request's
+  run context and drives resolve-schema → retrieve (cypher generator seam) → guardrail →
+  governed execute → synthesize (synthesizer seam owns the prose, B5).
+- **Governed reads (D1/B2):** the workspace organ ON makes execution force-pin the workspace
+  and set `enforce_workspace_filter`; nothing else touches the store.
+- **Honest abstain (D5):** `answer_source` distinguishes `structured` (answered),
+  `structured_no_evidence` (empty rows), and `structured_guardrail_rejected` (unsafe Cypher
+  refused) — a rejection is never reported as "no supporting evidence."
+- **Per-request GuardrailLedger:** built fresh per call, so the before/after governance
+  signal (rejection rate) is never poisoned across tenants/requests (the review's major).
+- The two seams (LLM text2cypher, `QueryAnswerSynthesizer`) default to the real
+  implementations but are **injectable** (`_structured_cypher_generator`,
+  `_structured_synthesizer`), so organ semantics are unit-tested without live LLM/DB; a
+  snapshot-store-backed `_pinned_schema_resolver` enables the pinned-schema organ.
+
+## Consequences
+
+- `Seocho.ask(..., engine="structured")` runs the governed, organ-flagged path; the default
+  `"deterministic"` path is byte-for-byte unchanged (fully additive).
+- **Refcount leak-safety (hadry's OS-resource concern):** the structured pipeline runs inside
+  the `pinned_run_context` + ContextVar wrapper, whose `finally` releases the pin even on an
+  exception — tested (a raising body releases the version pin; `min_pinned_epoch` returns to
+  None).
+- 4 new wiring tests (governed execute + metadata, honest abstain on guardrail reject, bare
+  arm skips the filter, refcount leak-safety); client/run-context/orchestrator suites green
+  (24 together). `ruff` clean.
+
+## Remaining (Step 2c/2)
+The default seams are the real LLM text2cypher + synthesizer; end-to-end validation on live
+MARA/DozerDB is the e2e itself. D3 single-federated-graph indexing (with `(id, _workspace_id)`
+MERGE per review #6) and D4 scheduler per-tenant fairness remain. bolt-rs is the I/O-plane organ
+on the roadmap.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1235,6 +1235,15 @@ Each entry must link to a full ADR when impact is non-trivial.
   - SharedInternTable.reconcile + union-find (_find, path-compressed) kept as the residual/explicit read-level reconciliation for fragments not caught at write
   - 6 tests; ontology/identity/intern green (332). Note for D3: MERGE on (id,_workspace_id) so two tenants' identical ~xs| entity never share a node (review #6)
 
+## 2026-08-16 (structured runtime Step 2c/1: engine=structured axis wired into Seocho.ask)
+
+- [Accepted] ADR-0205 engine="structured" axis — orchestrator wired into Seocho.ask (seocho-ia4)
+  - orthogonal `engine` param (deterministic default | structured) on Seocho.ask/ask_response/_LocalEngine.ask; NOT overloading query_mode (reasoning semantics)
+  - structured routes (inside the per-request pin + ContextVar) to _run_structured_pipeline -> StructuredQueryOrchestrator: resolve schema -> retrieve (seam) -> guardrail (pinned-snapshot policy) -> governed execute (force-pin workspace + enforce_workspace_filter, D1/B2) -> synthesizer owns prose (B5)
+  - honest abstain (D5): answer_source in {structured | structured_no_evidence | structured_guardrail_rejected} (a rejection is never "no evidence"); per-request GuardrailLedger (un-poisoned across tenants); seams injectable (unit-tested without live LLM/DB), snapshot-store resolver enables pinned schema organ
+  - refcount leak-safety: structured pipeline inside pinned_run_context+ContextVar finally -> pin released even on exception (tested). default deterministic path byte-for-byte unchanged. 4 wiring tests; client/run-context/orchestrator green (24)
+  - remaining Step 2c/2: live e2e validation (MARA/DozerDB), D3 single-graph indexing ((id,_workspace_id) MERGE), D4 scheduler fairness, bolt-rs I/O organ
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1199,6 +1199,7 @@ class Seocho:
         repair_budget: int = 0,
         query_mode: Optional[str] = None,
         cot_mode: bool = False,
+        engine: str = "deterministic",
     ) -> str:
         """Ask a question through the primary public query facade.
 
@@ -1221,6 +1222,7 @@ class Seocho:
             repair_budget=repair_budget,
             query_mode=query_mode,
             cot_mode=cot_mode,
+            engine=engine,
         ).response
 
     def ask_response(
@@ -1238,6 +1240,7 @@ class Seocho:
         repair_budget: int = 0,
         query_mode: Optional[str] = None,
         cot_mode: bool = False,
+        engine: str = "deterministic",
     ) -> AskResponse:
         """Return the primary query answer plus runtime metadata."""
         normalized_query_mode = _resolve_semantic_query_mode(
@@ -1253,6 +1256,7 @@ class Seocho:
                 repair_budget=repair_budget,
                 query_mode=normalized_query_mode,
                 ontology_override=self._ontology_registry.get(db),
+                engine=engine,
             )
             metadata = self.last_query_metadata
             semantic_context = dict(metadata.get("semantic_context", {}) or {})

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -101,6 +101,17 @@ class _LocalEngine:
         self._ontology_pin_registry: Any = None
         self._active_ontology_pointer: Any = None
         self._last_run_context: Any = None
+        # Structured engine (ADR-0205): the organ-flagged orchestrator path. All
+        # optional/injectable so `engine="deterministic"` (the default) never
+        # touches any of this. A snapshot-store-backed resolver enables the pinned
+        # schema organ; the two seams default to real (LLM text2cypher +
+        # QueryAnswerSynthesizer) but are injectable for tests.
+        from .query.arm_config import ArmConfig
+
+        self._structured_arm = ArmConfig.governed()
+        self._pinned_schema_resolver: Any = None
+        self._structured_cypher_generator: Any = None
+        self._structured_synthesizer: Any = None
         self._events = NullEventPublisher()
         self._ingest_request_cls = IngestRequest
 
@@ -553,8 +564,15 @@ class _LocalEngine:
         repair_budget: Optional[int] = None,
         query_mode: str = DEFAULT_QUERY_MODE,
         ontology_override: Optional[Any] = None,
+        engine: str = "deterministic",
     ) -> str:
-        """Ontology-aware query: generate Cypher -> execute -> synthesize answer."""
+        """Ontology-aware query: generate Cypher -> execute -> synthesize answer.
+
+        ``engine`` selects the runtime (orthogonal to ``query_mode``, which is
+        reasoning semantics): ``"deterministic"`` (default) is the existing
+        monolithic pipeline; ``"structured"`` routes through the organ-flagged
+        :class:`~seocho.query.structured_orchestrator.StructuredQueryOrchestrator`
+        (the governed multi-agent path the arm×organ e2e exercises)."""
         query_mode = normalize_query_mode(query_mode)
         active_ontology = ontology_override or self.ontology
         ontology_context = self._ontology_context_cache.get(
@@ -663,6 +681,13 @@ class _LocalEngine:
             # multi-tenant asks() cannot clobber each other (B7).
             token = _ACTIVE_RUN_CONTEXT.set(pinned_context)
             try:
+                if str(engine) == "structured":
+                    return self._run_structured_pipeline(
+                        question,
+                        database=database,
+                        active_ontology=active_ontology,
+                        run_context=pinned_context,
+                    )
                 return self._run_query_pipeline(
                     question,
                     database=database,
@@ -693,6 +718,79 @@ class _LocalEngine:
         Mid-run consumers must read :func:`active_run_context` (ContextVar-isolated)
         instead."""
         return self._last_run_context
+
+    def _structured_seams(self, active_ontology: Any, database: str):
+        """The (cypher_generator, synthesizer) the structured orchestrator drives.
+        Injectable (set the ``_structured_*`` attrs) for tests; the defaults are the
+        real LLM text2cypher + the QueryAnswerSynthesizer, invoked only with a live
+        LLM/graph (the e2e)."""
+        gen = self._structured_cypher_generator
+        if gen is None:
+            def gen(question: str, schema_text: str) -> str:  # noqa: E306
+                cypher, _params, _intent, _err = self._generate_cypher(question, active_ontology)
+                return cypher or ""
+        synth = self._structured_synthesizer
+        if synth is None:
+            answerer = QueryAnswerSynthesizer(query_strategy=self._query, llm=self.llm)
+
+            def synth(question: str, rows: List[Dict[str, Any]]) -> str:  # noqa: E306
+                return answerer.synthesize(question, rows)
+        return gen, synth
+
+    def _run_structured_pipeline(
+        self, question: str, *, database: str, active_ontology: Any, run_context: Any
+    ) -> str:
+        """Organ-flagged structured path (ADR-0205): resolve schema -> retrieve ->
+        guardrail -> governed execute -> synthesize, over the per-request run
+        context. A per-request GuardrailLedger keeps the before/after governance
+        signal un-poisoned across tenants; abstain is honest (a guardrail
+        rejection is reported as such, never as 'no supporting evidence')."""
+        from .query.structured_orchestrator import StructuredQueryOrchestrator
+
+        ledger = None
+        try:
+            from .integrations.openai_agents import GuardrailLedger
+            ledger = GuardrailLedger()
+        except Exception:
+            ledger = None
+
+        gen, synth = self._structured_seams(active_ontology, database)
+        orchestrator = StructuredQueryOrchestrator(
+            arm=self._structured_arm,
+            graph_store=self.graph_store,
+            ontology=active_ontology,
+            cypher_generator=gen,
+            synthesizer=synth,
+            resolver=self._pinned_schema_resolver,
+            get_schema_fn=lambda: self._get_schema_info(database),
+            database=database,
+        )
+        result = orchestrator.answer(question, run_context, workspace_id=self.workspace_id)
+        if ledger is not None:
+            ledger.record(result.guardrail_violations)
+
+        # Honest abstain (D5): a guardrail rejection is NOT "no evidence".
+        if result.guardrail_rejected:
+            answer_source = "structured_guardrail_rejected"
+        elif not result.rows:
+            answer_source = "structured_no_evidence"
+        else:
+            answer_source = "structured"
+
+        self._last_query_metadata = {
+            "schema_version": "local_query_metadata.v1",
+            "workspace_id": self.workspace_id,
+            "database": database,
+            "engine": "structured",
+            "answer_source": answer_source,
+            "arm": self._structured_arm.to_dict(),
+            "structured": result.to_dict(),
+            "guardrail_ledger": ledger.summary() if ledger is not None else {},
+            "semantic_context": {},
+            "cypher": result.cypher,
+            "result_count": len(result.rows),
+        }
+        return result.answer
 
     @contextmanager
     def _traced_stage(

--- a/tests/seocho/test_structured_engine_wiring.py
+++ b/tests/seocho/test_structured_engine_wiring.py
@@ -1,0 +1,107 @@
+"""engine="structured" wiring into the local runtime (ADR-0205, Step 2c/1).
+
+Routes Seocho.ask -> _LocalEngine._run_structured_pipeline -> the organ-flagged
+orchestrator: governed reads (D1), honest abstain (D5), per-request GuardrailLedger.
+Exercised with injected seams (no live LLM/DB); the engine is built via __new__ so
+the heavy __init__ (indexing pipeline, strategies) is not needed for the wiring test.
+"""
+
+from __future__ import annotations
+
+from seocho.local_engine import _LocalEngine
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology.run_context import OntologyRunContext, pinned_run_context
+from seocho.ontology.active_pointer import ActiveOntologyPointer
+from seocho.ontology.version_pin import VersionPinRegistry
+from seocho.query.arm_config import ArmConfig
+
+
+def _onto():
+    return Ontology("erb", package_id="erb", version="1.0.0", nodes={
+        "Company": NodeDef(description="c", properties={"name": P(str, unique=True)}),
+    })
+
+
+class _FakeGraph:
+    def __init__(self):
+        self.calls = []
+        self.rows = [{"c": {"name": "Acme"}}]
+
+    def query(self, cypher, *, params=None, database="neo4j", workspace_id=None,
+              enforce_workspace_filter=False):
+        self.calls.append({"cypher": cypher, "workspace_id": workspace_id,
+                           "enforce_workspace_filter": enforce_workspace_filter})
+        return list(self.rows)
+
+    def get_schema(self, *, database="neo4j"):
+        return {"labels": ["Company"], "relationship_types": []}
+
+
+SAFE = "MATCH (c:Company {_workspace_id:$workspace_id}) RETURN c.name AS name LIMIT $limit"
+UNSAFE = "MATCH (f:Foo) RETURN f LIMIT $limit"
+
+
+def _engine(graph, *, arm, gen_cypher):
+    e = object.__new__(_LocalEngine)          # bypass the heavy __init__
+    e.graph_store = graph
+    e.workspace_id = "acme"
+    e.llm = None
+    e._query = None
+    e._structured_arm = arm
+    e._pinned_schema_resolver = None          # -> introspected schema via get_schema
+    e._structured_cypher_generator = lambda q, schema: gen_cypher
+    e._structured_synthesizer = lambda q, rows: f"answer:{len(rows)}rows"
+    e._last_query_metadata = {}
+    return e
+
+
+def _ctx():
+    return OntologyRunContext(workspace_id="acme", ontology_id="erb")
+
+
+def test_structured_pipeline_governed_execute_and_metadata():
+    g = _FakeGraph()
+    e = _engine(g, arm=ArmConfig.governed(), gen_cypher=SAFE)
+    ans = e._run_structured_pipeline("q", database="neo4j", active_ontology=_onto(),
+                                     run_context=_ctx())
+    assert ans == "answer:1rows"                       # synthesizer owns the prose (B5)
+    assert g.calls[-1]["enforce_workspace_filter"] is True      # governed execute (B2)
+    assert g.calls[-1]["workspace_id"] == "acme"
+    md = e._last_query_metadata
+    assert md["engine"] == "structured" and md["answer_source"] == "structured"
+    assert md["arm"]["name"] == "governed"
+    assert md["guardrail_ledger"]["allowed"] == 1
+
+
+def test_structured_honest_abstain_on_guardrail_reject():
+    g = _FakeGraph()
+    e = _engine(g, arm=ArmConfig.governed(), gen_cypher=UNSAFE)
+    e._run_structured_pipeline("q", database="neo4j", active_ontology=_onto(), run_context=_ctx())
+    md = e._last_query_metadata
+    # a guardrail rejection is reported AS a rejection, never as "no evidence" (D5)
+    assert md["answer_source"] == "structured_guardrail_rejected"
+    assert md["guardrail_ledger"]["rejected"] == 1
+    assert len(g.calls) == 0                           # rejected Cypher never executed
+
+
+def test_bare_arm_does_not_force_workspace_filter():
+    g = _FakeGraph()
+    e = _engine(g, arm=ArmConfig.bare(), gen_cypher=SAFE)
+    e._run_structured_pipeline("q", database="neo4j", active_ontology=_onto(), run_context=_ctx())
+    assert g.calls[-1]["enforce_workspace_filter"] is False
+
+
+def test_refcount_leak_safety_pin_released_on_exception(tmp_path):
+    """The pin wrapping the request releases even when the pipeline raises — no
+    refcount leak (hadry's OS-resource-handle concern)."""
+    pointer = ActiveOntologyPointer(tmp_path / "active.db")
+    pins = VersionPinRegistry(pointer)
+    pointer.publish("acme", "erb", version="1.0.0", fingerprint="fp", fencing_token=1)
+    try:
+        with pinned_run_context(_ctx(), pin_registry=pins, package_id="erb",
+                                active_pointer=pointer):
+            assert pins.min_pinned_epoch("acme", "erb") == 0    # held during the body
+            raise RuntimeError("boom in the structured pipeline")
+    except RuntimeError:
+        pass
+    assert pins.min_pinned_epoch("acme", "erb") is None, "pin must be released on error"


### PR DESCRIPTION
## engine="structured" — wire the orchestrator into Seocho.ask (ADR-0205, Step 2c/1)

The organ-flagged `StructuredQueryOrchestrator` (ADR-0202) was a composable unit not reachable from `Seocho.ask`. This adds the **orthogonal `engine` axis** the orchestrator review asked for (not overloading `query_mode`).

### What changed
- `engine` param — `"deterministic"` (default, **unchanged**) | `"structured"` — on `Seocho.ask` / `ask_response` / `_LocalEngine.ask`.
- `engine="structured"` routes, **inside the existing per-request pin + ContextVar wrapper**, to `_run_structured_pipeline` → `StructuredQueryOrchestrator`: resolve schema → retrieve (cypher-gen seam) → guardrail (policy from the pinned snapshot) → **governed execute** (force-pin workspace + `enforce_workspace_filter`, D1/B2) → **synthesizer owns the prose** (B5).
- **Honest abstain (D5):** `answer_source` ∈ {`structured`, `structured_no_evidence`, `structured_guardrail_rejected`} — a guardrail rejection is never reported as "no supporting evidence."
- **Per-request `GuardrailLedger`** — fresh per call, so the before/after governance signal is never poisoned across tenants.
- Seams (LLM text2cypher, `QueryAnswerSynthesizer`) default to the real impls but are **injectable**, so organ semantics are unit-tested without live LLM/DB; a snapshot-store resolver enables the pinned-schema organ.

### Refcount leak-safety (hadry's OS-resource concern)
The structured pipeline runs inside `pinned_run_context` + the ContextVar, whose `finally` releases the version pin **even on an exception** — tested (`min_pinned_epoch` returns to None after a raising body).

### Validation
4 wiring tests (governed execute + metadata, honest abstain on reject, bare arm skips the filter, refcount leak-safety); client / run-context / orchestrator suites green (**24 together**). `ruff` clean; `check_adr_index` 205. Default deterministic path byte-for-byte unchanged.

### Remaining (Step 2c/2)
Live e2e validation on MARA/DozerDB (the seams' real impls); D3 single-federated-graph indexing (`(id, _workspace_id)` MERGE per review #6); D4 scheduler per-tenant fairness; bolt-rs I/O-plane organ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
