### PR TITLE
fix(query): _count anchors the filter entity on the ontology-declared side

### DIFF
--- a/src/seocho/query/cypher_builder.py
+++ b/src/seocho/query/cypher_builder.py
@@ -1039,11 +1039,31 @@ class CypherBuilder:
         # scan and report the total node count.
         if anchor_entity and relationship_type in self.ontology.relationships:
             src_label = target_label if target_label in self.ontology.nodes else label
-            src_clause = f":{quote_identifier(src_label)}" if src_label else ""
-            rel_clause = f":{quote_identifier(relationship_type)}"
             # Anchor label matters twice: it makes the pattern index-eligible and it
             # tells us which identity key to compare against.
             anchor_label = label if label in self.ontology.nodes else src_label
+            # When the ontology declares two DISTINCT endpoint labels, the
+            # declaration is authoritative for which side is counted and which
+            # side carries the anchor predicate. Plans routinely arrive with the
+            # counted label in the anchor slot ("how many projects in Vietnam"
+            # → anchor_label=Project), and _orient_relationship then pins the
+            # anchor to the declared source — so the filter equality landed on
+            # the counted side (anchor.registry_id = 'Vietnam') while the
+            # pattern ran against the declared direction reversed: a valid query
+            # that always matches zero rows. Same-label relationships (TRANSFER:
+            # Account -> Account) keep the existing role-based behaviour.
+            rel_def = self.ontology.relationships[relationship_type]
+            if (
+                rel_def.source in self.ontology.nodes
+                and rel_def.target in self.ontology.nodes
+                and rel_def.source != rel_def.target
+            ):
+                if getattr(self, "anchor_role", "") == "source":
+                    anchor_label, src_label = rel_def.source, rel_def.target
+                else:
+                    anchor_label, src_label = rel_def.target, rel_def.source
+            src_clause = f":{quote_identifier(src_label)}" if src_label else ""
+            rel_clause = f":{quote_identifier(relationship_type)}"
             anchor_clause = f":{quote_identifier(anchor_label)}" if anchor_label else ""
             sargable = self._sargable_anchor("anchor", anchor_label, anchor_entity)
             if sargable is not None:

--- a/tests/seocho/test_cypher_builder_ontology_aware.py
+++ b/tests/seocho/test_cypher_builder_ontology_aware.py
@@ -77,3 +77,58 @@ def test_anchor_matches_ticker_branch() -> None:
     assert params["anchor"] == "JKHY"
     # period OR year matching present (FY period vs bare year)
     assert "m.period" in cypher
+
+
+# ---------------------------------------------------------------------------
+# _count: ontology-declared endpoints are authoritative for anchor vs counted
+# ---------------------------------------------------------------------------
+
+def _carbon_like_ontology() -> Ontology:
+    """Distinct endpoint labels: Project -LOCATED_IN-> HostCountry."""
+    return Ontology(
+        name="carbon_like",
+        graph_model="lpg",
+        nodes={
+            "Project": NodeDef(properties={"registry_id": P(str, unique=True), "name": P(str)}),
+            "HostCountry": NodeDef(properties={"country_iso": P(str, unique=True), "name": P(str, index=True)}),
+        },
+        relationships={
+            "LOCATED_IN": RelDef(source="Project", target="HostCountry",
+                                 description="project located in country"),
+        },
+    )
+
+
+def test_count_filter_entity_anchors_on_declared_target() -> None:
+    """Regression: "How many projects are in Vietnam" produced
+    (src:HostCountry)-[:LOCATED_IN]->(anchor:Project) with
+    anchor.registry_id = 'Vietnam' — declared-direction reversed AND the filter
+    equality on the counted label, so the count was always 0. With distinct
+    endpoint labels the declaration decides: counted = source, anchor = target,
+    regardless of how the plan filled anchor_label/target_label."""
+    builder = CypherBuilder(_carbon_like_ontology())
+    for anchor_label, target_label in (("HostCountry", "Project"), ("Project", "HostCountry")):
+        cypher, params = builder.build(
+            intent="count", anchor_entity="Vietnam",
+            anchor_label=anchor_label, target_label=target_label,
+            relationship_type="LOCATED_IN", workspace_id="ws",
+        )
+        assert "(src:`Project`)-[:`LOCATED_IN`]->(anchor:`HostCountry`)" in cypher
+        assert "anchor:`Project`" not in cypher
+        assert "Vietnam" in list(params.values())
+
+
+def test_count_same_label_relationship_keeps_in_degree() -> None:
+    """FinBench-style Account -TRANSFER-> Account keeps the existing
+    anchor-as-arrow-head behaviour (no override for same-label endpoints)."""
+    ontology = Ontology(
+        name="fin", graph_model="lpg",
+        nodes={"Account": NodeDef(properties={"id": P(str, unique=True)})},
+        relationships={"TRANSFER": RelDef(source="Account", target="Account")},
+    )
+    cypher, _ = CypherBuilder(ontology).build(
+        intent="count", anchor_entity="42",
+        anchor_label="Account", target_label="Account",
+        relationship_type="TRANSFER", workspace_id="ws",
+    )
+    assert "(src:`Account`)-[:`TRANSFER`]->(anchor:`Account`)" in cypher


### PR DESCRIPTION
## Symptom

On our production carbon-registry graph (17.5k `Project` nodes, `Project -LOCATED_IN-> HostCountry`), the question **"How many carbon crediting projects are registered in Vietnam?"** answered **0** (actual: 96), with `support_assessment.reason: graph_records_returned` — a plausible wrong answer rather than an error.

## Root cause

The executed query (captured at the bolt level) was:

```cypher
MATCH (src:`HostCountry`)-[:`LOCATED_IN`]->(anchor:`Project`)
WHERE (anchor.`registry_id` = $anchor_key_0)   -- $anchor_key_0 = 'Vietnam'
...
RETURN count(DISTINCT src) AS count
```

Two compounding effects in `_count`'s relationship-aware branch:

1. Plans routinely put the **counted** label in the anchor slot (`anchor_label=Project` for "how many projects…"), and `_orient_relationship` pins the anchor to the declared source — so the filter equality lands on the counted side (`Project.registry_id = 'Vietnam'`).
2. The default (non-`anchor_role=source`) pattern places the anchor at the arrow head, which combined with (1) emits the traversal **against** the declared direction.

Both plan shapes (`anchor=HostCountry` and `anchor=Project`) collapse into the same always-zero query. The failure is invisible on same-label schemas (FinBench `TRANSFER: Account -> Account`) where orientation repair is a no-op — it needs distinct endpoint labels to surface.

## Fix

When the relationship declares two **distinct** endpoint labels, the declaration is authoritative: counted side = source, anchored side = target (flipped under `anchor_role="source"`). Same-label relationships keep the existing role-based behaviour unchanged.

With the fix, both plan shapes emit:

```cypher
MATCH (src:`Project`)-[:`LOCATED_IN`]->(anchor:`HostCountry`)
WHERE (anchor.`country_iso` = $anchor_key_0 OR anchor.`name` = $anchor_key_1)
...
RETURN count(DISTINCT src) AS count
```

which returns 96 on our graph.

## Tests

- 2 regression tests added in `test_cypher_builder_ontology_aware.py` (distinct-label authority for both plan shapes; same-label in-degree behaviour preserved)
- `pytest tests/seocho -k "cypher or count or lpg or builder"`: 84 passed, 1 pre-existing failure (`test_workspace_filter_enforcement.py::test_enforce_workspace_filter_passes_when_cypher_references_param` — fails identically on 59d7028 without this change)

## Related observations (separate, happy to file issues)

- `_local_support_assessment` treats `row_count > 0` as `supported` — for count queries the single `{count: 0}` row made the zero answer look supported. A count-shape check would help.
- A single-token mention passes the `_sargable_anchor` identifier gate even when it is a display name ("Vietnam" vs `country_iso='VNM'`); we worked around it ontology-side with `index: true` on `HostCountry.name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnEzVBLjwxgEYFmDTrCaqw