### PR TITLE
fix: Enforce workspace filter in Seocho.query()

### DIFF
--- a/src/seocho/client.py
+++ b/src/seocho/client.py
@@ -1531,7 +1531,13 @@ class Seocho:
         """
         if not self._local_mode:
             raise RuntimeError("query() requires local engine mode (ontology + graph_store + llm)")
-        return self.graph_store.query(cypher, params=params, database=database)
+        return self.graph_store.query(
+            cypher,
+            params=params,
+            database=database,
+            workspace_id=self.workspace_id,
+            enforce_workspace_filter=True,
+        )
 
     # ------------------------------------------------------------------
     # Agent-level session API


### PR DESCRIPTION
Severity: High

Vulnerability: Missing authorization checks on `Seocho.query()` in local mode. Direct graph store queries bypass the workspace filtering that restricts data access by tenant.

Impact: A user calling `query()` could inadvertently access or modify data belonging to other workspaces (tenant isolation bypass) if they pass malicious Cypher.

Fix: Added `workspace_id=self.workspace_id` and `enforce_workspace_filter=True` to the `self.graph_store.query()` call inside `Seocho.query()`.

Validation: Ran `bash scripts/ci/run_basic_ci.sh` to ensure no tests break and local tests verify the behavior.

Risks: Queries constructed without a workspace variable in the string may now correctly fail with a `WorkspaceFilterMissingError`. Users relying on global access (which is unintended in tenant environments) must opt out via `enforce_workspace_filter` or provide unscoped queries via lower-level driver directly.

Modified Files: src/seocho/client.py

---
*PR created automatically by Jules for task [1714042385666734580](https://jules.google.com/task/1714042385666734580) started by @tteon*