### PR TITLE
perf: stream JSONL during eval to reduce memory overhead

### DIFF
--- a/src/seocho/eval/graphrag_bench.py
+++ b/src/seocho/eval/graphrag_bench.py
@@ -142,26 +142,25 @@ def load_question_directory(
                 raise FileNotFoundError(f"missing official question file: {path}")
             digest = sha256_file(path)
             parsed: list[GraphRAGBenchCase] = []
-            for row_index, line in enumerate(
-                path.read_text(encoding="utf-8").splitlines(), start=1
-            ):
-                if not line.strip():
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
-                if not isinstance(raw, Mapping):
-                    raise ValueError(f"{path}:{row_index}: expected an object")
-                parsed.append(
-                    parse_question_row(
-                        raw,
-                        question_type=question_type,
-                        row_index=row_index,
-                        source_file=path.name,
-                        source_sha256=digest,
+            with path.open("r", encoding="utf-8") as f:
+                for row_index, line in enumerate(f, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
+                    if not isinstance(raw, Mapping):
+                        raise ValueError(f"{path}:{row_index}: expected an object")
+                    parsed.append(
+                        parse_question_row(
+                            raw,
+                            question_type=question_type,
+                            row_index=row_index,
+                            source_file=path.name,
+                            source_sha256=digest,
+                        )
                     )
-                )
             selected = parsed[:limit_per_type] if limit_per_type else parsed
             cases.extend(selected)
             files[question_type] = {


### PR DESCRIPTION
What:
Replaced `path.read_text(encoding="utf-8").splitlines()` with lazy streaming (`with path.open("r", encoding="utf-8") as f:`) when parsing `graphrag_bench.py` JSONL inputs.

Why:
Loading an entire JSONL file as a single string and splitting it into a list of strings introduces significant memory overhead, particularly for large evaluation datasets. 

Expected Impact:
Lower memory ceiling during evaluation suite startup due to streaming iteration, directly addressing the "avoidable file I/O or JSONL overhead" priority area.

Validation:
- Ran `pytest tests/seocho/test_eval_benchmark.py` successfully.
- Ran full `bash scripts/ci/run_basic_ci.sh` successfully.

Risks:
Negligible. The implementation preserves existing behaviour identically, including `json.loads` processing and skipping blank lines.

Modified Files:
- src/seocho/eval/graphrag_bench.py
- .jules/bolt.md

---
*PR created automatically by Jules for task [2310269533069278913](https://jules.google.com/task/2310269533069278913) started by @tteon*