### PR TITLE
fix(index): recover a prose-not-JSON extraction by splitting, not the heuristic

### DIFF
--- a/scripts/ci/run_basic_ci.sh
+++ b/scripts/ci/run_basic_ci.sh
@@ -142,6 +142,7 @@ uv run pytest \
   tests/seocho/test_ontology_enforcement.py \
   tests/seocho/test_generic_label_coercion.py \
   tests/seocho/test_generic_relationship_coercion.py \
+  tests/seocho/test_extraction_split_retry.py \
   tests/seocho/test_run_template.py \
   tests/seocho/test_sweep.py \
   tests/seocho/test_entity_identity.py \

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -468,6 +468,55 @@ class IndexingPipeline:
             coerced.append(node)
         return coerced
 
+    def _extract_by_splitting(
+        self, text: str, *, category: str, metadata: Optional[Dict[str, Any]],
+        depth: int = 0,
+    ) -> Optional[Dict[str, Any]]:
+        """Recover a failed extraction by halving the chunk, or return None.
+
+        A hosted reasoning model that emits prose-not-JSON on a large chunk
+        usually emits clean JSON on a smaller one. Rather than fall straight to
+        the capitalized-token heuristic -- which loses every real relationship --
+        split at a paragraph or sentence boundary near the middle and extract
+        each half, merging the results.
+
+        Bounded: at most 2 splits deep, and text below _SPLIT_FLOOR chars is not
+        split (below that a failure is not size-related, so retrying smaller only
+        burns tokens). Returns None when splitting cannot help, so the caller
+        falls through to its existing heuristic/strict handling unchanged.
+        """
+        _SPLIT_FLOOR = 800
+        if depth >= 2 or len(text) <= _SPLIT_FLOOR:
+            return None
+
+        mid = len(text) // 2
+        # Prefer a paragraph break, then a sentence break, near the midpoint, so
+        # a relationship is not cut across the split.
+        for sep in ("\n\n", ". ", "\n", " "):
+            cut = text.rfind(sep, _SPLIT_FLOOR // 2, mid + mid // 2)
+            if cut > 0:
+                mid = cut + len(sep)
+                break
+        halves = [text[:mid].strip(), text[mid:].strip()]
+
+        merged: Dict[str, List[Any]] = {"nodes": [], "relationships": []}
+        recovered_any = False
+        for half in halves:
+            if not half:
+                continue
+            try:
+                part = self._graph_extraction.extract(
+                    half, category=category, metadata=metadata)
+            except Exception:  # noqa: BLE001 - this half may still be too big
+                part = self._extract_by_splitting(
+                    half, category=category, metadata=metadata, depth=depth + 1)
+                if part is None:
+                    continue
+            recovered_any = True
+            merged["nodes"].extend(part.get("nodes", []) or [])
+            merged["relationships"].extend(part.get("relationships", []) or [])
+        return merged if recovered_any else None
+
     def _coerce_generic_relationship_types(
         self, rels: Sequence[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
@@ -908,7 +957,27 @@ class IndexingPipeline:
                     )
                 extracted = response
             except Exception as exc:
-                if not self.enforcement_policy.allow_heuristic_fallback:
+                # A hosted reasoning model spends its budget thinking and, on a
+                # large chunk, emits reasoning prose with no JSON at all --
+                # measured live on MARA MiniMax-M2.7, "no JSON object found
+                # (head: 'Let me analyze this text carefully...')". The same
+                # model emits clean JSON on a smaller input. So before falling to
+                # the capitalized-token heuristic (which manufactures
+                # Entity/MENTIONS structure and loses every real relationship),
+                # try halving the chunk and extracting each part. This recovers
+                # real structure the heuristic cannot, and then falls through the
+                # normal downstream path exactly as a clean extraction would.
+                split = self._extract_by_splitting(
+                    chunk, category=category, metadata=metadata)
+                if split is not None:
+                    extracted = split
+                    try:
+                        get_metrics().add(
+                            "seocho.index.extraction.split_retry.count", 1,
+                            {"ontology": self.ontology.name})
+                    except Exception:  # noqa: BLE001 - telemetry never fails indexing
+                        pass
+                elif not self.enforcement_policy.allow_heuristic_fallback:
                     # seocho-snt strict: an LLM transport failure becomes a
                     # recorded error, not fabricated out-of-vocabulary graph
                     # structure.
@@ -919,17 +988,18 @@ class IndexingPipeline:
                     )
                     result.skipped_chunks += 1
                     continue
-                logger.warning(
-                    "LLM extraction failed for chunk %d, using heuristic fallback: %s",
-                    i, exc,
-                )
-                # Heuristic fallback — capture capitalized tokens as Entity
-                # nodes so the chunk produces *some* graph structure even
-                # without LLM access.  Marks the result as fallback_used for
-                # parity with server-side fallback_records tracking.
-                extracted = self._fallback_extract(chunk, source_id=source_id)
-                result.fallback_used = True
-                result.fallback_reason = f"{type(exc).__name__}: {str(exc)[:200]}"
+                else:
+                    logger.warning(
+                        "LLM extraction failed for chunk %d, using heuristic fallback: %s",
+                        i, exc,
+                    )
+                    # Heuristic fallback — capture capitalized tokens as Entity
+                    # nodes so the chunk produces *some* graph structure even
+                    # without LLM access.  Marks the result as fallback_used for
+                    # parity with server-side fallback_records tracking.
+                    extracted = self._fallback_extract(chunk, source_id=source_id)
+                    result.fallback_used = True
+                    result.fallback_reason = f"{type(exc).__name__}: {str(exc)[:200]}"
 
             nodes = extracted.get("nodes", [])
             rels = extracted.get("relationships", [])

--- a/tests/seocho/test_extraction_split_retry.py
+++ b/tests/seocho/test_extraction_split_retry.py
@@ -1,0 +1,121 @@
+"""A prose-not-JSON extraction failure is recovered by splitting, not discarded.
+
+A hosted reasoning model spends its output budget thinking and, on a large
+chunk, emits reasoning prose with no JSON at all -- measured live on MARA
+MiniMax-M2.7 ("no JSON object found (head: 'Let me analyze this text
+carefully...')"). The same model emits clean JSON on a smaller input.
+
+Before this, such a chunk fell straight to the capitalized-token heuristic,
+which manufactures Entity/MENTIONS structure and loses every real relationship.
+Now the pipeline halves the chunk and extracts each part first, so the real
+structure is recovered.
+
+Tested deterministically with a fake extractor that raises above a size
+threshold and returns JSON below it -- the exact shape of the live failure,
+without the live cost or non-determinism.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+from seocho.index.pipeline import IndexingPipeline
+
+
+class _SizeGatedExtractor:
+    """Raises on text longer than `limit`, returns JSON below it.
+
+    Mirrors a reasoning model that reasons past its token budget on large
+    inputs. Each successful call yields one node named after the first word,
+    so a caller can tell how many sub-extractions happened.
+    """
+
+    def __init__(self, limit: int):
+        self.limit = limit
+        self.calls = []
+
+    def extract(self, text, *, category="general", metadata=None):
+        self.calls.append(len(text))
+        if len(text) > self.limit:
+            raise ValueError("no JSON object found in response (reasoning prose)")
+        first = (text.strip().split() or ["x"])[0]
+        return {
+            "nodes": [{"id": first, "label": "Entity",
+                       "properties": {"name": first}}],
+            "relationships": [],
+        }
+
+    # The pipeline references these on the extraction engine.
+    def _normalize_relationship_type(self, raw):
+        return raw
+
+
+def _ontology():
+    return Ontology(
+        name="split",
+        nodes={"Entity": NodeDef(properties={"name": P(str, unique=True), "kind": P(str)},
+                                 identity_keys=["name"])},
+        relationships={"RELATED_TO": RelDef(source="Entity", target="Entity",
+                                            description="A relationship.")},
+    )
+
+
+def _pipe(limit):
+    pipe = IndexingPipeline(ontology=_ontology(), graph_store=object(), llm=object())
+    pipe._graph_extraction = _SizeGatedExtractor(limit)
+    return pipe
+
+
+def test_split_recovers_where_the_whole_chunk_failed():
+    """The whole text is too big; each half is small enough."""
+    # Halves must each exceed the 800-char split floor and stay under `limit`,
+    # so the whole (~1800) fails and each half (~900) succeeds.
+    pipe = _pipe(limit=1000)
+    text = ("Alpha " * 150).strip() + "\n\n" + ("Bravo " * 150).strip()
+    out = pipe._extract_by_splitting(text, category="general", metadata=None)
+    assert out is not None, "splitting a too-large chunk should recover structure"
+    names = {n["properties"]["name"] for n in out["nodes"]}
+    assert names == {"Alpha", "Bravo"}, "both halves must be extracted and merged"
+
+
+def test_returns_none_below_the_floor():
+    """A small chunk that still fails is not size-related; do not loop."""
+    pipe = _pipe(limit=0)  # everything fails
+    out = pipe._extract_by_splitting("short text", category="general", metadata=None)
+    assert out is None, "below the floor, splitting cannot help"
+
+
+def test_recursion_is_bounded():
+    """Everything fails; recursion must terminate and return None, not hang."""
+    pipe = _pipe(limit=0)
+    big = "word " * 2000  # 10k chars, always fails
+    out = pipe._extract_by_splitting(big, category="general", metadata=None)
+    assert out is None
+    # depth<=2 and floor stop it well short of one call per word.
+    assert len(pipe._graph_extraction.calls) < 20
+
+
+def test_partial_recovery_keeps_the_half_that_worked():
+    """If one half still fails past the depth bound, keep the half that parsed."""
+    # left half ~900 (parses at limit 1000), right half ~3000 (fails, and its
+    # sub-halves ~1500 also fail) -> keep the left.
+    pipe = _pipe(limit=1000)
+    text = ("Alpha " * 150).strip() + "\n\n" + ("Bravo " * 500).strip()
+    out = pipe._extract_by_splitting(text, category="general", metadata=None)
+    assert out is not None
+    names = {n["properties"]["name"] for n in out["nodes"]}
+    assert "Alpha" in names, "the half that parsed must be kept"
+
+
+def test_pipeline_tries_split_before_heuristic():
+    """The wiring: the split path runs before the capitalized-token fallback."""
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2]
+           / "src" / "seocho" / "index" / "pipeline.py").read_text()
+    exc_block = src[src.index("except Exception as exc:"):]
+    exc_block = exc_block[:exc_block.index("_fallback_extract")]
+    assert "_extract_by_splitting" in exc_block, (
+        "the heuristic fallback runs before the split retry is attempted"
+    )


### PR DESCRIPTION
The upstream recall risk the benchmark broadening surfaced.

## The failure

A hosted reasoning model spends its output budget thinking and, on a large chunk, emits **reasoning prose with no JSON at all** — measured live on MARA MiniMax-M2.7:

```
no JSON object found (head: 'Let me analyze this text carefully...')
```

The extraction call raised, and the pipeline fell **straight to the capitalized-token heuristic** — which manufactures `Entity`/`MENTIONS` structure and loses every real relationship. A silent recall collapse: the chunk's facts are simply gone.

## The lever is input size, not max_tokens

Extraction already gets `max_tokens=8192` for reasoning models. The same model emits clean JSON on a **smaller** input. So on an extraction exception, before the heuristic, the chunk is **halved at a paragraph/sentence boundary** and each part extracted, merging the results. Only if that also fails does the heuristic (or, under strict enforcement, a recorded skip) apply.

Bounded and safe:
- at most **2 splits deep**;
- no split below **800 chars** (a failure there isn't size-related — retrying smaller just burns tokens);
- **partial recovery** keeps the half that parsed;
- recursion verified to terminate well short of one call per word.

A recovered split emits `seocho.index.extraction.split_retry.count` so the rate is visible.

Recovered nodes/rels flow through the normal downstream path, so the label (#583) and relationship-type (#585) coercions apply to them too.

## Tested deterministically

A size-gated fake extractor — raises above a threshold, returns JSON below it — is the exact shape of the live failure without the live cost or non-determinism.

```
pytest test_extraction_split_retry -> 5 passed
pytest 5 extraction/indexing suites -> 31 passed
bash scripts/ci/run_basic_ci.sh -> passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)