### PR TITLE
[Draft] Optimize evaluation trace reading memory usage

### DIFF
--- a/src/seocho/eval/graphrag_bench.py
+++ b/src/seocho/eval/graphrag_bench.py
@@ -142,26 +142,25 @@ def load_question_directory(
                 raise FileNotFoundError(f"missing official question file: {path}")
             digest = sha256_file(path)
             parsed: list[GraphRAGBenchCase] = []
-            for row_index, line in enumerate(
-                path.read_text(encoding="utf-8").splitlines(), start=1
-            ):
-                if not line.strip():
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
-                if not isinstance(raw, Mapping):
-                    raise ValueError(f"{path}:{row_index}: expected an object")
-                parsed.append(
-                    parse_question_row(
-                        raw,
-                        question_type=question_type,
-                        row_index=row_index,
-                        source_file=path.name,
-                        source_sha256=digest,
+            with path.open("r", encoding="utf-8") as f:
+                for row_index, line in enumerate(f, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
+                    if not isinstance(raw, Mapping):
+                        raise ValueError(f"{path}:{row_index}: expected an object")
+                    parsed.append(
+                        parse_question_row(
+                            raw,
+                            question_type=question_type,
+                            row_index=row_index,
+                            source_file=path.name,
+                            source_sha256=digest,
+                        )
                     )
-                )
             selected = parsed[:limit_per_type] if limit_per_type else parsed
             cases.extend(selected)
             files[question_type] = {

--- a/tests/seocho/test_graphrag_bench_adapter.py
+++ b/tests/seocho/test_graphrag_bench_adapter.py
@@ -76,9 +76,7 @@ def test_loader_balances_smoke_subset_and_writes_jsonl(tmp_path) -> None:
     assert manifest["files"]["FB"]["rows_total"] == 2
     assert manifest["files"]["FB"]["rows_selected"] == 1
     assert write_jsonl(cases, destination) == 5
-    rows = [
-        json.loads(line)
-        for line in destination.read_text(encoding="utf-8").splitlines()
-    ]
+    with destination.open("r", encoding="utf-8") as f:
+        rows = [json.loads(line) for line in f]
     assert len(rows) == 5
     assert all("question" not in row and "answer" not in row for row in rows)


### PR DESCRIPTION
**What:**
Refactored JSONL file reading in `src/seocho/eval/graphrag_bench.py` and `tests/seocho/test_graphrag_bench_adapter.py` to stream lines sequentially using `with path.open(...)` instead of loading the entire file into memory as a string and then splitting it with `.read_text().splitlines()`.

**Why:**
The current approach reads the entire JSONL trace into memory before processing it line by line. This can lead to excessive memory consumption and potential Out-Of-Memory (OOM) errors, especially when parsing large evaluation trace files.

**Expected Impact:**
Memory usage will be significantly reduced during evaluation processes involving large `.jsonl` files since only one line is read into memory at a time. The code retains the same functional behavior and handles edge cases appropriately.

**Validation:**
Verified changes using:
- `uv run pytest tests/seocho/test_graphrag_bench_adapter.py`
- `bash scripts/ci/run_basic_ci.sh`
All tests passed successfully, confirming no regressions were introduced.

**Risks:**
Very low risk. The logic within the iteration loops remains unchanged, and file handles are safely managed with context managers.

**Modified Files:**
- `src/seocho/eval/graphrag_bench.py`
- `tests/seocho/test_graphrag_bench_adapter.py`
- `.jules/bolt.md`

---
*PR created automatically by Jules for task [741138852034057534](https://jules.google.com/task/741138852034057534) started by @tteon*