### PR TITLE
fix(llm): SeochoCredentialError names the real provider's env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project are documented here. Versioning follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **`SeochoCredentialError` on missing LLM credentials.** Constructing an LLM
+  backend (including via `Seocho.local(...)`) with no API key now raises a
+  SEOCHO-native error naming the actual provider and its environment
+  variable(s) (e.g. `MARA_API_KEY`), instead of the upstream `openai` client's
+  `OPENAI_API_KEY`-branded error. Keyless local gateways keep working via the
+  documented `api_key="EMPTY"` sentinel (vLLM applies it automatically).
+
 ## [0.6.0] — 2026-08-18
 
 Minor release covering everything since the last published version (0.4.1,

--- a/src/seocho/__init__.py
+++ b/src/seocho/__init__.py
@@ -133,6 +133,7 @@ _MODULE_EXPORTS: Dict[str, Iterable[str]] = {
     ],
     ".exceptions": [
         "SeochoConnectionError",
+        "SeochoCredentialError",
         "SeochoError",
         "SeochoHTTPError",
     ],
@@ -458,6 +459,7 @@ __all__ = [
     # Errors users catch
     "SeochoError",
     "SeochoConnectionError",
+    "SeochoCredentialError",
     "SeochoHTTPError",
     "OntologyDriftError",
 ]

--- a/src/seocho/exceptions.py
+++ b/src/seocho/exceptions.py
@@ -11,6 +11,15 @@ class SeochoConnectionError(SeochoError):
     """Raised when the client cannot reach the SEOCHO backend."""
 
 
+class SeochoCredentialError(SeochoError):
+    """Raised when an LLM provider credential is missing.
+
+    Replaces the upstream ``openai`` client's ``OPENAI_API_KEY``-branded
+    construction error with a message that names the actual provider and
+    the environment variable(s) SEOCHO resolves for it.
+    """
+
+
 class SeochoHTTPError(SeochoError):
     """Raised when the SEOCHO backend returns an HTTP error."""
 

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -181,6 +181,16 @@ def _resolve_client_kwargs(
             resolved_api_key = _strip_text(os.getenv(env_name))
             if resolved_api_key:
                 break
+    if not resolved_api_key:
+        from ..exceptions import SeochoCredentialError
+
+        env_names = " or ".join((spec.api_key_env, *spec.api_key_env_aliases))
+        raise SeochoCredentialError(
+            f"No API key found for LLM provider '{spec.name}'. "
+            f"Pass api_key=... (e.g. Seocho.local(ontology, api_key=...)) "
+            f"or set the {env_names} environment variable. "
+            f'For a local gateway that needs no key, pass api_key="EMPTY".'
+        )
     kwargs: Dict[str, Any] = {"timeout": timeout}
     if resolved_api_key:
         kwargs["api_key"] = resolved_api_key

--- a/tests/seocho/test_llm_credential_error.py
+++ b/tests/seocho/test_llm_credential_error.py
@@ -1,0 +1,83 @@
+"""A missing LLM credential must fail with a SEOCHO-native message.
+
+Before this guard, ``Seocho.local(onto)`` with no key crashed inside the
+``openai`` client with an ``OPENAI_API_KEY``-branded error even when the
+selected provider was MARA — the first-run experience pointed users at the
+wrong environment variable. Construction now raises
+:class:`seocho.exceptions.SeochoCredentialError` naming the actual provider
+and the env var(s) SEOCHO resolves for it.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from seocho.exceptions import SeochoCredentialError, SeochoError
+from seocho.store.llm import create_llm_backend
+
+
+@pytest.fixture
+def fake_openai(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = ModuleType("openai")
+    module.OpenAI = lambda **kwargs: SimpleNamespace(kwargs=kwargs)
+    module.AsyncOpenAI = lambda **kwargs: SimpleNamespace(kwargs=kwargs)
+    monkeypatch.setitem(sys.modules, "openai", module)
+
+_ALL_KEY_ENVS = [
+    "OPENAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "MOONSHOT_API_KEY",
+    "XAI_API_KEY",
+    "GROK_API_KEY",
+    "DASHSCOPE_API_KEY",
+    "MARA_API_KEY",
+    "SEOCHO_VLLM_API_KEY",
+    "VLLM_API_KEY",
+]
+
+
+@pytest.fixture(autouse=True)
+def _no_provider_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env in _ALL_KEY_ENVS:
+        monkeypatch.delenv(env, raising=False)
+
+
+def test_mara_without_key_raises_seocho_error_naming_mara_env() -> None:
+    with pytest.raises(SeochoCredentialError) as exc:
+        create_llm_backend(provider="mara")
+
+    message = str(exc.value)
+    assert "mara" in message
+    assert "MARA_API_KEY" in message
+    # The whole point: never point a MARA user at OpenAI's variable.
+    assert "OPENAI_API_KEY" not in message
+
+
+def test_message_lists_env_aliases() -> None:
+    with pytest.raises(SeochoCredentialError) as exc:
+        create_llm_backend(provider="grok")
+
+    message = str(exc.value)
+    assert "XAI_API_KEY" in message
+    assert "GROK_API_KEY" in message
+
+
+def test_credential_error_is_a_seocho_error() -> None:
+    # Users catching the documented base class keep working.
+    with pytest.raises(SeochoError):
+        create_llm_backend(provider="openai")
+
+
+def test_vllm_stays_keyless_via_empty_sentinel(fake_openai: None) -> None:
+    # vLLM runs unauthenticated by default; its backend passes the documented
+    # "EMPTY" sentinel, so the credential guard must not fire.
+    backend = create_llm_backend(provider="vllm", model="Qwen2.5-7B-Instruct")
+    assert backend._api_key == "EMPTY"
+
+
+def test_explicit_empty_opts_out_for_local_gateways(fake_openai: None) -> None:
+    backend = create_llm_backend(provider="openai", api_key="EMPTY")
+    assert backend._api_key == "EMPTY"


### PR DESCRIPTION
## Summary
- Backend construction with no API key now raises `SeochoCredentialError` (a `SeochoError`, exported from the package root) naming the actual provider and the env var(s) SEOCHO resolves — including aliases — instead of the upstream openai client's `OPENAI_API_KEY`-branded error.
- First-run DX gap flagged during the 0.6.0 release smoke: `Seocho.local(onto)` on the default MARA provider pointed users at OpenAI's variable.
- Keyless local gateways unaffected: vLLM's documented `"EMPTY"` sentinel applies before resolution; any provider accepts explicit `api_key="EMPTY"`.

## Validation
- new `tests/seocho/test_llm_credential_error.py` (5 tests)
- llm backend + observability suites green (45)
- full `run_basic_ci.sh` with `MARA_API_KEY`/`OPENAI_API_KEY` stripped from the environment — no test relied on ambient keys (the 2 failures in that run were the pre-existing env-contract drift fixed in the compose-hygiene PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)