### PR TITLE
feat(text2cypher): decode-time grammar enforcement + ontology conformance report

### DIFF
--- a/src/seocho/ontology/conformance.py
+++ b/src/seocho/ontology/conformance.py
@@ -1,0 +1,164 @@
+"""Does the declared ontology describe the graph that is actually loaded?
+
+Everything text2cypher does rests on the ontology: it is what goes into the prompt, what
+``policy_from_ontology`` validates against, and what :mod:`seocho.query.grammar` derives the
+decode-time grammar from. Nothing else checks it against the graph, and the drift fails
+silently in both directions — measured on the AIsummit26 FinBench graph (2026-08-22), where
+five real, fully-populated properties were undeclared:
+
+* **declared but absent** — the prompt advertises a label, relationship or property that does
+  not exist; the model uses it, the query returns nothing, and nothing errors.
+* **present but undeclared** — the graph has something the ontology hides; the validator
+  rejects a correct query (``unknown_properties``) and the repair loop burns generations on
+  something no repair can fix, while the grammar makes the same question *unrepresentable*.
+* **identity keys** — the properties the ontology names as identities are what text2cypher
+  anchors on; an unindexed one turns every anchored query into a sweep.
+* **relationship endpoints** — a declared ``(source)-[TYPE]->(target)`` triple that never
+  occurs lets the grammar admit a pattern that can only ever match nothing. Endpoint
+  declarations use the ``Person|Company`` union syntax, and the check expands it: treating
+  the union as a literal label reported four real relationships as never occurring, which was
+  a bug in the first version of this check rather than drift in the ontology.
+
+Read-only, dependency-free: the caller supplies ``run_query`` (any callable that executes a
+Cypher string and returns ``list[dict]``), so this works against neo4j-python, the rust
+driver, or a test double alike.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Mapping, Sequence, Set, Tuple
+
+RunQuery = Callable[[str], List[Dict[str, Any]]]
+
+
+def _labels(value: Any) -> List[str]:
+    """Endpoint labels with the ontology's union syntax expanded."""
+    if value is None:
+        return []
+    values = value if isinstance(value, (list, tuple)) else [value]
+    out: List[str] = []
+    for item in values:
+        out.extend(part.strip() for part in str(item).split("|") if part.strip())
+    return out
+
+
+def declared_view(ontology: Any) -> Dict[str, Any]:
+    """The ontology as the prompt, the policy, and the grammar see it."""
+    nodes = getattr(ontology, "nodes", None) or {}
+    rels = getattr(ontology, "relationships", None) or {}
+
+    def props_of(spec: Any) -> List[str]:
+        p = getattr(spec, "properties", None)
+        if p is None and isinstance(spec, Mapping):
+            p = spec.get("properties")
+        return sorted((p or {}).keys())
+
+    def ident_of(spec: Any) -> List[str]:
+        k = getattr(spec, "identity_keys", None)
+        if k is None and isinstance(spec, Mapping):
+            k = spec.get("identity_keys")
+        return list(k or [])
+
+    endpoints: List[str] = []
+    for name, spec in rels.items():
+        src = getattr(spec, "source", None) or (spec.get("source") if isinstance(spec, Mapping) else None)
+        dst = getattr(spec, "target", None) or (spec.get("target") if isinstance(spec, Mapping) else None)
+        endpoints.extend(f"{a}-[{name}]->{b}" for a in _labels(src) for b in _labels(dst))
+    return {
+        "labels": sorted(nodes.keys()),
+        "rel_types": sorted(rels.keys()),
+        "node_properties": {k: props_of(v) for k, v in nodes.items()},
+        "rel_properties": {k: props_of(v) for k, v in rels.items()},
+        "identity_keys": {k: ident_of(v) for k, v in nodes.items()},
+        "rel_endpoints": sorted(set(endpoints)),
+    }
+
+
+def graph_view(run_query: RunQuery, *, sample: int = 5000) -> Dict[str, Any]:
+    """What the database actually contains, read through its own schema procedures."""
+    labels = sorted(r["label"] for r in run_query("CALL db.labels() YIELD label RETURN label"))
+    rel_types = sorted(r["relationshipType"] for r in run_query(
+        "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType"))
+    node_props: Dict[str, List[str]] = {}
+    for label in labels:
+        rows = run_query(
+            f"MATCH (n:`{label}`) WITH keys(n) AS k LIMIT {int(sample)} "
+            "UNWIND k AS key RETURN DISTINCT key ORDER BY key")
+        node_props[label] = [r["key"] for r in rows]
+    rel_props: Dict[str, List[str]] = {}
+    for rt in rel_types:
+        rows = run_query(
+            f"MATCH ()-[r:`{rt}`]->() WITH keys(r) AS k LIMIT {int(sample)} "
+            "UNWIND k AS key RETURN DISTINCT key ORDER BY key")
+        rel_props[rt] = [r["key"] for r in rows]
+    endpoints = sorted(
+        f'{r["src"]}-[{r["t"]}]->{r["dst"]}' for r in run_query(
+            "MATCH (a)-[r]->(b) WITH labels(a) AS la, type(r) AS t, labels(b) AS lb "
+            "UNWIND la AS src UNWIND lb AS dst RETURN DISTINCT src, t, dst"))
+    indexed: Set[Tuple[str, str]] = set()
+    for ix in run_query("SHOW INDEXES YIELD labelsOrTypes, properties "
+                        "RETURN labelsOrTypes, properties"):
+        for lab in (ix.get("labelsOrTypes") or []):
+            for prop in (ix.get("properties") or []):
+                indexed.add((lab, prop))
+    return {"labels": labels, "rel_types": rel_types, "node_properties": node_props,
+            "rel_properties": rel_props, "rel_endpoints": endpoints,
+            "indexed": sorted(indexed)}
+
+
+def conformance_report(ontology: Any, run_query: RunQuery, *,
+                       infrastructure_prefix: str = "_") -> Dict[str, Any]:
+    """Compare declaration against reality; every mismatch names its consequence.
+
+    Properties starting with ``infrastructure_prefix`` (tenant scope, harness-derived
+    degree columns) are infrastructure, not domain schema — the ontology is not expected
+    to declare them.
+    """
+    d = declared_view(ontology)
+    g = graph_view(run_query)
+    problems: List[str] = []
+
+    def diff(scope: str, decl: Set[str], real: Set[str]) -> Dict[str, Any]:
+        absent, undeclared = sorted(decl - real), sorted(real - decl)
+        if absent:
+            problems.append(f"{scope}: declared but absent {absent}")
+        if undeclared:
+            problems.append(f"{scope}: present but undeclared {undeclared}")
+        return {"scope": scope, "declared_but_absent": absent,
+                "present_but_undeclared": undeclared}
+
+    diffs = [diff("labels", set(d["labels"]), set(g["labels"])),
+             diff("relationship_types", set(d["rel_types"]), set(g["rel_types"]))]
+    for label in sorted(set(d["labels"]) | set(g["labels"])):
+        real = {p for p in g["node_properties"].get(label, [])
+                if not p.startswith(infrastructure_prefix)}
+        diffs.append(diff(f"properties:{label}",
+                          set(d["node_properties"].get(label, [])), real))
+    for rt in sorted(set(d["rel_types"]) | set(g["rel_types"])):
+        real = {p for p in g["rel_properties"].get(rt, [])
+                if not p.startswith(infrastructure_prefix)}
+        diffs.append(diff(f"rel_properties:{rt}",
+                          set(d["rel_properties"].get(rt, [])), real))
+
+    indexed = {tuple(x) for x in g["indexed"]}
+    identity_rows = []
+    for label, keys in sorted(d["identity_keys"].items()):
+        for key in keys:
+            exists = key in set(g["node_properties"].get(label, []))
+            is_indexed = (label, key) in indexed
+            identity_rows.append({"label": label, "identity_key": key,
+                                  "exists_in_graph": exists, "indexed": is_indexed})
+            if not exists:
+                problems.append(f"{label}.{key}: identity key not in graph")
+            elif not is_indexed:
+                problems.append(f"{label}.{key}: identity key NOT INDEXED — "
+                                f"anchored queries on it sweep")
+
+    endpoint_diff = diff("relationship_endpoints",
+                         set(d["rel_endpoints"]), set(g["rel_endpoints"]))
+    return {"declared": d, "graph": g, "diffs": diffs, "identity_keys": identity_rows,
+            "endpoint_diff": endpoint_diff, "problems": problems,
+            "conformant": not problems}
+
+
+__all__ = ["conformance_report", "declared_view", "graph_view"]

--- a/src/seocho/query/grammar.py
+++ b/src/seocho/query/grammar.py
@@ -1,0 +1,182 @@
+"""Decode-time enforcement of the Text2Cypher policy: an EBNF the ontology derives.
+
+`validate_text2cypher_fallback` rejects after the fact, and every rejection costs a full
+regeneration — prompt prefill plus decode, repeated until the model guesses the rule it was
+never shown. Measured on the AIsummit26 graph-agentic-RAG harness (gpt-oss-120b, 26-episode
+arm): 2.8-3.9 attempts per generation and 101.7 s of failed-generation LLM time booked in one
+run. The rules the validator checks are structural, and the policy is strict, which makes them
+expressible as a grammar instead of a rejection: under constrained decoding an undeclared
+label, a missing tenant scope, an inlined literal, or a missing `LIMIT $limit` stops being a
+repair case because it cannot be emitted at all. vLLM (>= 0.27) takes the EBNF through
+`provider_options={"structured_outputs": {"grammar": ...}}`.
+
+The envelope matters: the text2cypher contract is a JSON object with a `cypher` key, so the
+grammar produces *that*, with the query inside the string. That is only safe because the
+policy already forbids inlined literals — a conforming query contains no double quote to
+escape.
+
+Positioning, measured rather than hoped (arXiv-style caveats up front):
+
+* The guarantee is **validity, scope and auditability**, not answer quality. On small models
+  the structural rescue is total (Qwen2.5-1.5B: 0/8 -> 8/8 valid generations); on a 120B the
+  unconstrained decode already writes valid Cypher and the grammar can *steer it off* a
+  high-prior idiom it needed (a constraint shifts probability mass at every branch point —
+  admissibility of the right answer does not make the right answer likely).
+* Some endpoints accept `structured_outputs` with HTTP 200 and silently ignore it. Never
+  A/B a grammar without `grammar_is_honored` — the false null looks exactly like a finding.
+
+EVERY repetition is bounded — `{0,N}` instead of `*` — because under constrained decoding an
+unbounded repetition is an attractor. Measured twice on gpt-oss-120b before the rule became
+absolute: unbounded whitespace produced a run of spaces until the token cap truncated the
+envelope, and after that was bounded, the repair turn fell into the AND-chain instead —
+19,390 characters of `AND a.acct_no = $acct_no` repeated until an 8,000-token cap. Once the
+model has emitted the same clause twice, the highest-probability continuation is a third.
+
+Relationship variables are mandatory (`[t:TRANSFER]`, never `[:TRANSFER]`): "a variable an
+aggregate references must be bound in the pattern" is context-sensitive and no CFG can say
+it, and the measured failure mode is the model aggregating an anonymous relationship and
+repeating the mistake through the repair turn. Forcing a name does not *prove* the reference
+is bound, but the model reuses the name it was made to write.
+
+A bare `(var)` node re-references a variable bound earlier — the second-MATCH continuation
+and comma patterns need it, and every gold query in the measured corpus uses it. A CFG cannot
+check the variable *was* bound, so an all-bare pattern is admissible and would sweep; that is
+accepted deliberately, because the sweep guard was never the grammar's to give (a fully
+scoped query has been measured sweeping 6.4M db hits *through an index*) — cost belongs to a
+plan-shape check (leaf EstimatedRows), admissibility to this grammar.
+
+Predicates compare `var.prop` against a parameter, plus exactly two more forms: `a <> b`
+node inequality (the self-loop-exclusion idiom reachability queries use) and
+`a.prop <> b.prop`. The nonsense form (`node <> $param`) stays out. The `param` rule must
+name what the *executor* accepts, not whatever the caller has bound — a grammar that admits
+an alias the executor drops produces ParameterMissing at run time (28 of 43 tool failures in
+one measured run).
+
+A question this subset cannot express is a finding about the subset, not a licence to widen
+it silently — `covers()` exists so callers can report which questions fall outside.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+_AGGREGATES = ("count", "sum", "avg", "min", "max", "collect")
+
+
+def _alt(values: Iterable[str]) -> str:
+    """EBNF alternation of literal strings, longest first so prefixes cannot shadow."""
+    uniq = sorted({v for v in values if v}, key=lambda s: (-len(s), s))
+    return " | ".join(f'"{v}"' for v in uniq) or '"NONE"'
+
+
+def grammar_from_policy(policy: Any, *, params: Sequence[str],
+                        workspace_property: Optional[str] = None,
+                        max_hops: Optional[int] = None) -> str:
+    """An EBNF that only admits Cypher this policy would accept."""
+    labels = tuple(getattr(policy, "allowed_labels", ()) or ())
+    rels = tuple(getattr(policy, "allowed_relationships", ()) or ())
+    props = tuple(getattr(policy, "allowed_properties", ()) or ())
+    ws_prop = workspace_property or getattr(policy, "workspace_property", "_workspace_id")
+    hops = int(max_hops or getattr(policy, "max_graph_hops", 4) or 4)
+    # `$limit` and `$workspace_id` are mandatory by contract, so they are terminals rather
+    # than choices; the rest of the parameter list is what the harness bound for this question.
+    param_names = tuple(p for p in params if p not in ("workspace_id",))
+
+    return f'''root ::= "{{" ws "\\"cypher\\"" ws ":" ws "\\"" query "\\"" ws "}}"
+
+query ::= match_clause (ws match_clause){{0,3}} (ws where_clause)? ws return_clause (ws order_clause)? ws limit_clause
+
+match_clause ::= "MATCH " pattern ("," ws pattern){{0,2}}
+pattern ::= node (rel node){{0,4}}
+node ::= refnode | fullnode
+refnode ::= "(" var ")"
+fullnode ::= "(" var? label_part? scope ")"
+label_part ::= ":" label ("|" label){{0,2}}
+scope ::= " {{" wsp "{ws_prop}" wsp ":" wsp "$workspace_id" wsp ("," ws prop wsp ":" wsp param wsp){{0,2}} "}}"
+rel ::= arrow_l ws rel_detail ws arrow_r ws
+arrow_l ::= "-" | "<-"
+arrow_r ::= "->" | "-"
+rel_detail ::= "[" var ":" reltype hop_bound? "]"
+hop_bound ::= "*1.." digit
+digit ::= {_alt(str(i) for i in range(1, hops + 1))}
+
+where_clause ::= "WHERE " predicate (" AND " predicate){{0,5}}
+predicate ::= qref ws comparator ws param | var " <> " var | qref " <> " qref
+qref ::= var "." prop
+comparator ::= "=" | ">=" | "<=" | ">" | "<" | "<>"
+param ::= {_alt("$" + p for p in param_names) if param_names else '"$limit"'}
+
+return_clause ::= "RETURN " ret_item (", " ret_item){{0,7}}
+ret_item ::= (aggregate | ref | "DISTINCT " ref) (" AS " var)?
+aggregate ::= agg_fn "(" ("DISTINCT " )? ref ")"
+agg_fn ::= {_alt(_AGGREGATES)}
+
+order_clause ::= "ORDER BY " ref (" DESC" | " ASC")?
+limit_clause ::= "LIMIT $limit"
+
+ref ::= var ("." prop)?
+label ::= {_alt(labels)}
+reltype ::= {_alt(rels)}
+prop ::= {_alt(props)}
+var ::= [a-z] [a-z0-9_]{{0,24}}
+ws ::= " "?
+wsp ::= " "?
+'''
+
+
+def covers(cypher: str, policy: Any) -> Tuple[bool, List[str]]:
+    """A cheap structural check that a query is inside the subset the grammar admits.
+
+    Not a parser — a way for the benchmark to say "this question needs constructs the grammar
+    does not have" instead of quietly attributing the failure to the model.
+    """
+    reasons: List[str] = []
+    text = " ".join(cypher.split())
+    upper = text.upper()
+    if "LIMIT $LIMIT" not in upper:
+        reasons.append("missing LIMIT $limit")
+    ws_prop = getattr(policy, "workspace_property", "_workspace_id")
+    if ws_prop not in text:
+        reasons.append(f"missing scope {ws_prop}")
+    if '"' in text or "'" in text:
+        reasons.append("string literal (policy requires parameters)")
+    for kw in ("WITH ", "UNWIND ", "CALL ", "UNION", "OPTIONAL MATCH", "CASE "):
+        if kw in upper:
+            reasons.append(f"outside subset: {kw.strip()}")
+    return (not reasons), reasons
+
+async def grammar_is_honored(backend: Any, model: str) -> Dict[str, Any]:
+    """Prove the endpoint actually applies a grammar before believing a grammar-mode result.
+
+    Some endpoints accept `structured_outputs` (and the older `guided_grammar`) with HTTP 200
+    and ignore it — measured 2026-08-22 against a hosted gpt-oss-120b: the output was
+    byte-identical to the unconstrained baseline for all three request spellings. An A/B run
+    without this check reports "the grammar did not help" when the truth is "the grammar was
+    never applied". So the probe asks a question only one answer can satisfy.
+
+    Two traps this probe already absorbed, kept so they stay absorbed: reasoning-channel
+    models spend ~70 tokens before the constrained final channel opens, so a tight
+    `max_tokens` truncates the sentinel and reports a WORKING grammar as ignored (the false
+    null in the opposite direction); and harmony-format models append terminator artifacts
+    like `<|end|>`, so the test is containment, not equality — an unconstrained model asked
+    to say hello never emits the sentinel, so containment cannot false-positive.
+    """
+    sentinel = "GRAMMAR_WAS_HONORED"
+    try:
+        r = await backend.acomplete(
+            system="",
+            user="Say hello in one sentence.",
+            temperature=0.0,
+            max_tokens=2048,
+            task_hint="probe",
+            mode="pipeline",
+            model=model,
+            provider_options={"structured_outputs": {"grammar": f'root ::= "{sentinel}"'}},
+        )
+        text = (getattr(r, "text", None) or str(r)).strip()
+    except Exception as exc:  # a refusal is an answer: the endpoint cannot do this
+        return {"honored": False, "error": f"{type(exc).__name__}: {str(exc)[:160]}"}
+    return {"honored": sentinel in text, "output": text[:120]}
+
+
+__all__ = ["grammar_from_policy", "covers", "grammar_is_honored"]

--- a/src/seocho/query/text2cypher.py
+++ b/src/seocho/query/text2cypher.py
@@ -24,6 +24,17 @@ class Text2CypherResult:
     attempts: int
     explained: bool
     prompt_version: str = "seocho.text2cypher.v1"
+    # Wall time spent generating, across every attempt. Callers attributing episode time
+    # need it on the SUCCESS path here — and on the FAILURE path it rides the raised
+    # ValueError as `exc.generate_ms`, because a failed generation still spent its wall
+    # time in the LLM. Measured before that stamp existed: one 26-episode harness run
+    # booked 101.7 s of failed-generation LLM time as *database* time, because the
+    # episode's residual accounting had nowhere else to put it.
+    generate_ms: float = 0.0
+    # Token usage summed across attempts (prompt/completion/cached), from the backend's
+    # LLMResponse.usage. cached_tokens is what makes prefix-cache economics measurable
+    # per call rather than server-wide.
+    usage: Mapping[str, int] | None = None
 
 
 async def generate_validated_cypher(
@@ -35,8 +46,19 @@ async def generate_validated_cypher(
     backend: LLMBackend,
     model: str,
     explain: Explain,
+    grammar: str | None = None,
 ) -> Text2CypherResult:
-    """Generate, validate, EXPLAIN, and at most once repair a read query."""
+    """Generate, validate, EXPLAIN, and at most once repair a read query.
+
+    ``grammar`` — an EBNF (see :mod:`seocho.query.grammar`) enforced at decode time via
+    ``provider_options={"structured_outputs": {"grammar": ...}}``. When set,
+    ``response_format`` is not sent: the two are mutually exclusive ways of constraining
+    the same output and vLLM refuses both at once (the grammar itself produces the JSON
+    envelope, so the contract still holds). Only meaningful on an endpoint that honors
+    structured outputs — verify with :func:`seocho.query.grammar.grammar_is_honored`
+    first, because some endpoints accept the option with HTTP 200 and silently ignore it,
+    and the resulting A/B is a false null that looks like a finding.
+    """
 
     # The contract has to be stated exactly, because the validator checks it
     # exactly. "It must include tenant scope" left the model to guess the
@@ -59,6 +81,7 @@ async def generate_validated_cypher(
     feedback: list[str] = []
     metrics = get_metrics()
     started = time.perf_counter()
+    usage_totals = {"prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0}
 
     def _finish(outcome: str) -> None:
         metrics.record(
@@ -87,11 +110,16 @@ async def generate_validated_cypher(
             # generations in the SF1000 arm comparison. Reasoning-capable models also
             # spend budget before emitting the object.
             max_tokens=int(os.getenv("SEOCHO_TEXT2CYPHER_MAX_TOKENS", "2000")),
-            response_format={"type": "json_object"},
+            response_format=None if grammar else {"type": "json_object"},
             task_hint="text2cypher",
             mode="pipeline",
             model=model,
+            provider_options=(
+                {"structured_outputs": {"grammar": grammar}} if grammar else None
+            ),
         )
+        for key in usage_totals:
+            usage_totals[key] += int((response.usage or {}).get(key, 0) or 0)
         payload = response.json()
         cypher = str(payload.get("cypher", "")).strip()
         violations = validate_text2cypher_fallback(cypher, params=params, policy=policy)
@@ -120,9 +148,16 @@ async def generate_validated_cypher(
             params=dict(params),
             attempts=attempt,
             explained=True,
+            generate_ms=round((time.perf_counter() - started) * 1000, 3),
+            usage=dict(usage_totals),
         )
     _finish("rejected")
-    raise ValueError("text2cypher rejected: " + ",".join(feedback))
+    exc = ValueError("text2cypher rejected: " + ",".join(feedback))
+    # The failed attempts spent this wall time in the LLM; a caller attributing episode
+    # time must not book it elsewhere just because the generation raised.
+    exc.generate_ms = round((time.perf_counter() - started) * 1000, 3)  # type: ignore[attr-defined]
+    exc.usage = dict(usage_totals)  # type: ignore[attr-defined]
+    raise exc
 
 
 __all__ = ["Text2CypherResult", "generate_validated_cypher"]

--- a/src/seocho/store/llm.py
+++ b/src/seocho/store/llm.py
@@ -630,7 +630,11 @@ class OpenAICompatibleBackend(LLMBackend):
             )
         kwargs.update(reasoning_overrides)
         if provider_options:
-            allowed = {"prompt_cache_key", "cache_salt", "thinking"}
+            # structured_outputs carries a decode-time constraint (vLLM >= 0.27 takes an
+            # EBNF as {"grammar": ...}); it rides extra_body like the cache options do.
+            # Callers that set it must not also set response_format — the two are mutually
+            # exclusive ways of constraining the same output and vLLM refuses both at once.
+            allowed = {"prompt_cache_key", "cache_salt", "thinking", "structured_outputs"}
             unknown = sorted(set(provider_options) - allowed)
             if unknown:
                 raise ValueError(

--- a/tests/seocho/test_ontology_conformance.py
+++ b/tests/seocho/test_ontology_conformance.py
@@ -1,0 +1,72 @@
+"""Conformance catches drift in both directions, and expands endpoint unions.
+
+The measured incident this guards: five real, fully-populated graph properties were
+undeclared, so the validator rejected correct queries (unknown_properties) while the
+ontology-derived grammar made the same questions unrepresentable — the repair loop burned
+generations on something no repair could fix. And the check's own first version treated
+`Person|Company` as a literal label, reporting four real relationships as never occurring;
+the union-expansion test keeps that fixed.
+"""
+
+from __future__ import annotations
+
+from seocho.ontology import Ontology
+from seocho.ontology.conformance import conformance_report
+
+
+def _fake_graph(run_map):
+    def run_query(cypher: str):
+        for key, rows in run_map.items():
+            if key in cypher:
+                return rows
+        return []
+    return run_query
+
+
+ONTO = Ontology.from_dict({
+    "name": "t",
+    "nodes": {
+        "Account": {"identity_keys": ["acct_no"],
+                    "properties": {"acct_no": {"type": "INTEGER"},
+                                   "iban": {"type": "STRING"}}},
+        "Person": {"properties": {"id": {"type": "STRING"}}},
+        "Company": {"properties": {"id": {"type": "STRING"}}},
+    },
+    "relationships": {
+        "OWN": {"source": "Person|Company", "target": "Account"},
+    },
+})
+
+GRAPH = {
+    "db.labels": [{"label": "Account"}, {"label": "Person"}, {"label": "Company"}],
+    "db.relationshipTypes": [{"relationshipType": "OWN"}],
+    "MATCH (n:`Account`)": [{"key": "acct_no"}, {"key": "iban"}, {"key": "age"},
+                            {"key": "_workspace_id"}],
+    "MATCH (n:`Person`)": [{"key": "id"}],
+    "MATCH (n:`Company`)": [{"key": "id"}],
+    "MATCH ()-[r:`OWN`]->()": [],
+    "labels(a)": [{"src": "Person", "t": "OWN", "dst": "Account"},
+                  {"src": "Company", "t": "OWN", "dst": "Account"}],
+    "SHOW INDEXES": [{"labelsOrTypes": ["Account"], "properties": ["acct_no"]}],
+}
+
+
+def test_undeclared_property_is_reported_and_infrastructure_is_not() -> None:
+    report = conformance_report(ONTO, _fake_graph(GRAPH))
+    assert not report["conformant"]
+    assert any("undeclared ['age']" in p for p in report["problems"])
+    # _workspace_id is infrastructure, never demanded of the ontology.
+    assert not any("_workspace_id" in p for p in report["problems"])
+
+
+def test_union_endpoints_expand_instead_of_reporting_phantom_drift() -> None:
+    report = conformance_report(ONTO, _fake_graph(GRAPH))
+    assert report["endpoint_diff"]["declared_but_absent"] == []
+    assert not any("endpoints" in p and "absent" in p for p in report["problems"])
+
+
+def test_unindexed_identity_key_is_a_performance_finding() -> None:
+    graph = dict(GRAPH)
+    graph["SHOW INDEXES"] = []
+    report = conformance_report(ONTO, _fake_graph(graph))
+    assert any("NOT INDEXED" in p for p in report["problems"])

--- a/tests/seocho/test_text2cypher_grammar.py
+++ b/tests/seocho/test_text2cypher_grammar.py
@@ -1,0 +1,233 @@
+"""The grammar admits what the validator would pass, and cannot emit what it would reject.
+
+Every safety property here was a measured failure before it was a rule (AIsummit26 harness,
+gpt-oss-120b and Qwen2.5-1.5B, 2026-08-22):
+
+* an unscoped node, an inlined literal, an anonymous relationship — the rejection classes
+  that cost 2.8-3.9 repair attempts per generation when enforced after the fact;
+* the 9-AND runaway — under constrained decoding an unbounded repetition is an attractor
+  (19,390 characters of the same clause, measured), so every repetition carries a bound;
+* the expressibility set — union labels, comma patterns, reference nodes, `a <> b` node
+  inequality — each added because a correct human-written query in the measured corpus
+  needed it, and its absence pushed the constrained model into wrong-but-admissible output.
+
+Membership tests compile the EBNF with xgrammar — the same engine vLLM constrains with — so
+"the grammar admits X" is decided by the enforcement engine itself, not a reimplementation.
+They skip cleanly where xgrammar is not installed; the structural tests always run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from seocho.query.grammar import covers, grammar_from_policy
+from seocho.query.workload_compiler import Text2CypherFallbackPolicy
+
+
+@pytest.fixture
+def policy() -> Text2CypherFallbackPolicy:
+    return Text2CypherFallbackPolicy(
+        allowed_labels=("Account", "Person", "Company"),
+        allowed_relationships=("TRANSFER", "OWN"),
+        allowed_properties=("acct_no", "amount", "id", "_workspace_id"),
+        workspace_property="_workspace_id",
+        required_parameters=("workspace_id",),
+        max_graph_hops=4,
+        max_result_rows=50,
+        max_repair_attempts=1,
+        require_explain_before_execute=True,
+    )
+
+
+PARAMS = ("workspace_id", "limit", "acct_no")
+
+
+def test_grammar_derives_from_the_policy(policy) -> None:
+    g = grammar_from_policy(policy, params=PARAMS)
+    # The ontology's vocabulary, verbatim: labels, relationship types, properties.
+    for term in ("Account", "Person", "TRANSFER", "OWN", "acct_no"):
+        assert f'"{term}"' in g
+    # The two contract terminals are hard-coded, not choices.
+    assert "$workspace_id" in g
+    assert 'limit_clause ::= "LIMIT $limit"' in g
+    # No unbounded repetition anywhere: `*` may only appear inside quoted terminals
+    # (the variable-length hop syntax), never as an EBNF repetition operator.
+    for line in g.splitlines():
+        outside_quotes = "".join(
+            part for i, part in enumerate(line.split('"')) if i % 2 == 0
+        )
+        assert "*" not in outside_quotes, f"unbounded repetition in: {line}"
+
+
+def test_covers_reports_the_subset_boundary(policy) -> None:
+    inside = (
+        "MATCH (a:Account { _workspace_id: $workspace_id, acct_no: $acct_no })"
+        "-[t:TRANSFER]->(b:Account { _workspace_id: $workspace_id }) "
+        "RETURN count(t) AS n LIMIT $limit"
+    )
+    ok, reasons = covers(inside, policy)
+    assert ok, reasons
+
+    with_pipeline = (
+        "MATCH (o:Person { _workspace_id: $workspace_id })-[r:OWN]->(a:Account "
+        "{ _workspace_id: $workspace_id }) WITH o, count(a) AS held "
+        "RETURN o.id AS owner, held LIMIT $limit"
+    )
+    ok, reasons = covers(with_pipeline, policy)
+    assert not ok
+    assert any("WITH" in r for r in reasons)
+
+
+# --- membership: decided by the enforcement engine itself -------------------------------
+
+xgr = pytest.importorskip("xgrammar")
+
+
+@pytest.fixture
+def matcher(policy):
+    grammar = grammar_from_policy(policy, params=PARAMS)
+    info = xgr.TokenizerInfo(
+        [chr(c) for c in range(32, 127)], vocab_type=xgr.VocabType.RAW
+    )
+    compiled = xgr.GrammarCompiler(info).compile_grammar(xgr.Grammar.from_ebnf(grammar))
+
+    def member(cypher: str) -> bool:
+        m = xgr.GrammarMatcher(compiled)
+        text = '{"cypher": "' + " ".join(cypher.split()) + '"}'
+        return bool(m.accept_string(text) and m.is_completed())
+
+    return member
+
+
+def test_admits_the_canonical_query_shapes(matcher) -> None:
+    for cypher in (
+        # anchored aggregate, anchor in the node map
+        "MATCH (a:Account { _workspace_id: $workspace_id, acct_no: $acct_no })"
+        "-[t:TRANSFER]->(b:Account { _workspace_id: $workspace_id }) "
+        "RETURN count(t) AS n, sum(t.amount) AS total LIMIT $limit",
+        # union label the ontology itself declares
+        "MATCH (o:Person|Company { _workspace_id: $workspace_id })-[r:OWN]->"
+        "(a:Account { _workspace_id: $workspace_id, acct_no: $acct_no }) "
+        "RETURN o.id AS owner LIMIT $limit",
+        # second MATCH re-referencing a bound variable, variable-length hops,
+        # node-inequality self-loop exclusion
+        "MATCH (s:Account { _workspace_id: $workspace_id, acct_no: $acct_no }) "
+        "MATCH (s)-[t:TRANSFER*1..2]->(r:Account { _workspace_id: $workspace_id }) "
+        "WHERE r <> s RETURN count(DISTINCT r) AS reach LIMIT $limit",
+    ):
+        assert matcher(cypher), cypher
+
+
+def test_rejects_every_validator_class_at_decode_time(matcher) -> None:
+    rejected = {
+        "unscoped node": "MATCH (a:Account) RETURN count(a) AS n LIMIT $limit",
+        "inlined literal": (
+            "MATCH (a:Account { _workspace_id: $workspace_id }) "
+            "WHERE a.amount > 3 RETURN count(a) AS n LIMIT $limit"
+        ),
+        "anonymous relationship": (
+            "MATCH (a:Account { _workspace_id: $workspace_id })-[:TRANSFER]->"
+            "(b:Account { _workspace_id: $workspace_id }) "
+            "RETURN count(b) AS n LIMIT $limit"
+        ),
+        "node compared to a parameter": (
+            "MATCH (a:Account { _workspace_id: $workspace_id })-[t:TRANSFER]->"
+            "(b:Account { _workspace_id: $workspace_id }) "
+            "WHERE b <> $acct_no RETURN count(t) AS n LIMIT $limit"
+        ),
+        "missing LIMIT": (
+            "MATCH (a:Account { _workspace_id: $workspace_id, acct_no: $acct_no })"
+            "-[t:TRANSFER]->(b:Account { _workspace_id: $workspace_id }) "
+            "RETURN count(t) AS n"
+        ),
+        "repetition runaway": (
+            "MATCH (a:Account { _workspace_id: $workspace_id }) "
+            "WHERE a.acct_no = $acct_no"
+            + " AND a.acct_no = $acct_no" * 8
+            + " RETURN count(a) AS n LIMIT $limit"
+        ),
+    }
+    for name, cypher in rejected.items():
+        assert not matcher(cypher), name
+
+
+# --- the option threads through generate_validated_cypher --------------------------------
+
+
+class _StubResponse:
+    def __init__(self, cypher: str) -> None:
+        self._cypher = cypher
+        self.text = '{"cypher": "' + cypher + '"}'
+        self.usage = {"prompt_tokens": 100, "completion_tokens": 40, "cached_tokens": 80}
+
+    def json(self):
+        return {"cypher": self._cypher}
+
+
+class _StubBackend:
+    """Captures the request kwargs; returns a fixed, policy-conforming query."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def acomplete(self, **kwargs):
+        self.calls.append(kwargs)
+        return _StubResponse(
+            "MATCH (a:Account { _workspace_id: $workspace_id, acct_no: $acct_no })"
+            "-[t:TRANSFER]->(b:Account { _workspace_id: $workspace_id }) "
+            "RETURN count(t) AS n LIMIT $limit"
+        )
+
+
+
+async def test_grammar_option_reaches_the_request_and_displaces_response_format(policy) -> None:
+    from seocho.query.text2cypher import generate_validated_cypher
+
+    backend = _StubBackend()
+    grammar = grammar_from_policy(policy, params=PARAMS)
+
+    async def explain(cypher, params) -> None:
+        return None
+
+    result = await generate_validated_cypher(
+        question="how many transfers?",
+        schema={"Account": ("acct_no",)},
+        params={"workspace_id": "t1", "limit": 50, "acct_no": 1},
+        policy=policy,
+        backend=backend,
+        model="m",
+        explain=explain,
+        grammar=grammar,
+    )
+    call = backend.calls[0]
+    # The grammar rides provider_options, and response_format is NOT sent alongside it:
+    # vLLM refuses both constraint mechanisms on one request.
+    assert call["provider_options"] == {"structured_outputs": {"grammar": grammar}}
+    assert call["response_format"] is None
+    # Timing and usage are on the result — the failure path carries the same numbers on
+    # the raised exception, so episode accounting never books LLM time as database time.
+    assert result.generate_ms > 0
+    assert result.usage == {"prompt_tokens": 100, "completion_tokens": 40, "cached_tokens": 80}
+
+
+
+async def test_without_grammar_the_request_is_unchanged(policy) -> None:
+    from seocho.query.text2cypher import generate_validated_cypher
+
+    backend = _StubBackend()
+
+    async def explain(cypher, params) -> None:
+        return None
+
+    await generate_validated_cypher(
+        question="how many transfers?",
+        schema={"Account": ("acct_no",)},
+        params={"workspace_id": "t1", "limit": 50, "acct_no": 1},
+        policy=policy,
+        backend=backend,
+        model="m",
+        explain=explain,
+    )
+    call = backend.calls[0]
+    assert call["provider_options"] is None
+    assert call["response_format"] == {"type": "json_object"}


### PR DESCRIPTION
## What

Two capabilities the AIsummit26 graph-agentic-RAG measurements showed seocho's text2cypher needs, ported from the harness where they were developed and measured:

1. **`seocho.query.grammar`** — `grammar_from_policy(policy, params)` derives an EBNF from `Text2CypherFallbackPolicy` and `generate_validated_cypher(grammar=...)` enforces it at decode time via `provider_options={"structured_outputs": {"grammar": ...}}` (vLLM ≥ 0.27; allowlist widened). Under the grammar, the validator's structural rejection classes — undeclared label, missing tenant scope, inlined literal, missing `LIMIT $limit` — **cannot be emitted at all**, so those repair cases stop existing instead of being caught. `covers()` reports the subset boundary; `grammar_is_honored()` proves the endpoint applies grammars before any A/B (some accept the option with HTTP 200 and silently ignore it — measured).
2. **`seocho.ontology.conformance`** — `conformance_report(ontology, run_query)` checks the declaration against the loaded graph: labels/types/properties both directions, identity-key existence **and index coverage**, endpoint triples with `Person|Company` unions expanded. Driver-agnostic (`run_query` injected), dict-fake-testable.

Plus instrumentation the measurements demanded: `Text2CypherResult.generate_ms` and summed token `usage` (prompt/completion/**cached**), stamped onto the raised `ValueError` on the failure path too — a failed generation still spent its wall time in the LLM, and one measured run booked 101.7 s of that as *database* time because the exception carried nothing.

## Why (measured, not hoped)

- Repair loop cost: 2.8–3.9 attempts/generation on gpt-oss-120b, 101.7 s failed-generation LLM time in one 26-episode run — every rejection is a full re-prefill + decode.
- Ontology drift is a silent double failure: five real, fully-populated properties were undeclared → validator rejected *correct* queries (`unknown_properties`, unfixable by repair) while the grammar made the same questions unrepresentable.
- Inner-call prefix cache measured at 73–98% once `cached_tokens` was recorded per call — the serving-economics half of the story this instrumentation makes visible.

## Honest scope (please read before adopting the grammar by default)

- The guarantee is **validity, tenant scope, and auditability — not answer quality**. Small models are rescued structurally (Qwen2.5-1.5B: 0/8 → 8/8 *valid*); on a 120B the unconstrained decode already writes valid Cypher and a constraint can **steer it off** a high-prior idiom it needed (measured: a grammar-expressible, plain-solvable question failed 2/2 under the grammar because the mandatory relationship variable displaced the `[:TRANSFER*1..2]` idiom). Constraints shift probability mass at every branch point; admissibility of the right answer does not make the right answer likely.
- Hard-won grammar rules are encoded and tested: every repetition bounded (unbounded repetitions are decoding attractors — 19,390 chars of one repeated clause, measured), relationship variables mandatory, the `param` rule names what the **executor** accepts (28/43 tool failures in one run were `ParameterMissing` from an admitted alias).

## Tests

- `test_text2cypher_grammar.py`: structural properties always; **membership decided by xgrammar itself** (the engine vLLM constrains with) — admits the canonical shapes, rejects every validator class at decode time; skips cleanly without xgrammar. Option-threading tests via stub backend (grammar → `provider_options`, `response_format` displaced; unchanged requests without it).
- `test_ontology_conformance.py`: undeclared-property detection, infrastructure-prefix exemption, union-endpoint expansion (regression for the phantom-drift bug), unindexed-identity-key finding.
- Sweep on touched areas: 147 passed, 1 skipped (two pre-existing collection errors on clean main excluded: `test_okx_release_gate.py`, `test_okx_e2e_trace_live.py`).

Raw measurement provenance lives in the AIsummit26 repo (`results/bench/*20260822*`, commits `4a5035e`, `999310e`, `422e9ab`, `e2033a0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)