### PR TITLE
Fix missing workspace_id in tools.py cypher query

### DIFF
--- a/src/seocho/tools.py
+++ b/src/seocho/tools.py
@@ -393,7 +393,7 @@ def make_execute_cypher_tool(
             params = {}
 
         try:
-            records = graph_store.query(cypher, params=params, database=database)
+            records = graph_store.query(cypher, params=params, database=database, workspace_id=workspace_id, enforce_workspace_filter=True)
             payload = {
                 "records": records,
                 "count": len(records),


### PR DESCRIPTION
Severity: High
Vulnerability: Unsafe dynamic Cypher execution without workspace isolation.
Impact: Potential for data leakage across tenants/workspaces.
Fix: Added workspace_id and enforce_workspace_filter=True to graph_store.query in execute_cypher tool.
Validation: Ran bash scripts/ci/run_basic_ci.sh and uv run pytest tests/seocho/test_session_agent.py.
Risks: Minimal. The enforce_workspace_filter mechanism is robust and already tested in core queries.
Modified Files: src/seocho/tools.py

---
*PR created automatically by Jules for task [2366576694932280618](https://jules.google.com/task/2366576694932280618) started by @tteon*