### PR TITLE
feat(agent): controlled query agent via a single deterministic tool (Phase 1)

### DIFF
--- a/src/seocho/agent/factory.py
+++ b/src/seocho/agent/factory.py
@@ -239,6 +239,50 @@ def create_query_agent(
     )
 
 
+def create_controlled_query_agent(
+    *,
+    ontology: Any,
+    graph_store: Any,
+    llm: Any,
+    vector_store: Any = None,
+    workspace_id: str = "default",
+    model: Optional[str] = None,
+    name: str = "QueryAgent",
+) -> Any:
+    """A query agent driven by a CONTROLLED flow: one deterministic tool.
+
+    ADR-0217 (spike-verified): the autonomous multi-tool query loop did not
+    converge with a hosted reasoning model (ADR-0215 MaxTurnsExceeded). Giving the
+    agent a single deterministic tool (`answer_from_graph`, the ADR-0214 path)
+    shrinks its job to "call once, relay" and the hand-off converges. The moat
+    stays deterministic; the SDK only supplies the loop/hand-off/guardrail slots.
+    """
+    from agents import Agent
+
+    from ..tools import make_deterministic_query_tool
+
+    _ensure_sdk_tracing_policy()
+
+    tool = make_deterministic_query_tool(
+        ontology=ontology,
+        graph_store=graph_store,
+        llm=llm,
+        vector_store=vector_store,
+        workspace_id=workspace_id,
+    )
+    return Agent(
+        name=name,
+        instructions=(
+            "Answer the user's question by calling answer_from_graph exactly once "
+            "with the question verbatim, then relay its result as the final answer. "
+            "Do not call it more than once; do not write Cypher yourself."
+        ),
+        tools=[tool],
+        model=llm.to_agents_sdk_model(model=model),
+        model_settings=_tool_agent_model_settings(llm, temperature=0.0),
+    )
+
+
 def create_supervisor_agent(
     *,
     ontology: Any,

--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -422,6 +422,51 @@ def make_execute_cypher_tool(
     return execute_cypher
 
 
+def make_deterministic_query_tool(
+    *,
+    ontology: Any,
+    graph_store: Any,
+    llm: Any,
+    vector_store: Any = None,
+    workspace_id: str = "default",
+    default_database: str = "neo4j",
+):
+    """One controlled tool that runs SEOCHO's deterministic query path end to end.
+
+    Wraps the deterministic path (intent slots -> planner builds Cypher -> execute
+    -> synthesize; the accuracy winner in ADR-0214) as a single SDK function-tool.
+    Giving a query agent THIS tool instead of the free-form
+    text2cypher/execute/validate set turns its job into "call once, relay" -- a
+    controlled flow that CONVERGES where the autonomous multi-tool loop did not
+    (ADR-0215 MaxTurnsExceeded; ADR-0217 spike). `workspace_id` is closed over,
+    so scope cannot leak through a hand-off.
+    """
+    from agents import function_tool
+
+    from .local_engine import _LocalEngine
+
+    engine = _LocalEngine(
+        ontology=ontology,
+        graph_store=graph_store,
+        llm=llm,
+        vector_store=vector_store,
+        workspace_id=workspace_id,
+    )
+
+    @function_tool
+    def answer_from_graph(question: str, database: str = default_database) -> str:
+        """Answer a question from the knowledge graph using SEOCHO's deterministic
+        ontology-grounded query path. Pass the user's question verbatim and call
+        this exactly once; its result is the final answer."""
+        try:
+            return str(engine.ask(question, database=database))
+        except Exception as exc:  # noqa: BLE001 - surface the error to the model, do not raise
+            logger.error("answer_from_graph failed: %s", exc)
+            return json.dumps({"error": str(exc)})
+
+    return answer_from_graph
+
+
 def make_search_similar_tool(vector_store: Any):
     """Create a search_similar tool bound to this vector store."""
     from agents import function_tool

--- a/tests/seocho/test_controlled_query_agent.py
+++ b/tests/seocho/test_controlled_query_agent.py
@@ -1,0 +1,45 @@
+"""Phase 1 (ADR-0217): a controlled query agent driven by ONE deterministic tool.
+
+The autonomous multi-tool query loop did not converge with a hosted reasoning
+model (ADR-0215). The spike showed a controlled flow — a single deterministic
+`answer_from_graph` tool — converges. These tests lock the wiring: the tool
+exists and the controlled agent carries exactly that one tool.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+
+
+def _ontology() -> Ontology:
+    return Ontology(
+        name="ctrl",
+        nodes={"Entity": NodeDef(properties={"name": P(str, unique=True)}, identity_keys=["name"])},
+        relationships={"RELATED_TO": RelDef(source="Entity", target="Entity", description="")},
+    )
+
+
+def test_deterministic_query_tool_builds():
+    pytest.importorskip("agents")
+    from seocho.tools import make_deterministic_query_tool
+
+    tool = make_deterministic_query_tool(
+        ontology=_ontology(), graph_store=object(), llm=object(), workspace_id="w")
+    assert getattr(tool, "name", None) == "answer_from_graph"
+
+
+def test_controlled_query_agent_has_single_deterministic_tool():
+    pytest.importorskip("agents")
+    from seocho.agent.factory import create_controlled_query_agent
+
+    class _LLM:
+        provider = "mara"
+        def to_agents_sdk_model(self, *, model=None):
+            return "mara/model"
+
+    agent = create_controlled_query_agent(
+        ontology=_ontology(), graph_store=object(), llm=_LLM(), workspace_id="w")
+    names = [getattr(t, "name", None) for t in agent.tools]
+    assert names == ["answer_from_graph"], names


### PR DESCRIPTION
## What (ADR-0217 Phase 1)
A **controlled query agent** driven by a single deterministic tool, instead of the autonomous multi-tool loop that didn't converge.

## Why
ADR-0215: the SDK autonomous query loop hit `MaxTurnsExceeded` with the hosted reasoning model (the free-form text2cypher/execute/validate tools spun). A spike showed a **controlled flow converges**: give the agent ONE tool that runs SEOCHO's deterministic ontology-grounded path end to end (the ADR-0214 accuracy winner), shrinking its job to "call once, relay".

## Change (additive)
- `make_deterministic_query_tool` — wraps `_LocalEngine.ask` as a single SDK function-tool `answer_from_graph`; `workspace_id` closed over → scope can't leak through a hand-off.
- `create_controlled_query_agent` — a query agent with only that tool + bounded instructions. The existing tiered `create_query_agent` is untouched.

## Live spike (MARA MiniMax-M2.7 + Agents SDK, supervisor→handoff, max_turns=6)
| | autonomous loop (ADR-0215) | controlled flow (this PR) |
|---|---|---|
| convergence | ❌ MaxTurnsExceeded | ✅ both questions converged (last_agent=QueryAgent) |
| workspace isolation | n/a (no answer) | held (B decoy facts never surfaced) |

**Proves the failure was loop control, not the framework** — so the Agents SDK is kept, driven deterministically.

## Tests
`tests/seocho/test_controlled_query_agent.py` (2). CI `run_basic_ci.sh` green.
