### PR TITLE
feat(query): text2cypher repair loop — feed guardrail rejections back (ADR-0209)

### DIFF
--- a/docs/decisions/ADR-0209-text2cypher-repair-loop.md
+++ b/docs/decisions/ADR-0209-text2cypher-repair-loop.md
@@ -1,0 +1,32 @@
+# ADR-0209: text2cypher repair loop — feed guardrail rejections back for a retry
+
+- Status: accepted
+- Date: 2026-08-16
+- Tickets: seocho-ia4.13 (text2cypher)
+- Related: ADR-0208 (grounded text2cypher), ADR-0189 (profile gate)
+
+## Context
+
+ADR-0208 made the structured engine's generator conformant-by-prompt, and named a repair loop
+as the natural follow-up: an LLM can still emit non-conformant Cypher on a harder schema, and
+without a retry the governed arm abstains on an answerable question — the Plane-2 confound
+(governed looks worse for a generator defect, not for governance).
+
+## Decision
+
+`StructuredQueryOrchestrator` gains a `repair_budget` (default 0 = off; the local engine sets
+1). When the guardrail rejects the generated Cypher, the orchestrator feeds the **violation
+reasons + the rejected query** back to the generator (`generate_grounded_cypher(..., feedback=)`)
+and retries, up to the budget, before abstaining. `_call_gen` passes `feedback=` when the
+generator accepts it and falls back for a 2-arg test double, so injected generators stay
+compatible. `StructuredQueryResult.repair_attempts` records how many retries were spent.
+
+## Consequences
+
+- A fixable non-conformance (a missing workspace scope on one node, an inlined literal) is
+  repaired instead of forcing an abstain, so the governed arm's answer/abstain reflects
+  GOVERNANCE, not a one-shot generator miss — removing the confound before the Plane-2 A/B.
+- Bounded + honest: after `repair_budget` retries a still-rejected query abstains (a rejection
+  is still reported as a rejection, ADR-0205 D5); `repair_attempts` is measurable per request.
+- 3 tests: repair recovers a rejected query (feedback seen, attempts=1, executes), no-budget =
+  no-repair, gives-up-after-budget. Orchestrator/engine/generator suites green (16).

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1265,6 +1265,12 @@ Each entry must link to a full ADR when impact is non-trivial.
   - generate_grounded_cypher(llm, question, schema_text, *, workspace_id, limit) -> (cypher, params): declared ids only, every value a $param (no inlined literal), {_workspace_id:$workspace_id} on EVERY node (satisfies store verify_workspace_binding, not just the anchor), LIMIT $limit; returns value params. Now the structured engine's default generator; orchestrator threads (cypher,params) into guardrail + governed execute (back-compat with bare-string generators)
   - LIVE-VALIDATED (DozerDB+MARA): governed arm produced conformant workspace-scoped Cypher, guardrail allowed:1/rejected:0, store filter passed, CORRECT answer (real incident) vs deterministic confabulation. Plane-2 blocker removed. wires the ADR-0191 grounding thesis into the runtime. 3 unit tests; orchestrator/engine green (13). asset: scripts/agentos/e2e_structured_smoke.py
 
+## 2026-08-16 (structured runtime: text2cypher repair loop)
+
+- [Accepted] ADR-0209 text2cypher repair loop (seocho-ia4.13)
+  - StructuredQueryOrchestrator.repair_budget (default 0; local engine sets 1): on a guardrail rejection, feed the violation reasons + rejected query back to generate_grounded_cypher(feedback=) and retry up to budget before abstaining; _call_gen keeps 2-arg test doubles compatible; StructuredQueryResult.repair_attempts records retries
+  - removes the Plane-2 confound (governed abstaining on a fixable one-shot miss); bounded + honest (still abstains after budget). 3 tests; structured suites green (16)
+
 ## Template
 
 Use this block for new entries:

--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -112,6 +112,7 @@ class _LocalEngine:
         self._pinned_schema_resolver: Any = None
         self._structured_cypher_generator: Any = None
         self._structured_synthesizer: Any = None
+        self._structured_repair_budget = 1   # guardrail-reject -> retry-with-feedback (ADR-0209)
         self._events = NullEventPublisher()
         self._ingest_request_cls = IngestRequest
 
@@ -728,14 +729,16 @@ class _LocalEngine:
         if gen is None:
             from .query.grounded_text2cypher import generate_grounded_cypher
 
-            def gen(question: str, schema_text: str):  # noqa: E306
+            def gen(question: str, schema_text: str, feedback=None):  # noqa: E306
                 # Ontology-grounded, guardrail-conformant: declared identifiers,
                 # $params (no inlined literals), $workspace_id scope, LIMIT $limit —
                 # so the governed guardrail passes it instead of rejecting the
                 # deterministic planner's non-conformant Cypher (the live-smoke gap).
+                # `feedback` carries a prior guardrail rejection for the repair loop.
                 return generate_grounded_cypher(
                     self.llm, question, schema_text,
-                    workspace_id=self.workspace_id, limit=getattr(self, "row_cap", 50))
+                    workspace_id=self.workspace_id, limit=getattr(self, "row_cap", 50),
+                    feedback=feedback)
         synth = self._structured_synthesizer
         if synth is None:
             answerer = QueryAnswerSynthesizer(query_strategy=self._query, llm=self.llm)
@@ -771,6 +774,7 @@ class _LocalEngine:
             resolver=self._pinned_schema_resolver,
             get_schema_fn=lambda: self._get_schema_info(database),
             database=database,
+            repair_budget=getattr(self, "_structured_repair_budget", 1),
         )
         result = orchestrator.answer(question, run_context, workspace_id=self.workspace_id)
         if ledger is not None:

--- a/src/seocho/query/grounded_text2cypher.py
+++ b/src/seocho/query/grounded_text2cypher.py
@@ -62,6 +62,20 @@ def _extract_json(text: str) -> Dict[str, Any]:
         return {}
 
 
+def _feedback_note(feedback: Any) -> str:
+    """A retry directive built from the guardrail's rejection of a prior attempt."""
+    if not feedback:
+        return ""
+    prior = str((feedback or {}).get("prior_cypher", ""))[:400]
+    viols = ", ".join(str(v) for v in (feedback or {}).get("violations", []))[:400]
+    return ("\n\nYOUR PREVIOUS QUERY WAS REJECTED — fix it and try again.\n"
+            f"Rejected query: {prior}\n"
+            f"Violations (each MUST be fixed): {viols}\n"
+            "Common fixes: use only SCHEMA identifiers; add "
+            "`{_workspace_id: $workspace_id}` to EVERY node; replace every inlined "
+            "literal with a `$param`; end with `LIMIT $limit`.")
+
+
 def generate_grounded_cypher(
     llm: Any,
     question: str,
@@ -69,12 +83,14 @@ def generate_grounded_cypher(
     *,
     workspace_id: str = "default",
     limit: int = 50,
+    feedback: Any = None,
 ) -> Tuple[str, Dict[str, Any]]:
     """Generate guardrail-conformant Cypher + its value params for ``question``,
     grounded in ``schema_text`` (the pinned-schema block). Returns
     ``(cypher, params)``; ``params`` excludes ``workspace_id``/``limit`` (the
-    orchestrator binds those)."""
-    system = build_text2cypher_system_prompt(schema_text)
+    orchestrator binds those). ``feedback`` (a prior rejection) drives a repair
+    retry that names the violations to fix."""
+    system = build_text2cypher_system_prompt(schema_text) + _feedback_note(feedback)
     try:
         resp = complete_with_task_hints(
             llm, system=system, user=question, temperature=0.0,

--- a/src/seocho/query/structured_orchestrator.py
+++ b/src/seocho/query/structured_orchestrator.py
@@ -40,6 +40,7 @@ class StructuredQueryResult:
     guardrail_on: bool = False
     guardrail_violations: Tuple[str, ...] = ()
     guardrail_rejected: bool = False
+    repair_attempts: int = 0
     arm: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
@@ -51,6 +52,7 @@ class StructuredQueryResult:
             "guardrail_on": self.guardrail_on,
             "guardrail_violations": list(self.guardrail_violations),
             "guardrail_rejected": self.guardrail_rejected,
+            "repair_attempts": self.repair_attempts,
         }
 
 
@@ -75,6 +77,7 @@ class StructuredQueryOrchestrator:
         get_schema_fn: Optional[Callable[[], Dict[str, Any]]] = None,
         database: str = "neo4j",
         row_cap: int = 50,
+        repair_budget: int = 0,
     ) -> None:
         self.arm = arm
         self.graph_store = graph_store
@@ -85,6 +88,7 @@ class StructuredQueryOrchestrator:
         self._get_schema_fn = get_schema_fn or (lambda: graph_store.get_schema(database=database))
         self.database = database
         self.row_cap = row_cap
+        self.repair_budget = max(0, int(repair_budget))   # guardrail-reject -> retry-with-feedback
 
     # -- schema organ (pinned frozen snapshot vs real introspection) ----------
     def _resolve_schema(self, run_context: Any) -> Tuple[str, Any, str, str]:
@@ -117,25 +121,39 @@ class StructuredQueryOrchestrator:
             cypher, params={**gen_params, "limit": self.row_cap}, database=self.database
         )
 
+    def _call_gen(self, question: str, schema_text: str, feedback: Any):
+        """Call the generator, passing repair ``feedback`` when it accepts it
+        (the grounded generator does; a 2-arg test double does not)."""
+        try:
+            gen_out = self._gen(question, schema_text, feedback=feedback)
+        except TypeError:
+            gen_out = self._gen(question, schema_text)
+        if isinstance(gen_out, tuple):
+            return (gen_out[0] or ""), (gen_out[1] or {})
+        return (gen_out or ""), {}
+
     def answer(self, question: str, run_context: Any, *, workspace_id: str) -> StructuredQueryResult:
         schema_text, policy, source, version = self._resolve_schema(run_context)
-        gen_out = self._gen(question, schema_text)        # retrieve step (no prose)
-        # the generator may return just a cypher string (back-compat) or
-        # (cypher, params) — the grounded generator returns value params so no
-        # literal is inlined (guardrail rule) yet the query stays executable.
-        if isinstance(gen_out, tuple):
-            cypher, gen_params = gen_out[0], (gen_out[1] or {})
-        else:
-            cypher, gen_params = gen_out, {}
-        cypher = cypher or ""
 
+        # Retrieve step (no prose), with a repair loop: when the guardrail rejects
+        # the generated Cypher, feed the violation reasons back for a retry (up to
+        # repair_budget) so a fixable non-conformance does not force an abstain —
+        # the governed arm then differs by GOVERNANCE, not a generator defect.
         violations: Tuple[str, ...] = ()
-        rejected = False
-        if self.arm.guardrail:
+        cypher, gen_params, feedback, attempts = "", {}, None, 0
+        while True:
+            cypher, gen_params = self._call_gen(question, schema_text, feedback)
+            if not self.arm.guardrail:
+                violations = ()
+                break
             violations = tuple(validate_text2cypher_fallback(
                 cypher, params={**gen_params, "workspace_id": workspace_id, "limit": 1},
                 policy=policy))
-            rejected = bool(violations)
+            if not violations or attempts >= self.repair_budget:
+                break
+            feedback = {"prior_cypher": cypher, "violations": list(violations)}
+            attempts += 1
+        rejected = bool(violations)
 
         rows = [] if rejected else self._execute(cypher, workspace_id, gen_params)
         answer = self._synth(question, rows)              # the ONLY prose writer (B5)
@@ -144,5 +162,5 @@ class StructuredQueryOrchestrator:
             answer=answer, cypher=cypher, rows=rows, schema_source=source,
             pinned_version=version, workspace_enforced=self.arm.workspace_enforce,
             guardrail_on=self.arm.guardrail, guardrail_violations=violations,
-            guardrail_rejected=rejected, arm=self.arm.name,
+            guardrail_rejected=rejected, repair_attempts=attempts, arm=self.arm.name,
         )

--- a/tests/seocho/test_repair_loop.py
+++ b/tests/seocho/test_repair_loop.py
@@ -1,0 +1,70 @@
+"""text2cypher repair loop: a guardrail rejection is fed back for a retry, so a
+fixable non-conformance does not force an abstain (ADR-0208 follow-up)."""
+
+from __future__ import annotations
+
+from seocho.ontology import NodeDef, Ontology, P
+from seocho.ontology.run_context import OntologyRunContext
+from seocho.query.arm_config import ArmConfig
+from seocho.query.structured_orchestrator import StructuredQueryOrchestrator
+
+SAFE = "MATCH (c:Company {_workspace_id: $workspace_id, name: $n}) RETURN c.name AS name LIMIT $limit"
+UNSAFE = "MATCH (f:Foo) RETURN f LIMIT $limit"
+
+
+def _onto():
+    return Ontology("t", package_id="t", version="1.0.0", nodes={
+        "Company": NodeDef(description="c", properties={"name": P(str, unique=True)})})
+
+
+class _FakeGraph:
+    def __init__(self): self.calls = []
+    def query(self, cypher, **k): self.calls.append(cypher); return [{"c": {"name": "Acme"}}]
+    def get_schema(self, *, database="neo4j"): return {"labels": ["Company"], "relationship_types": []}
+
+
+class _RepairableGen:
+    """Emits UNSAFE first; once it sees repair feedback, emits SAFE."""
+    def __init__(self): self.calls = 0; self.saw_feedback = False
+    def __call__(self, question, schema_text, feedback=None):
+        self.calls += 1
+        if feedback:
+            self.saw_feedback = True
+            return SAFE, {"n": "Acme"}
+        return UNSAFE, {}
+
+
+def _orch(arm, gen, graph, budget):
+    return StructuredQueryOrchestrator(
+        arm=arm, graph_store=graph, ontology=_onto(), cypher_generator=gen,
+        synthesizer=lambda q, rows: f"answer:{len(rows)}", repair_budget=budget)
+
+
+def _ctx():
+    return OntologyRunContext(workspace_id="acme", ontology_id="t")
+
+
+def test_repair_recovers_a_rejected_query():
+    g, gen = _FakeGraph(), _RepairableGen()
+    orch = _orch(ArmConfig.governed(), gen, g, budget=1)
+    r = orch.answer("who is Acme?", _ctx(), workspace_id="acme")
+    assert gen.saw_feedback, "the guardrail violations were fed back for a retry"
+    assert r.repair_attempts == 1
+    assert not r.guardrail_rejected, "the repaired query passed the guardrail"
+    assert len(g.calls) == 1 and r.answer == "answer:1"
+
+
+def test_no_budget_means_no_repair():
+    g, gen = _FakeGraph(), _RepairableGen()
+    orch = _orch(ArmConfig.governed(), gen, g, budget=0)
+    r = orch.answer("who is Acme?", _ctx(), workspace_id="acme")
+    assert r.repair_attempts == 0 and r.guardrail_rejected
+    assert gen.calls == 1 and len(g.calls) == 0
+
+
+def test_repair_gives_up_after_budget_if_still_bad():
+    g = _FakeGraph()
+    always_bad = lambda q, s, feedback=None: (UNSAFE, {})  # noqa: E731
+    orch = _orch(ArmConfig.governed(), always_bad, g, budget=2)
+    r = orch.answer("q", _ctx(), workspace_id="acme")
+    assert r.repair_attempts == 2 and r.guardrail_rejected and len(g.calls) == 0


### PR DESCRIPTION
Organ 1/4 of the remaining set. On a guardrail rejection the orchestrator feeds the violation reasons + rejected query back to `generate_grounded_cypher(feedback=)` and retries up to `repair_budget` (default 0; local engine sets 1) before abstaining. Removes the Plane-2 confound (governed abstaining on a fixable one-shot generator miss, not for governance); bounded + honest (still abstains after budget; records `repair_attempts`). 3 tests; structured suites green (16). ADR-0209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)