### PR TITLE
feat(scheduling): point lookups take the light lane; per-tenant isolation is structural (ADR-0207)

### DIFF
--- a/docs/decisions/ADR-0207-scheduling-per-tenant-and-point-lookup-lane.md
+++ b/docs/decisions/ADR-0207-scheduling-per-tenant-and-point-lookup-lane.md
@@ -1,0 +1,46 @@
+# ADR-0207: Scheduling — per-tenant isolation is structural; point lookups take the light lane (D4)
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-ia4 (structured runtime), the multi-agent-flow review (#5)
+- Related: ADR-0158/0159 (LaneScheduler), ADR-0203 (read-side resolver)
+
+## Context
+
+The flow review's blocker #5 said the scheduler "has no tenant dimension … one tenant's N
+heavy fan-out reads monopolize the heavy lane and starve co-tenants." Verified against
+origin/main, that claim does not hold for this model: `LaneScheduler` is created **per
+`SeochoOS` instance**, and `SeochoOS` is **one instance per `(workspace, database)`**. So each
+tenant already has its **own** scheduler and its own permit pool — one tenant's storm consumes
+only its own permits; it cannot starve a co-tenant. Cross-tenant fairness is **structural by
+the instance model**, not a shared-scheduler accounting gap. (This is the same stale-tree
+over-reading pattern as the review's refuted #1 and #6-resolver claims.)
+
+The *real* residual is **within** a workspace: a fan-out issues a burst of cheap
+id-equality + `LIMIT 1` canonical-id resolves (exactly the ADR-0203 read-side resolver
+shape); under `LaneScheduler`'s "unknown means heavy" EWMA cold-start, each is classified
+heavy on first sight and floods the protected heavy lane precisely when the fan-out is widest.
+
+## Decision
+
+- **Document** that cross-tenant scheduling isolation is structural (per-`(workspace,
+  database)` `SeochoOS` → per-workspace `LaneScheduler`); do not build a redundant
+  per-workspace permit cap. Disclose the honest residual: there is no *global* cross-tenant
+  admission ceiling across many instances in one process — a deliberate isolation-over-global-
+  cap choice (a process-wide ceiling is future work if hosted density demands it).
+- **Route cheap point lookups to the light lane** directly: `execute_query` classifies an
+  id-equality + `LIMIT 1` statement (no aggregation/ordering) as `light` when a light lane
+  exists, bypassing the "unknown means heavy" cold-start. `LaneScheduler.has_light_lane` gates
+  it; everything else keeps the observed per-statement EWMA classification.
+
+## Consequences
+
+- A fan-out's canonical-id resolves no longer flood the heavy lane on first sight, so the
+  protected heavy lane stays available for genuinely heavy reads — the within-workspace
+  scheduling-quality fix the review's minor identified, and it composes with D2/D3 (the
+  read-side resolver's lookups are the exact shape now fast-pathed).
+- The OS scheduling story is now stated precisely: **cross-tenant = separate instances
+  (isolation), within-tenant = light/heavy lanes + high/normal reserve + EWMA, with cheap
+  point lookups seeded light.**
+- 3 tests: point-lookup shape detection, `has_light_lane` gating, structural per-tenant
+  scheduler isolation. operating-layer/admission suites green (31); `ruff` clean.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1251,6 +1251,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - fix: node MERGE (n:L {id, _workspace_id: $ws}) + rel endpoints MATCH scoped by _workspace_id; write() already stamps _workspace_id on every node so existing nodes still match -> no migration break; two tenants' identical id now key to distinct (id,_workspace_id) nodes
   - 3 tests assert workspace-scoped Cypher (node + both rel endpoints, distinct ws per tenant); LWW test endpoint assertion updated. graph/index/convergence green (24). test_graph_db_span's 3 fails are PRE-EXISTING on origin/main (query-path fake missing default_access_mode, unrelated)
 
+## 2026-08-16 (structured runtime D4: scheduling — per-tenant structural + point-lookup light lane)
+
+- [Accepted] ADR-0207 scheduling: per-tenant isolation is structural; point lookups take the light lane (seocho-ia4, review #5)
+  - review #5 ("no tenant dimension -> one tenant starves co-tenants") REFUTED vs origin/main: LaneScheduler is per SeochoOS instance, SeochoOS is one per (workspace,database) -> each tenant has its own scheduler+permits (structural isolation, no starvation). Same stale-tree over-read as #1/#6-resolver. Disclosed residual: no global cross-tenant ceiling (isolation-over-global-cap choice; future work)
+  - real within-workspace fix: a fan-out's burst of id-equality+LIMIT1 canonical-id resolves (ADR-0203 shape) flooded the heavy lane on 'unknown=heavy' cold-start -> execute_query now routes cheap point lookups to the light lane (has_light_lane gate), keeping the protected heavy lane free
+  - OS scheduling stated precisely: cross-tenant=separate instances, within-tenant=light/heavy+high/normal reserve+EWMA with point-lookups seeded light. 3 tests; operating-layer/admission green (31)
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/operating_layer.py
+++ b/src/seocho/operating_layer.py
@@ -47,9 +47,26 @@ layer across the FinBench SF axis under concurrent sessions.
 
 from __future__ import annotations
 
+import re
 import threading
 import time
 import uuid
+
+# A cheap single-node point lookup — an id-equality bound + LIMIT 1, no
+# aggregation/ordering. This is exactly the read-side canonical resolver's shape
+# (ADR-0203: WHERE n.id=$addr LIMIT 1), and a fan-out issues a BURST of them. Left
+# to the "unknown means heavy" EWMA cold-start they would flood the heavy lane on
+# first sight — so route them to the light lane directly (seocho-ia4 D4).
+_POINT_LOOKUP_ID = re.compile(r"(\{[^}]*\bid\b\s*:)|(\bid\b\s*=)|(\bid\b\s+IN)", re.IGNORECASE)
+_LIMIT_ONE = re.compile(r"\bLIMIT\s+1\b", re.IGNORECASE)
+_HEAVY_SHAPE = re.compile(r"\b(count|sum|avg|collect|order\s+by)\b", re.IGNORECASE)
+
+
+def _is_cheap_point_lookup(cypher: str) -> bool:
+    c = cypher or ""
+    if not _LIMIT_ONE.search(c) or _HEAVY_SHAPE.search(c):
+        return False
+    return bool(_POINT_LOOKUP_ID.search(c))
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -199,6 +216,10 @@ class LaneScheduler:
         # to 0/85 — the probe that caught it is e2_s2_probe.py).
         self._lane_service_ms: Dict[str, float] = {}
         self._cond = threading.Condition()
+
+    @property
+    def has_light_lane(self) -> bool:
+        return "light" in self._permits
 
     # -- classification ----------------------------------------------------
 
@@ -470,7 +491,14 @@ class SeochoOS:
 
         statement_key = _hashlib.blake2b(
             " ".join(cypher.split()).encode(), digest_size=8).hexdigest()
-        lane = self._admission.classify(statement_key)
+        # A cheap point lookup goes to the light lane directly, so a fan-out's
+        # burst of canonical-id resolves (ADR-0203) does not flood the protected
+        # heavy lane on EWMA cold-start (D4); everything else uses the observed
+        # per-statement classification.
+        if self._admission.has_light_lane and _is_cheap_point_lookup(cypher):
+            lane = "light"
+        else:
+            lane = self._admission.classify(statement_key)
         self._admit(session, lane)
         started = _time.perf_counter()
         try:

--- a/tests/seocho/test_scheduler_point_lookup_lane.py
+++ b/tests/seocho/test_scheduler_point_lookup_lane.py
@@ -1,0 +1,51 @@
+"""Scheduling: cheap point lookups take the light lane (seocho-ia4 D4).
+
+Cross-tenant fairness is STRUCTURAL — a SeochoOS (and its LaneScheduler) is one
+instance per (workspace, database), so one tenant's storm consumes only its own
+permits (the flow review's "one tenant starves co-tenants" does not apply to this
+instance model). The remaining, real scheduling-quality fix is within a workspace:
+a fan-out's burst of id-equality+LIMIT-1 resolves must not flood the heavy lane on
+EWMA cold-start.
+"""
+
+from __future__ import annotations
+
+from seocho.operating_layer import LaneScheduler, _is_cheap_point_lookup
+
+
+def test_point_lookup_shape_detection():
+    assert _is_cheap_point_lookup(
+        "MATCH (n {id: $addr, _workspace_id: $ws}) RETURN n LIMIT 1")
+    assert _is_cheap_point_lookup("MATCH (n) WHERE n.id = $x RETURN n.name LIMIT 1")
+    # a scan / aggregation is NOT a cheap point lookup
+    assert not _is_cheap_point_lookup(
+        "MATCH (a)-[r]->(b) RETURN count(r) LIMIT 1")
+    assert not _is_cheap_point_lookup(
+        "MATCH (n:Company {_workspace_id: $ws}) RETURN n ORDER BY n.name LIMIT 1")
+    assert not _is_cheap_point_lookup(          # no LIMIT 1 => not obviously cheap
+        "MATCH (n {id: $x}) RETURN n LIMIT $limit")
+
+
+def test_light_lane_presence_gates_the_fast_path():
+    with_light = LaneScheduler(max_inflight=8, light_permits=4)
+    assert with_light.has_light_lane is True
+    single = LaneScheduler(max_inflight=8)      # light_permits=0 -> single lane
+    assert single.has_light_lane is False
+
+
+def test_cross_tenant_scheduler_isolation_is_structural():
+    """Two workspaces get two SeochoOS instances -> two LaneSchedulers -> one
+    tenant's inflight never consumes another's permits (no starvation by design)."""
+    from seocho.operating_layer import SeochoOS
+    from seocho.ontology import Ontology
+
+    class _G:  # minimal graph store; we never execute here
+        def query(self, *a, **k):
+            return []
+
+    onto = Ontology("t", package_id="t", version="1.0.0", nodes={})
+    a = SeochoOS(graph_store=_G(), ontology=onto, database="neo4j", workspace_id="acme",
+                 max_inflight=4, light_permits=2)
+    b = SeochoOS(graph_store=_G(), ontology=onto, database="neo4j", workspace_id="globex",
+                 max_inflight=4, light_permits=2)
+    assert a._admission is not b._admission, "each workspace has its own scheduler"


### PR DESCRIPTION
## Scheduling: per-tenant isolation is structural; point lookups take the light lane (ADR-0207, D4)

The flow review's blocker **#5** ("no tenant dimension → one tenant's fan-out starves co-tenants") does **not** hold against origin/main: `LaneScheduler` is created **per `SeochoOS` instance**, and `SeochoOS` is **one instance per `(workspace, database)`** — so each tenant already has its own scheduler and permit pool. Cross-tenant fairness is **structural** (no starvation by design), not a shared-scheduler accounting gap. (Same stale-tree over-read as the review's refuted #1 / #6-resolver.)

### What this changes
- **Documents** the structural isolation and discloses the honest residual: there is no *global* cross-tenant admission ceiling across many instances in one process (a deliberate isolation-over-global-cap choice; process-wide ceiling is future work).
- **Fixes the real within-workspace issue:** a fan-out issues a burst of cheap id-equality + `LIMIT 1` canonical-id resolves (exactly the ADR-0203 read-side resolver shape); under "unknown means heavy" EWMA cold-start they flooded the protected heavy lane. `execute_query` now routes such point lookups to the **light lane** (`LaneScheduler.has_light_lane` gates it); everything else keeps the observed EWMA classification.

### Result
The OS scheduling story is now precise: **cross-tenant = separate instances (isolation); within-tenant = light/heavy lanes + high/normal reserve + EWMA, with cheap point lookups seeded light** so a fan-out never floods the heavy lane.

### Validation
3 tests: point-lookup shape detection, `has_light_lane` gating, structural per-tenant scheduler isolation. operating-layer / admission suites green (**31**); `ruff` clean; `check_adr_index` 207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
