### PR TITLE
Fix missing workspace filter in Session context cache query

### DIFF
--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -795,9 +795,11 @@ class Session:
             try:
                 sid = memory.memory_id
                 rows = self.graph_store.query(
-                    "MATCH (n) WHERE n._source_id = $sid "
+                    "MATCH (n) WHERE n._source_id = $sid AND ($workspace_id = '' OR n._workspace_id = $workspace_id) "
                     "RETURN labels(n)[0] AS label, n.name AS name, properties(n) AS props",
-                    params={"sid": sid}, database=database,
+                    params={"sid": sid, "workspace_id": self.workspace_id}, database=database,
+                    workspace_id=self.workspace_id,
+                    enforce_workspace_filter=True,
                 )
                 for row in rows:
                     extracted_nodes.append({


### PR DESCRIPTION
Severity: Medium

Vulnerability: The `_add_via_pipeline` method in `Session` executed a Cypher query to extract nodes for the context cache without filtering by `workspace_id` and without enforcing the workspace filter parameter.

Impact: A tenant could potentially read nodes from another tenant if they share the same `_source_id`, violating tenant isolation.

Fix: Added `workspace_id=self.workspace_id` and `enforce_workspace_filter=True` to the `graph_store.query` call, and updated the Cypher query to include `($workspace_id = '' OR n._workspace_id = $workspace_id)`.

Validation: Ran basic CI tests and `tests/seocho/test_session_agent.py` successfully.

Risks: Very low risk as the changes enforce existing isolation paradigms.

Modified Files: src/seocho/session.py

---
*PR created automatically by Jules for task [6396363151298804552](https://jules.google.com/task/6396363151298804552) started by @tteon*