### PR TITLE
feat(agent): Supervisor routes to the controlled query agent by default

### DIFF
--- a/src/seocho/agent/factory.py
+++ b/src/seocho/agent/factory.py
@@ -295,6 +295,7 @@ def create_supervisor_agent(
     workspace_id: str = "default",
     model: Optional[str] = None,
     name: str = "Supervisor",
+    controlled_query: bool = True,
 ) -> Any:
     from agents import Agent, handoff
 
@@ -309,15 +310,30 @@ def create_supervisor_agent(
         workspace_id=workspace_id,
         model=model,
     )
-    qry_agent = create_query_agent(
-        ontology=ontology,
-        graph_store=graph_store,
-        llm=llm,
-        vector_store=vector_store,
-        ontology_context=ontology_context,
-        workspace_id=workspace_id,
-        model=model,
-    )
+    # Default to the controlled query agent (one deterministic tool): the
+    # autonomous multi-tool query loop did not converge with a hosted reasoning
+    # model (ADR-0215 MaxTurnsExceeded), while the controlled flow converges
+    # (ADR-0217 spike, #607). Set controlled_query=False to route to the tiered
+    # autonomous agent instead.
+    if controlled_query:
+        qry_agent = create_controlled_query_agent(
+            ontology=ontology,
+            graph_store=graph_store,
+            llm=llm,
+            vector_store=vector_store,
+            workspace_id=workspace_id,
+            model=model,
+        )
+    else:
+        qry_agent = create_query_agent(
+            ontology=ontology,
+            graph_store=graph_store,
+            llm=llm,
+            vector_store=vector_store,
+            ontology_context=ontology_context,
+            workspace_id=workspace_id,
+            model=model,
+        )
     return Agent(
         name=name,
         instructions=supervisor_system_prompt(ontology, routing_policy=routing_policy),

--- a/tests/seocho/test_supervisor_controlled_routing.py
+++ b/tests/seocho/test_supervisor_controlled_routing.py
@@ -1,0 +1,58 @@
+"""The Supervisor routes queries to the controlled agent by default (ADR-0217).
+
+The autonomous multi-tool query loop did not converge with a hosted reasoning
+model (ADR-0215). #607 shipped a controlled query agent that converges; this
+makes the Supervisor route to it by default so the proven path is the product
+default. `controlled_query=False` preserves the tiered autonomous route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho import NodeDef, Ontology, P, RelDef
+
+
+def _ontology() -> Ontology:
+    return Ontology(
+        name="sup",
+        nodes={"Entity": NodeDef(properties={"name": P(str, unique=True)}, identity_keys=["name"])},
+        relationships={"RELATED_TO": RelDef(source="Entity", target="Entity", description="")},
+    )
+
+
+class _LLM:
+    provider = "mara"
+    def to_agents_sdk_model(self, *, model=None):
+        return "mara/model"
+
+
+def test_supervisor_builds_and_routes_to_query_and_indexing():
+    pytest.importorskip("agents")
+    from seocho.agent.factory import create_supervisor_agent
+
+    sup = create_supervisor_agent(ontology=_ontology(), graph_store=object(), llm=_LLM())
+    names = {getattr(h, "agent_name", None) for h in sup.handoffs}
+    assert names == {"IndexingAgent", "QueryAgent"}, names
+
+
+def test_controlled_query_is_the_default():
+    """The default path is the controlled query agent (single deterministic tool)."""
+    pytest.importorskip("agents")
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[2]
+           / "src" / "seocho" / "agent" / "factory.py").read_text()
+    sup_block = src[src.index("def create_supervisor_agent"):]
+    assert "controlled_query: bool = True" in sup_block, "controlled routing must default on"
+    assert "create_controlled_query_agent(" in sup_block, "supervisor must use the controlled agent"
+
+
+def test_tiered_route_still_available():
+    pytest.importorskip("agents")
+    from seocho.agent.factory import create_supervisor_agent
+
+    # controlled_query=False must still build (the tiered autonomous route).
+    sup = create_supervisor_agent(
+        ontology=_ontology(), graph_store=object(), llm=_LLM(), controlled_query=False)
+    assert len(sup.handoffs) == 2


### PR DESCRIPTION
## What
Makes the **Supervisor route queries to the controlled query agent by default** — the natural next move after ADR-0217 / #607, turning the proven-convergent path into the product default.

## Why
The autonomous multi-tool query hand-off spun to `MaxTurnsExceeded` with a hosted reasoning model (ADR-0215). #607 shipped `create_controlled_query_agent` (one deterministic `answer_from_graph` tool) which the spike showed **converges**. This wires the Supervisor to it.

## Change
`create_supervisor_agent(..., controlled_query=True)` — default builds the query hand-off target via `create_controlled_query_agent`. `controlled_query=False` keeps the tiered autonomous route. Indexing hand-off unchanged (not the failing path).

## Tests
`tests/seocho/test_supervisor_controlled_routing.py` (3): routes to Query+Indexing; controlled is the default; tiered route still builds. CI `run_basic_ci.sh` green.
