### PR TITLE
[Draft] fix: improve empty state message clarity in CLI

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -500,7 +500,7 @@ def handle(args: argparse.Namespace) -> int:
                 print(json.dumps(clusters, indent=2, ensure_ascii=False))
             else:
                 if not clusters:
-                    print("quarantine empty")
+                    print("Quarantine is empty.")
                 for c in clusters:
                     print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
                           f"candidates={c['candidate_labels']}")


### PR DESCRIPTION
What: Updated empty state print messages to sentence case (e.g. 'no memories found' -> 'No memories found.').
Why: To improve CLI output clarity and consistency.
Accessibility / UX Impact: Makes the empty state messages read as proper sentences, providing a minor UX improvement.
Validation: Ran bash scripts/ci/run_basic_ci.sh and bash scripts/pm/lint-agent-docs.sh.
Risks: Minor. Output parsing might fail if external scripts rely on the exact lowercase string, but this is unlikely for empty state messages.
Modified Files: src/seocho/cli/__init__.py, src/seocho/cli/ontology.py, .jules/palette.md

---
*PR created automatically by Jules for task [15798399578279348790](https://jules.google.com/task/15798399578279348790) started by @tteon*