### PR TITLE
fix(index): remap sequential-id relationship endpoints so domain edges persist

### DIFF
--- a/src/seocho/index/extraction_engine.py
+++ b/src/seocho/index/extraction_engine.py
@@ -293,13 +293,24 @@ class CanonicalExtractionEngine:
                 continue
             nodes.append(normalized)
             props = normalized.get("properties", {})
-            for key in (
+            new_id = str(normalized["id"])
+            keys = [
                 str(normalized.get("id", "")),
                 str(props.get("name", "")),
                 str(props.get("uri", "")),
-            ):
+            ]
+            # The original LLM id -- typically a sequential integer -- is what
+            # the model writes in relationship endpoints. _normalize_node
+            # replaces a sequential id with the entity name (cross-document
+            # collision avoidance, line 474), which drops the original->new
+            # mapping. Without this key, a relationship referencing "2" resolves
+            # to nothing, orphans, and the edge is silently lost -- the measured
+            # "47 extracted, 0 domain edges persisted" symptom. Key by it too.
+            if isinstance(raw_node, dict):
+                keys.append(str(raw_node.get("id", "")))
+            for key in keys:
                 if key:
-                    node_lookup[key] = str(normalized["id"])
+                    node_lookup[key] = new_id
 
         relationships = []
         for raw_rel in (raw_relationships or raw_triples):

--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -122,6 +122,8 @@ class IndexingResult:
     layered_graph_summary: Optional[Dict[str, Any]] = None
     fallback_used: bool = False
     fallback_reason: str = ""
+    # Domain-relationship survival count per write-path stage (diagnostic).
+    relationship_census: Dict[str, int] = field(default_factory=dict)
 
     # Materialised extracted graph payload — the post-write graph view that the
     # caller (e.g. ``_LocalEngine.add``) can surface to users via
@@ -684,6 +686,57 @@ class IndexingPipeline:
         except Exception as exc:
             logger.warning("Semantic artifact draft skipped: %s", exc)
 
+    #: Relationship types the pipeline writes for provenance, not extraction.
+    #: The census counts everything else -- the ontology's own edges, the ones
+    #: a question actually traverses.
+    _PROVENANCE_REL_TYPES = frozenset({
+        "MENTIONS", "HAS_CHUNK", "HAS_SECTION", "HAS_VERSION",
+        "CURRENT_VERSION", "HAS_OBSERVATION",
+    })
+
+    def _relcensus(self, result: IndexingResult, stage: str,
+                   rels: Sequence[Dict[str, Any]], *,
+                   already_domain: bool = False) -> None:
+        """Record how many domain (non-provenance) relationships survive a stage.
+
+        Stored on result.relationship_census and emitted as a metric, so one
+        live run shows exactly where between extraction and the store a real
+        edge is lost -- rather than inferring it from a 47->0 end state.
+        """
+        if already_domain:
+            count = len(rels)
+        else:
+            count = sum(
+                1 for r in rels
+                if str((r or {}).get("type") or "").strip()
+                not in self._PROVENANCE_REL_TYPES
+            )
+        census = getattr(result, "relationship_census", None)
+        if census is None:
+            census = {}
+            try:
+                result.relationship_census = census
+            except Exception:  # noqa: BLE001 - result is a dataclass; attr may be slotted
+                pass
+        census[stage] = count
+        try:
+            get_metrics().add(
+                "seocho.index.relationship_survival.count", count,
+                {"ontology": getattr(self.ontology, "name", "?"), "stage": stage})
+        except Exception:  # noqa: BLE001 - telemetry never fails indexing
+            pass
+
+    @staticmethod
+    def _resolvable_rels(nodes: Sequence[Dict[str, Any]],
+                         rels: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Rels whose BOTH endpoints match a node id present in the payload."""
+        ids = {str((n or {}).get("id")) for n in nodes}
+        out = []
+        for r in rels:
+            if str((r or {}).get("source")) in ids and str((r or {}).get("target")) in ids:
+                out.append(r)
+        return out
+
     def _shape_and_write_graph(
         self,
         *,
@@ -707,6 +760,14 @@ class IndexingPipeline:
         source_type = "text"
         if isinstance(metadata, dict):
             source_type = str(metadata.get("source_type") or "text")
+
+        # Relationship-survival census across the write path. The measured
+        # symptom was 47 relationships extracted and 0 domain edges persisted,
+        # non-deterministically -- so where in this pipeline a real edge is lost
+        # was unknown. Each stage records how many NON-provenance relationships
+        # (the ontology's own types, not MENTIONS/HAS_CHUNK/etc.) survive it, and
+        # every stage's count is emitted so a single live run pins the drop.
+        self._relcensus(result, "extracted", all_rels)
 
         if all_nodes or all_rels:
             try:
@@ -734,6 +795,7 @@ class IndexingPipeline:
                 result.layered_graph_summary = shaped.get("layered_graph_summary")
             except Exception as exc:
                 logger.warning("Memory graph shaping skipped: %s", exc)
+        self._relcensus(result, "after_memory_shaping", all_rels)
 
         if not (all_nodes or all_rels):
             return all_nodes, all_rels
@@ -743,6 +805,7 @@ class IndexingPipeline:
             all_rels,
             ontology_context,
         )
+        self._relcensus(result, "after_ontology_context", all_rels)
 
         # seocho-uxs: rewrite ids to composite identities for node types that
         # declare identity_keys, so dimension-bearing entities (same name,
@@ -754,6 +817,11 @@ class IndexingPipeline:
             self.ontology, all_nodes, all_rels,
             intern_table=self._intern_table, workspace_id=self.workspace_id,
         )
+        self._relcensus(result, "after_identity_keys", all_rels)
+        # Endpoint resolvability against the node id set at write time: a rel
+        # whose source/target is not a written node id cannot become an edge.
+        self._relcensus(result, "endpoints_resolvable",
+                        self._resolvable_rels(all_nodes, all_rels))
 
         if _graph_cot_properties_enabled():
             shaper = PropertyShaper()
@@ -812,6 +880,9 @@ class IndexingPipeline:
         )
         result.total_nodes = summary.get("nodes_created", 0)
         result.total_relationships = summary.get("relationships_created", 0)
+        self._relcensus(result, "written_to_store",
+                        [{"type": "?"}] * int(summary.get("relationships_created", 0) or 0),
+                        already_domain=True)
         result.write_errors = summary.get("errors", [])
         result.merge_conflicts = summary.get("merge_conflicts", [])
 

--- a/src/seocho/metrics.py
+++ b/src/seocho/metrics.py
@@ -168,6 +168,7 @@ METRIC_SPECS: dict[str, MetricSpec] = {
         _spec("seocho.index.extraction.retry.count", "counter", "{attempt}", ("ontology", "reason"), "Extraction retries by reason."),
         _spec("seocho.index.off_ontology_label.count", "counter", "{node}", ("ontology",), "Extracted node labels the ontology does not declare."),
         _spec("seocho.index.off_vocabulary_value.count", "counter", "{value}", ("ontology",), "Property values outside a declared vocabulary."),
+        _spec("seocho.index.relationship_survival.count", "histogram", "{item}", ("ontology", "stage"), "Domain relationships surviving each write-path stage."),
         _spec("seocho.index.observations_reified.count", "counter", "{observation}", ("ontology",), "Observation nodes reified during indexing."),
         _spec("seocho.query.plan.speedup", "histogram", "1", ("cohort",), "Baseline-to-candidate query-plan speedup after semantic parity."),
         _spec("seocho.query.plan.db_hits_reduction", "histogram", "1", ("cohort",), "Fractional DB-hit reduction for a semantically equivalent query plan."),

--- a/tests/seocho/test_relationship_census.py
+++ b/tests/seocho/test_relationship_census.py
@@ -1,0 +1,70 @@
+"""Per-stage relationship-survival census: the instrument that pinned the drop.
+
+The census exists so a single live index run shows, stage by stage, how many
+domain (non-provenance) relationships survive the write path -- rather than
+inferring a loss from a "47 extracted, 0 persisted" end state. These tests lock
+its two counting rules deterministically:
+
+  * _relcensus counts only NON-provenance edges (a graph full of MENTIONS must
+    not read as healthy domain structure), and records per stage.
+  * _resolvable_rels counts only edges whose BOTH endpoints are real node ids --
+    the exact predicate that went 12 -> 0 and located the orphaned-endpoint bug.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from seocho.index.pipeline import IndexingPipeline
+
+
+@dataclass
+class _Result:
+    relationship_census: Dict[str, int] = field(default_factory=dict)
+
+
+def _pipe() -> IndexingPipeline:
+    return IndexingPipeline(ontology=object(), graph_store=object(), llm=object())
+
+
+def test_census_counts_only_domain_edges():
+    rels = [
+        {"type": "RELATED_TO"},
+        {"type": "MENTIONS"},       # provenance -- must not count
+        {"type": "HAS_CHUNK"},      # provenance -- must not count
+        {"type": "RELATED_TO"},
+    ]
+    r = _Result()
+    _pipe()._relcensus(r, "extracted", rels)
+    assert r.relationship_census["extracted"] == 2
+
+
+def test_census_already_domain_counts_all():
+    """After the store returns domain edges, they are all domain -- count raw."""
+    r = _Result()
+    _pipe()._relcensus(r, "written_to_store", [{}, {}, {}], already_domain=True)
+    assert r.relationship_census["written_to_store"] == 3
+
+
+def test_resolvable_rels_requires_both_endpoints():
+    nodes = [{"id": "cornwall"}, {"id": "goonhilly_down"}]
+    rels = [
+        {"source": "goonhilly_down", "target": "cornwall"},  # both real -> kept
+        {"source": "2", "target": "1"},                      # orphaned -> dropped
+        {"source": "cornwall", "target": "99"},              # half real -> dropped
+    ]
+    out = IndexingPipeline._resolvable_rels(nodes, rels)
+    assert len(out) == 1
+    assert out[0]["source"] == "goonhilly_down"
+
+
+def test_pipeline_wires_the_census_at_the_endpoint_stage():
+    """The wiring: endpoints_resolvable must be measured, or the bug is invisible."""
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2]
+           / "src" / "seocho" / "index" / "pipeline.py").read_text()
+    assert '"endpoints_resolvable"' in src, (
+        "the endpoint-resolution stage must be censused -- it is where the drop was"
+    )

--- a/tests/seocho/test_relationship_endpoint_remap.py
+++ b/tests/seocho/test_relationship_endpoint_remap.py
@@ -1,0 +1,76 @@
+"""A relationship endpoint that references a sequential id survives normalization.
+
+The measured symptom was "47 relationships extracted, 0 domain edges persisted",
+non-deterministically. Root cause, pinned by per-stage survival census: when a
+model emits sequential node ids (`"1"`, `"2"`) plus names, `_normalize_node`
+replaces the sequential id with the entity name (cross-document collision
+avoidance). But the relationship endpoints still reference the *original*
+sequential id, and the node lookup was built only from the new id / name / uri --
+never the original. So `source: "2"` resolved to nothing, the edge orphaned, and
+it was silently dropped before the write.
+
+These tests lock the endpoint remap deterministically: no LLM, no graph, no live
+cost -- just the payload contract that `normalize_payload` must honor.
+"""
+
+from __future__ import annotations
+
+from seocho.index.extraction_engine import CanonicalExtractionEngine
+
+
+def _engine() -> CanonicalExtractionEngine:
+    # normalize_payload never touches the llm; a bare object is enough.
+    return CanonicalExtractionEngine(ontology=None, llm=object())
+
+
+def test_sequential_id_endpoints_resolve_to_name_ids():
+    """The exact live shape: integer ids + names, edge by integer id."""
+    payload = {
+        "nodes": [
+            {"id": "1", "label": "Entity", "properties": {"name": "Cornwall"}},
+            {"id": "2", "label": "Entity", "properties": {"name": "Goonhilly Down"}},
+        ],
+        "relationships": [
+            {"source": "2", "target": "1", "type": "RELATED_TO", "properties": {}},
+        ],
+    }
+    out = _engine().normalize_payload(payload)
+    node_ids = {n["id"] for n in out["nodes"]}
+    assert len(out["relationships"]) == 1, "the edge must survive normalization"
+    rel = out["relationships"][0]
+    assert rel["source"] in node_ids and rel["target"] in node_ids, (
+        "both endpoints must resolve to real node ids, not orphaned integers"
+    )
+    # And specifically to the name-based ids the node normalization produced.
+    assert rel["source"] == "goonhilly_down" and rel["target"] == "cornwall"
+
+
+def test_name_referenced_endpoints_still_resolve():
+    """A model that references endpoints by name (not id) keeps working."""
+    payload = {
+        "nodes": [
+            {"id": "1", "label": "Entity", "properties": {"name": "Cornwall"}},
+            {"id": "2", "label": "Entity", "properties": {"name": "Goonhilly Down"}},
+        ],
+        "relationships": [
+            {"source": "Goonhilly Down", "target": "Cornwall", "type": "RELATED_TO"},
+        ],
+    }
+    out = _engine().normalize_payload(payload)
+    rel = out["relationships"][0]
+    node_ids = {n["id"] for n in out["nodes"]}
+    assert rel["source"] in node_ids and rel["target"] in node_ids
+
+
+def test_unknown_endpoint_is_left_untouched_not_invented():
+    """An endpoint referencing no node is passed through, not silently mapped."""
+    payload = {
+        "nodes": [{"id": "1", "label": "Entity", "properties": {"name": "Cornwall"}}],
+        "relationships": [
+            {"source": "1", "target": "99", "type": "RELATED_TO"},
+        ],
+    }
+    out = _engine().normalize_payload(payload)
+    rel = out["relationships"][0]
+    assert rel["source"] == "cornwall", "the known endpoint resolves"
+    assert rel["target"] == "99", "an unknown endpoint is not fabricated"


### PR DESCRIPTION
## What

Fixes the root cause of **"N domain relationships extracted, 0 persisted"** — measured non-deterministically live on MARA MiniMax-M2.7 + DozerDB 5.26.3.

When a model emits sequential node ids (`"1"`, `"2"`) plus names, `_normalize_node` replaces the sequential id with the entity name (cross-document collision avoidance). But `normalize_payload` built `node_lookup` only from the *new* id / name / uri — never the original sequential id — so a relationship referencing `"2"` resolved to nothing, orphaned, and was silently dropped before the write.

## How it was pinned

Added a per-stage **relationship-survival census** to the index write path (`_relcensus` / `_resolvable_rels` over 6 stages, emitted as `seocho.index.relationship_survival.count`). One live run showed domain edges alive through `after_identity_keys` and going **12 → 0 exactly at endpoint resolution** — not at extraction, memory shaping, or identity.

## Fix

Key `node_lookup` by the original raw id as well.

**Live before/after (same benchmark doc):**

| stage | before | after |
|---|---|---|
| `endpoints_resolvable` | 0 | 12 |
| `RELATED_TO` persisted in graph | 0 | 12 |

## Why this matters for the GraphRAG stage breakdown

Indexing is stage 1. With 0 domain edges the retrieval/text2cypher stage traverses an **empty graph**, so all failure misattributes downstream (retrieval/generation take the blame for a stage-1 loss). This closes the most upstream contributor before any breakdown numbers are read.

## Tests

- `test_relationship_endpoint_remap.py` — sequential-id endpoints resolve; name-referenced endpoints still work; unknown endpoints are not fabricated.
- `test_relationship_census.py` — census counts only non-provenance edges; `_resolvable_rels` requires both endpoints; wiring guard.

Both deterministic (no LLM, no graph).

## CI

`bash scripts/ci/run_basic_ci.sh` → **1106 passed, 3 skipped**; runtime-shell, module-ownership, import-boundary, root-hierarchy, env, and doc-lint contracts all green.
