### PR TITLE
feat(agent): wire ontology guardrail onto factory agents + neutral SDK tracing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ CHAT_INTERFACE_PORT=8501
 # Choose one of: none | console | jsonl | opik
 SEOCHO_TRACE_BACKEND=none
 SEOCHO_TRACE_JSONL_PATH=./traces/seocho-runtime.jsonl
+# OpenAI Agents SDK tracing is disabled by default (its default exporter phones
+# home to OpenAI and needs an OpenAI key; SEOCHO tracing is vendor-neutral,
+# ADR-0216). Set to 1/true to opt the SDK exporter back in.
+# SEOCHO_AGENTS_SDK_TRACING=
 
 # FinDER tutorials (docker-compose.tutorials.yml)
 # Fully embedded — JupyterLab only, no external graph server.

--- a/src/seocho/agent/factory.py
+++ b/src/seocho/agent/factory.py
@@ -1,6 +1,29 @@
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_sdk_tracing_policy() -> None:
+    """Keep the Agents SDK's tracing vendor-neutral (ADR-0216).
+
+    The SDK's default trace processor exports to OpenAI's backend and needs an
+    OpenAI API key (the 401 seen in ADR-0215); SEOCHO's tracing is vendor-neutral
+    (ADR-0144, Opik/OTLP). Disable the SDK exporter unless a deployment explicitly
+    opts in with SEOCHO_AGENTS_SDK_TRACING=1, so building a SEOCHO agent never
+    phones home. Idempotent and best-effort.
+    """
+    if os.getenv("SEOCHO_AGENTS_SDK_TRACING", "").strip().lower() in ("1", "true", "yes"):
+        return
+    try:
+        from agents import set_tracing_disabled
+
+        set_tracing_disabled(True)
+    except Exception as exc:  # noqa: BLE001 - tracing policy must never block agent build
+        logger.debug("could not set Agents SDK tracing policy: %s", exc)
 
 
 def _tool_agent_model_settings(llm: Any, *, temperature: float) -> Any:
@@ -165,6 +188,8 @@ def create_indexing_agent(
     from agents import Agent
     from ..tools import create_indexing_tools
 
+    _ensure_sdk_tracing_policy()
+
     tools = create_indexing_tools(
         ontology=ontology,
         graph_store=graph_store,
@@ -196,6 +221,8 @@ def create_query_agent(
     from agents import Agent
     from ..tools import create_query_tools
 
+    _ensure_sdk_tracing_policy()
+
     tools = create_query_tools(
         ontology=ontology,
         graph_store=graph_store,
@@ -226,6 +253,8 @@ def create_supervisor_agent(
     name: str = "Supervisor",
 ) -> Any:
     from agents import Agent, handoff
+
+    _ensure_sdk_tracing_policy()
 
     idx_agent = create_indexing_agent(
         ontology=ontology,

--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -727,4 +727,23 @@ def create_query_tools(
     ]
     if vector_store is not None:
         tools.append(make_search_similar_tool(vector_store))
+
+    # ADR-0215/0216 Phase 0: gate execute_cypher with SEOCHO's deterministic
+    # ontology guardrail (a SDK tool_input_guardrail). It runs BEFORE the tool
+    # touches the database and rejects an off-schema / unscoped / literal-inlined
+    # query with a message the model repairs from -- turning an unguarded loop
+    # (the MaxTurnsExceeded seen in ADR-0215) into a bounded repair. Defense in
+    # depth: never let attaching it break tool creation.
+    if ontology is not None:
+        try:
+            from .integrations.openai_agents import make_ontology_guardrail
+
+            guardrail = make_ontology_guardrail(ontology)
+            for _t in tools:
+                if getattr(_t, "name", None) == "execute_cypher":
+                    _t.tool_input_guardrails = [guardrail]
+                    break
+        except Exception as exc:  # noqa: BLE001 - guardrail is additive hardening
+            logger.warning("ontology guardrail not attached to execute_cypher: %s", exc)
+
     return tools

--- a/tests/seocho/test_agent_guardrail_wiring.py
+++ b/tests/seocho/test_agent_guardrail_wiring.py
@@ -1,0 +1,53 @@
+"""Phase 0 (ADR-0215/0216): the execute_cypher tool is guarded by the ontology.
+
+The multi-agent hand-off (ADR-0215) looped to MaxTurnsExceeded because the
+agent-mode query tool reached the database unguarded. SEOCHO already has the
+deterministic ontology guardrail (integrations/openai_agents.make_ontology_guardrail)
+but the factory-built agents did not wire it. These tests lock the wiring:
+execute_cypher carries a tool_input_guardrail, and the tracing policy keeps the
+SDK from phoning home.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+
+
+def _ontology() -> Ontology:
+    return Ontology(
+        name="guard",
+        nodes={"Entity": NodeDef(properties={"name": P(str, unique=True)}, identity_keys=["name"])},
+        relationships={"RELATED_TO": RelDef(source="Entity", target="Entity", description="")},
+    )
+
+
+def test_execute_cypher_tool_is_guarded():
+    pytest.importorskip("agents")
+    from seocho.tools import create_query_tools
+
+    tools = create_query_tools(ontology=_ontology(), graph_store=object())
+    exec_tool = next((t for t in tools if getattr(t, "name", None) == "execute_cypher"), None)
+    assert exec_tool is not None, "execute_cypher tool must be present"
+    guardrails = getattr(exec_tool, "tool_input_guardrails", None)
+    assert guardrails, "execute_cypher must carry an ontology tool_input_guardrail"
+
+
+def test_tracing_policy_is_idempotent_and_safe():
+    pytest.importorskip("agents")
+    from seocho.agent.factory import _ensure_sdk_tracing_policy
+
+    # Two calls, no exception; the SDK exporter is disabled by default so a
+    # SEOCHO agent build never requires an OpenAI key.
+    _ensure_sdk_tracing_policy()
+    _ensure_sdk_tracing_policy()
+
+
+def test_tracing_opt_in_respected(monkeypatch):
+    pytest.importorskip("agents")
+    from seocho.agent import factory
+
+    monkeypatch.setenv("SEOCHO_AGENTS_SDK_TRACING", "1")
+    # With opt-in set, the policy returns early without disabling — no raise.
+    factory._ensure_sdk_tracing_policy()


### PR DESCRIPTION
## What (ADR-0216 Phase 0)
Wires SEOCHO's **deterministic ontology guardrail** onto the factory-built agents' `execute_cypher` tool (as the SDK `tool_input_guardrail`), and keeps the Agents SDK's **tracing vendor-neutral**.

## Why
ADR-0215 found the factory agents ran `execute_cypher` **unguarded** — a malformed/off-schema query reached the DB and spun the hand-off loop. The guardrail (`integrations/openai_agents.make_ontology_guardrail`) already existed but wasn't attached. Now it rejects off-schema/unscoped/literal-inlined Cypher **before execution** with a repair message. Separately, the SDK's default trace exporter phones home to OpenAI (the 401 in ADR-0215); `_ensure_sdk_tracing_policy()` disables it unless `SEOCHO_AGENTS_SDK_TRACING=1`, keeping traces on Opik/OTLP (ADR-0144).

## Honest scope
Guardrail + tracing hardening lands (tests green, no workspace leak observed). **But the SDK autonomous multi-agent loop still does not converge with the hosted reasoning model (MaxTurnsExceeded persists)** — a loop-control problem, not a guardrail problem. Tracked for Phase 1 (planner as a function-tool + bounded turns) and the orchestration-framework decision.

## Tests
`tests/seocho/test_agent_guardrail_wiring.py` (execute_cypher is guarded; tracing policy idempotent + opt-in respected). `.env.example` declares `SEOCHO_AGENTS_SDK_TRACING`. CI `run_basic_ci.sh` green (1105 passed, 3 skipped).
