### PR TITLE
fix(graph): workspace-scoped node/rel MERGE — no cross-tenant node collision (ADR-0206)

### DIFF
--- a/docs/decisions/ADR-0206-workspace-scoped-graph-merge.md
+++ b/docs/decisions/ADR-0206-workspace-scoped-graph-merge.md
@@ -1,0 +1,49 @@
+# ADR-0206: Workspace-scoped node/rel MERGE (review #6, D3 code-half)
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-ia4 (structured runtime), the multi-agent-flow review (#6)
+- Related: ADR-0204 (cross-source convergence — source-agnostic `~xs|` ids),
+  ADR-0164 (workspace isolation)
+
+## Context
+
+`Neo4jGraphStore.write` MERGEd nodes on `id` alone (`MERGE (n:L {id: row.id})`) and matched
+relationship endpoints on `id` alone. ADR-0204 made cross-source-unique entities share a
+**source-agnostic id** (`~xs|<name>`) that is IDENTICAL across tenants for the same-named
+entity. In a shared graph (the D3 single-federated-graph model, and any multi-workspace-in-
+one-database deployment) that means two tenants' "Acme Corp" would MERGE onto **one physical
+node** and a relationship could bridge two tenants' nodes — a cross-tenant collision (the
+review's blocker #6). `_workspace_id` was written as a *property* but was not part of node
+IDENTITY, so it could not prevent the merge.
+
+## Decision
+
+Make `_workspace_id` part of the write-time node identity and the relationship endpoint match:
+
+- Node: `MERGE (n:L {id: row.id, _workspace_id: $ws})` (batch and single-row), with
+  `ws=workspace_id` bound.
+- Relationship endpoints: `MATCH (a:… {id: row.src, _workspace_id: $ws}), (b:… {id: row.tgt,
+  _workspace_id: $ws})` so a relationship only ever connects nodes of the SAME tenant.
+
+`write(...)` already stamps `props["_workspace_id"] = workspace_id` on every node, so existing
+nodes carry the property and are still matched by the new key — **no migration break** for the
+common case (single-tenant nodes all share `_workspace_id="default"`). Two tenants' identical
+`id` now key to distinct `(id, _workspace_id)` nodes.
+
+## Consequences
+
+- Two tenants' identical entity id (source-agnostic or otherwise) never share a physical node,
+  and no relationship bridges tenants — the shared-graph model (D3) is tenant-safe at the
+  write path, and CLAUDE.md's "write paths must preserve workspace_id" is honoured in node
+  IDENTITY, not just as a filterable property.
+- 3 new tests assert the generated Cypher is workspace-scoped (node MERGE + both rel
+  endpoints) and that two tenants bind distinct `ws`; the existing LWW writer test's endpoint
+  assertion was updated to the new pattern. Graph/index/convergence suites green (24).
+  (`test_graph_db_span`'s 3 failures are pre-existing on origin/main — a query-path fake
+  missing `default_access_mode`, unrelated to this write-path change.)
+
+## Note
+This is the code-half of D3. The full single-federated-graph indexing (all sources into one
+workspace-scoped graph, `_source_platform` stamped) + its live validation is the e2e; this
+change makes that graph tenant-safe by construction.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1244,6 +1244,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - refcount leak-safety: structured pipeline inside pinned_run_context+ContextVar finally -> pin released even on exception (tested). default deterministic path byte-for-byte unchanged. 4 wiring tests; client/run-context/orchestrator green (24)
   - remaining Step 2c/2: live e2e validation (MARA/DozerDB), D3 single-graph indexing ((id,_workspace_id) MERGE), D4 scheduler fairness, bolt-rs I/O organ
 
+## 2026-08-16 (structured runtime: workspace-scoped graph MERGE, review #6)
+
+- [Accepted] ADR-0206 workspace-scoped node/rel MERGE (seocho-ia4, review #6, D3 code-half)
+  - Neo4jGraphStore.write MERGEd nodes on id alone; with ADR-0204's source-agnostic ~xs|<name> ids (identical across tenants), a shared graph would MERGE two tenants' entity onto ONE node + rels could bridge tenants (cross-tenant collision)
+  - fix: node MERGE (n:L {id, _workspace_id: $ws}) + rel endpoints MATCH scoped by _workspace_id; write() already stamps _workspace_id on every node so existing nodes still match -> no migration break; two tenants' identical id now key to distinct (id,_workspace_id) nodes
+  - 3 tests assert workspace-scoped Cypher (node + both rel endpoints, distinct ws per tenant); LWW test endpoint assertion updated. graph/index/convergence green (24). test_graph_db_span's 3 fails are PRE-EXISTING on origin/main (query-path fake missing default_access_mode, unrelated)
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -650,7 +650,12 @@ class Neo4jGraphStore(GraphStore):
                         )
 
                 batch_q = (
-                    f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id}})"
+                    # seocho review-#6: scope node identity by (id, _workspace_id) so
+                    # two tenants' identical id (e.g. the source-agnostic ~xs|<name>
+                    # from cross-source convergence) NEVER MERGE onto one physical
+                    # node in a shared graph. _workspace_id is always set on props
+                    # (below), so existing nodes still match — no migration break.
+                    f"UNWIND $rows AS row MERGE (n:{label} {{id: row.id, _workspace_id: $ws}})"
                     + _conflict_with("row.props", "n, row")
                     + " SET n += CASE WHEN n._writer_ts IS NULL "
                     "OR n._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
@@ -658,14 +663,14 @@ class Neo4jGraphStore(GraphStore):
                     + " RETURN row.id AS id, _conflicts AS conflicts"
                 )
                 try:
-                    for record in session.run(batch_q, rows=rows):
+                    for record in session.run(batch_q, rows=rows, ws=workspace_id):
                         summary["nodes_created"] += 1
                         _collect_conflicts(record)
                 except Exception:
                     for row in rows:
                         try:
                             single_q = (
-                                f"MERGE (n:{label} {{id: $id}})"
+                                f"MERGE (n:{label} {{id: $id, _workspace_id: $ws}})"
                                 + _conflict_with("$props", "n")
                                 + " SET n += CASE WHEN "
                                 "n._writer_ts IS NULL OR n._writer_ts <= $props._writer_ts "
@@ -673,7 +678,7 @@ class Neo4jGraphStore(GraphStore):
                                 + sources_clause.format(p="$props")
                                 + " RETURN $id AS id, _conflicts AS conflicts"
                             )
-                            for record in session.run(single_q, id=row["id"], props=row["props"]):
+                            for record in session.run(single_q, id=row["id"], props=row["props"], ws=workspace_id):
                                 _collect_conflicts(record)
                             summary["nodes_created"] += 1
                         except Exception as exc:
@@ -687,28 +692,34 @@ class Neo4jGraphStore(GraphStore):
                     "WHEN NOT {p}._source_id IN r._sources THEN r._sources + {p}._source_id "
                     "ELSE r._sources END"
                 )
-                source_pattern = f"(a:{source_label} {{id: row.src}})" if source_label else "(a {id: row.src})"
-                target_pattern = f"(b:{target_label} {{id: row.tgt}})" if target_label else "(b {id: row.tgt})"
+                # endpoints matched within the SAME workspace (review-#6): a rel
+                # never bridges two tenants' nodes even when they share an id.
+                source_pattern = (f"(a:{source_label} {{id: row.src, _workspace_id: $ws}})"
+                                  if source_label else "(a {id: row.src, _workspace_id: $ws})")
+                target_pattern = (f"(b:{target_label} {{id: row.tgt, _workspace_id: $ws}})"
+                                  if target_label else "(b {id: row.tgt, _workspace_id: $ws})")
                 batch_q = (f"UNWIND $rows AS row MATCH {source_pattern}, {target_pattern} "
                            f"MERGE (a)-[r:{rtype}]->(b) "
                            "SET r += CASE WHEN r._writer_ts IS NULL "
                            "OR r._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
                            + rel_sources_clause.format(p="row.props"))
                 try:
-                    session.run(batch_q, rows=rows)
+                    session.run(batch_q, rows=rows, ws=workspace_id)
                     summary["relationships_created"] += len(rows)
                 except Exception:
                     for row in rows:
                         try:
-                            source_single = f"(a:{source_label} {{id: $src}})" if source_label else "(a {id: $src})"
-                            target_single = f"(b:{target_label} {{id: $tgt}})" if target_label else "(b {id: $tgt})"
+                            source_single = (f"(a:{source_label} {{id: $src, _workspace_id: $ws}})"
+                                             if source_label else "(a {id: $src, _workspace_id: $ws})")
+                            target_single = (f"(b:{target_label} {{id: $tgt, _workspace_id: $ws}})"
+                                             if target_label else "(b {id: $tgt, _workspace_id: $ws})")
                             session.run(
                                 f"MATCH {source_single}, {target_single} "
                                 f"MERGE (a)-[r:{rtype}]->(b) SET r += CASE WHEN "
                                 "r._writer_ts IS NULL OR r._writer_ts <= $props._writer_ts "
                                 "THEN $props ELSE {} END"
                                 + rel_sources_clause.format(p="$props"),
-                                src=row["src"], tgt=row["tgt"], props=row["props"])
+                                src=row["src"], tgt=row["tgt"], props=row["props"], ws=workspace_id)
                             summary["relationships_created"] += 1
                         except Exception as exc:
                             summary["errors"].append(

--- a/tests/seocho/test_graph_write_workspace_scoped_merge.py
+++ b/tests/seocho/test_graph_write_workspace_scoped_merge.py
@@ -1,0 +1,94 @@
+"""Workspace-scoped node/rel MERGE (review #6): node identity is (id, _workspace_id),
+so two tenants' identical id (e.g. the cross-source ~xs|<name>) never merge onto one
+physical node in a shared graph, and a relationship never bridges two tenants' nodes.
+
+Offline (fake driver): asserts the generated Cypher carries `_workspace_id: $ws` in
+every MERGE/MATCH and that `ws=workspace_id` is bound.
+"""
+
+from __future__ import annotations
+
+from seocho.store.graph import Neo4jGraphStore
+
+
+class _Rec:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+
+        class _R:
+            def single(self_inner):
+                return None
+
+            def __iter__(self_inner):
+                return iter([{"id": params.get("id", ""), "conflicts": []}])
+
+        return _R()
+
+
+class _SessCtx:
+    def __init__(self, rec):
+        self._rec = rec
+
+    def __enter__(self):
+        return self._rec
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self):
+        self.rec = _Rec()
+
+    def session(self, database=None, **kw):
+        return _SessCtx(self.rec)
+
+    def close(self):
+        pass
+
+
+def _store():
+    s = Neo4jGraphStore("bolt://unit-test:7687", "neo4j", "p")
+    s._driver = _FakeDriver()
+    return s
+
+
+def test_node_merge_is_workspace_scoped():
+    s = _store()
+    s.write([{"id": "~xs|acme corp", "label": "Company", "properties": {"name": "Acme Corp"}}],
+            [], workspace_id="acme")
+    node_calls = [(q, p) for q, p in s._driver.rec.calls if "MERGE (n:" in q]
+    assert node_calls, "a node MERGE ran"
+    q, p = node_calls[0]
+    assert "_workspace_id: $ws" in q, "node identity must include _workspace_id"
+    assert p.get("ws") == "acme"
+
+
+def test_relationship_endpoints_are_workspace_scoped():
+    s = _store()
+    s.write(
+        [{"id": "a", "label": "Company", "properties": {"name": "A"}},
+         {"id": "b", "label": "Company", "properties": {"name": "B"}}],
+        [{"source": "a", "target": "b", "type": "RELATED_TO", "properties": {}}],
+        workspace_id="acme",
+    )
+    rel_calls = [(q, p) for q, p in s._driver.rec.calls if "-[r:" in q and "MATCH" in q]
+    assert rel_calls, "a relationship MATCH+MERGE ran"
+    q, p = rel_calls[0]
+    assert q.count("_workspace_id: $ws") >= 2, "both endpoints scoped by workspace"
+    assert p.get("ws") == "acme"
+
+
+def test_two_tenants_same_id_bind_distinct_workspace():
+    """The same source-agnostic id written under two tenants carries a different
+    ws each — so the DB keys them as distinct (id, _workspace_id) nodes."""
+    s = _store()
+    s.write([{"id": "~xs|acme corp", "label": "Company", "properties": {"name": "Acme Corp"}}],
+            [], workspace_id="acme")
+    s.write([{"id": "~xs|acme corp", "label": "Company", "properties": {"name": "Acme Corp"}}],
+            [], workspace_id="globex")
+    node_calls = [p.get("ws") for q, p in s._driver.rec.calls if "MERGE (n:" in q]
+    assert node_calls == ["acme", "globex"]

--- a/tests/seocho/test_graph_writer_lww.py
+++ b/tests/seocho/test_graph_writer_lww.py
@@ -120,7 +120,9 @@ def test_relationship_write_uses_typed_endpoints_when_declared():
         source_id="src1",
     )
     rel_calls = [c for c in store._driver.rec.calls if "MERGE (a)-[r:" in c[0]]
-    assert "MATCH (a:Company {id: row.src}), (b:Metric {id: row.tgt})" in rel_calls[0][0]
+    # endpoints are workspace-scoped (review #6): a rel never bridges two tenants' nodes
+    assert ("MATCH (a:Company {id: row.src, _workspace_id: $ws}), "
+            "(b:Metric {id: row.tgt, _workspace_id: $ws})") in rel_calls[0][0]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/seocho/test_index_coverage.py
+++ b/tests/seocho/test_index_coverage.py
@@ -3,7 +3,7 @@
 Before this, three property sets were disjoint:
 
   the ontology indexed   whatever was declared `unique` / `index`
-  the writer MERGEd on   `id`            (store/graph.py: MERGE (n:L {id: row.id}))
+  the writer MERGEd on   `id` (+`_workspace_id` since review #6: MERGE (n:L {id: row.id, _workspace_id: $ws}))
   the retriever filters  the display property and `_workspace_id`
 
 So no index served any predicate a correct query would use. The consequence is


### PR DESCRIPTION
## Workspace-scoped node/rel MERGE — no cross-tenant node collision (ADR-0206, review #6)

The multi-agent-flow review's blocker **#6**, and the code-half of D3. `Neo4jGraphStore.write` MERGEd nodes on `id` alone. ADR-0204 gave cross-source-unique entities a **source-agnostic id** `~xs|<name>` that is *identical across tenants* for the same-named entity — so in a shared graph, two tenants' "Acme Corp" would MERGE onto **one physical node** and a relationship could bridge two tenants' nodes. `_workspace_id` was a property but not part of node **identity**, so it couldn't stop the merge.

### Fix
- Node: `MERGE (n:L {id: row.id, _workspace_id: $ws})` (batch + single-row).
- Relationship endpoints: `MATCH (a:… {id: row.src, _workspace_id: $ws}), (b:… {id: row.tgt, _workspace_id: $ws})` — a rel only ever connects same-tenant nodes.
- `write()` already stamps `_workspace_id` on every node, so **existing nodes still match** the new key → no migration break. Two tenants' identical id now key to distinct `(id, _workspace_id)` nodes.

### Validation
3 new tests assert the generated Cypher is workspace-scoped (node MERGE + both rel endpoints) and that two tenants bind distinct `ws`; the existing LWW writer test's endpoint assertion was updated to the new pattern. graph / index / cross-source-convergence suites green (**24**). `ruff` clean; `check_adr_index` 206.
- Note: `test_graph_db_span`'s 3 failures are **pre-existing on origin/main** (a query-path fake missing `default_access_mode`), unrelated to this write-path change — verified against a clean `origin/main` export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
