### PR TITLE
docs(adr): ADR-0214 ontology modeling drives graph-RAG accuracy + demand-proposer

### DIFF
--- a/docs/decisions/ADR-0214-ontology-modeling-drives-accuracy.md
+++ b/docs/decisions/ADR-0214-ontology-modeling-drives-accuracy.md
@@ -1,0 +1,120 @@
+# ADR-0214: Ontology modeling drives graph-RAG accuracy — and can be demand-proposed
+
+- Status: experimental
+- Date: 2026-08-17
+- Tickets: seocho-5ny (breakdown epic)
+- Related: ADR-0213 (stage breakdown, records=0), #592 (anchor de-framing),
+  #593 (real write counters), ADR-0114 (ontology scorecard),
+  seocho-5bg / #493 (ontology import), #279 (`seocho run` YAML)
+
+## Context
+
+ADR-0213 localized a graph-RAG failure to a mix of stage-1 (extraction coverage)
+and stage-3 (anchor mis-selection), but ran on a **generic single-`Entity`
+ontology** — which the dbt "Semantic Layer vs Text-to-SQL 2026" benchmark would
+call *modeling turned off*. dbt's headline finding: deterministic query
+generation over a **well-modeled** ontology hits ~100% and fails loud, while
+text-to-SQL fails silently; and *"data modeling quality matters enormously."*
+
+SEOCHO's default query path (`DeterministicQueryPlanner`) is the Semantic-Layer
+analog: the LLM decomposes the question into typed slots, and the planner builds
+the Cypher deterministically. So the open question was: **are we using the
+ontology well, and does modeling move SEOCHO's accuracy the way dbt predicts?**
+
+Two enabling fixes landed first: **#592** (strip source-framing clauses before
+anchor-slot extraction — closes the ADR-0213 anchor bug) and **#593** (write()
+reads real Neo4j counters, not submitted rows — makes the census terminal stage
+trustworthy).
+
+## Experiment
+
+Live on MARA MiniMax-M2.7 + DozerDB 5.26.3. One document (a Cornwall travelogue),
+**8 stratified questions** with verifiable golds (alias, term-meaning, entity-
+attribute, lookup, relationship). Accuracy graded by a **MARA judge** into
+`correct / refused / silent_wrong` (not a bare substring, per ADR-0213 caveat).
+
+### Axis 1 — ontology modeling (deterministic path)
+
+| ontology | correct | refused | silent_wrong | gold fact in structure |
+|---|---|---|---|---|
+| **GENERIC** (single `Entity` + `RELATED_TO`) | **1/8** | 7/8 | **0** | ❌ |
+| **MODELED** (typed: Plant/Place/Person/Animal/Term + typed rels) | **5/8** | 3/8 | **0** | ✅ |
+
+- Extraction side: GENERIC wrote 17 nodes / 11 domain edges, all labeled `Entity`;
+  MODELED wrote 20 nodes / 6 domain edges across typed labels, and lifted the
+  alias "Cornish heath" into structure. Fewer domain edges but the *answer-bearing*
+  facts landed in typed slots — the extraction/query tension is real (rich
+  ontology aids query, changes extraction shape).
+- **silent_wrong = 0 in both.** SEOCHO fails loud (refuses) rather than
+  confidently wrong — the property dbt names as decisive in production.
+
+### Control — ceiling
+
+Inject the `erica vagans →(ALSO_KNOWN_AS)→ Cornish heath` alias into the MODELED
+graph and re-ask the alias question → **correct**. Proves the query+generation
+path recovers the answer when the fact is present; the earlier failures were
+upstream (extraction/modeling), not retrieval/generation defects.
+
+### Axis 2 — can the modeled ontology be *proposed* from the questions?
+
+A prototype `propose_ontology(doc, questions)` asks an LLM to draft the **minimal
+typed ontology** that covers the questions (draft-never-persists), then the same
+coverage loop grades it:
+
+| ontology source | correct | note |
+|---|---|---|
+| GENERIC (no modeling) | 1/8 | baseline |
+| **proposed v1** (zero hand-authoring) | **3/8** | some facts modeled as properties on broad entities → extraction didn't fill them |
+| **proposed v2** (prompt prefers *dedicated typed nodes* for answer-bearing facts) | **4/8** | e.g. a `Breed` node fixed the ponies question |
+| hand-MODELED | 5/8 | last point is extraction non-determinism, not modeling |
+
+The loop **moves the bottleneck**: 1/8 (no slots) → 3/8 (slots, some mis-placed)
+→ 4/8 (dedicated typed nodes) — after which the residual refusals are **stage-1
+extraction-coverage** misses (the typed slot exists but the hosted model didn't
+populate it), not modeling gaps. That is exactly the signal a coverage-feedback
+loop should surface to the user for the next iteration.
+
+## Decision / product direction
+
+1. **Ontology modeling is the highest-leverage accuracy lever on the query
+   side** (1/8 → 5/8 here), and SEOCHO run with a generic ontology is *not* using
+   the ontology. Guide users to typed modeling.
+2. **Guide it demand-first, not blank-editor-first.** A blank schema editor
+   reproduces GENERIC (users under-model). The natural UX is a loop:
+   `documents + target questions → propose_ontology draft → review/edit (arrows
+   import / YAML run-spec / CLI) → index + coverage + scorecard feedback →
+   iterate`. Every proposed slot exists because a question needs it, which also
+   keeps the ontology minimal — a natural regularizer against the extraction
+   tension.
+3. **Design rule for the proposer (measured):** model an answer-bearing fact as
+   its **own typed node** (Breed, Term, Person), not a free-text property on a
+   broad entity — dedicated nodes get populated by extraction reliably; broad-
+   entity string slots often don't.
+
+Building blocks that already exist: `run_spec.py` (YAML ontology), `ontology_import.py`
+(arrows/cypher import), `ontology_scorecard.py` (`score_ontology`), `cli/ontology.py`.
+The one new piece is the demand-driven `propose_ontology` + the coverage-feedback
+surface (prototyped here, not yet productized).
+
+## Review caveats (carried from ADR-0213, still binding)
+
+- **n is small:** 1 document, 8 questions, mostly single runs — indexing is
+  non-deterministic on the hosted model, so per-cell counts carry ±1–2 noise.
+  Not yet a class-level claim; a stratified ≥20-question set with repeats + CIs
+  is needed to publish the magnitudes.
+- `gold_hit` substring was replaced by a MARA judge here, but the judge itself is
+  unaudited; spot-checked against substring, they agreed on this set.
+- Only the deterministic path was run; the text2cypher arm (dbt's Text-to-SQL
+  analog) is designed (`HybridQueryPlanner` + `SEOCHO_QUERY_PRECEDENCE=generated_first`)
+  but not yet executed.
+
+## Consequences / follow-ups
+
+- **Productize `propose_ontology(docs, questions)`** as the guided entry point
+  (draft-never-persists, review checklist), wired to the coverage + scorecard
+  feedback. (new ticket)
+- **Coverage-feedback surface:** turn refused-question → suggested-missing-slot
+  into a user-facing report. (new ticket)
+- **Broaden the benchmark** to ≥20 stratified questions across ≥3 documents with
+  repeats, and add the text2cypher arm, before publishing magnitudes. (new ticket)
+- Data: `ADR-0214-ontology-modeling.json`.

--- a/docs/decisions/ADR-0214-ontology-modeling.json
+++ b/docs/decisions/ADR-0214-ontology-modeling.json
@@ -1,0 +1,360 @@
+{
+  "adr": "ADR-0214",
+  "status": "experimental",
+  "date": "2026-08-17",
+  "environment": {
+    "llm": "MARA MiniMax-M2.7",
+    "graph": "DozerDB 5.26.3",
+    "code": "origin/main @ #593",
+    "judge": "MARA MiniMax-M2.7"
+  },
+  "questions": 8,
+  "axis1_modeling": {
+    "generic": {
+      "agg": {
+        "refused": 7,
+        "correct": 1
+      },
+      "coverage": {
+        "labels": [
+          {
+            "l": "Entity",
+            "c": 13
+          },
+          {
+            "l": "Document",
+            "c": 1
+          },
+          {
+            "l": "DocumentVersion",
+            "c": 1
+          },
+          {
+            "l": "Chunk",
+            "c": 1
+          },
+          {
+            "l": "Section",
+            "c": 1
+          }
+        ],
+        "domain_edges": 11,
+        "cornish_heath_in_structure": false,
+        "index_nodes": 17,
+        "index_rels": 42
+      },
+      "rows": [
+        {
+          "id": "q1_alias",
+          "qtype": "alias/appositive",
+          "gold": "Cornish heath",
+          "anchor": "Erica vagans",
+          "exec_rows": [
+            1
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results provided, I cannot fully answer this question. The results show that **Erica vagans** is related to **Cornwall** (as a location), b"
+        },
+        {
+          "id": "q2_meaning",
+          "qtype": "term-meaning",
+          "gold": "hunting ground",
+          "anchor": "Goonhilly",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results, the knowledge graph does not contain any information about the meaning of \"Goonhilly\" from old Cornish. The query returned an empt"
+        },
+        {
+          "id": "q3_named_after",
+          "qtype": "relationship",
+          "gold": "Ruan",
+          "anchor": "Goonhilly Down",
+          "exec_rows": [
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results provided, I cannot answer this question. The knowledge graph returned no results for this query.\n\nThe available data does not conta"
+        },
+        {
+          "id": "q4_ponies",
+          "qtype": "lookup",
+          "gold": "Goonhillies",
+          "anchor": "Goonhilly Down",
+          "exec_rows": [
+            3
+          ],
+          "substr_hit": true,
+          "judge": "correct",
+          "answer": "\n\nBased on the query results, the ponies associated with Goonhilly Down were called **Goonhillies**.\n\nThe query shows that \"Goonhillies\" is classified as an Ani"
+        },
+        {
+          "id": "q5_native",
+          "qtype": "relationship",
+          "gold": "Portugal",
+          "anchor": "Cornish heath",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nNo results"
+        },
+        {
+          "id": "q6_nationality",
+          "qtype": "entity-attribute",
+          "gold": "Irish",
+          "anchor": "St. Rumon",
+          "exec_rows": [
+            2
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nThe query results do not contain information about St. Rumon's nationality. The results only show relationships to Ruan Major and Ruan Minor, but no nationali"
+        },
+        {
+          "id": "q7_giant",
+          "qtype": "lookup",
+          "gold": "Cormoran",
+          "anchor": "Cornish legend",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results provided, no information was found regarding pre-historic heroes and giants of Cornish legend. The query returned an empty result s"
+        },
+        {
+          "id": "q8_fauna",
+          "qtype": "lookup",
+          "gold": "rabbit",
+          "anchor": "Goonhilly",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results, I do not have information in the knowledge graph about the fauna of Goonhilly or what two small creatures represent the most dange"
+        }
+      ]
+    },
+    "modeled": {
+      "agg": {
+        "correct": 5,
+        "refused": 3
+      },
+      "coverage": {
+        "labels": [
+          {
+            "l": "Place",
+            "c": 6
+          },
+          {
+            "l": "Person",
+            "c": 5
+          },
+          {
+            "l": "Term",
+            "c": 3
+          },
+          {
+            "l": "Plant",
+            "c": 1
+          },
+          {
+            "l": "Animal",
+            "c": 1
+          },
+          {
+            "l": "Document",
+            "c": 1
+          },
+          {
+            "l": "DocumentVersion",
+            "c": 1
+          },
+          {
+            "l": "Chunk",
+            "c": 1
+          },
+          {
+            "l": "Section",
+            "c": 1
+          }
+        ],
+        "domain_edges": 6,
+        "cornish_heath_in_structure": true,
+        "index_nodes": 20,
+        "index_rels": 43
+      },
+      "rows": [
+        {
+          "id": "q1_alias",
+          "qtype": "alias/appositive",
+          "gold": "Cornish heath",
+          "anchor": "Erica vagans",
+          "exec_rows": [
+            0,
+            1
+          ],
+          "substr_hit": true,
+          "judge": "correct",
+          "answer": "\n\nBased on the query results, the plant known scientifically as **Erica vagans** is also called **Cornish heath**.\n\nThis is indicated by the \"aliases\" property "
+        },
+        {
+          "id": "q2_meaning",
+          "qtype": "term-meaning",
+          "gold": "hunting ground",
+          "anchor": "Goonhilly",
+          "exec_rows": [
+            1
+          ],
+          "substr_hit": true,
+          "judge": "correct",
+          "answer": "\n\nBased on the query results, the place name **Goonhilly** comes from old Cornish and means **\"hunting ground\"**."
+        },
+        {
+          "id": "q3_named_after",
+          "qtype": "relationship",
+          "gold": "Ruan",
+          "anchor": "St. Rumon",
+          "exec_rows": [
+            2
+          ],
+          "substr_hit": true,
+          "judge": "correct",
+          "answer": "\n\nBased on the query results, the two villages are **Ruan Major** and **Ruan Minor**. Both are places that have a \"NAMED_AFTER\" relationship with St. Rumon, ind"
+        },
+        {
+          "id": "q4_ponies",
+          "qtype": "lookup",
+          "gold": "Goonhillies",
+          "anchor": "Goonhilly Down",
+          "exec_rows": [
+            1
+          ],
+          "substr_hit": true,
+          "judge": "correct",
+          "answer": "\n\nBased on the query results, Goonhilly Down was once noted for a breed of small, strong ponies called **Goonhillies**."
+        },
+        {
+          "id": "q5_native",
+          "qtype": "relationship",
+          "gold": "Portugal",
+          "anchor": "Cornish heath",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nNo information available."
+        },
+        {
+          "id": "q6_nationality",
+          "qtype": "entity-attribute",
+          "gold": "Irish",
+          "anchor": "St. Rumon",
+          "exec_rows": [
+            1
+          ],
+          "substr_hit": true,
+          "judge": "correct",
+          "answer": "\n\nIrish"
+        },
+        {
+          "id": "q7_giant",
+          "qtype": "lookup",
+          "gold": "Cormoran",
+          "anchor": "giant",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results provided, there is no information available to answer this question. The query returned empty results, meaning there are no entries"
+        },
+        {
+          "id": "q8_fauna",
+          "qtype": "lookup",
+          "gold": "rabbit",
+          "anchor": "Goonhilly",
+          "exec_rows": [
+            0,
+            0
+          ],
+          "substr_hit": false,
+          "judge": "refused",
+          "answer": "\n\nBased on the query results provided, I cannot answer this question. The knowledge graph returned no results (empty array) for this query.\n\nThe narrative about"
+        }
+      ]
+    },
+    "ceiling_alias_injected_q1": {
+      "judge": "correct",
+      "substr": true,
+      "answer": "\n\nBased on the query results, the plant known scientifically as *Erica vagans* is also called **Cornish heath**."
+    }
+  },
+  "axis2_proposer": {
+    "proposed_v1": {
+      "agg": {
+        "correct": 3,
+        "refused": 5
+      },
+      "nodes": [
+        "Plant",
+        "Place",
+        "Village",
+        "Country",
+        "Person"
+      ],
+      "index": {
+        "nodes": 11,
+        "rels": 24
+      }
+    },
+    "proposed_v2_dedicated_nodes": {
+      "agg": {
+        "correct": 4,
+        "refused": 4
+      },
+      "nodes": [
+        "Plant",
+        "Term",
+        "Place",
+        "Village",
+        "Saint",
+        "Breed",
+        "Country",
+        "Giant",
+        "Animal"
+      ],
+      "index": {
+        "nodes": 19,
+        "rels": 44
+      }
+    }
+  },
+  "headline": {
+    "generic": "1/8",
+    "modeled": "5/8",
+    "proposed_v1": "3/8",
+    "proposed_v2": "4/8",
+    "silent_wrong": "0 in all cells"
+  },
+  "finding": "Ontology modeling is the top query-side accuracy lever; a demand-driven proposer climbs 1->3->4/8 with zero hand-authoring; residual failures shift to stage-1 extraction coverage; SEOCHO fails loud (0 silent-wrong).",
+  "caveats": [
+    "n small (1 doc, 8 Q, mostly single runs; indexing non-deterministic)",
+    "MARA judge unaudited (agreed with substring on this set)",
+    "only deterministic path run; text2cypher arm designed not executed"
+  ]
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1335,3 +1335,14 @@ Use this block for new entries:
   (alias not lifted) AND **stage-3** (anchor-slot picks the question's framing-clause
   book title). n=1 with no ceiling/floor control ⇒ not a class claim. Lowest-
   complexity fix: strip question framing clauses before anchor-slot extraction.
+
+- [Experimental] ADR-0214 ontology-modeling-drives-accuracy (seocho-5ny) — live on
+  MARA MiniMax-M2.7 + DozerDB, 8 stratified Qs, MARA-judged. Ontology modeling is
+  the top query-side accuracy lever: generic single-Entity **1/8** vs typed MODELED
+  **5/8**, silent_wrong **0** in all cells (SEOCHO fails loud). Ceiling (inject the
+  alias) → recovers, so failures were upstream not retrieval. A demand-driven
+  `propose_ontology(docs, questions)` prototype climbs **1→3→4/8** with zero
+  hand-authoring; after modeling is right the residual shifts to stage-1 extraction
+  coverage. Enabled by #592 (anchor de-framing) + #593 (real write counters).
+  Caveats: n small, single-path, judge unaudited. Follow-ups: productize proposer +
+  coverage-feedback surface, broaden to ≥20 Qs + text2cypher arm.


### PR DESCRIPTION
## What
Records the ontology-modeling experiment (the "are we using the ontology well?" answer) and the demand-driven ontology proposer. **Experimental** status; deliberately minimal (no SDK code, just the recorded finding + follow-up tickets).

## Findings (live: MARA MiniMax-M2.7 + DozerDB 5.26.3, 8 stratified Qs, MARA-judged)
| ontology | correct | silent_wrong |
|---|---|---|
| GENERIC (single `Entity` + `RELATED_TO`) | **1/8** | 0 |
| MODELED (typed entities + typed relations) | **5/8** | 0 |
| proposed v1 (zero hand-authoring) | 3/8 | 0 |
| proposed v2 (prefers dedicated typed nodes) | 4/8 | 0 |

- **Ontology modeling is the top query-side accuracy lever** — dbt's "modeling matters enormously" reproduced on SEOCHO's deterministic (Semantic-Layer-analog) path.
- **silent_wrong = 0 everywhere** — SEOCHO fails loud (refuses), the property dbt calls decisive in production.
- **Ceiling control**: inject the alias into the modeled graph → the question recovers, so failures were upstream (extraction/modeling), not retrieval/generation.
- **`propose_ontology(docs, questions)`** prototype climbs 1→3→4/8 with zero hand-authoring; the dedicated-typed-node rule fixed the ponies question. After modeling is right, the residual shifts to **stage-1 extraction coverage** — the breakdown bottleneck moving cleanly between stages.

## Enabled by
`#592` (strip framing clauses before anchor-slot extraction) and `#593` (write() reads real Neo4j counters).

## Product direction
Guide users **demand-first**: `documents + target questions → propose_ontology draft → review (arrows import / YAML run-spec / CLI) → coverage + scorecard feedback → iterate`. Building blocks (`run_spec`, `ontology_import`, `ontology_scorecard`, `cli/ontology`) already exist; the new piece is the proposer + coverage-feedback surface.

## Caveats (binding)
n small (1 doc, 8 Qs, mostly single runs; indexing non-deterministic); MARA judge unaudited (agreed with substring on this set); only the deterministic path run (text2cypher arm designed, not executed).

## Follow-ups (seocho-5ny)
productize `propose_ontology`; coverage-feedback surface (refused-question → missing slot); broaden to ≥20 Qs × ≥3 docs + text2cypher arm.

Data in the companion `.json`. Validation: `check-doc-contracts.sh` green.
