### PR TITLE
fix(query): strip source-framing clauses before anchor-slot extraction

### DIFF
--- a/src/seocho/query/planner.py
+++ b/src/seocho/query/planner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Dict, Optional, Sequence
 
 from ..store.llm import complete_with_task_hints
@@ -9,6 +10,39 @@ from .contracts import QueryPlan
 from .cypher_builder import CypherBuilder
 
 logger = logging.getLogger(__name__)
+
+# A leading source-framing clause names a document, not the entity the question
+# is about -- e.g. "In the narrative of 'An Unsentimental Journey through
+# Cornwall', which plant ...". Left in, the intent extractor anchors on the
+# quoted TITLE, the anchor matches no node, and retrieval returns 0 rows
+# (measured live: ADR-0213 records=0 diagnosis). Strip only a leading clause
+# that (a) starts with a framing preposition, (b) cites a quoted title, and
+# (c) ends at the first comma -- conservative, so ordinary questions are
+# untouched and only the framing noise is removed.
+_QUOTE = "\"'‘’“”"
+_FRAMING_CLAUSE = re.compile(
+    r"^\s*(?:in|within|according to|based on|from|per|throughout)\b"
+    r"[^,]*?[" + _QUOTE + r"][^" + _QUOTE + r"]+[" + _QUOTE + r"]"
+    r"[^,]*,\s+",
+    re.IGNORECASE,
+)
+
+
+def _strip_framing_clause(question: str) -> str:
+    """Drop a leading source-framing clause so the anchor is the real subject.
+
+    Returns the question unchanged unless a conservative framing clause matches
+    AND enough question remains after it (a bare title with nothing following is
+    left intact rather than stripped to empty).
+    """
+    q = question or ""
+    m = _FRAMING_CLAUSE.match(q)
+    if not m:
+        return question
+    remainder = q[m.end():].strip()
+    if len(remainder) < 12:  # nothing substantive left -> do not strip
+        return question
+    return remainder
 
 
 class DeterministicQueryPlanner:
@@ -21,10 +55,13 @@ class DeterministicQueryPlanner:
 
     def plan(self, question: str) -> QueryPlan:
         builder = CypherBuilder(self.ontology)
-        question_hints = builder.derive_schema_hints(question)
+        # De-frame the question for all anchor-relevant steps; keep the original
+        # on the returned QueryPlan for provenance.
+        focus = _strip_framing_clause(question)
+        question_hints = builder.derive_schema_hints(focus)
         response = self._complete(
             system=builder.intent_extraction_prompt(schema_hints=question_hints),
-            user=f'Question:\n"""\n{question}\n"""',
+            user=f'Question:\n"""\n{focus}\n"""',
             temperature=0.0,
             response_format={"type": "json_object"},
             reasoning_mode=False,
@@ -35,11 +72,11 @@ class DeterministicQueryPlanner:
             intent_data = response.json()
         except (json.JSONDecodeError, ValueError):
             logger.error("LLM returned non-JSON intent: %s", response.text[:200])
-            intent_data = {"intent": "neighbors", "anchor_entity": question}
+            intent_data = {"intent": "neighbors", "anchor_entity": focus}
 
-        intent_data = builder.normalize_intent(question, intent_data)
+        intent_data = builder.normalize_intent(focus, intent_data)
         schema_hints = builder.derive_schema_hints(
-            question,
+            focus,
             raw_intent=intent_data,
             resolved_entities=[
                 str(intent_data.get("anchor_entity", "") or "").strip(),
@@ -52,7 +89,7 @@ class DeterministicQueryPlanner:
         try:
             cypher, params = builder.build(
                 intent=intent_data.get("intent", "neighbors"),
-                anchor_entity=intent_data.get("anchor_entity", question),
+                anchor_entity=intent_data.get("anchor_entity", focus),
                 anchor_label=intent_data.get("anchor_label", ""),
                 target_entity=intent_data.get("target_entity", ""),
                 target_label=intent_data.get("target_label", ""),

--- a/tests/seocho/test_anchor_framing_strip.py
+++ b/tests/seocho/test_anchor_framing_strip.py
@@ -1,0 +1,62 @@
+"""A leading source-framing clause is stripped before anchor-slot extraction.
+
+Measured live (ADR-0213 records=0 diagnosis): on "In the narrative of 'An
+Unsentimental Journey through Cornwall', which plant known as Erica vagans ...",
+the intent extractor anchored on the quoted BOOK TITLE, so the Cypher matched no
+node and retrieval returned 0 rows. The deterministic stripper drops only a
+conservative leading framing clause (framing preposition + quoted title + comma)
+so the anchor becomes the real subject; ordinary questions are untouched.
+"""
+
+from __future__ import annotations
+
+from seocho.query.planner import _strip_framing_clause
+
+
+def test_strips_narrative_framing_clause():
+    q = ("In the narrative of 'An Unsentimental Journey through Cornwall', which "
+         "plant known scientifically as Erica vagans is also referred to by "
+         "another common name?")
+    out = _strip_framing_clause(q)
+    assert out.startswith("which plant"), out
+    assert "Unsentimental Journey" not in out
+    assert "Erica vagans" in out
+
+
+def test_strips_common_framing_prepositions():
+    for lead in [
+        "According to \"The 2023 Annual Report\", ",
+        "Based on 'Moby-Dick', ",
+        "In “War and Peace”, ",
+        "From 'the Q3 filing', ",
+    ]:
+        q = lead + "who is the main character described?"
+        out = _strip_framing_clause(q)
+        assert out == "who is the main character described?", (lead, out)
+
+
+def test_plain_question_is_untouched():
+    q = "Which common name is Erica vagans also known by?"
+    assert _strip_framing_clause(q) == q
+
+
+def test_no_quoted_title_is_untouched():
+    # "In Cornwall" has no quoted title -> it is a real locative, not framing.
+    q = "In Cornwall, which plants grow on the serpentine soil?"
+    assert _strip_framing_clause(q) == q
+
+
+def test_bare_title_with_nothing_after_is_not_stripped_to_empty():
+    q = "In the report 'Q3 Earnings'."
+    # remainder after the clause is empty/trivial -> keep the original
+    assert _strip_framing_clause(q) == q
+
+
+def test_planner_uses_the_stripper():
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2]
+           / "src" / "seocho" / "query" / "planner.py").read_text()
+    assert "_strip_framing_clause(question)" in src, (
+        "plan() must de-frame the question before intent extraction"
+    )


### PR DESCRIPTION
## What
Fixes the `records=0` failure diagnosed in ADR-0213: the deterministic query planner's intent extractor anchored on a **quoted book title** in the question's framing clause, so the Cypher matched no node and retrieval returned 0 rows.

## Root cause
On `"In the narrative of 'An Unsentimental Journey through Cornwall', which plant known as Erica vagans ...?"` the LLM slot extractor picked `anchor_entity = "An Unsentimental Journey through Cornwall"` (the title), not `"Erica vagans"`. Non-deterministic across runs. `records=0` was faithful — the executor genuinely got 0 rows.

## Fix
`DeterministicQueryPlanner.plan()` de-frames the question with a conservative `_strip_framing_clause` (leading framing preposition + quoted title + comma, only when substantive text remains) and uses the de-framed `focus` for intent extraction / schema hints / normalize / anchor fallback. The original question stays on the `QueryPlan` for provenance.

## Live before/after (MARA MiniMax-M2.7 + DozerDB 5.26.3)
| | before | after |
|---|---|---|
| `anchor_entity` | "An Unsentimental Journey through Cornwall" | **"Erica vagans"** |
| executed anchor query rows | 0 | **3** |

gold_hit is still 0 on this sample — the alias "Cornish heath" is genuinely absent from the graph (a separate stage-1 extraction gap, not this fix's scope).

## Tests
`tests/seocho/test_anchor_framing_strip.py` — 6 deterministic cases (strips narrative/according-to/based-on/from framing; leaves plain questions, locatives like "In Cornwall,", and bare-title-no-remainder untouched).

CI: `bash scripts/ci/run_basic_ci.sh` green. Closes seocho-5ny.4.
