### PR TITLE
[Draft] Add --json flag to local-ask CLI command

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -364,6 +364,7 @@ def build_parser() -> argparse.ArgumentParser:
     local_ask_parser.add_argument("--llm-base-url", default=None, help="Override the provider base URL")
     local_ask_parser.add_argument("--reasoning", action="store_true", help="Enable reasoning mode (auto-retry)")
     local_ask_parser.add_argument("--repair-budget", type=int, default=2, help="Max repair attempts")
+    local_ask_parser.add_argument("--json", dest="output_json", action="store_true", help="JSON output")
 
     status_parser = subparsers.add_parser("status", help="Show graph database status")
     status_parser.add_argument("--database", default="neo4j", help="Target database")
@@ -1534,7 +1535,10 @@ def _cmd_local_ask(args: argparse.Namespace) -> int:
             reasoning_mode=args.reasoning,
             repair_budget=args.repair_budget,
         )
-        print(answer)
+        if getattr(args, "output_json", False):
+            print(json.dumps({"answer": answer}, indent=2))
+        else:
+            print(answer)
     finally:
         client.close()
 


### PR DESCRIPTION
What:
Added the `--json` (`output_json`) flag to the `seocho local-ask` CLI command parser and updated the `_cmd_local_ask` function to respect this flag by outputting a JSON payload `{"answer": ...}` instead of plain text when invoked.

Why:
Most other CLI commands in SEOCHO (e.g., `ask`, `serve`, `index`, `search`) support the `--json` flag to emit structured, machine-readable output. `local-ask` was missing this capability, which made it harder for operators and automated scripts to parse its output programmatically.

Accessibility / UX Impact:
Improves developer/operator experience (DX/UX) by making local query outputs easily scriptable and consistent with the rest of the CLI's JSON emission patterns. 

Validation:
- Validated parser modification via `uv run seocho local-ask --help`.
- Verified changes with `git diff --staged`.
- Ran basic CI script (`bash scripts/ci/run_basic_ci.sh`), and all tests passed.
- Ran agent docs lint script (`bash scripts/pm/lint-agent-docs.sh`), and no issues were found.

Risks:
Low risk. The new behavior is entirely opt-in (defaults to `False`) and preserves existing plain text output for standard terminal usage.

Modified Files:
src/seocho/cli/__init__.py

---
*PR created automatically by Jules for task [548275734383206793](https://jules.google.com/task/548275734383206793) started by @tteon*