### PR TITLE
fix(store): write() counts real Neo4j counters, not submitted rows

### DIFF
--- a/src/seocho/index/pipeline.py
+++ b/src/seocho/index/pipeline.py
@@ -880,9 +880,25 @@ class IndexingPipeline:
         )
         result.total_nodes = summary.get("nodes_created", 0)
         result.total_relationships = summary.get("relationships_created", 0)
+        # Terminal census stage: count DOMAIN edges actually in the store for
+        # this write, so it is comparable to the domain-only earlier stages.
+        # The write summary's relationships_created is provenance-inclusive
+        # (MENTIONS/HAS_CHUNK/...), which made written_to_store apples-to-oranges
+        # vs endpoints_resolvable (audit 2026-08-17). A single scoped count query.
+        domain_persisted = int(summary.get("relationships_created", 0) or 0)
+        try:
+            _rows = self.graph_store.query(
+                "MATCH (a)-[r]->(b) WHERE a._workspace_id=$ws AND r._source_id=$sid "
+                "AND NOT type(r) IN $prov RETURN count(r) AS c",
+                params={"ws": self.workspace_id, "sid": source_id,
+                        "prov": list(self._PROVENANCE_REL_TYPES)},
+                database=database)
+            if _rows:
+                domain_persisted = int((_rows[0].get("c") if _rows[0] else 0) or 0)
+        except Exception:  # noqa: BLE001 - census must never fail the write
+            pass
         self._relcensus(result, "written_to_store",
-                        [{"type": "?"}] * int(summary.get("relationships_created", 0) or 0),
-                        already_domain=True)
+                        [{"type": "?"}] * domain_persisted, already_domain=True)
         result.write_errors = summary.get("errors", [])
         result.merge_conflicts = summary.get("merge_conflicts", [])
 

--- a/src/seocho/store/graph.py
+++ b/src/seocho/store/graph.py
@@ -663,9 +663,12 @@ class Neo4jGraphStore(GraphStore):
                     + " RETURN row.id AS id, _conflicts AS conflicts"
                 )
                 try:
-                    for record in session.run(batch_q, rows=rows, ws=workspace_id):
-                        summary["nodes_created"] += 1
+                    _res = session.run(batch_q, rows=rows, ws=workspace_id)
+                    for record in _res:
                         _collect_conflicts(record)
+                    # Real created count, not one-per-submitted-row (a MERGE onto
+                    # an existing node creates zero). audit 2026-08-17.
+                    summary["nodes_created"] += _res.consume().counters.nodes_created
                 except Exception:
                     for row in rows:
                         try:
@@ -678,9 +681,10 @@ class Neo4jGraphStore(GraphStore):
                                 + sources_clause.format(p="$props")
                                 + " RETURN $id AS id, _conflicts AS conflicts"
                             )
-                            for record in session.run(single_q, id=row["id"], props=row["props"], ws=workspace_id):
+                            _res = session.run(single_q, id=row["id"], props=row["props"], ws=workspace_id)
+                            for record in _res:
                                 _collect_conflicts(record)
-                            summary["nodes_created"] += 1
+                            summary["nodes_created"] += _res.consume().counters.nodes_created
                         except Exception as exc:
                             summary["errors"].append(f"Node {row['id']}: {exc}")
 
@@ -704,8 +708,16 @@ class Neo4jGraphStore(GraphStore):
                            "OR r._writer_ts <= row.props._writer_ts THEN row.props ELSE {} END"
                            + rel_sources_clause.format(p="row.props"))
                 try:
-                    session.run(batch_q, rows=rows, ws=workspace_id)
-                    summary["relationships_created"] += len(rows)
+                    # Count edges ACTUALLY created (not submitted rows): the
+                    # batch is MATCH (a),(b) MERGE, so a row whose endpoint node
+                    # is absent creates zero edges, and a MERGE onto an existing
+                    # edge creates zero. len(rows) counted both as writes,
+                    # inflating total_relationships and masking the exact
+                    # orphan-drop the survival census exists to catch (audit
+                    # 2026-08-17). Read the real server counter, as execute_write
+                    # already does.
+                    _res = session.run(batch_q, rows=rows, ws=workspace_id)
+                    summary["relationships_created"] += _res.consume().counters.relationships_created
                 except Exception:
                     for row in rows:
                         try:
@@ -713,14 +725,14 @@ class Neo4jGraphStore(GraphStore):
                                              if source_label else "(a {id: $src, _workspace_id: $ws})")
                             target_single = (f"(b:{target_label} {{id: $tgt, _workspace_id: $ws}})"
                                              if target_label else "(b {id: $tgt, _workspace_id: $ws})")
-                            session.run(
+                            _res = session.run(
                                 f"MATCH {source_single}, {target_single} "
                                 f"MERGE (a)-[r:{rtype}]->(b) SET r += CASE WHEN "
                                 "r._writer_ts IS NULL OR r._writer_ts <= $props._writer_ts "
                                 "THEN $props ELSE {} END"
                                 + rel_sources_clause.format(p="$props"),
                                 src=row["src"], tgt=row["tgt"], props=row["props"], ws=workspace_id)
-                            summary["relationships_created"] += 1
+                            summary["relationships_created"] += _res.consume().counters.relationships_created
                         except Exception as exc:
                             summary["errors"].append(
                                 f"Rel {row['src']}-[{rtype}]->{row['tgt']}: {exc}")

--- a/tests/seocho/test_graph_writer_lww.py
+++ b/tests/seocho/test_graph_writer_lww.py
@@ -19,6 +19,17 @@ from seocho.store.graph import Neo4jGraphStore
 # Offline — stamping + guard wiring (mock driver, no DB)
 # --------------------------------------------------------------------------- #
 
+class _FakeCounters:
+    def __init__(self, nodes_created=0, relationships_created=0):
+        self.nodes_created = nodes_created
+        self.relationships_created = relationships_created
+
+
+class _FakeSummary:
+    def __init__(self, counters):
+        self.counters = counters
+
+
 class _Rec:
     def __init__(self):
         self.calls = []
@@ -32,6 +43,11 @@ class _Rec:
 
             def __iter__(self_inner):
                 return iter([])
+
+            def consume(self_inner):
+                # write() now reads real server counters; the bare fake reports
+                # zero created (tests here assert query shape, not counts).
+                return _FakeSummary(_FakeCounters())
 
         return _R()
 
@@ -242,6 +258,9 @@ class _ConflictRec(_Rec):
                         ]}
                     ])
                 return iter([])
+
+            def consume(self_inner):
+                return _FakeSummary(_FakeCounters(nodes_created=1 if is_node_merge else 0))
 
         return _R()
 


### PR DESCRIPTION
## What
`GraphStore.write()` was counting **submitted rows** (`len(rows)`), not edges/nodes actually created. Observability audit flagged this as HIGH severity.

## Why it matters
The batch write is `MATCH (a),(b) MERGE (a)-[r]->(b)`. `len(rows)` over-counts because (a) a MERGE onto an existing node/edge creates zero, and (b) **when an endpoint node is absent, the MATCH yields no rows and no edge is created — yet every row was still counted.** This inflated `IndexingResult.total_relationships`, the `sdk.extraction` span, and worst of all the relationship-survival census's terminal `written_to_store` stage: the one number meant to prove domain edges reached the store could read healthy while zero real edges existed — masking the exact orphan-drop the census (from #589) exists to catch.

## Fix
- Read `result.consume().counters.{nodes,relationships}_created` from each `session.run` (batch + single fallback, nodes + rels) — exactly as `execute_write()` already does.
- Make the census `written_to_store` stage a scoped **domain-only** count of edges actually in the store (one count query), comparable to the domain-only earlier stages instead of the provenance-inclusive total.

## Live before/after (MARA MiniMax-M2.7 + DozerDB 5.26.3, Erica sample)
Census terminal `written_to_store`: **40 → 11**, now matching both `endpoints_resolvable`=11 and the actual domain `RELATED_TO` count in the graph.

```
extracted 11 → after_memory_shaping 11 → after_ontology_context 11
→ after_identity_keys 11 → endpoints_resolvable 11 → written_to_store 11
```
Apples-to-apples end to end.

## Tests
`test_graph_writer_lww.py` fakes updated to model `result.consume().counters` (8 passed). CI `run_basic_ci.sh` green (1105 passed, 3 skipped).
