### PR TITLE
[Draft] Capitalize and punctuate CLI empty state messages

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -500,7 +500,7 @@ def handle(args: argparse.Namespace) -> int:
                 print(json.dumps(clusters, indent=2, ensure_ascii=False))
             else:
                 if not clusters:
-                    print("quarantine empty")
+                    print("Quarantine empty.")
                 for c in clusters:
                     print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
                           f"candidates={c['candidate_labels']}")


### PR DESCRIPTION
### What
Capitalized and punctuated informal empty state strings printed by the CLI.

### Why
Empty state and error messages in the CLI should use proper sentence casing and punctuation rather than informal lowercase strings to maintain a professional and consistent tone.

### Accessibility / UX Impact
Minor readability and polish improvement for CLI operators encountering empty states.

### Validation
- Validated via `bash scripts/ci/run_basic_ci.sh` which checks the runtime and CLI.
- Validated via `bash scripts/pm/lint-agent-docs.sh` to ensure documentation and operator contracts remain consistent.

### Risks
None. These are display-only strings printed to stdout/stderr in edge cases.

### Modified Files:
- src/seocho/cli/__init__.py
- src/seocho/cli/ontology.py
- .jules/palette.md

---
*PR created automatically by Jules for task [18354803605668431058](https://jules.google.com/task/18354803605668431058) started by @tteon*