### PR TITLE
UX: Capitalize and punctuate CLI empty state messages

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -500,7 +500,7 @@ def handle(args: argparse.Namespace) -> int:
                 print(json.dumps(clusters, indent=2, ensure_ascii=False))
             else:
                 if not clusters:
-                    print("quarantine empty")
+                    print("Quarantine empty.")
                 for c in clusters:
                     print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
                           f"candidates={c['candidate_labels']}")


### PR DESCRIPTION
What: Update empty state print messages across the CLI to use proper sentence casing and punctuation.
Why: Current messages ("no memories found", "no graph targets configured", etc.) are informal lowercase strings which are inconsistent with the rest of the CLI UX and standard conventions.
Accessibility / UX Impact: Improves the clarity, professionalism, and readability of terminal outputs for the operator.
Validation: Ran `bash scripts/ci/run_basic_ci.sh`, `bash scripts/pm/lint-agent-docs.sh`, and focused pytest suite `uv run pytest tests/seocho/test_cli_parser_contract.py`. All tests passed. Changes are strictly confined to human-readable print statements and do not impact JSON output modes.
Risks: Minimal to none. The updated outputs are purely for human operators and remain bypassed in automated/JSON modes.

Modified Files:
- src/seocho/cli/__init__.py
- src/seocho/cli/ontology.py
- .jules/palette.md

---
*PR created automatically by Jules for task [18363918929120426328](https://jules.google.com/task/18363918929120426328) started by @tteon*