### PR TITLE
[Draft] chore: improve CLI help text clarity for chat command

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -87,7 +87,7 @@ def build_parser() -> argparse.ArgumentParser:
     search_parser.add_argument("--database", action="append", dest="databases", default=[], help="Database scope")
     _add_client_options(search_parser, include_scope=True, include_json=True)
 
-    chat_parser = subparsers.add_parser("chat", help="Ask from memories")
+    chat_parser = subparsers.add_parser("chat", help="Chat with the agent using memory context")
     chat_parser.add_argument("message", help="Question to ask")
     chat_parser.add_argument("--limit", type=int, default=5, help="Max number of retrieval results")
     chat_parser.add_argument("--graph-id", action="append", dest="graph_ids", default=[], help="Graph routing hint")


### PR DESCRIPTION
**What:**
Changed the help text for the `chat` command in the CLI from "Ask from memories" to "Chat with the agent using memory context".

**Why:**
The previous help text was slightly awkward and less clear about its distinction from the `ask` command. The new text provides a clearer instruction on what the command actually does.

**Accessibility / UX Impact:**
Improves developer and operator experience by making the CLI documentation clearer and easier to understand. This is a small but clear usability benefit.

**Validation:**
- Verified CLI output visually using `uv run seocho --help`.
- Ran `bash scripts/pm/lint-agent-docs.sh` to validate docs and it passed.
- Ran `bash scripts/ci/run_basic_ci.sh` to run the basic test suites and all tests passed.

**Risks:**
No residual risks. The change strictly alters a string argument for `argparse` help output and does not affect any runtime logic or execution paths.

**Modified Files:**
- src/seocho/cli/__init__.py
- .jules/palette.md

---
*PR created automatically by Jules for task [6443669180517330140](https://jules.google.com/task/6443669180517330140) started by @tteon*