### PR TITLE
fix(query): workspace-bound GraphQueryExecutor enforces the workspace filter

### DIFF
--- a/src/seocho/local_engine.py
+++ b/src/seocho/local_engine.py
@@ -896,7 +896,8 @@ class _LocalEngine:
             llm=self.llm,
             workspace_id=self.workspace_id,
         )
-        executor = GraphQueryExecutor(graph_store=self.graph_store, database=database)
+        executor = GraphQueryExecutor(graph_store=self.graph_store, database=database,
+                                      workspace_id=self.workspace_id)
         answer_synthesizer = QueryAnswerSynthesizer(
             query_strategy=self._query,
             llm=self.llm,
@@ -1357,6 +1358,7 @@ class _LocalEngine:
         active_executor = executor or GraphQueryExecutor(
             graph_store=self.graph_store,
             database=database,
+            workspace_id=self.workspace_id,
         )
         execution = active_executor.execute(QueryPlan(question="", cypher=cypher, params=params))
         return execution.records, execution.error

--- a/src/seocho/query/executor.py
+++ b/src/seocho/query/executor.py
@@ -11,9 +11,19 @@ logger = logging.getLogger(__name__)
 class GraphQueryExecutor:
     """Canonical graph query executor for local SDK and adapter runtimes."""
 
-    def __init__(self, *, graph_store: Any, database: str) -> None:
+    def __init__(
+        self,
+        *,
+        graph_store: Any,
+        database: str,
+        workspace_id: Optional[str] = None,
+    ) -> None:
         self.graph_store = graph_store
         self.database = database
+        # When a workspace is bound, every executed plan is required to carry
+        # the $workspace_id predicate (store-level enforcement, seocho-y4at).
+        # None keeps the legacy unscoped behavior for workspace-less callers.
+        self.workspace_id = workspace_id
 
     def explain(self, plan: QueryPlan) -> Optional[Dict[str, Any]]:
         """Return the query's plan tree without executing it.
@@ -35,6 +45,12 @@ class GraphQueryExecutor:
                 plan.cypher,
                 params=plan.params,
                 database=self.database,
+                **(
+                    {"workspace_id": self.workspace_id,
+                     "enforce_workspace_filter": True}
+                    if self.workspace_id is not None
+                    else {}
+                ),
             )
             return QueryExecution(
                 cypher=plan.cypher,

--- a/tests/seocho/test_cypher_builder.py
+++ b/tests/seocho/test_cypher_builder.py
@@ -245,7 +245,7 @@ class _FakeGraphStore:
     def get_schema(self, *, database: str = "neo4j") -> dict:
         return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED", "reported"]}
 
-    def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+    def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
         self.calls.append({"cypher": cypher, "params": dict(params or {}), "database": database})
         return [
             {
@@ -312,7 +312,7 @@ def test_local_engine_relationship_answer_includes_titles_from_target_properties
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "Person"], "relationship_types": ["EMPLOYS"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "source": "Alphabet Inc.",
@@ -363,7 +363,7 @@ def test_local_engine_legal_relationship_answer_lists_issues() -> None:
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "LegalIssue"], "relationship_types": ["INVOLVED_IN"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "source": "Microsoft",
@@ -435,7 +435,7 @@ def test_local_engine_legal_neighbors_answer_keeps_specific_issue_sentences() ->
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "LegalIssue"], "relationship_types": ["INVOLVED_IN"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "entity": "Microsoft",
@@ -472,7 +472,7 @@ def test_local_engine_financial_lookup_compares_multiple_years_without_currency_
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "company": "Tesla",
@@ -534,7 +534,7 @@ def test_local_engine_financial_lookup_explains_nvidia_gross_margin_expansion() 
         def get_schema(self, *, database: str = "neo4j") -> dict:
             return {"labels": ["Company", "FinancialMetric"], "relationship_types": ["REPORTED"]}
 
-        def query(self, cypher: str, *, params=None, database: str = "neo4j"):  # noqa: ANN001
+        def query(self, cypher: str, *, params=None, database: str = "neo4j", **kwargs):  # noqa: ANN001
             return [
                 {
                     "company": "NVIDIA",

--- a/tests/seocho/test_executor_workspace_enforcement.py
+++ b/tests/seocho/test_executor_workspace_enforcement.py
@@ -1,0 +1,42 @@
+"""The canonical planner-path executor enforces workspace scope at the store.
+
+#613 closed the agent-facing execute_cypher tool; this closes the same gap on
+GraphQueryExecutor, which every deterministic-engine plan flows through. A
+workspace-bound executor must pass workspace_id + enforce_workspace_filter=True
+so the store refuses unscoped Cypher; a workspace-less executor keeps the
+legacy call shape (embedded/local single-tenant callers).
+"""
+
+from __future__ import annotations
+
+from seocho.query.contracts import QueryPlan
+from seocho.query.executor import GraphQueryExecutor
+
+
+class _RecordingStore:
+    def __init__(self):
+        self.kwargs = None
+
+    def query(self, cypher, **kwargs):
+        self.kwargs = kwargs
+        return [{"ok": 1}]
+
+
+SCOPED = "MATCH (c:Company {_workspace_id: $workspace_id}) RETURN c LIMIT 5"
+
+
+def test_workspace_bound_executor_enforces_at_the_store():
+    store = _RecordingStore()
+    ex = GraphQueryExecutor(graph_store=store, database="neo4j", workspace_id="acme")
+    result = ex.execute(QueryPlan(question="q", cypher=SCOPED, params={"workspace_id": "acme"}))
+    assert result.error is None and result.records == [{"ok": 1}]
+    assert store.kwargs["workspace_id"] == "acme"
+    assert store.kwargs["enforce_workspace_filter"] is True
+
+
+def test_workspaceless_executor_keeps_legacy_call_shape():
+    store = _RecordingStore()
+    ex = GraphQueryExecutor(graph_store=store, database="neo4j")
+    ex.execute(QueryPlan(question="q", cypher=SCOPED, params={}))
+    assert "workspace_id" not in store.kwargs
+    assert "enforce_workspace_filter" not in store.kwargs

--- a/tests/seocho/test_session_agent.py
+++ b/tests/seocho/test_session_agent.py
@@ -117,7 +117,7 @@ class FakeGraphStore:
         })
         return {"nodes_created": len(nodes), "relationships_created": len(relationships), "errors": []}
 
-    def query(self, cypher: str, *, params=None, database="neo4j") -> List[Dict[str, Any]]:
+    def query(self, cypher: str, *, params=None, database="neo4j", **kwargs) -> List[Dict[str, Any]]:
         self.queries.append(cypher)
         return [{"name": "TestCorp", "industry": "Tech"}]
 


### PR DESCRIPTION
## Summary
- Closes the planner-path half of the workspace-isolation gap: `GraphQueryExecutor` ran `plan.cypher` unscoped; a workspace-bound executor now passes `workspace_id` + `enforce_workspace_filter=True` so the store refuses unscoped Cypher loudly. Workspace-less construction keeps the legacy call shape.
- All three `LocalEngine` construction sites bind the workspace; probed every deterministic builder intent×shape — all already emit `$workspace_id`, so this adds a guarantee, not breakage.
- Supersedes #595 (same finding; that branch committed its own patch scripts and is unmergeable).

## Validation
- 2 new tests (`test_executor_workspace_enforcement.py`); fakes updated to the real store protocol
- full unit sweep vs a same-environment main baseline: zero new failures
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)