### PR TITLE
ux(cli): standardize empty state messages with proper punctuation (Draft)

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:


### PR DESCRIPTION
What:
Capitalized and added trailing periods to the "No memories found", "no graph targets configured", and "no semantic artifacts found" empty state messages in the CLI formatting functions.

Why:
These are user-facing output messages. Using proper sentence casing and punctuation makes the CLI feel more professional, readable, and consistent.

Accessibility / UX Impact:
A small UX wording fix. Improves clarity for terminal users reading empty states.

Validation:
- `uv run pytest tests/seocho/test_cli_parser_contract.py`
- `bash scripts/pm/lint-agent-docs.sh`
- `bash scripts/ci/run_basic_ci.sh`

Risks:
Very low risk. The change only touches printed string literals in the CLI presentation layer and does not affect the semantic query path or runtime API responses.

Modified Files:
- src/seocho/cli/__init__.py
- .jules/palette.md

---
*PR created automatically by Jules for task [672496854787548062](https://jules.google.com/task/672496854787548062) started by @tteon*