### PR TITLE
[Draft] UX: Improve readability of interactive CLI prompt for properties

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -1326,7 +1326,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
             break
         label = label[0].upper() + label[1:] if label else label
         desc = input(f"  Description for {label}: ").strip()
-        props_input = input(f"  Properties for {label} (comma-separated, e.g. name,age,role): ").strip()
+        props_input = input(f"  Properties for {label} (comma-separated, e.g. name, age, role): ").strip()
         props: Dict[str, P] = {}
         if props_input:
             for i, pname in enumerate(props_input.split(",")):


### PR DESCRIPTION
What:
Adds spaces after commas in the interactive CLI prompt example for properties in `seocho init`.

Why:
The previous prompt example was `(comma-separated, e.g. name,age,role)`. When users naturally typed `name, age, role` with spaces, the property names were created with leading spaces (e.g., ` age`), which is not desirable. While the backend strips spaces for each property now, presenting the example with spaces encourages cleaner input and is visually more readable.

Accessibility / UX Impact:
A small UX win. The instruction text is easier to read, and it models a more natural typing pattern for users, reducing confusion during interactive ontology creation.

Validation:
- Ran `pytest tests/seocho/test_cli_parser_contract.py tests/seocho/test_cli_ontology.py` manually.
- Ran `bash scripts/ci/run_basic_ci.sh` successfully.
- Ran `bash scripts/pm/lint-agent-docs.sh` successfully.

Risks:
Negligible. This is a pure string change in a CLI prompt. It does not affect runtime logic, parsing logic, or API contracts.

Modified Files:
- `src/seocho/cli/__init__.py`
- `.jules/palette.md`

---
*PR created automatically by Jules for task [14415374716620451715](https://jules.google.com/task/14415374716620451715) started by @tteon*