### PR TITLE
docs(adr): ADR-0213 honesty correction — downgrade to experimental

### DIFF
--- a/docs/decisions/ADR-0213-graphrag-stage-breakdown.json
+++ b/docs/decisions/ADR-0213-graphrag-stage-breakdown.json
@@ -1,6 +1,7 @@
 {
   "adr": "ADR-0213",
   "title": "Graph agentic-RAG stage breakdown",
+  "status": "experimental (downgraded after multi-agent review 2026-08-17)",
   "date": "2026-08-17",
   "environment": {
     "llm": "MARA MiniMax-M2.7 (hosted)",
@@ -39,12 +40,19 @@
   },
   "generated_cypher_stage3": "MATCH (n:`Entity`) WHERE (toLower(coalesce(n.name,n.uri,'')) CONTAINS toLower($entity) OR toLower(coalesce(n.name,n.uri,'')) CONTAINS toLower($entity_norm)) AND ($workspace_id='' OR coalesce(n._workspace_id,'')=$workspace_id) AND coalesce(n._superseded_by,'')='' RETURN n LIMIT $limit",
   "intent_data_stage3": {"intent": "entity_lookup", "anchor_entity": "Erica vagans", "target_entity": "", "relationship_type": ""},
-  "reporting_artifact": {"symptom": "_last_query_metadata.records == 0 while manual re-exec of same cypher+params returned 1 row", "impact": "diagnostics undercount only; answers unaffected"},
+  "correction_2026_08_17": {
+    "records_zero_is_faithful": "executor feeds the same records list to synthesis and metadata; metadata cannot undercount. On the captured run the anchor was mis-selected as the book title and 0 rows returned (direct re-exec also 0).",
+    "root_cause": "stage-3 anchor-slot extraction non-deterministically picks the question framing-clause book title 'An Unsentimental Journey through Cornwall' as the anchor entity",
+    "attribution_revised": "failure spans stage-1 (alias not lifted) AND stage-3 (anchor mis-selection), non-deterministic; n=1 with no ceiling/floor control cannot attribute to one stage"
+  },
   "gold_hit_rate": "0/3",
-  "conclusion": "For appositive/alias fact-retrieval, GraphRAG breaks at stage-1 extraction coverage; retrieval/generation cannot recover an answer that is structurally absent. Highest-leverage fix is extraction-side alias capture + an ontology alias slot.",
+  "conclusion": "For THIS sample: no answer because the fact was not reliably in the graph (stage 1) AND the anchor was mis-selected (stage 3), non-deterministically. NOT a defensible class-level claim about alias fact-retrieval (needs stratified sample + ceiling/floor controls). Lowest-complexity/highest-frequency fix: strip question framing clauses before anchor-slot extraction.",
+  "review_caveats": [
+    "graph_store.write counts submitted rows not created edges (no .consume()); written_to_store/total_relationships inflated + provenance-inclusive",
+    "gold_hit is a bare substring match (false pos on name-dropping refusal, false neg on paraphrase)",
+    "n=1, no ceiling/floor control though query_no_graph_records / indexing_no_graph_writes exist"
+  ],
   "followups": [
-    "extraction: appositive/alias capture -> ALSO_KNOWN_AS edge or alias property + ontology slot (prove before/after gold_hit)",
-    "retrieval: intent classifier routes 'also known as / another name for' as alias traversal, not entity_lookup",
-    "bug: _LocalEngine._last_query_metadata['records'] undercounts retrieved rows"
+    "retrieval (highest-value): anchor-slot extraction strips question framing clauses and ranks real-subject names over quoted titles"
   ]
 }

--- a/docs/decisions/ADR-0213-graphrag-stage-breakdown.md
+++ b/docs/decisions/ADR-0213-graphrag-stage-breakdown.md
@@ -1,6 +1,8 @@
 # ADR-0213: Graph agentic-RAG stage breakdown — where end-to-end quality is lost
 
-- Status: accepted
+- Status: experimental (downgraded from accepted 2026-08-17 after multi-agent
+  review — the attribution below is not yet defensible; see "Correction" and
+  "Review caveats")
 - Date: 2026-08-17
 - Tickets: seocho-5ny (OS ablation epic, sibling instrument)
 - Related: ADR-0144 (rag.ask span tree), #589 (relationship-endpoint remap),
@@ -61,20 +63,39 @@ Per-stage attribution, 3 identical runs (fixed code, same doc/question):
 |---|---|---|
 | **1. indexing / extraction** | ❌ **dominant miss** | `erica vagans` node created 3/3, but the appositive alias "Cornish heath" was **not** lifted into structure — no second node, no `ALSO_KNOWN_AS` edge, no alias property. `erica vagans` edges are only to Goonhilly Down / serpentine / magnesian earth. "Cornish heath" exists **only in `Chunk.text`** (1 chunk), unreachable by graph traversal. |
 | **2. ontology** | ⚠️ contributes | the generic single-`Entity` + "verb-in-a-property" design has **no slot** for an appositive alias, so even a willing extractor has nowhere canonical to put "also known as". |
-| **3. retrieval / text2cypher** | ❌ secondary miss | intent classified as `entity_lookup` (`relationship_type=""`, `target_entity=""`); the generated Cypher fetches the `erica vagans` node and does **not** traverse an alias relationship. |
-| **4. generation** | ✅ honest | the synthesizer refused to fabricate: *"erica vagans exists … but I cannot fully answer."* No hallucination — the desired failure mode. |
+| **3. retrieval / text2cypher** | ❌ **real miss (see Correction)** | anchor-slot extraction non-deterministically picks the question's framing-clause book title ("An Unsentimental Journey through Cornwall") as the anchor entity, so the Cypher matches no node and returns 0 rows — faithfully. |
+| **4. generation** | ✅ honest | refused to fabricate; the "erica vagans exists" phrasing echoes the question, not a retrieved node (retrieval returned 0). |
 
-Result: **gold_hit 0/3.** The gold answer is structurally absent from the graph,
-so no retrieval or generation quality could recover it.
+Result: **gold_hit 0/3.**
+
+### Correction (post-review, 2026-08-17)
+
+A follow-up diagnostic overturned two claims in the original write-up:
+
+1. **`records=0` is faithful, not a reporting artifact.** The executor feeds the
+   *same* `records` list to synthesis and to the metadata (`local_engine.py`
+   ~964 vs ~987), so metadata cannot undercount what synthesis received. On the
+   captured run the executed Cypher was anchored on the book title
+   (`anchor="An Unsentimental Journey through Cornwall"`) and returned 0 rows;
+   a direct re-exec of that exact Cypher+params also returned 0. The earlier
+   "1 row on manual re-exec" came from a *different* run where the slot
+   extractor happened to anchor on "Erica vagans" — i.e. the anchor selection
+   is **non-deterministic**.
+2. **The failure is not cleanly stage-1.** It spans **stage-1** (the appositive
+   alias is never lifted into structure) *and* **stage-3** (anchor-slot
+   mis-selection retrieves nothing). On the captured run stage-3 alone would
+   fail even with a perfectly indexed alias. A single sample (n=1) with no
+   ceiling/floor control cannot attribute the loss to one stage.
 
 ### Conclusion
 
-For appositive/alias fact-retrieval, GraphRAG breaks at **stage 1 (extraction
-coverage)**, not at retrieval or generation. The highest-leverage improvement is
-extraction-side alias capture (appositive `X — the Y` → `ALSO_KNOWN_AS` edge or
-`alias` property), paired with an ontology slot to hold it — **not** a retrieval
-fix. This is the kind of attribution the breakdown exists to produce: it moves
-the work to the stage that actually loses the answer.
+For this sample the honest statement is narrow: **GraphRAG returned no answer
+because the fact was not reliably in the graph (stage 1) AND the anchor was
+mis-selected (stage 3) — non-deterministically.** This is *not* evidence that
+alias fact-retrieval as a class breaks at stage 1; that claim needs a stratified
+sample and ceiling/floor controls (see "Review caveats"). The lowest-complexity,
+highest-frequency fix surfaced here is stage-3: strip question framing clauses
+("In the narrative of 'X', …") before anchor-slot extraction.
 
 Observability confirmed: the `rag.ask` root span nested the full stage tree
 (`rag.schema → rag.compile_cypher → rag.execute → rag.retrieve_ctx →
@@ -85,16 +106,33 @@ rag.synthesize`), 17 spans emitted for one ask (ADR-0144).
 - **Follow-up (extraction):** appositive/alias capture at stage 1 + an ontology
   alias slot. Prove with before/after `gold_hit` on this sample and broaden the
   base. (new ticket)
-- **Follow-up (retrieval):** intent classifier should route "also known
-  as / another name for" as an alias/relationship traversal, not `entity_lookup`.
-  (new ticket)
-- **Bug (reporting artifact):** `_LocalEngine._last_query_metadata["records"]`
-  read 0 while the executed Cypher returned 1 row on manual re-exec (the
-  synthesizer did see the node) — the metadata undercounts retrieved rows.
-  Diagnostics only; does not change answers. (new ticket)
-- **Kept:** the relationship-survival census is a permanent index-quality
-  instrument; any future "graph looks empty" regression is one live run from a
-  stage-localised diagnosis.
+- **Follow-up (retrieval, highest-value / lowest-complexity):** anchor-slot
+  extraction must strip question framing clauses ("In the narrative of 'X', …")
+  and rank real-subject entity names over quoted titles, so it does not anchor
+  on the book title. (new ticket)
+- **Kept:** the relationship-survival census is a useful index-quality
+  instrument — but see the counter caveat below before trusting its terminal
+  numbers.
+
+## Review caveats (multi-agent review, 2026-08-17)
+
+Four independent reviews (indexing, retrieval, ontology, RAG-eval) landed
+**ADJUST/REDIRECT**. What is solid vs not:
+
+- **Solid:** #589 (endpoint remap) is correct and safe; the `endpoints_resolvable`
+  0→12 before/after was read directly from the graph. Observability spine
+  (ADR-0144) is a keeper.
+- **Instrument caveat:** `graph_store.write` counts *submitted rows*, not edges
+  actually created (no `.consume()` counter read), so `written_to_store` /
+  `total_relationships` are inflated and provenance-inclusive — do not compare
+  them to the domain-only earlier census stages.
+- **Metric caveat:** `gold_hit` is a bare substring match, prone to false
+  positives (refusal that name-drops the term) and false negatives (paraphrase).
+- **Attribution caveat:** n=1, no ceiling/floor control; the SDK already exposes
+  `query_no_graph_records` / `indexing_no_graph_writes` for exactly these
+  controls. Any class-level claim needs a stratified sample first.
+
+These are recorded as caveats, not new build work — deliberately kept minimal.
 
 ## Validation
 

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1327,11 +1327,11 @@ Use this block for new entries:
   / `sc.platform` / `sc.sessions` group 54 of 80 facade methods; `AsyncSeocho`'s
   25 missing methods are generated rather than hand-written; additive, nothing
   deprecated yet
-- [Accepted] ADR-0213 graphrag-stage-breakdown (seocho-5ny) — e2e attribution on
-  MARA MiniMax-M2.7 + live DozerDB: with the #589 endpoint-remap fix landed
-  (`endpoints_resolvable` 0→12), stage 1 is healthy but appositive-alias fact
-  retrieval (Erica vagans → "Cornish heath") fails at **stage-1 extraction
-  coverage** — the alias is never lifted into a node/edge, so retrieval and the
-  (honest, non-hallucinating) generator cannot recover it; gold_hit 0/3.
-  Follow-ups: extraction alias capture + ontology slot, alias-aware intent
-  routing, and a `_last_query_metadata["records"]` undercount bug
+- [Experimental] ADR-0213 graphrag-stage-breakdown (seocho-5ny) — e2e attribution
+  on MARA MiniMax-M2.7 + live DozerDB. #589 (endpoint remap, `endpoints_resolvable`
+  0→12) is solid. The stage attribution was **downgraded after multi-agent review**:
+  a follow-up diagnostic showed `records=0` is faithful (not an artifact) and the
+  Erica vagans → "Cornish heath" failure is non-deterministic across **stage-1**
+  (alias not lifted) AND **stage-3** (anchor-slot picks the question's framing-clause
+  book title). n=1 with no ceiling/floor control ⇒ not a class claim. Lowest-
+  complexity fix: strip question framing clauses before anchor-slot extraction.


### PR DESCRIPTION
## What

Honesty correction to ADR-0213 after the multi-agent review + a `records=0` diagnostic. **Downgrades the ADR from `accepted` to `experimental`.** No new build work — deliberately minimal.

## Why

Two claims in the original write-up were overturned:

1. **`records=0` is faithful, not a reporting artifact.** The executor feeds the *same* `records` list to synthesis and to the metadata, so metadata cannot undercount what synthesis received. On the captured run the anchor was mis-selected as the question's framing-clause book title (`anchor="An Unsentimental Journey through Cornwall"`) and 0 rows returned; a direct re-exec of that exact Cypher+params also returned 0. The earlier "1 row on manual re-exec" came from a **different** run where the slot extractor happened to anchor on "Erica vagans" — the anchor selection is **non-deterministic**.
2. **The failure is not cleanly stage-1.** It spans **stage-1** (appositive alias never lifted into structure) *and* **stage-3** (anchor-slot mis-selection retrieves nothing). n=1 with no ceiling/floor control cannot attribute the loss to one stage.

## Kept solid

`#589` (endpoint remap, `endpoints_resolvable` 0→12, read directly from the graph) stands; ADR-0144 observability spine is a keeper.

## Added review caveats (recorded, not built)

- `graph_store.write` counts *submitted rows*, not created edges (no `.consume()`) → `written_to_store` / `total_relationships` inflated + provenance-inclusive.
- `gold_hit` is a bare substring match (false pos on name-dropping refusal, false neg on paraphrase).
- n=1, no ceiling/floor control though `query_no_graph_records` / `indexing_no_graph_writes` already exist.

## Follow-up

`seocho-5ny.4` — strip question framing clauses before anchor-slot extraction (lowest-complexity, highest-frequency fix surfaced here).

Validation: `check-doc-contracts.sh` green.
