### PR TITLE
style(cli): update empty state messages to use sentence case and punctuation

### DIFF
--- a/src/seocho/cli/__init__.py
+++ b/src/seocho/cli/__init__.py
@@ -979,7 +979,7 @@ def _print_search_results(results: Sequence[SearchResult], output_json: bool) ->
         return
 
     if not results:
-        print("no memories found")
+        print("No memories found.")
         return
 
     for index, result in enumerate(results, start=1):
@@ -994,7 +994,7 @@ def _print_graphs(graphs: Iterable[GraphTarget], output_json: bool) -> None:
         return
 
     if not graph_list:
-        print("no graph targets configured")
+        print("No graph targets configured.")
         return
 
     for graph in graph_list:
@@ -1008,7 +1008,7 @@ def _print_artifacts(artifacts: Sequence[SemanticArtifactSummary], output_json: 
         return
 
     if not artifacts:
-        print("no semantic artifacts found")
+        print("No semantic artifacts found.")
         return
 
     for artifact in artifacts:

--- a/src/seocho/cli/ontology.py
+++ b/src/seocho/cli/ontology.py
@@ -500,7 +500,7 @@ def handle(args: argparse.Namespace) -> int:
                 print(json.dumps(clusters, indent=2, ensure_ascii=False))
             else:
                 if not clusters:
-                    print("quarantine empty")
+                    print("Quarantine empty.")
                 for c in clusters:
                     print(f"  {c['frequency']:4d}×  {c['surface']:30s} signals={c['signals']} "
                           f"candidates={c['candidate_labels']}")
@@ -601,7 +601,7 @@ def handle(args: argparse.Namespace) -> int:
             else:
                 term_records = parse_review_sheet(raw)
         else:
-            print("datahub-apply: provide --terms <file> or --gms <url>")
+            print("Datahub-apply: Provide --terms <file> or --gms <url>.")
             return 2
         spec = datahub_glossary_to_mapping_spec(term_records, only_status=args.status, ontology_name=ontology.name)
         new_onto = apply_mapping_spec(ontology, spec)


### PR DESCRIPTION
**What**
Updates several informal, lowercase CLI empty-state and error messages in `src/seocho/cli/__init__.py` and `src/seocho/cli/ontology.py` to use proper sentence casing and punctuation. Added rule to `.jules/palette.md`.

**Why**
The repository constraints emphasize CLI help text clarity and improving empty states/error copy. Using consistent, professional capitalization and punctuation creates a better, more polished operator-facing experience.

**Accessibility / UX Impact**
Provides a minor but concrete UX readability win by making console outputs standard sentence-cased messages.

**Validation**
- `uv run pytest tests/seocho/test_cli_parser_contract.py`
- `bash scripts/ci/run_basic_ci.sh` passed.
- `bash scripts/pm/lint-agent-docs.sh` passed.

**Risks**
Extremely low. Changes only target user-facing `print()` outputs in human-readable pathways (not `--output-json`), therefore avoiding automated parsing breakages.

Modified Files:
`src/seocho/cli/__init__.py`
`src/seocho/cli/ontology.py`
`.jules/palette.md`

(Draft PR)

---
*PR created automatically by Jules for task [4347724918481523951](https://jules.google.com/task/4347724918481523951) started by @tteon*