### PR TITLE
docs(adr): ADR-0218 the agentic-RAG bottleneck is LLM round-trips

### DIFF
--- a/docs/decisions/ADR-0218-agentic-rag-bottleneck.json
+++ b/docs/decisions/ADR-0218-agentic-rag-bottleneck.json
@@ -1,0 +1,24 @@
+{
+  "adr": "ADR-0218", "status": "experimental", "date": "2026-08-17",
+  "goal": "identify where the agentic-RAG bottleneck is",
+  "environment": {"model": "MARA MiniMax-M2.7 (API)", "graph": "DozerDB 5.26.3",
+                  "orchestration": "OpenAI Agents SDK", "trace": "SEOCHO OTLP -> Tempo",
+                  "sample": "EnterpriseRAG-Bench (multipart upload limits)", "runs_per_arm": 3},
+  "gen_ai_chat_seconds": {
+    "compile_cypher": {"agentic": [10.0, 9.4, 7.6], "direct": [17.6, 15.9, 5.2]},
+    "synthesize":     {"agentic": [7.1, 4.1, 3.6],  "direct": [6.0, 4.9, 4.9]},
+    "orchestration":  {"agentic": [177.3, 16.8],    "direct": []}
+  },
+  "graph_ops_per_run_ms": {"agentic": 41.6, "direct": 19.6},
+  "findings": {
+    "graph_db_share_of_latency": "~0.1% (NOT the bottleneck)",
+    "cost_is": "LLM round-trips (~11s/call avg on MiniMax-M2.7, high variance)",
+    "agentic_tax": "agentic adds >=1 orchestration LLM turn/query; direct adds 0",
+    "worst_tail": "177s single supervisor orchestration turn (reasoning-model spin)"
+  },
+  "decision": "bottleneck = LLM round-trips; most removable slice = agentic orchestration. Prefer direct controlled query agent for single-intent; Agent.as_tool over handoff; do not optimize the graph (0.1%). Faster model / self-hosted vLLM attacks the floor.",
+  "chart": "https://claude.ai/code/artifact/6d49ed3c-7ff9-40ed-8ee9-19dcc0016d89",
+  "caveats": ["n=3, large API-latency variance (order-of-magnitude only)",
+              "177s is one real outlier kept visible",
+              "answer quality is a separate axis (ADR-0214 generic ontology); latency path is answer-independent"]
+}

--- a/docs/decisions/ADR-0218-agentic-rag-bottleneck.md
+++ b/docs/decisions/ADR-0218-agentic-rag-bottleneck.md
@@ -1,0 +1,73 @@
+# ADR-0218: The agentic-RAG bottleneck is LLM round-trips — and the agentic layer is the removable slice
+
+- Status: experimental
+- Date: 2026-08-17
+- Tickets: seocho-5ny (breakdown epic)
+- Related: ADR-0144 (rag.ask span tree), ADR-0214 (answer-quality axis),
+  ADR-0216/0217 (Agents SDK coupling / orchestration), #606/#607/#609 (controlled path)
+
+## Context
+
+Goal: identify **where the agentic-RAG bottleneck is**. Ran an EnterpriseRAG-Bench
+question e2e through the OpenAI Agents SDK on MARA MiniMax-M2.7 + live DozerDB
+5.26.3, with SEOCHO's OTLP tracing → otel-collector → Tempo. Two arms, same
+question, same indexed graph, 3 runs each:
+
+- **agentic** — `create_supervisor_agent` → SDK hand-off → controlled QueryAgent → tool
+- **direct** — `create_controlled_query_agent` via Runner (no supervisor)
+
+Durations read back from the Tempo trace API per stage
+(`rag.compile_cypher`, `rag.synthesize`, `gen_ai.chat`, `db.query`).
+
+Chart (shareable): https://claude.ai/code/artifact/6d49ed3c-7ff9-40ed-8ee9-19dcc0016d89
+
+## Findings (real traces)
+
+1. **The graph database is NOT the bottleneck: ~0.1% of latency.** `db.query` +
+   traversal totalled ~20–40 ms per query in both arms. GraphRAG's graph tier is
+   effectively free.
+2. **LLM round-trips are the entire cost.** Per-call `gen_ai.chat` averaged ~11 s
+   on MiniMax-M2.7, with large variance.
+3. **The agentic layer adds removable orchestration turns.** The direct arm made
+   **0** orchestration LLM calls; the agentic arm made **≥1** per query (routing /
+   hand-off / relay) — pure overhead the direct path does not incur.
+4. **The worst tail lives in the agentic layer:** one supervisor orchestration
+   turn took **177 s** (the reasoning model spun), vs typical ~17 s. RAG stages
+   (compile ~8–17 s, synth ~4–7 s) never showed that tail.
+
+Per-arm gen_ai.chat calls captured (seconds):
+
+| stage | agentic | direct |
+|---|---|---|
+| compile_cypher | 10.0, 9.4, 7.6 | 17.6, 15.9, 5.2 |
+| synthesize | 7.1, 4.1, 3.6 | 6.0, 4.9, 4.9 |
+| orchestration (agent-loop) | 177.3, 16.8 | *(none)* |
+| graph ops (per run) | ~0.042 s | ~0.020 s |
+
+## Decision / implications
+
+- **The bottleneck is LLM round-trips, and the single most *removable* slice is the
+  agentic orchestration itself.** For single-intent queries, prefer the direct
+  controlled query agent (#607) over the supervisor hand-off; it eliminates the
+  orchestration turns and their tail with no loss (both routed to the same
+  QueryAgent). Where a manager agent is needed, prefer `Agent.as_tool` (control
+  returns, no relay turn) over a handoff transfer.
+- **Model latency dominates the rest.** MiniMax-M2.7 at ~11 s/call sets the floor;
+  a faster model or the self-hosted vLLM target (reference: vLLM verified end to
+  end) attacks every remaining slice.
+- **Do not optimize the graph.** It is 0.1% of latency; effort there is wasted.
+
+## Caveats (binding)
+
+n=3 per arm with large per-call API-latency variance — magnitudes are
+order-of-magnitude, not precise. The 177 s point is one real outlier, kept
+visible. Answer *quality* is a separate axis (the generic single-Entity ontology
+did not surface this ERB fact — ADR-0214); latency takes the same path regardless
+of correctness, so the bottleneck attribution holds independent of the answer.
+
+## Consequences / follow-ups (seocho-5ny)
+
+- Measure `Agent.as_tool` vs handoff latency directly (quantify the relay-turn saving).
+- Re-run the arms on the self-hosted vLLM / a faster model to confirm the floor shifts.
+- Broaden to more ERB questions for tighter distributions.
+- Data: `ADR-0218-agentic-rag-bottleneck.json`.

--- a/docs/decisions/ADR-0218-arms-agg.txt
+++ b/docs/decisions/ADR-0218-arms-agg.txt
@@ -1,0 +1,50 @@
+{
+  "agentic": {
+    "runs_with_ragask": 3,
+    "agent_loop_llm": {
+      "calls": 2,
+      "total_ms": 194028,
+      "per_run_calls": 0.67,
+      "per_run_ms": 64676
+    },
+    "compile_llm": {
+      "calls": 3,
+      "total_ms": 26991,
+      "per_run_ms": 8997
+    },
+    "synth_llm": {
+      "calls": 3,
+      "total_ms": 14766,
+      "per_run_ms": 4922
+    },
+    "graph_ops": {
+      "calls": 13,
+      "total_ms": 124.9,
+      "per_run_ms": 41.6
+    }
+  },
+  "direct": {
+    "runs_with_ragask": 3,
+    "agent_loop_llm": {
+      "calls": 0,
+      "total_ms": 0,
+      "per_run_calls": 0.0,
+      "per_run_ms": 0
+    },
+    "compile_llm": {
+      "calls": 3,
+      "total_ms": 38722,
+      "per_run_ms": 12907
+    },
+    "synth_llm": {
+      "calls": 3,
+      "total_ms": 15730,
+      "per_run_ms": 5243
+    },
+    "graph_ops": {
+      "calls": 12,
+      "total_ms": 58.7,
+      "per_run_ms": 19.6
+    }
+  }
+}

--- a/docs/decisions/DECISION_LOG.md
+++ b/docs/decisions/DECISION_LOG.md
@@ -1377,3 +1377,12 @@ Use this block for new entries:
   LangGraph; LangGraph stays deferred behind seocho-ihg's MCP-first triple gate,
   reconsidered only if a durable/branching/resumable StateGraph becomes required.
   Orchestration kept a thin swappable adapter behind agent/factory + integrations.
+
+- [Experimental] ADR-0218 agentic-rag-bottleneck (seocho-5ny) — EnterpriseRAG e2e via
+  Agents SDK + MARA MiniMax-M2.7 + live DozerDB, traced to Tempo, agentic vs direct arm
+  (3 runs each). **Graph DB = ~0.1% of latency (NOT the bottleneck)**; LLM round-trips are
+  the entire cost; the **agentic layer adds >=1 removable orchestration turn/query (direct=0)
+  and holds the worst tail (177s spin)**. Implication: prefer the direct controlled query
+  agent for single-intent, Agent.as_tool over handoff, don't optimize the graph; faster
+  model / self-hosted vLLM attacks the floor. Shareable chart artifact. Caveats: n=3, high
+  variance, answer-quality is a separate axis (ADR-0214).


### PR DESCRIPTION
## What
Records the **agentic-RAG bottleneck** finding from a live EnterpriseRAG e2e. **Experimental.**

## Setup (real data)
ERB question e2e through the OpenAI Agents SDK on MARA MiniMax-M2.7 + live DozerDB 5.26.3, traced via SEOCHO OTLP → Tempo. Two arms, 3 runs each: **agentic** (supervisor→handoff→QueryAgent) vs **direct** (controlled QueryAgent only).

## Findings
1. **Graph DB is NOT the bottleneck — ~0.1% of latency** (~20–40 ms). GraphRAG's graph tier is effectively free.
2. **LLM round-trips are the entire cost** (~11 s/call on MiniMax-M2.7, high variance).
3. **The agentic layer adds removable orchestration turns**: direct = **0**, agentic = **≥1**/query (routing/relay).
4. **The worst tail lives in the agentic layer**: one supervisor turn = **177 s** (reasoning-model spin); RAG stages never showed that tail.

## Implication
Bottleneck = LLM round-trips; most **removable** slice = the agentic orchestration. Prefer the direct controlled query agent for single-intent queries, `Agent.as_tool` over handoff; don't optimize the graph; a faster model / self-hosted vLLM attacks the floor.

## Shareable chart
https://claude.ai/code/artifact/6d49ed3c-7ff9-40ed-8ee9-19dcc0016d89

Data in the companion `.json` + `-arms-agg.txt`. Caveats: n=3, large API-latency variance, answer-quality is a separate axis (ADR-0214). `check-doc-contracts.sh` green.
