### PR TITLE
fix: Update CLI empty states to proper sentence casing

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:


### PR DESCRIPTION
Draft PR: True

## What
Updated three CLI empty state messages in `src/seocho/cli/__init__.py` from lowercase informal to sentence-cased strings with punctuation:
* `no memories found` -> `No memories found.`
* `no graph targets configured` -> `No graph targets configured.`
* `no semantic artifacts found` -> `No semantic artifacts found.`

Modified Files:
* `src/seocho/cli/__init__.py`
* `.jules/palette.md`

## Why
Adheres to the repository's preference for clear, sentence-cased CLI output text.

## Accessibility / UX Impact
Improves text readability and professional appearance for CLI users encountering empty state results.

## Validation
* Ran local CI suite successfully via `bash scripts/ci/run_basic_ci.sh`.
* Verified CLI string replacements didn't affect structured JSON output logic.
* Verified agent docs linting via `bash scripts/pm/lint-agent-docs.sh`.

## Risks
Extremely low risk as changes strictly affect string presentation to the CLI output user and omit structured JSON rendering contexts.

---
*PR created automatically by Jules for task [5061415109963198942](https://jules.google.com/task/5061415109963198942) started by @tteon*