### PR TITLE
perf: Stream JSONL evaluation files via lazy iteration

### DIFF
--- a/src/seocho/eval/graphrag_bench.py
+++ b/src/seocho/eval/graphrag_bench.py
@@ -142,26 +142,25 @@ def load_question_directory(
                 raise FileNotFoundError(f"missing official question file: {path}")
             digest = sha256_file(path)
             parsed: list[GraphRAGBenchCase] = []
-            for row_index, line in enumerate(
-                path.read_text(encoding="utf-8").splitlines(), start=1
-            ):
-                if not line.strip():
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
-                if not isinstance(raw, Mapping):
-                    raise ValueError(f"{path}:{row_index}: expected an object")
-                parsed.append(
-                    parse_question_row(
-                        raw,
-                        question_type=question_type,
-                        row_index=row_index,
-                        source_file=path.name,
-                        source_sha256=digest,
+            with path.open("r", encoding="utf-8") as f:
+                for row_index, line in enumerate(f, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
+                    if not isinstance(raw, Mapping):
+                        raise ValueError(f"{path}:{row_index}: expected an object")
+                    parsed.append(
+                        parse_question_row(
+                            raw,
+                            question_type=question_type,
+                            row_index=row_index,
+                            source_file=path.name,
+                            source_sha256=digest,
+                        )
                     )
-                )
             selected = parsed[:limit_per_type] if limit_per_type else parsed
             cases.extend(selected)
             files[question_type] = {


### PR DESCRIPTION
### What
Replaces `path.read_text(encoding="utf-8").splitlines()` with lazy streaming (`with path.open("r", encoding="utf-8") as f:`) when reading JSONL question files in `src/seocho/eval/graphrag_bench.py`.

### Why
Using `read_text().splitlines()` loads the entire file as a single massive string, then allocates a massive list of strings. This creates avoidable and severe memory overhead for large JSONL evaluation datasets. Iterating directly over the open file object avoids bringing the full raw string into memory.

### Expected Impact
Greatly reduced memory allocations and memory ceiling during large graphrag_bench.py evaluations, preventing OOMs and garbage collection pressure when the JSONL corpus grows large. Qualitative memory improvement and minor speedup.

### Validation
Verified the correctness of the refactor by testing with existing unit tests. 
Ran `bash scripts/ci/run_basic_ci.sh` which passed successfully. 
The trailing newline stripping logic natively maps well to the iteration block and preserves the existing behavior.

### Risks
Minimal risk as `json.loads` natively ignores the un-stripped trailing newlines that exist during file iteration. This introduces no change in behavior or output format. 

Modified Files:
- `src/seocho/eval/graphrag_bench.py`
- `.jules/bolt.md`

---
*PR created automatically by Jules for task [6368367161243819992](https://jules.google.com/task/6368367161243819992) started by @tteon*