### PR TITLE
perf: Stream JSONL traces in graphrag_bench.py instead of reading into memory

### DIFF
--- a/src/seocho/eval/graphrag_bench.py
+++ b/src/seocho/eval/graphrag_bench.py
@@ -142,26 +142,25 @@ def load_question_directory(
                 raise FileNotFoundError(f"missing official question file: {path}")
             digest = sha256_file(path)
             parsed: list[GraphRAGBenchCase] = []
-            for row_index, line in enumerate(
-                path.read_text(encoding="utf-8").splitlines(), start=1
-            ):
-                if not line.strip():
-                    continue
-                try:
-                    raw = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
-                if not isinstance(raw, Mapping):
-                    raise ValueError(f"{path}:{row_index}: expected an object")
-                parsed.append(
-                    parse_question_row(
-                        raw,
-                        question_type=question_type,
-                        row_index=row_index,
-                        source_file=path.name,
-                        source_sha256=digest,
+            with path.open("r", encoding="utf-8") as f:
+                for row_index, line in enumerate(f, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        raw = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(f"{path}:{row_index}: invalid JSON") from exc
+                    if not isinstance(raw, Mapping):
+                        raise ValueError(f"{path}:{row_index}: expected an object")
+                    parsed.append(
+                        parse_question_row(
+                            raw,
+                            question_type=question_type,
+                            row_index=row_index,
+                            source_file=path.name,
+                            source_sha256=digest,
+                        )
                     )
-                )
             selected = parsed[:limit_per_type] if limit_per_type else parsed
             cases.extend(selected)
             files[question_type] = {


### PR DESCRIPTION
Draft PR.

### What
Replaced `path.read_text(encoding="utf-8").splitlines()` with a lazy iterator `with path.open("r", encoding="utf-8") as f: for line in f:` in `load_question_directory` within `src/seocho/eval/graphrag_bench.py`.

### Why
To eliminate unnecessary file I/O overhead and memory consumption from reading entire large `.jsonl` evaluation files into memory as a single string and splitting them.

### Expected Impact
Lower peak memory usage and marginally faster start-up time when loading benchmarking datasets. This is qualitative/quantitative but primarily guards against OOM issues on very large eval datasets.

### Validation
Ran `bash scripts/ci/run_basic_ci.sh` which passed. Specifically validated changes against `tests/seocho/test_benchmarking.py` and `tests/seocho/test_finder_benchmark_script.py` which execute correctly.

### Risks
Extremely low risk; `json.loads` handles the trailing newlines identically to `.strip()`, so behavior is preserved precisely.

### Modified Files
`src/seocho/eval/graphrag_bench.py`, `.jules/bolt.md`

---
*PR created automatically by Jules for task [12364438176912514463](https://jules.google.com/task/12364438176912514463) started by @tteon*