### PR TITLE
Fix IDOR/Workspace Bypass in Session Pipeline Fallback

### DIFF
--- a/src/seocho/session.py
+++ b/src/seocho/session.py
@@ -795,9 +795,11 @@ class Session:
             try:
                 sid = memory.memory_id
                 rows = self.graph_store.query(
-                    "MATCH (n) WHERE n._source_id = $sid "
+                    "MATCH (n) WHERE n._workspace_id = $workspace_id AND n._source_id = $sid "
                     "RETURN labels(n)[0] AS label, n.name AS name, properties(n) AS props",
                     params={"sid": sid}, database=database,
+                    workspace_id=self.workspace_id,
+                    enforce_workspace_filter=True,
                 )
                 for row in rows:
                     extracted_nodes.append({


### PR DESCRIPTION
**Severity**
High

**Vulnerability**
Cross-Tenant Data Leak / IDOR

**Impact**
In the pipeline fallback mode (`Session._add_via_pipeline`), the `graph_store.query()` method was checking for nodes based solely on `_source_id` without filtering by the tenant scope. Since `_source_id`s could theoretically collide or be predictable across tenants, a user could extract data belonging to another tenant's workspace if the agent failed over to the pipeline.

**Fix**
Modified the fallback Cypher query to strictly bind against the current workspace using `n._workspace_id = $workspace_id`. Also passed `workspace_id` and `enforce_workspace_filter=True` to explicitly invoke the `graph_store.query` layer's fail-closed tenant scoping checks.

**Validation**
- Validated via local tests (`uv run pytest tests/seocho/test_session_agent.py`)
- Verified standard CI tests pass perfectly (`bash scripts/ci/run_basic_ci.sh`)

**Risks**
Negligible. This merely brings the fallback querying functionality in-line with the primary `graph_store.query` calls elsewhere in the repository that enforce tenant scope.

**Modified Files**
- `src/seocho/session.py`

---
*PR created automatically by Jules for task [4960483397142833785](https://jules.google.com/task/4960483397142833785) started by @tteon*