### PR TITLE
Draft: Fix CLI empty state capitalization

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -500,7 +500,7 @@ def handle(args: argparse.Namespace) -> int:
                 print(json.dumps(clusters, indent=2, ensure_ascii=False))
             else:
                 if not clusters:
-                    print("quarantine empty")
+                    print("Quarantine empty.")
                 for c in clusters:
                     print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
                           f"candidates={c['candidate_labels']}")


### PR DESCRIPTION
What:
Capitalized informal lowercase strings in CLI empty state and error messages (e.g. changing "no memories found" to "No memories found.").

Why:
To improve text clarity and professionalism in operator-facing CLI output by using proper sentence case and punctuation.

Accessibility / UX Impact:
Provides a clearer, more standard reading experience for CLI users and operators, aligning with general interface text guidelines.

Validation:
- Validated via focused `pytest` runs for `tests/seocho/test_cli_parser_contract.py` and `tests/seocho/test_ontology_import.py`.
- Validated via `bash scripts/pm/lint-agent-docs.sh`.
- The changed messages are bounded within plain text `print` statements conditionally executed when `output_json` is False, meaning they do not affect machine-readable JSON output formats.

Risks:
Very low risk. The change only affects human-readable terminal output and preserves existing functionality and machine-readable JSON formats.

Modified Files: src/seocho/cli/__init__.py, src/seocho/cli/ontology.py, .jules/palette.md

---
*PR created automatically by Jules for task [1794572748629507362](https://jules.google.com/task/1794572748629507362) started by @tteon*