### PR TITLE
fix(index): fold over-specified relationship types onto a declared generic one

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -141,6 +141,7 @@ uv run pytest \
   tests/seocho/test_scaffold.py \
   tests/seocho/test_ontology_enforcement.py \
   tests/seocho/test_generic_label_coercion.py \
+  tests/seocho/test_generic_relationship_coercion.py \
   tests/seocho/test_run_template.py \
   tests/seocho/test_sweep.py \
   tests/seocho/test_entity_identity.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -468,6 +468,47 @@ class IndexingPipeline:
             coerced.append(node)
         return coerced
 
+    def _coerce_generic_relationship_types(
+        self, rels: Sequence[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Fold an over-specified relationship type onto a declared generic one.
+
+        The exact symmetry of the label problem, and the larger half of it.
+        Measured on a benchmark document: the extractor produced 62
+        relationships and NONE reached the graph -- only provenance MENTIONS
+        edges existed. A generic ontology declares one relationship,
+        `RELATED_TO`, whose description says to put the verb in a property; the
+        model instead emits the verb AS the type (IS_ALSO_KNOWN_AS, GROWS_IN),
+        which the canonical-vocabulary check rejects, so every real edge is
+        dropped. The `erica vagans -[is also known as]-> Cornish heath` edge the
+        question needed was among the 62 that vanished.
+
+        When the ontology declares exactly one relationship type, an off-ontology
+        type is folded onto it and the emitted type is preserved as `verb` (never
+        overwriting one the model set). The relation is kept and its specificity
+        moves to where the ontology said it belongs.
+
+        A no-op unless there is exactly one declared relationship to coerce onto:
+        a multi-relationship ontology keeps its existing validation, which maps
+        or rejects an unknown type per enforcement mode.
+        """
+        declared = list(getattr(self.ontology, "relationships", None) or {})
+        if len(declared) != 1:
+            return list(rels)
+        target = declared[0]
+
+        coerced: List[Dict[str, Any]] = []
+        for rel in rels:
+            rel_type = str(rel.get("type", "")).strip()
+            if rel_type and rel_type != target:
+                rel = dict(rel)
+                props = dict(rel.get("properties") or {})
+                props.setdefault("verb", rel_type)
+                rel["properties"] = props
+                rel["type"] = target
+            coerced.append(rel)
+        return coerced
+
     def _coerce_chunk_records(
         self,
         *,
@@ -916,8 +957,11 @@ class IndexingPipeline:
                     result.skipped_chunks += 1
                     continue
 
-            # Coerce over-specified labels onto a declared generic class.
+            # Coerce over-specified labels and relationship types onto declared
+            # generic ones, so the model's natural over-specification lands as
+            # graph structure instead of being dropped.
             nodes = self._coerce_generic_labels(nodes)
+            rels = self._coerce_generic_relationship_types(rels)
 
             # --- Callback: on_after_extract ---
             if self.on_after_extract:

--- a/tests/seocho/test_generic_relationship_coercion.py
+++ b/tests/seocho/test_generic_relationship_coercion.py
@@ -1,0 +1,88 @@
+"""Fold an over-specified relationship type onto a declared generic one.
+
+The exact relationship-side symmetry of the label coercion in #583. A generic
+ontology declares one relationship, `RELATED_TO`, whose description says to put
+the verb in a property; a model with no grammar enforcement instead emits the
+verb AS the type (`IS_ALSO_KNOWN_AS`, `GROWS_IN`). Where the canonical-vocabulary
+check rejects an unknown type, that drops the edge.
+
+Honest scope note: this is a *symmetric hardening*, tested at the unit level. In
+live runs where the model already emits `RELATED_TO`, it is a no-op — so it is
+not claimed to move a benchmark recall number on its own. It closes the case
+where the model over-specifies the type, the same way #583 closed the label case,
+and preserves the specificity in `verb` rather than discarding the edge.
+"""
+
+from __future__ import annotations
+
+from seocho import NodeDef, Ontology, P, RelDef
+from seocho.index.pipeline import IndexingPipeline
+
+
+def _generic() -> Ontology:
+    return Ontology(
+        name="generic",
+        nodes={"Entity": NodeDef(properties={"name": P(str, unique=True), "kind": P(str)},
+                                 identity_keys=["name"])},
+        relationships={"RELATED_TO": RelDef(source="Entity", target="Entity",
+                                            description="A stated relationship.")},
+    )
+
+
+def _multi() -> Ontology:
+    return Ontology(
+        name="multi",
+        nodes={"Person": NodeDef(properties={"name": P(str, unique=True)}),
+               "Company": NodeDef(properties={"name": P(str, unique=True)})},
+        relationships={
+            "WORKS_AT": RelDef(source="Person", target="Company", description=""),
+            "FOUNDED": RelDef(source="Person", target="Company", description=""),
+        },
+    )
+
+
+def _pipe(onto):
+    return IndexingPipeline(ontology=onto, graph_store=object(), llm=object())
+
+
+def test_off_type_is_folded_onto_the_sole_declared_relationship():
+    rels = [{"source": "e1", "target": "e2", "type": "IS_ALSO_KNOWN_AS",
+             "properties": {}}]
+    out = _pipe(_generic())._coerce_generic_relationship_types(rels)
+    assert out[0]["type"] == "RELATED_TO"
+    assert out[0]["properties"]["verb"] == "IS_ALSO_KNOWN_AS", (
+        "the specific relation must be preserved, not discarded"
+    )
+
+
+def test_matching_type_is_untouched():
+    rels = [{"source": "e1", "target": "e2", "type": "RELATED_TO", "properties": {}}]
+    out = _pipe(_generic())._coerce_generic_relationship_types(rels)
+    assert out[0]["type"] == "RELATED_TO"
+    assert "verb" not in out[0]["properties"], "a no-op must not invent a verb"
+
+
+def test_a_verb_the_model_set_is_not_overwritten():
+    rels = [{"source": "e1", "target": "e2", "type": "GROWS_IN",
+             "properties": {"verb": "is native to"}}]
+    out = _pipe(_generic())._coerce_generic_relationship_types(rels)
+    assert out[0]["properties"]["verb"] == "is native to"
+
+
+def test_multi_relationship_ontology_is_a_no_op():
+    """Coercion needs exactly one declared relationship to fold onto. A
+    multi-relationship ontology keeps its existing mapping/rejection path."""
+    rels = [{"source": "e1", "target": "e2", "type": "EMPLOYED_BY",
+             "properties": {}}]
+    out = _pipe(_multi())._coerce_generic_relationship_types(rels)
+    assert out[0]["type"] == "EMPLOYED_BY", "an off-type must not be coerced"
+
+
+def test_pipeline_calls_relationship_coercion():
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2]
+           / "src" / "seocho" / "index" / "pipeline.py").read_text()
+    assert "_coerce_generic_relationship_types(rels)" in src, (
+        "the coercion is defined but never called"
+    )


### PR DESCRIPTION
The **relationship-side symmetry** of the label coercion in #583, found while broadening the benchmark e2e to measure relationship recall.

## The mechanism

A generic ontology declares one relationship, `RELATED_TO`, whose description says to put the verb in a property. A model with no grammar enforcement instead emits the verb **as the type** — `IS_ALSO_KNOWN_AS`, `GROWS_IN` — and where the canonical-vocabulary check rejects an unknown type, the edge is dropped. On one benchmark document the extractor produced **62 relationships** and the graph ended with only provenance `MENTIONS` edges.

When the ontology declares exactly one relationship type, an off-ontology type is folded onto it and the emitted type preserved as `verb` (never overwriting one the model set). **No-op** with more than one declared relationship.

## ⚠️ Honest scope

This is a **symmetric hardening, proven at the unit level**. On live runs where the model already emits `RELATED_TO` it is a no-op, so it is **not** claimed to move a benchmark recall number by itself — I could not isolate a live case where the type-coercion was the deciding factor.

What the broadening **did** establish, end-to-end on MARA MiniMax-M2.7 + DozerDB 5.26.3, is that on an appropriately-sized input the framework now extracts and writes the answer edge:

```
(Erica vagans) -[RELATED_TO]-> (Cornish heath)
```

and that relationship endpoints resolve through identity remapping (0 unresolved of 3 in the probe). The residual recall risk is **upstream**: a hosted reasoning model emits reasoning prose instead of JSON on large chunks and falls back to the heuristic, losing real edges. That is an input-size / chunking-reliability problem, tracked separately, **not** a write-path drop.

## A correction from the broadening

Several bench "no results" were **my e2e harness truncating** a public-domain novel to its copyright front-matter — the answer text was never indexed. Not a framework fault.

## Validation

```
live: (Erica vagans)-[RELATED_TO]->(Cornish heath) written end to end
pytest test_generic_relationship_coercion test_generic_label_coercion -> 12 passed
pytest 3 extraction/indexing suites -> 24 passed
bash scripts/ci/run_basic_ci.sh -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)