### PR TITLE
[Draft] Fix WCAG 2 AA contrast in evaluation UI buttons

### DIFF
--- a/evaluation/static/styles.css
+++ b/evaluation/static/styles.css
@@ -241,7 +241,7 @@ body {
 
 #ingestBtn {
   background: var(--accent-green);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -257,7 +257,7 @@ body {
 
 #oneClickDemoBtn {
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   border-radius: 4px;
   padding: 0.4rem 0.75rem;
@@ -353,7 +353,7 @@ body {
 .composer button {
   align-self: flex-end;
   background: var(--accent-blue);
-  color: #fff;
+  color: #0d1117;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;


### PR DESCRIPTION
What: Changed text color from #fff to #0d1117 for buttons using --accent-green and --accent-blue backgrounds in evaluation/static/styles.css.
Why: The Palantir AIP theme colors (#3fb950 and #2f81f7) do not provide sufficient contrast with white text (#fff) to meet WCAG 2 AA guidelines.
Accessibility / UX Impact: Improves accessibility by ensuring text on primary action buttons meets contrast ratio requirements.
Validation: Ran basic CI checks to ensure no regressions.
Risks: Minor visual change in the evaluation UI.
Modified Files: evaluation/static/styles.css, .jules/palette.md

---
*PR created automatically by Jules for task [2002986610676088273](https://jules.google.com/task/2002986610676088273) started by @tteon*