### PR TITLE
fix(index): honour a declared generic Entity class; fold over-specified labels

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -140,6 +140,7 @@ uv run pytest \
   tests/seocho/test_e2e_runner.py \
   tests/seocho/test_scaffold.py \
   tests/seocho/test_ontology_enforcement.py \
+  tests/seocho/test_generic_label_coercion.py \
   tests/seocho/test_run_template.py \
   tests/seocho/test_sweep.py \
   tests/seocho/test_entity_identity.py \

--- a/src/seocho/index/extraction_engine.py
+++ b/src/seocho/index/extraction_engine.py
@@ -34,8 +34,24 @@ _ONTOLOGY_RELAXED_RETRY_GUIDANCE = (
 _STRICT_VOCABULARY_GUIDANCE = (
     "Closed vocabulary: only use the entity and relationship types listed "
     "above. If something in the text does not fit a listed type, omit it. "
-    "Never use the generic 'Entity' label. An empty result is acceptable "
-    "when nothing in the text fits the listed types."
+    "An empty result is acceptable when nothing in the text fits the listed "
+    "types."
+)
+# Appended ONLY when the ontology does not declare a class literally named
+# `Entity`. The base guidance forbids inventing types; this line additionally
+# forbids the lazy `Entity` fallback that collapses a rich schema (FIBO's many
+# classes) into one bucket. But an open-domain ontology whose single declared
+# class IS `Entity` -- the generic who/what/how-related schema the benchmark
+# corpora need -- was being told never to use its own only label, so the
+# extractor invented Place/Person/Value from the `kind` hint instead. The
+# query side then MATCHed (:Entity) against a graph that had none, and every
+# such question returned no result. This clause is gated on a single fact --
+# is `Entity` a declared label -- not on ontology structure, so the
+# extraction-firewall invariant (rendered context byte-identical under
+# broader/same_as enrichment) is untouched.
+_NO_GENERIC_ENTITY_CLAUSE = (
+    "Do not fall back to a generic 'Entity' label; use one of the listed "
+    "types or omit the node."
 )
 
 
@@ -84,6 +100,10 @@ class CanonicalExtractionEngine:
         )
         if self.enforcement_policy.prompt_strict and self.ontology is not None:
             system = f"{system}\n\n{_STRICT_VOCABULARY_GUIDANCE}"
+            declared = {str(lbl).strip().lower()
+                        for lbl in (getattr(self.ontology, "nodes", None) or {})}
+            if "entity" not in declared:
+                system = f"{system} {_NO_GENERIC_ENTITY_CLAUSE}"
         response = complete_with_task_hints(
             self.llm,
             system=system,

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -424,6 +424,50 @@ class IndexingPipeline:
                 entity_ids.append(node_id)
         return entity_ids
 
+    def _coerce_generic_labels(
+        self, nodes: Sequence[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Fold an over-specified label onto a declared generic class.
+
+        A generic open-domain ontology declares one catch-all class -- `Entity`
+        with a `kind` property whose description enumerates person/place/etc --
+        precisely so the specific type lives in `kind`, not in the label. But a
+        model with no grammar enforcement (any hosted endpoint) reads that
+        enumeration and promotes it: it emits label="Place", label="Person",
+        which the query side, matching (:Entity), cannot find. Measured over ten
+        benchmark documents, this was the dominant failure -- 8 of 10 questions
+        returned no result against graphs full of correctly-extracted facts
+        under the wrong labels.
+
+        So when a node's label is not declared but the ontology has a class
+        literally named `Entity`, the node is relabelled to `Entity` and the
+        emitted label is preserved as `kind` (never overwriting a kind the model
+        already set). The specificity is not lost, it moves to where the
+        ontology said it belongs.
+
+        A no-op for a rich ontology: with no `Entity` class declared, an
+        off-ontology label still falls through to the existing validation, which
+        warns or rejects it per enforcement mode. Coercion needs a catch-all to
+        coerce onto, and only the generic ontology has one.
+        """
+        ontology_nodes = getattr(self.ontology, "nodes", None) or {}
+        declared = set(ontology_nodes)
+        if "Entity" not in declared:
+            return list(nodes)
+
+        coerced: List[Dict[str, Any]] = []
+        for node in nodes:
+            label = str(node.get("label", "")).strip()
+            if (label and label != "Entity" and label not in declared
+                    and not self._system_layer_label(label)):
+                node = dict(node)
+                props = dict(node.get("properties") or {})
+                props.setdefault("kind", label)
+                node["properties"] = props
+                node["label"] = "Entity"
+            coerced.append(node)
+        return coerced
+
     def _coerce_chunk_records(
         self,
         *,
@@ -871,6 +915,9 @@ class IndexingPipeline:
                 if not nodes and not rels:
                     result.skipped_chunks += 1
                     continue
+
+            # Coerce over-specified labels onto a declared generic class.
+            nodes = self._coerce_generic_labels(nodes)
 
             # --- Callback: on_after_extract ---
             if self.on_after_extract:

--- a/tests/seocho/test_generic_label_coercion.py
+++ b/tests/seocho/test_generic_label_coercion.py
@@ -1,0 +1,153 @@
+"""An over-specified label folds onto a declared generic class.
+
+A generic open-domain ontology declares one catch-all class -- `Entity` with a
+`kind` property whose description enumerates person/place/organisation/etc --
+precisely so the specific type lives in `kind`, not in the label. A hosted model
+with no grammar enforcement reads that enumeration and promotes it: it emits
+`label="Place"`, `label="Person"`, which the query side (matching `(:Entity)`)
+cannot find.
+
+Measured over ten benchmark documents on a live MARA MiniMax-M2.7 run, this was
+the dominant failure: 8 of 10 questions returned no result against graphs full
+of correctly-extracted facts sitting under the wrong labels
+(`Place:34, Organisation:4, Person:3, ...` with `Entity:0`).
+
+Two prior guards did not catch it:
+  - the extraction prompt already lists `Entity` as the only type, and the
+    model ignored it (no grammar on a hosted endpoint);
+  - `off_ontology_label` counted the deviation but, under the default guided
+    enforcement, the nodes were still written.
+
+So the pipeline folds the emitted label back onto `Entity` and preserves it as
+`kind`. The specificity is not lost; it moves to where the ontology said it
+belongs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+from seocho.index.pipeline import IndexingPipeline
+
+
+def _generic() -> Ontology:
+    return Ontology(
+        name="generic",
+        nodes={"Entity": NodeDef(
+            description="A named thing: person, place, organisation, concept.",
+            properties={"name": P(str, unique=True), "kind": P(str)},
+            identity_keys=["name"])},
+        relationships={"RELATED_TO": RelDef(source="Entity", target="Entity",
+                                            description="A stated relationship.")},
+    )
+
+
+def _rich() -> Ontology:
+    return Ontology(
+        name="rich",
+        nodes={
+            "Company": NodeDef(properties={"name": P(str, unique=True)}),
+            "Person": NodeDef(properties={"name": P(str, unique=True)}),
+        },
+        relationships={},
+    )
+
+
+def _pipe(onto):
+    # graph_store/llm are unused by _coerce_generic_labels.
+    return IndexingPipeline(ontology=onto, graph_store=object(), llm=object())
+
+
+def test_off_label_is_folded_onto_entity():
+    pipe = _pipe(_generic())
+    nodes = [{"id": "n1", "label": "Place",
+              "properties": {"name": "Cornwall"}}]
+    out = pipe._coerce_generic_labels(nodes)
+    assert out[0]["label"] == "Entity"
+    assert out[0]["properties"]["kind"] == "Place", (
+        "the emitted specificity must be preserved in kind, not discarded"
+    )
+
+
+def test_declared_label_is_untouched():
+    pipe = _pipe(_generic())
+    nodes = [{"id": "n1", "label": "Entity",
+              "properties": {"name": "x", "kind": "plant"}}]
+    out = pipe._coerce_generic_labels(nodes)
+    assert out[0]["label"] == "Entity"
+    assert out[0]["properties"]["kind"] == "plant", "an existing kind is kept"
+
+
+def test_a_kind_the_model_set_is_not_overwritten():
+    pipe = _pipe(_generic())
+    nodes = [{"id": "n1", "label": "Place",
+              "properties": {"name": "Cornwall", "kind": "county"}}]
+    out = pipe._coerce_generic_labels(nodes)
+    assert out[0]["properties"]["kind"] == "county", (
+        "coercion must not clobber a kind the model already provided"
+    )
+
+
+def test_provenance_labels_are_not_coerced():
+    pipe = _pipe(_generic())
+    nodes = [{"id": "c1", "label": "Chunk", "properties": {}}]
+    out = pipe._coerce_generic_labels(nodes)
+    assert out[0]["label"] == "Chunk", "the provenance layer is not the model's"
+
+
+def test_rich_ontology_is_a_no_op():
+    """No catch-all to coerce onto: off-ontology labels fall through to the
+    existing validation, which warns or rejects per enforcement mode."""
+    pipe = _pipe(_rich())
+    nodes = [{"id": "n1", "label": "Place", "properties": {"name": "x"}}]
+    out = pipe._coerce_generic_labels(nodes)
+    assert out[0]["label"] == "Place", (
+        "a rich ontology must keep its off-label handling; coercion needs a "
+        "declared Entity class and this one has none"
+    )
+
+
+def test_declared_labels_in_a_mixed_ontology_survive():
+    """If Entity is one of several declared classes, the others still pass."""
+    onto = Ontology(
+        name="mixed",
+        nodes={
+            "Entity": NodeDef(properties={"name": P(str, unique=True), "kind": P(str)}),
+            "Company": NodeDef(properties={"name": P(str, unique=True)}),
+        },
+        relationships={},
+    )
+    out = _pipe(onto)._coerce_generic_labels([
+        {"id": "1", "label": "Company", "properties": {"name": "Acme"}},
+        {"id": "2", "label": "Place", "properties": {"name": "Cornwall"}},
+    ])
+    labels = {n["id"]: n["label"] for n in out}
+    assert labels["1"] == "Company", "a declared label must not be coerced"
+    assert labels["2"] == "Entity", "an undeclared label folds onto Entity"
+
+
+def test_the_prompt_stops_forbidding_a_declared_entity():
+    """The other half of the fix: strict guidance no longer tells a generic
+    ontology never to use its own only label."""
+    from seocho.index.extraction_engine import CanonicalExtractionEngine
+
+    class _LLM:
+        def __init__(self):
+            self.calls = []
+
+        def complete(self, *, system, user, **kw):
+            self.calls.append(system)
+
+            class _R:
+                text = '{"nodes": [], "relationships": []}'
+
+                def json(self):
+                    return {"nodes": [], "relationships": []}
+            return _R()
+
+    llm = _LLM()
+    engine = CanonicalExtractionEngine(ontology=_generic(), llm=llm,
+                                       enforcement="strict")
+    engine.extract("Some text.")
+    assert "Do not fall back to a generic 'Entity'" not in llm.calls[0]

--- a/tests/seocho/test_ontology_enforcement.py
+++ b/tests/seocho/test_ontology_enforcement.py
@@ -203,7 +203,33 @@ def test_strict_disables_relaxed_retry_and_adds_constant_prompt_line() -> None:
     assert result == {"nodes": [], "relationships": []}
     assert len(llm.calls) == 1  # no relaxed retry call
     assert "Closed vocabulary" in llm.calls[0]["system"]
-    assert "Never use the generic 'Entity' label" in llm.calls[0]["system"]
+    # This ontology declares Company/etc but NOT a class named Entity, so the
+    # no-generic-Entity clause applies and forbids the lazy fallback.
+    assert "generic 'Entity'" in llm.calls[0]["system"]
+
+
+def test_declared_entity_class_is_not_forbidden() -> None:
+    """An open-domain ontology whose only class is `Entity` must be allowed to
+    use it. The unconditional 'Never use Entity' line told the extractor to
+    forbid its own only label, so it invented Place/Person/Value from the
+    `kind` hint and the query side matched (:Entity) against a graph with none.
+    """
+    from seocho import Ontology, NodeDef, P
+    entity_onto = Ontology(
+        name="generic",
+        nodes={"Entity": NodeDef(properties={"name": P(str, unique=True),
+                                             "kind": P(str)})},
+        relationships={},
+    )
+    llm = _RecordingLLM([{"nodes": [], "relationships": []}])
+    engine = CanonicalExtractionEngine(ontology=entity_onto, llm=llm,
+                                       enforcement="strict")
+    engine.extract("Some text.")
+    system = llm.calls[0]["system"]
+    assert "Closed vocabulary" in system, "base guidance must still apply"
+    assert "Do not fall back to a generic 'Entity'" not in system, (
+        "the extractor was told to forbid the ontology's only declared label"
+    )
 
 
 def test_guided_keeps_relaxed_retry_and_plain_prompt() -> None:


### PR DESCRIPTION
Found by **broadening the benchmark e2e to 10 documents** (5 ERB + 5 GraphRAG-Bench) and watching where failures fell. **8 of 10 questions returned no result** — not from bad retrieval, but from a graph full of correctly-extracted facts under the **wrong labels**:

```
Place:34  Organisation:4  Person:3  ...   Entity:0
```

against a query side matching `(:Entity)`.

Two faults, both in the indexing layer.

## 1. The strict prompt forbade the ontology's own only label

`_STRICT_VOCABULARY_GUIDANCE` said, unconditionally, *"Never use the generic 'Entity' label."* Right for a rich ontology (FIBO's many classes) — it stops the model collapsing everything into one bucket. Exactly **wrong** for a generic open-domain ontology whose single declared class *is* `Entity`, because it tells the extractor to forbid its only valid label. So the model invented `Place`/`Person`/`Value` from the `kind` hint.

The clause is now appended **only when the ontology does not declare a class named `Entity`**. Gated on one fact — is `Entity` a declared label — not on ontology structure, so the extraction-firewall invariant (`to_extraction_context` byte-identical under `broader`/`same_as` enrichment) is untouched. That suite still passes.

## 2. Necessary but not sufficient — a hosted model over-specifies anyway

No grammar enforcement on a hosted endpoint, so even with the prompt fixed the model emits `Place`/`Person`. The ontology declares `Entity` with a `kind` property whose description enumerates person/place/organisation — the specific type is **meant** to live in `kind`, not the label.

The pipeline now folds an off-ontology label onto `Entity` and preserves the emitted label as `kind` (never overwriting a kind the model set).

**Measured live after:** labels `Place:34/Person:3/…` → `Entity:42`, off-ontology label count `5 → 0`, and the answer entity (`erica vagans`) was found.

A **no-op for a rich ontology**: no `Entity` class to coerce onto, so an off-label still falls through to existing validation and warns/rejects per enforcement mode.

## An honest correction from the broadening

Several bench "no results" were my **e2e harness truncating** the source doc to its first 4000 chars — for a public-domain novel, that's the copyright/front-matter, not the narrative. Indexing the answer-bearing window found the entity. The residual gap there — the extractor didn't emit the "is also known as" `RELATED_TO` edge between `erica vagans` and `Cornish heath` — is a **relationship-recall** issue, tracked separately, not a labelling one.

## Validation

```
live MARA MiniMax-M2.7 + DozerDB 5.26.3: Entity:0 -> Entity:42, off_label 5->0
pytest test_generic_label_coercion   -> 7 passed
pytest 5 extraction/indexing suites  -> 50 passed
bash scripts/ci/run_basic_ci.sh      -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)