### PR TITLE
[Draft] Fix CLI empty state and error messages to use sentence case

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -500,7 +500,7 @@ def handle(args: argparse.Namespace) -> int:
                 print(json.dumps(clusters, indent=2, ensure_ascii=False))
             else:
                 if not clusters:
-                    print("quarantine empty")
+                    print("Quarantine empty.")
                 for c in clusters:
                     print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
                           f"candidates={c['candidate_labels']}")
@@ -601,7 +601,7 @@ def handle(args: argparse.Namespace) -> int:
             else:
                 term_records = parse_review_sheet(raw)
         else:
-            print("datahub-apply: provide --terms <file> or --gms <url>")
+            print("Datahub-apply: Provide --terms <file> or --gms <url>")
             return 2
         spec = datahub_glossary_to_mapping_spec(term_records, only_status=args.status, ontology_name=ontology.name)
         new_onto = apply_mapping_spec(ontology, spec)


### PR DESCRIPTION
## What
Standardizes the casing and punctuation for several CLI empty state and error messages (e.g., from `"no memories found"` to `"No memories found."`).

## Why
To provide a more polished, consistent, and professional experience for operators relying on terminal output. Uncapitalized messages without punctuation look informal and out of place next to the rest of the CLI's structured output.

## Accessibility / UX Impact
Improves text readability and professional polish for CLI users. Consistent casing helps users quickly identify and parse system messages vs. data payloads.

## Validation
- `bash scripts/ci/run_basic_ci.sh` passed.
- `bash scripts/pm/lint-agent-docs.sh` passed.
- Verified that these purely cosmetic changes do not break any tests or affect programmatic JSON outputs.

## Risks
Zero risk. These changes are localized to standard `print()` statements that are only executed in human-readable CLI contexts, not within JSON or programmatic output paths.

Modified Files: src/seocho/cli/__init__.py, src/seocho/cli/ontology.py, .jules/palette.md

---
*PR created automatically by Jules for task [7772329840169536896](https://jules.google.com/task/7772329840169536896) started by @tteon*