### PR TITLE
feat(query): ontology-grounded text2cypher for the structured engine (ADR-0208)

### DIFF
--- a/docs/decisions/ADR-0208-grounded-text2cypher.md
+++ b/docs/decisions/ADR-0208-grounded-text2cypher.md
@@ -1,0 +1,51 @@
+# ADR-0208: Ontology-grounded text2cypher for the structured engine (live-validated)
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-ia4 (structured runtime), seocho-ia4.13 (text2cypher)
+- Related: ADR-0191 (ontology-source A/B), ADR-0201 (pinned resolver), ADR-0205 (engine axis),
+  ADR-0206 (workspace-scoped MERGE)
+
+## Context
+
+The first live smoke of `engine="structured"` against DozerDB+MARA proved the path runs, but
+the governed arm ABSTAINED on a question whose answer existed: the default cypher generator
+(the deterministic planner) emitted Cypher with undeclared properties, inlined literals, and
+no tenant scope, so the guardrail (rightly) rejected it. That is the exact confound the e2e
+review warned about — the governed arm would look "worse" for the wrong reason (a generator
+defect), not because governance costs anything.
+
+## Decision
+
+Add `query/grounded_text2cypher.generate_grounded_cypher(llm, question, schema_text, *,
+workspace_id, limit) -> (cypher, params)` and make it the structured engine's default cypher
+generator. It emits guardrail-conformant Cypher **by construction**, grounded in the pinned
+schema (ADR-0201): declared identifiers only, every value a `$param` (never inlined),
+`{_workspace_id: $workspace_id}` on **every** node (so the store's `verify_workspace_binding`
+passes — every RETURNed node is scoped, not just the anchor), and `LIMIT $limit`. It returns
+the value params so the orchestrator can bind them for both the guardrail check and execution
+(a value never has to be inlined to be executable).
+
+`StructuredQueryOrchestrator` now accepts `(cypher, params)` from the generator (back-compat:
+a bare string still works) and threads the params into the guardrail validation and the
+governed execute.
+
+## Consequences
+
+- **Live-validated:** with the grounded generator, the governed arm produces
+  `MATCH (i:Incident {_workspace_id:$workspace_id})-[:AFFECTS]->(c:Company
+  {_workspace_id:$workspace_id, name:$company_name}) RETURN i LIMIT $limit`, the guardrail
+  PASSES (`allowed:1, rejected:0`), the store's `enforce_workspace_filter` passes, and the
+  answer is correct (the real incident) — versus the ungoverned deterministic path's run-to-run
+  confabulation. The Plane-2 blocker (governed spuriously abstaining) is removed.
+- This wires the "ontology grounds the query" thesis (ADR-0191, measured 0→100% conformance)
+  into the RUNTIME, not just an ablation: the pinned schema drives a generator that satisfies
+  BOTH governance gates (the ontology guardrail AND the store's workspace-binding proof).
+- 3 unit tests (prompt contract, param hygiene incl. stripping runtime-bound params, malformed
+  output → empty); orchestrator/engine suites green (13). Reproducible live asset:
+  `scripts/agentos/e2e_structured_smoke.py`.
+
+## Note
+The generator relies on the LLM; a repair loop (feed the guardrail's violation reasons back
+for a retry) is a natural follow-up if a model emits non-conformant Cypher on harder schemas.
+Today it is conformant-by-prompt and validated on the enterprise smoke.

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1258,6 +1258,13 @@ Each entry must link to a full ADR when impact is non-trivial.
   - real within-workspace fix: a fan-out's burst of id-equality+LIMIT1 canonical-id resolves (ADR-0203 shape) flooded the heavy lane on 'unknown=heavy' cold-start -> execute_query now routes cheap point lookups to the light lane (has_light_lane gate), keeping the protected heavy lane free
   - OS scheduling stated precisely: cross-tenant=separate instances, within-tenant=light/heavy+high/normal reserve+EWMA with point-lookups seeded light. 3 tests; operating-layer/admission green (31)
 
+## 2026-08-16 (structured runtime: ontology-grounded text2cypher, live-validated)
+
+- [Accepted] ADR-0208 ontology-grounded text2cypher for the structured engine (seocho-ia4.13)
+  - live smoke exposed: default (deterministic-planner) cypher_generator emits undeclared props + inlined literals + no tenant scope -> governed guardrail rejects -> governed arm spuriously abstains (the exact Plane-2 confound the review warned of)
+  - generate_grounded_cypher(llm, question, schema_text, *, workspace_id, limit) -> (cypher, params): declared ids only, every value a $param (no inlined literal), {_workspace_id:$workspace_id} on EVERY node (satisfies store verify_workspace_binding, not just the anchor), LIMIT $limit; returns value params. Now the structured engine's default generator; orchestrator threads (cypher,params) into guardrail + governed execute (back-compat with bare-string generators)
+  - LIVE-VALIDATED (DozerDB+MARA): governed arm produced conformant workspace-scoped Cypher, guardrail allowed:1/rejected:0, store filter passed, CORRECT answer (real incident) vs deterministic confabulation. Plane-2 blocker removed. wires the ADR-0191 grounding thesis into the runtime. 3 unit tests; orchestrator/engine green (13). asset: scripts/agentos/e2e_structured_smoke.py
+
 ## Template
 
 Use this block for new entries:

--- a/scripts/agentos/e2e_structured_smoke.py
+++ b/scripts/agentos/e2e_structured_smoke.py
@@ -1,0 +1,124 @@
+"""Live smoke: does the structured engine axis actually run against DozerDB+MARA?
+
+The critical unknown before the full arm×organ e2e: index a couple of tiny docs
+into a live graph via our own extraction, then ask ONE question through BOTH
+engines (deterministic + structured) and print the answers + the structured
+metadata (arm, guardrail ledger, answer_source). Isolated by a unique workspace_id
+on the default DB; cleaned up at the end.
+
+Usage: python scripts/agentos/e2e_structured_smoke.py [--model mara/MiniMax-M2.7]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_ROOT, "src"))
+
+
+def _load_mara() -> None:
+    for envf in [os.path.join(_ROOT, ".env"), "/home/hadry/lab/seocho/.env"]:
+        if os.path.exists(envf):
+            for line in open(envf):
+                if line.startswith(("MARA_API_KEY=", "MARA_BASE_URL=")) and "=" in line:
+                    k, v = line.strip().split("=", 1)
+                    os.environ.setdefault(k, v.strip().strip('"').strip("'"))
+            return
+
+
+def _ontology():
+    from seocho import NodeDef, Ontology, P, RelDef
+    return Ontology(
+        "enterprise", package_id="enterprise", version="1.0.0",
+        nodes={
+            # Company is globally name-unique across sources -> cross-source convergence
+            "Company": NodeDef(description="A company/organization.",
+                               properties={"name": P(str, unique=True)},
+                               cross_source_unique=True),
+            "Incident": NodeDef(description="An operational incident.",
+                                properties={"name": P(str, unique=True),
+                                            "summary": P(str)}),
+        },
+        relationships={
+            "AFFECTS": RelDef(description="An incident affects a company.",
+                              source="Incident", target="Company"),
+        },
+    )
+
+
+DOCS = [
+    ("jira__inc1", "Incident SUP-29410: a data-breach incident affecting Acme Corp "
+                   "was reported on the support platform. Severity high."),
+    ("confluence__policy1", "Acme Corp is an enterprise customer. The retention policy "
+                            "for Acme Corp mandates 90-day log retention."),
+]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", default="mara/MiniMax-M2.7")
+    ap.add_argument("--uri", default="bolt://localhost:17687")
+    ap.add_argument("--password", default="h0gatepass")
+    args = ap.parse_args()
+    _load_mara()
+
+    from seocho import Seocho
+
+    ws = f"e2e_smoke_{int(time.time())}"
+    print(f"workspace={ws} model={args.model} uri={args.uri}")
+    client = Seocho.local(
+        _ontology(),
+        llm=args.model,
+        graph=args.uri,
+        neo4j_user="neo4j",
+        neo4j_password=args.password,
+        api_key=os.environ.get("MARA_API_KEY"),
+        workspace_id=ws,
+    )
+
+    # DozerDB needs the (auto-derived) database to exist before writes.
+    db = getattr(client, "default_database", None) or "enterpriselpg"
+    try:
+        client._engine.graph_store.ensure_database(db)
+        print(f"ensured database={db}")
+    except Exception as e:
+        print(f"ensure_database({db}) warning: {type(e).__name__}: {str(e)[:120]}")
+
+    print("=== indexing tiny docs ===")
+    for sid, text in DOCS:
+        r = client.add(text, source_type=sid)
+        print(f"  {sid}: {r}")
+
+    q = "What incident affects Acme Corp?"
+    print(f"\n=== ask: {q!r} ===")
+    for engine in ("deterministic", "structured"):
+        try:
+            ans = client.ask(q, engine=engine)
+            md = client.last_query_metadata
+            print(f"\n[{engine}] answer_source={md.get('answer_source')} "
+                  f"arm={md.get('arm', {}).get('name') if md.get('arm') else '-'}")
+            print(f"  cypher={str(md.get('cypher',''))[:160]}")
+            print(f"  ledger={md.get('guardrail_ledger', {})}")
+            print(f"  ANSWER: {str(ans)[:300]}")
+        except Exception as e:
+            import traceback
+            print(f"[{engine}] ERROR: {type(e).__name__}: {str(e)[:200]}")
+            traceback.print_exc()
+
+    # cleanup: drop this workspace's nodes (write mode via the driver; store.query
+    # is READ-only on the governed path).
+    try:
+        drv = client._engine.graph_store._driver
+        with drv.session(database=db) as s:
+            s.run("MATCH (n {_workspace_id:$ws}) DETACH DELETE n", ws=ws)
+        print(f"\ncleaned up workspace {ws}")
+    except Exception as e:
+        print(f"cleanup skipped: {type(e).__name__}: {str(e)[:120]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -726,9 +726,16 @@ class _LocalEngine:
         LLM/graph (the e2e)."""
         gen = self._structured_cypher_generator
         if gen is None:
-            def gen(question: str, schema_text: str) -> str:  # noqa: E306
-                cypher, _params, _intent, _err = self._generate_cypher(question, active_ontology)
-                return cypher or ""
+            from .query.grounded_text2cypher import generate_grounded_cypher
+
+            def gen(question: str, schema_text: str):  # noqa: E306
+                # Ontology-grounded, guardrail-conformant: declared identifiers,
+                # $params (no inlined literals), $workspace_id scope, LIMIT $limit —
+                # so the governed guardrail passes it instead of rejecting the
+                # deterministic planner's non-conformant Cypher (the live-smoke gap).
+                return generate_grounded_cypher(
+                    self.llm, question, schema_text,
+                    workspace_id=self.workspace_id, limit=getattr(self, "row_cap", 50))
         synth = self._structured_synthesizer
         if synth is None:
             answerer = QueryAnswerSynthesizer(query_strategy=self._query, llm=self.llm)

--- a/src/seocho/query/__init__.py
+++ b/src/seocho/query/__init__.py
@@ -18,6 +18,7 @@ from .answering import (
 )
 from .arm_config import ArmConfig, ablation_arms
 from .constraints import SemanticConstraintSliceBuilder
+from .grounded_text2cypher import generate_grounded_cypher
 from .pinned_schema import PinnedSchemaResolver, ResolvedSchema
 from .structured_orchestrator import StructuredQueryOrchestrator, StructuredQueryResult
 from .contracts import (
@@ -113,6 +114,7 @@ from .workload_compiler import (
 )
 
 __all__ = [
+    "generate_grounded_cypher",
     "ArmConfig",
     "ablation_arms",
     "PinnedSchemaResolver",

--- a/src/seocho/query/grounded_text2cypher.py
+++ b/src/seocho/query/grounded_text2cypher.py
@@ -1,0 +1,95 @@
+"""Ontology-grounded text2cypher — the generator the guardrail will actually pass.
+
+The structured engine's live smoke exposed the gap: the deterministic planner emits
+Cypher with undeclared properties, inlined literals, and no tenant scope, so the
+governed guardrail (rightly) REJECTS it and the arm abstains even when the answer
+exists. This generator emits guardrail-conformant Cypher by construction, grounded
+in the PINNED schema (ADR-0201 resolver): declared identifiers only, every value a
+`$param` (never inlined), the tenant bound with `$workspace_id`, bounded by
+`LIMIT $limit`. It is the "ontology grounds the query" thesis (ADR-0191) wired into
+the runtime, not just measured in an ablation.
+
+Returns `(cypher, params)` — the params are the LLM's value bindings, which the
+orchestrator merges with `workspace_id` + `limit` for both the guardrail check and
+execution (so a value never has to be inlined to be executable).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, Tuple
+
+from ..store.llm import complete_with_task_hints
+
+_SYSTEM = (
+    "You translate the user's question into ONE read-only Cypher query for a "
+    "tenant-scoped property graph.\n"
+    "HARD RULES (a query that breaks any of these is rejected):\n"
+    "1. Use ONLY the node labels, relationship types, and properties in the SCHEMA "
+    "below. Never invent an identifier.\n"
+    "2. Bind `{{_workspace_id: $workspace_id}}` on EVERY node in the pattern — not "
+    "just the anchor — so every node you MATCH or RETURN is tenant-scoped, e.g. "
+    "`(c:Company {{_workspace_id: $workspace_id}})<-[:AFFECTS]-"
+    "(i:Incident {{_workspace_id: $workspace_id}})`.\n"
+    "3. Parameterize EVERY value as a `$name` parameter — never inline a string or "
+    "number literal.\n"
+    "4. End the query with `LIMIT $limit`.\n"
+    "5. Read-only: no CREATE/MERGE/SET/DELETE.\n\n"
+    "SCHEMA:\n{schema}\n\n"
+    'Return ONLY JSON: {{"cypher": "<one query>", "params": {{"<name>": <value>, ...}}}}. '
+    "Do not include $workspace_id or $limit in params (the runtime binds them)."
+)
+
+
+def build_text2cypher_system_prompt(schema_text: str) -> str:
+    return _SYSTEM.format(schema=schema_text)
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    raw = re.sub(r"^```(json)?|```$", "", (text or "").strip(), flags=re.MULTILINE).strip()
+    try:
+        obj = json.loads(raw)
+        return obj if isinstance(obj, dict) else {}
+    except (json.JSONDecodeError, ValueError):
+        m = re.search(r"\{.*\}", raw, flags=re.DOTALL)
+        if m:
+            try:
+                obj = json.loads(m.group(0))
+                return obj if isinstance(obj, dict) else {}
+            except (json.JSONDecodeError, ValueError):
+                return {}
+        return {}
+
+
+def generate_grounded_cypher(
+    llm: Any,
+    question: str,
+    schema_text: str,
+    *,
+    workspace_id: str = "default",
+    limit: int = 50,
+) -> Tuple[str, Dict[str, Any]]:
+    """Generate guardrail-conformant Cypher + its value params for ``question``,
+    grounded in ``schema_text`` (the pinned-schema block). Returns
+    ``(cypher, params)``; ``params`` excludes ``workspace_id``/``limit`` (the
+    orchestrator binds those)."""
+    system = build_text2cypher_system_prompt(schema_text)
+    try:
+        resp = complete_with_task_hints(
+            llm, system=system, user=question, temperature=0.0,
+            response_format={"type": "json_object"}, reasoning_mode=False,
+            task_hint="json_extraction",
+        )
+        text = resp.json() if hasattr(resp, "json") else None
+        data = text if isinstance(text, dict) else _extract_json(getattr(resp, "text", "") or "")
+    except Exception:
+        data = {}
+    cypher = str(data.get("cypher", "") or "").strip()
+    params = data.get("params", {})
+    if not isinstance(params, dict):
+        params = {}
+    # never let the model smuggle in the runtime-bound params
+    params.pop("workspace_id", None)
+    params.pop("limit", None)
+    return cypher, params

--- a/src/seocho/query/structured_orchestrator.py
+++ b/src/seocho/query/structured_orchestrator.py
@@ -99,33 +99,45 @@ class StructuredQueryOrchestrator:
         return _introspected_schema_text(schema), policy_from_ontology(self.ontology), "introspected", ""
 
     # -- workspace organ (governed execute vs bare) ---------------------------
-    def _execute(self, cypher: str, workspace_id: str) -> List[Dict[str, Any]]:
+    def _execute(self, cypher: str, workspace_id: str,
+                 gen_params: Dict[str, Any]) -> List[Dict[str, Any]]:
         if self.arm.workspace_enforce:
-            # governed: force-pin the tenant and let the store enforce the filter (B2)
+            # governed: force-pin the tenant and let the store enforce the filter (B2).
+            # The generator's value params ride along so a value never has to be
+            # inlined (which the guardrail forbids) to be executable.
             return self.graph_store.query(
                 cypher,
-                params={"workspace_id": workspace_id, "limit": self.row_cap},
+                params={**gen_params, "workspace_id": workspace_id, "limit": self.row_cap},
                 database=self.database,
                 workspace_id=workspace_id,
                 enforce_workspace_filter=True,
             )
         # bare: no forced workspace, no DB-enforced filter (a real un-governed read)
         return self.graph_store.query(
-            cypher, params={"limit": self.row_cap}, database=self.database
+            cypher, params={**gen_params, "limit": self.row_cap}, database=self.database
         )
 
     def answer(self, question: str, run_context: Any, *, workspace_id: str) -> StructuredQueryResult:
         schema_text, policy, source, version = self._resolve_schema(run_context)
-        cypher = self._gen(question, schema_text)         # retrieve step (no prose)
+        gen_out = self._gen(question, schema_text)        # retrieve step (no prose)
+        # the generator may return just a cypher string (back-compat) or
+        # (cypher, params) — the grounded generator returns value params so no
+        # literal is inlined (guardrail rule) yet the query stays executable.
+        if isinstance(gen_out, tuple):
+            cypher, gen_params = gen_out[0], (gen_out[1] or {})
+        else:
+            cypher, gen_params = gen_out, {}
+        cypher = cypher or ""
 
         violations: Tuple[str, ...] = ()
         rejected = False
         if self.arm.guardrail:
             violations = tuple(validate_text2cypher_fallback(
-                cypher, params={"workspace_id": workspace_id, "limit": 1}, policy=policy))
+                cypher, params={**gen_params, "workspace_id": workspace_id, "limit": 1},
+                policy=policy))
             rejected = bool(violations)
 
-        rows = [] if rejected else self._execute(cypher, workspace_id)
+        rows = [] if rejected else self._execute(cypher, workspace_id, gen_params)
         answer = self._synth(question, rows)              # the ONLY prose writer (B5)
 
         return StructuredQueryResult(

--- a/tests/seocho/test_grounded_text2cypher.py
+++ b/tests/seocho/test_grounded_text2cypher.py
@@ -1,0 +1,62 @@
+"""Ontology-grounded text2cypher generator (the guardrail-conformant retrieve step).
+
+Validated live against DozerDB+MARA (governed arm answered correctly once the
+generator emitted declared-only, all-node-workspace-scoped, parameterized Cypher);
+here we unit-test the prompt contract + JSON parsing + param hygiene with a fake LLM.
+"""
+
+from __future__ import annotations
+
+from seocho.query.grounded_text2cypher import (
+    build_text2cypher_system_prompt,
+    generate_grounded_cypher,
+)
+
+
+class _Resp:
+    def __init__(self, obj):
+        self._obj = obj
+        self.text = ""
+
+    def json(self):
+        return self._obj
+
+
+class _FakeLLM:
+    def __init__(self, obj):
+        self._obj = obj
+        self.last_system = None
+
+    def complete(self, *, system=None, user=None, **kw):
+        self.last_system = system
+        return _Resp(self._obj)
+
+
+def test_system_prompt_states_the_hard_rules_and_schema():
+    p = build_text2cypher_system_prompt("Node labels: Company, Incident")
+    assert "Node labels: Company, Incident" in p
+    assert "$workspace_id" in p and "EVERY node" in p        # all-node tenant scope
+    assert "LIMIT $limit" in p
+    assert "never inline" in p.lower()                       # parameterize values
+
+
+def test_returns_cypher_and_params_and_strips_runtime_params():
+    llm = _FakeLLM({
+        "cypher": "MATCH (c:Company {_workspace_id: $workspace_id, name: $company}) "
+                  "RETURN c LIMIT $limit",
+        # a model that wrongly tries to bind runtime params must be sanitized
+        "params": {"company": "Acme Corp", "workspace_id": "attacker", "limit": 999},
+    })
+    cypher, params = generate_grounded_cypher(llm, "who is Acme?", "schema",
+                                              workspace_id="acme", limit=50)
+    assert cypher.startswith("MATCH (c:Company")
+    assert params == {"company": "Acme Corp"}, "runtime-bound params stripped"
+
+
+def test_malformed_llm_output_yields_empty_cypher():
+    class _Bad(_FakeLLM):
+        def complete(self, **kw):
+            r = _Resp({}); r.text = "not json at all"; return r
+
+    cypher, params = generate_grounded_cypher(_Bad({}), "q", "schema")
+    assert cypher == "" and params == {}


### PR DESCRIPTION
## Ontology-grounded text2cypher for the structured engine (ADR-0208, live-validated)

The **first live e2e smoke** of `engine="structured"` against **DozerDB + MARA** proved the path runs — and exposed the real gap: the governed arm **abstained** on an answerable question because the default (deterministic-planner) cypher generator emitted **undeclared properties + inlined literals + no tenant scope**, so the guardrail (rightly) rejected it. That is exactly the **Plane-2 confound** the e2e review warned about (governed looks "worse" for the wrong reason).

### Fix
`generate_grounded_cypher(llm, question, schema_text, *, workspace_id, limit) -> (cypher, params)` — guardrail-conformant **by construction** from the pinned schema (ADR-0201):
- declared identifiers only; every value a `$param` (never inlined);
- `{_workspace_id: $workspace_id}` on **every** node (so the store's `verify_workspace_binding` passes — every RETURNed node scoped, not just the anchor); `LIMIT $limit`;
- returns the value params, which `StructuredQueryOrchestrator` threads into **both** the guardrail check and the governed execute (a value never has to be inlined to run). Now the structured engine's default generator; back-compat with bare-string generators.

### Live validation (DozerDB + MARA)
Governed arm produced `MATCH (i:Incident {_workspace_id:$workspace_id})-[:AFFECTS]->(c:Company {_workspace_id:$workspace_id, name:$company_name}) RETURN i LIMIT $limit`, guardrail `allowed:1 / rejected:0`, store filter passed, **correct answer** (the real incident) — vs the ungoverned deterministic path's run-to-run confabulation. The Plane-2 blocker (governed spuriously abstaining) is removed, and the ADR-0191 "ontology grounds the query" thesis is now wired into the **runtime**, satisfying BOTH governance gates (ontology guardrail + store workspace-binding proof).

### Validation
3 unit tests (prompt contract, param hygiene incl. stripping runtime-bound params, malformed→empty); orchestrator/engine suites green (13); `ruff` clean; `check_adr_index` 208. Reproducible asset: `scripts/agentos/e2e_structured_smoke.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
