### PR TITLE
perf: optimize JSONL reading in graphrag_bench.py by streaming instead of reading all into memory

### DIFF
--- a/src/seocho/eval/graphrag_bench.py
+++ b/src/seocho/eval/graphrag_bench.py
@@ -142,26 +142,25 @@ def load_question_directory(
                 raise FileNotFoundError(f"missing official question file: {path}")
             digest = sha256_file(path)
             parsed: list[GraphRAGBenchCase] = []
-            for row_index, line in enumerate(
-                path.read_text(encoding="utf-8").splitlines(), start=1
-            ):
-                if not line.strip():
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
-                if not isinstance(raw, Mapping):
-                    raise ValueError(f"{path}:{row_index}: expected an object")
-                parsed.append(
-                    parse_question_row(
-                        raw,
-                        question_type=question_type,
-                        row_index=row_index,
-                        source_file=path.name,
-                        source_sha256=digest,
+            with path.open("r", encoding="utf-8") as f:
+                for row_index, line in enumerate(f, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
+                    if not isinstance(raw, Mapping):
+                        raise ValueError(f"{path}:{row_index}: expected an object")
+                    parsed.append(
+                        parse_question_row(
+                            raw,
+                            question_type=question_type,
+                            row_index=row_index,
+                            source_file=path.name,
+                            source_sha256=digest,
+                        )
                     )
-                )
             selected = parsed[:limit_per_type] if limit_per_type else parsed
             cases.extend(selected)
             files[question_type] = {


### PR DESCRIPTION
**What:** Refactored `src/seocho/eval/graphrag_bench.py` to use a context manager for streaming JSONL files line-by-line instead of loading the entire file content into memory at once using `path.read_text().splitlines()`.

**Why:** Loading large evaluation trace JSONL files entirely into memory creates unnecessary memory pressure and overhead. Streaming the file is a standard practice and a clear performance/memory optimization listed in the priority areas for this repository.

**Expected Impact:** Reduced memory footprint and slightly faster evaluation times when processing large JSONL files. The logic and behavior of the tests remain completely unchanged.

**Validation:**
- Local CI (`bash scripts/ci/run_basic_ci.sh`) passes successfully.
- Specific tests for the `eval` module (`uv run pytest tests/seocho/ -k test_eval`) pass successfully.

**Risks:** Low risk. This is a standard refactor for handling file I/O more efficiently. The change preserves existing behavior, including error handling for malformed JSON and graceful skipping of empty lines.

**Modified Files:**
`src/seocho/eval/graphrag_bench.py`
`.jules/bolt.md`

---
*PR created automatically by Jules for task [16405900295401159367](https://jules.google.com/task/16405900295401159367) started by @tteon*