### PR TITLE
[Draft] Improve CLI empty state capitalization

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:


### PR DESCRIPTION
What: Capitalized the empty state/error messages in src/seocho/cli/__init__.py. 
Why: To comply with the repository convention for CLI messages to use proper sentence case and punctuation rather than informal lowercase strings. 
Accessibility / UX Impact: Clearer, more professional, and easier to read error output for developers and operators using the CLI. 
Validation: Verified locally by running bash scripts/ci/run_basic_ci.sh and bash scripts/pm/lint-agent-docs.sh. 
Risks: Very low risk as this only affects strings printed to standard output without altering any logical program flow. 
Modified Files: src/seocho/cli/__init__.py, .jules/palette.md

---
*PR created automatically by Jules for task [14092696230862534329](https://jules.google.com/task/14092696230862534329) started by @tteon*